### PR TITLE
Fixed #36290 -- Made TupleIn() lookup discard tuples containing None.

### DIFF
--- a/docs/releases/5.2.1.txt
+++ b/docs/releases/5.2.1.txt
@@ -12,3 +12,6 @@ Bugfixes
 * Fixed a regression in Django 5.2 that caused a crash when annotating
   aggregate expressions over query that uses explicit grouping by transforms
   followed by field references (:ticket:`36292`).
+
+* Fixed a regression in Django 5.2 that caused unnecessary queries when
+  prefetching nullable foreign key relationships (:ticket:`36290`).

--- a/tests/composite_pk/test_filter.py
+++ b/tests/composite_pk/test_filter.py
@@ -206,6 +206,13 @@ class CompositePKFilterTests(TestCase):
             [self.comment_1],
         )
 
+    def test_filter_by_pk_in_none(self):
+        with self.assertNumQueries(0):
+            self.assertSequenceEqual(
+                Comment.objects.filter(pk__in=[(None, 1), (1, None)]),
+                [],
+            )
+
     def test_filter_comments_by_user_and_order_by_pk_asc(self):
         self.assertSequenceEqual(
             Comment.objects.filter(user=self.user_1).order_by("pk"),

--- a/tests/foreign_object/models/person.py
+++ b/tests/foreign_object/models/person.py
@@ -84,7 +84,7 @@ class Friendship(models.Model):
     )
     from_friend_id = models.IntegerField()
     to_friend_country_id = models.IntegerField()
-    to_friend_id = models.IntegerField()
+    to_friend_id = models.IntegerField(null=True)
 
     # Relation Fields
     from_friend = models.ForeignObject(

--- a/tests/foreign_object/tests.py
+++ b/tests/foreign_object/tests.py
@@ -296,6 +296,19 @@ class MultiColumnFKTests(TestCase):
             self.assertEqual(friendships[0].to_friend, self.george)
             self.assertEqual(friendships[1].to_friend, self.sam)
 
+    def test_prefetch_foreignobject_null_hidden_forward_skipped(self):
+        fiendship = Friendship.objects.create(
+            from_friend_country=self.usa,
+            from_friend_id=self.bob.id,
+            to_friend_country_id=self.usa.id,
+            to_friend_id=None,
+        )
+        with self.assertNumQueries(1):
+            self.assertEqual(
+                Friendship.objects.prefetch_related("to_friend").get(),
+                fiendship,
+            )
+
     def test_prefetch_foreignobject_reverse(self):
         Membership.objects.create(
             membership_country=self.usa, person=self.bob, group=self.cia


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36290

#### Branch description

For the same reasons `lookups.In` discards of `None` members (since 5776a1660e54a95159164414829738b665c89916) `tuple_lookups.TupleIn` should discard tuples containing any `None` as `NULL != NULL` in SQL and the framework expects such queries to be elided under some circumstances (e.g. prefetching)

Refs ticket-31667, ticket-36116.

Thanks @bmispelon for bisecting the regression to 626d77e.
