### PR TITLE
Fixed #36293 -- Enabled non-blocking gzip compression for SSE responses.

### DIFF
--- a/django/middleware/gzip.py
+++ b/django/middleware/gzip.py
@@ -16,7 +16,7 @@ class GZipMiddleware(MiddlewareMixin):
     max_random_bytes = 100
 
     @classmethod
-    def should_streaming_gzip(cls, response=None) -> bool:
+    def should_gzip_streaming(cls, response=None) -> bool:
         """
         Determine whether gzip compression should be applied to the response.
         Can be disabled via response.no_gzip_streaming.
@@ -61,7 +61,7 @@ class GZipMiddleware(MiddlewareMixin):
             return response
 
         if response.streaming:
-            if not self.should_streaming_gzip(response=response):
+            if not self.should_gzip_streaming(response=response):
                 return response
             if response.is_async:
                 # pull to lexical scope to capture fixed reference in case

--- a/django/middleware/gzip.py
+++ b/django/middleware/gzip.py
@@ -45,9 +45,16 @@ class GZipMiddleware(MiddlewareMixin):
 
                 response.streaming_content = gzip_wrapper()
             else:
+                # Determine whether to flush after each write.
+                # This is important for SSE (Server-Sent Events) or similar streaming
+                # responses that benefit from reduced latency and timely delivery.
+                flush_each = response.get("Content-Type", "").startswith(
+                    "text/event-stream"
+                ) or getattr(response, "_flush_each", False)
                 response.streaming_content = compress_sequence(
                     response.streaming_content,
                     max_random_bytes=self.max_random_bytes,
+                    flush_each=flush_each,
                 )
             # Delete the `Content-Length` header for streaming content, because
             # we won't know the compressed size until we stream it.

--- a/django/utils/text.py
+++ b/django/utils/text.py
@@ -368,7 +368,7 @@ class StreamingBuffer(BytesIO):
 
 
 # Like compress_string, but for iterators of strings.
-def compress_sequence(sequence, *, max_random_bytes=None):
+def compress_sequence(sequence, *, max_random_bytes=None, flush_each=False):
     buf = StreamingBuffer()
     filename = _get_random_filename(max_random_bytes) if max_random_bytes else None
     with GzipFile(
@@ -378,6 +378,8 @@ def compress_sequence(sequence, *, max_random_bytes=None):
         yield buf.read()
         for item in sequence:
             zfile.write(item)
+            if flush_each:
+                zfile.flush()
             data = buf.read()
             if data:
                 yield data

--- a/tests/middleware/test_gzip.py
+++ b/tests/middleware/test_gzip.py
@@ -1,0 +1,44 @@
+import json
+import time
+
+from django.test import SimpleTestCase
+
+
+def new_sse_data(idx: int = 0):
+    data = dict(create=idx)
+    return json.dumps(data).encode("utf-8")
+
+
+def data_generator():
+    for i in range(5):
+        time.sleep(1)
+        yield new_sse_data(idx=i)
+    return
+
+
+class GzipMiddlewareTest(SimpleTestCase):
+    def test_flush_streaming_compression(self):
+        from django.utils.text import compress_sequence
+
+        start = time.time()
+        timestamps = []
+
+        for chunk in compress_sequence(data_generator(), flush_each=True):
+            if chunk:  # Ignore empty chunks
+                timestamps.append(time.time() - start)
+        # Only consider timestamps for non-empty chunks
+        durations = [round(t, 1) for t in timestamps]
+        # no flush: Each chunk arrived at: [0.0, 5.0]
+        # with flush: Each chunk arrived at: [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 5.0]
+        # Summary:
+        # - The first chunk is the Gzip header, emitted immediately (at 0.0s)
+        # - The next 5 chunks are compressed data blocks, roughly one per second.
+        # - The final chunk is the Gzip footer, emitted right after the 5th block.
+        # - Confirms zfile.flush() works: compression output is non-blocking.
+        print("Each chunk arrived at:", durations)
+
+        # Check that each chunk arrives roughly every second (allowing 0.5s tolerance)
+        for i in range(1, len(durations)):
+            self.assertGreaterEqual(durations[i], i * 0.5)
+        return
+

--- a/tests/middleware/test_gzip.py
+++ b/tests/middleware/test_gzip.py
@@ -41,4 +41,3 @@ class GzipMiddlewareTest(SimpleTestCase):
         for i in range(1, len(durations)):
             self.assertGreaterEqual(durations[i], i * 0.5)
         return
-


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36293

#### Branch description
This PR addresses an issue where Django’s GZip middleware blocks flushing for Server-Sent Events (SSE).

Traditionally, GZip compression buffered output, which interfered with SSE streaming by delaying events until the entire response is complete. This change ensures that when the response’s Content-Type is text/event-stream, gzip compression flushes data incrementally (flush_each=True) to allow real-time streaming.

This approach aligns with expectations for SSE delivery and allows developers to benefit from gzip without sacrificing responsiveness.


#### Checklist
- [ ] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
