### PR TITLE
Fixed #36289 -- Fixed bulk_create() crash with nullable geometry fields on PostGIS.

### DIFF
--- a/docs/releases/5.2.1.txt
+++ b/docs/releases/5.2.1.txt
@@ -15,3 +15,7 @@ Bugfixes
 
 * Fixed a regression in Django 5.2 that caused unnecessary queries when
   prefetching nullable foreign key relationships (:ticket:`36290`).
+
+* Fixed a regression in Django 5.2 that caused a crash of
+  ``QuerySet.bulk_create()`` with nullable geometry fields on PostGIS
+  (:ticket:`36289`).

--- a/tests/gis_tests/geo3d/models.py
+++ b/tests/gis_tests/geo3d/models.py
@@ -58,7 +58,7 @@ class SimpleModel(models.Model):
 
 
 class Point2D(SimpleModel):
-    point = models.PointField()
+    point = models.PointField(null=True)
 
 
 class Point3D(SimpleModel):

--- a/tests/gis_tests/geo3d/tests.py
+++ b/tests/gis_tests/geo3d/tests.py
@@ -206,6 +206,10 @@ class Geo3DTest(Geo3DLoadingHelper, TestCase):
         lm.save()
         self.assertEqual(3, MultiPoint3D.objects.count())
 
+    def test_bulk_create_point_field(self):
+        objs = Point2D.objects.bulk_create([Point2D(), Point2D()])
+        self.assertEqual(len(objs), 2)
+
     @skipUnlessDBFeature("supports_3d_functions")
     def test_union(self):
         """


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36289

#### Branch description

Swapped to an allow list instead of a deny list for field types to determine if the UNNEST optimization can be enabled to avoid further surprises with other types that would require further specialization to adapt.

Regression in a16eedcf9c69d8a11d94cac1811018c5b996d491.

Refs ticket-35936.

Thanks @jclgoodwin for the report and @sarahboyce for the test.
