### PR TITLE
Clarified pre_delete and post_delete's origin attributes.

### DIFF
--- a/docs/ref/signals.txt
+++ b/docs/ref/signals.txt
@@ -204,9 +204,8 @@ Arguments sent with this signal:
     The database alias being used.
 
 ``origin``
-
-    The origin of the deletion being the instance of a ``Model`` or
-    ``QuerySet`` class.
+    The ``Model`` or ``QuerySet`` instance from which the deletion originated,
+    that is, the instance whose ``delete()`` method was invoked.
 
 ``post_delete``
 ---------------
@@ -233,9 +232,8 @@ Arguments sent with this signal:
     The database alias being used.
 
 ``origin``
-
-    The origin of the deletion being the instance of a ``Model`` or
-    ``QuerySet`` class.
+    The ``Model`` or ``QuerySet`` instance from which the deletion originated,
+    that is, the instance whose ``delete()`` method was invoked.
 
 ``m2m_changed``
 ---------------


### PR DESCRIPTION
Initially created this branch for fixing the typo (blank line after the attribute name made the description text render as a blockquote -- see image), but I felt the cryptic descriptions could benefit from the clarity as well.


![screen](https://github.com/user-attachments/assets/dd251b63-a86d-4e4b-bc65-26d4a9fa5100)

