### PR TITLE
Refs #36055 -- Prevented overlap of object-tools buttons and page header in the admin on small screens.

### DIFF
--- a/django/contrib/admin/static/admin/css/responsive.css
+++ b/django/contrib/admin/static/admin/css/responsive.css
@@ -465,6 +465,10 @@ input[type="submit"], button {
         margin-left: 15px;
     }
 
+    .object-tools:has(a.addlink) {
+        margin-top: 0px;
+    }
+
     /* Forms */
 
     .form-row {


### PR DESCRIPTION
Visual regression in b1324a680add78de24c763911d0eefa19b9263bc.

Django 5.1:

![image](https://github.com/user-attachments/assets/79b5cae5-9b20-4d39-8b9e-0528c6a7d954)

Django 5.2rc1

![image](https://github.com/user-attachments/assets/caefd250-962d-4c7d-b3d4-65cb2ed57751)


With this patch:

![image](https://github.com/user-attachments/assets/30d6b161-0047-4038-b623-5ae64ac465fc)
