### PR TITLE
Fixed #36265 -- Added serialization support for ZoneInfo objects in migrations.

### DIFF
--- a/django/db/migrations/serializer.py
+++ b/django/db/migrations/serializer.py
@@ -10,6 +10,7 @@ import pathlib
 import re
 import types
 import uuid
+import zoneinfo
 
 from django.conf import SettingsReference
 from django.db import models
@@ -334,6 +335,11 @@ class UUIDSerializer(BaseSerializer):
         return "uuid.%s" % repr(self.value), {"import uuid"}
 
 
+class ZoneInfoSerializer(BaseSerializer):
+    def serialize(self):
+        return repr(self.value), {"import zoneinfo"}
+
+
 class Serializer:
     _registry = {
         # Some of these are order-dependent.
@@ -357,6 +363,7 @@ class Serializer:
         uuid.UUID: UUIDSerializer,
         pathlib.PurePath: PathSerializer,
         os.PathLike: PathLikeSerializer,
+        zoneinfo.ZoneInfo: ZoneInfoSerializer,
     }
 
     @classmethod

--- a/docs/releases/6.0.txt
+++ b/docs/releases/6.0.txt
@@ -178,6 +178,8 @@ Migrations
 * Squashed migrations can now themselves be squashed before being transitioned
   to normal migrations.
 
+* Migrations now support serialization of :class:`zoneinfo.ZoneInfo` instances.
+
 Models
 ~~~~~~
 

--- a/docs/topics/migrations.txt
+++ b/docs/topics/migrations.txt
@@ -778,6 +778,7 @@ Django can serialize the following:
 - ``list``, ``set``, ``tuple``, ``dict``, ``range``.
 - ``datetime.date``, ``datetime.time``, and ``datetime.datetime`` instances
   (include those that are timezone-aware)
+- :class:`zoneinfo.ZoneInfo` instances
 - ``decimal.Decimal`` instances
 - ``enum.Enum``  and ``enum.Flag`` instances
 - ``uuid.UUID`` instances
@@ -802,6 +803,10 @@ Django can serialize the following:
 - Unbound methods used from within the class body
 - Any class reference (must be in module's top-level scope)
 - Anything with a custom ``deconstruct()`` method (:ref:`see below <custom-deconstruct-method>`)
+
+.. versionchanged:: 6.0
+
+    Serialization support for :class:`zoneinfo.ZoneInfo` instances was added.
 
 Django cannot serialize:
 

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -612,6 +612,20 @@ class WriterTests(SimpleTestCase):
         string = MigrationWriter.serialize(field)[0]
         self.assertEqual(string, "models.FilePathField(path=%r)" % path_like.path)
 
+    def test_serialize_zoneinfo(self):
+        self.assertSerializedEqual(zoneinfo.ZoneInfo("Asia/Kolkata"))
+        self.assertSerializedResultEqual(
+            zoneinfo.ZoneInfo("Asia/Kolkata"),
+            (
+                "zoneinfo.ZoneInfo(key='Asia/Kolkata')",
+                {"import zoneinfo"},
+            ),
+        )
+        self.assertSerializedResultEqual(
+            zoneinfo.ZoneInfo("Europe/Paris"),
+            ("zoneinfo.ZoneInfo(key='Europe/Paris')", {"import zoneinfo"}),
+        )
+
     def test_serialize_functions(self):
         with self.assertRaisesMessage(ValueError, "Cannot serialize function: lambda"):
             self.assertSerializedEqual(lambda x: 42)


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36265

#### Branch description
Added serialization support for ZoneInfo objects in Django migrations.

This implementation ensures that ZoneInfo objects are correctly serialized and deserialized while maintaining backward compatibility with existing timezone handling.

All tests pass on SQLite, MySQL, and PostgreSQL.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
