### PR TITLE
Fixed #36284, Refs #31170 -- Ensured related lookup popups are closed properly.

### DIFF
--- a/django/contrib/admin/static/admin/js/admin/RelatedObjectLookups.js
+++ b/django/contrib/admin/static/admin/js/admin/RelatedObjectLookups.js
@@ -58,9 +58,9 @@
             elem.value = chosenId;
         }
         $(elem).trigger('change');
-        const index = window.relatedWindows.indexOf(win);
+        const index = relatedWindows.indexOf(win);
         if (index > -1) {
-            window.relatedWindows.splice(index, 1);
+            relatedWindows.splice(index, 1);
         }
         win.close();
     }
@@ -206,6 +206,7 @@
     window.dismissChangeRelatedObjectPopup = dismissChangeRelatedObjectPopup;
     window.dismissDeleteRelatedObjectPopup = dismissDeleteRelatedObjectPopup;
     window.dismissChildPopups = dismissChildPopups;
+    window.relatedWindows = relatedWindows;
 
     // Kept for backward compatibility
     window.showAddAnotherPopup = showRelatedObjectPopup;

--- a/js_tests/admin/RelatedObjectLookups.test.js
+++ b/js_tests/admin/RelatedObjectLookups.test.js
@@ -8,7 +8,6 @@ QUnit.module('admin.RelatedObjectLookups', {
             <input type="text" id="test_id" name="test" />
             <input type="text" id="many_test_id" name="many_test" class="vManyToManyRawIdAdminField" />
         `);
-        window.relatedWindows = window.relatedWindows || [];
     }
 });
 


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36284

#### Branch description
In the admin, when selecting related objects via the helpers defined in `RelatedObjectLookups.js`, the `dismissRelatedLookupPopup` function was attempting to access `window.relatedWindows`, which does not exist in real execution, causing related lookup popups to remain open.

This change ensures that this code correctly accesses the module-local `relatedWindows` by explicitly assigning it to `window.relatedWindows`.

Regression in 91bebf1adb43561b54bac18e76224759dc70acb3.

Thanks Matthias Kestenholz for the report and for test further testing.

#### Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
