### PR TITLE
Fixed typo in django/db/models/options.py.

### DIFF
--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -534,7 +534,7 @@ class Options:
         # For legacy reasons, the fields property should only contain forward
         # fields that are not private or with a m2m cardinality. Therefore we
         # pass these three filters as filters to the generator.
-        # The third lambda is a longwinded way of checking f.related_model - we don't
+        # The third filter is a longwinded way of checking f.related_model - we don't
         # use that property directly because related_model is a cached property,
         # and all the models may not have been loaded yet; we don't want to cache
         # the string reference to the related_model.


### PR DESCRIPTION
Hasn't been a lambda since 60586dd7379b295b72d8af4e03423c286913b5e8