### PR TITLE
Fixed #36293 -- Enabled non-blocking gzip compression for SSE responses.

### DIFF
--- a/django/middleware/gzip.py
+++ b/django/middleware/gzip.py
@@ -32,10 +32,9 @@ class GZipMiddleware(MiddlewareMixin):
             # Determine whether to flush after each write.
             # This is important for SSE (Server-Sent Events) or similar streaming
             # responses that benefit from reduced latency and timely delivery.
-            flush_each = (
-                response.get("Content-Type", "").startswith("text/event-stream")
-                or getattr(response, "_flush_each", False)
-            )
+            flush_each = response.get("Content-Type", "").startswith(
+                "text/event-stream"
+            ) or getattr(response, "_flush_each", False)
             # Delete the `Content-Length` header for streaming content, because
             # we won't know the compressed size until we stream it.
             response.streaming_content = compress_sequence(

--- a/django/utils/text.py
+++ b/django/utils/text.py
@@ -327,14 +327,15 @@ class StreamingBuffer(BytesIO):
 
 
 # Like compress_string, but for iterators of strings.
-def compress_sequence(sequence):
+def compress_sequence(sequence, flush_each=False):
     buf = StreamingBuffer()
     with GzipFile(mode="wb", compresslevel=6, fileobj=buf, mtime=0) as zfile:
         # Output headers...
         yield buf.read()
         for item in sequence:
             zfile.write(item)
-            zfile.flush()
+            if flush_each:
+                zfile.flush()
             data = buf.read()
             if data:
                 yield data

--- a/django/utils/text.py
+++ b/django/utils/text.py
@@ -334,6 +334,7 @@ def compress_sequence(sequence):
         yield buf.read()
         for item in sequence:
             zfile.write(item)
+            zfile.flush()
             data = buf.read()
             if data:
                 yield data

--- a/tests/middleware/test_gzip.py
+++ b/tests/middleware/test_gzip.py
@@ -23,7 +23,7 @@ class GzipMiddlewareTest(SimpleTestCase):
         start = time.time()
         timestamps = []
 
-        for chunk in compress_sequence(data_generator()):
+        for chunk in compress_sequence(data_generator(), flush_each=True):
             if chunk:  # Ignore empty chunks
                 timestamps.append(time.time() - start)
         # Only consider timestamps for non-empty chunks

--- a/tests/middleware/test_gzip.py
+++ b/tests/middleware/test_gzip.py
@@ -6,7 +6,7 @@ from django.test import SimpleTestCase
 
 def new_sse_data(idx: int = 0):
     data = dict(create=idx)
-    return json.dumps(data).encode('utf-8')
+    return json.dumps(data).encode("utf-8")
 
 
 def data_generator():

--- a/tests/middleware/test_gzip.py
+++ b/tests/middleware/test_gzip.py
@@ -1,0 +1,43 @@
+import json
+import time
+
+from django.test import SimpleTestCase
+
+
+def new_sse_data(idx: int = 0):
+    data = dict(create=idx)
+    return json.dumps(data).encode('utf-8')
+
+
+def data_generator():
+    for i in range(5):
+        time.sleep(1)
+        yield new_sse_data(idx=i)
+    return
+
+
+class GzipMiddlewareTest(SimpleTestCase):
+    def test_flush_streaming_compression(self):
+        from django.utils.text import compress_sequence
+
+        start = time.time()
+        timestamps = []
+
+        for chunk in compress_sequence(data_generator()):
+            if chunk:  # Ignore empty chunks
+                timestamps.append(time.time() - start)
+        # Only consider timestamps for non-empty chunks
+        durations = [round(t, 1) for t in timestamps]
+        # no flush: Each chunk arrived at: [0.0, 5.0]
+        # with flush: Each chunk arrived at: [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 5.0]
+        # Summary:
+        # - The first chunk is the Gzip header, emitted immediately (at 0.0s)
+        # - The next 5 chunks are compressed data blocks, roughly one per second.
+        # - The final chunk is the Gzip footer, emitted right after the 5th block.
+        # - Confirms zfile.flush() works: compression output is non-blocking.
+        print("Each chunk arrived at:", durations)
+
+        # Check that each chunk arrives roughly every second (allowing 0.5s tolerance)
+        for i in range(1, len(durations)):
+            self.assertGreaterEqual(durations[i], i * 0.5)
+        return


### PR DESCRIPTION
[ ticket 36293 ](https://code.djangoproject.com/ticket/36293#ticket)

Fixed sse gzip  blocking
Added a test to confirm zfile.flush() enables non-blocking gzip streaming.