### PR TITLE
Fixed #36184 -- Allowed migrating forward to squashed migrations.

### DIFF
--- a/django/db/migrations/executor.py
+++ b/django/db/migrations/executor.py
@@ -37,18 +37,18 @@ class MigrationExecutor:
                             if migration in applied:
                                 plan.append((self.loader.graph.nodes[migration], True))
                                 applied.pop(migration)
+            # If the target is missing, it's likely a replaced migration.
+            # Reload the graph without replacements.
+            elif (
+                self.loader.replace_migrations
+                and target not in self.loader.graph.node_map
+            ):
+                self.loader.replace_migrations = False
+                self.loader.build_graph()
+                return self.migration_plan(targets, clean_start=clean_start)
             # If the migration is already applied, do backwards mode,
             # otherwise do forwards mode.
             elif target in applied:
-                # If the target is missing, it's likely a replaced migration.
-                # Reload the graph without replacements.
-                if (
-                    self.loader.replace_migrations
-                    and target not in self.loader.graph.node_map
-                ):
-                    self.loader.replace_migrations = False
-                    self.loader.build_graph()
-                    return self.migration_plan(targets, clean_start=clean_start)
                 # Don't migrate backwards all the way to the target node (that
                 # may roll back dependencies in other apps that don't need to
                 # be rolled back); instead roll back through target's immediate

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -1331,6 +1331,16 @@ class MigrateTests(MigrationTestBase):
     @override_settings(
         MIGRATION_MODULES={"migrations": "migrations.test_migrations_squashed"}
     )
+    def test_migrate_forward_to_squashed_migration(self):
+        try:
+            call_command("migrate", "migrations", "0001_initial", verbosity=0)
+        finally:
+            # Unmigrate everything.
+            call_command("migrate", "migrations", "zero", verbosity=0)
+
+    @override_settings(
+        MIGRATION_MODULES={"migrations": "migrations.test_migrations_squashed"}
+    )
     def test_migrate_backward_to_squashed_migration(self):
         try:
             call_command("migrate", "migrations", "0001_squashed_0002", verbosity=0)


### PR DESCRIPTION
#### Trac ticket number
ticket-36184

#### Branch description
Before, you couldn't migrate forward to a squashed (replaced) migration specified by name.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
