### PR TITLE
Fixed #36279 -- Added support for translating unnamed URL paths in translate_url

### DIFF
--- a/django/urls/base.py
+++ b/django/urls/base.py
@@ -191,11 +191,15 @@ def translate_url(url, lang_code):
     except Resolver404:
         pass
     else:
-        to_be_reversed = (
-            "%s:%s" % (match.namespace, match.url_name)
-            if match.namespace
-            else match.url_name
-        )
+        if match.url_name is None:
+            to_be_reversed = match.func
+        else:
+            to_be_reversed = (
+                "%s:%s" % (match.namespace, match.url_name)
+                if match.namespace
+                else match.url_name
+            )
+
         with override(lang_code):
             try:
                 url = reverse(to_be_reversed, args=match.args, kwargs=match.kwargs)

--- a/tests/i18n/patterns/tests.py
+++ b/tests/i18n/patterns/tests.py
@@ -186,6 +186,10 @@ class URLTranslationTests(URLTestCaseBase):
                 translate_url("/en/account/register-as-path/", "nl"),
                 "/nl/profiel/registreren-als-pad/",
             )
+            self.assertEqual(
+                translate_url("/en/register-as-path/", "nl"),
+                "/nl/registreren-als-pad/",
+            )
             self.assertEqual(translation.get_language(), "en")
             # re_path() URL with parameters.
             self.assertEqual(

--- a/tests/i18n/patterns/urls/default.py
+++ b/tests/i18n/patterns/urls/default.py
@@ -35,4 +35,5 @@ urlpatterns += i18n_patterns(
     re_path(
         _(r"^account/"), include("i18n.patterns.urls.namespace", namespace="account")
     ),
+    path(_("register-as-path/"), view),
 )


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36279

#### Branch description
This branch fixes a bug in Django’s translate_url function. The issue occurs when a URL path that’s marked for translation doesn’t have a name attribute. This causes a 404 error when trying to change the language using the set_language view.

**Issue:** If a URL path in urlpatterns doesn’t have a name attribute, the translate_url function fails, resulting in a 404 error after changing the language.

**Solution:** A check was added in the translate_url function to handle cases where url_name is None. This ensures the URL is translated correctly, even if there is no name attribute.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
