### PR TITLE
Refs #36088, Refs #36260 - Added supports_expression_defaults checks in bulk_create tests.

### DIFF
--- a/tests/bulk_create/models.py
+++ b/tests/bulk_create/models.py
@@ -148,6 +148,12 @@ class DbDefaultModel(models.Model):
     name = models.CharField(max_length=10)
     created_at = models.DateTimeField(db_default=Now())
 
+    class Meta:
+        required_db_features = {"supports_expression_defaults"}
+
 
 class DbDefaultPrimaryKey(models.Model):
     id = models.DateTimeField(primary_key=True, db_default=Now())
+
+    class Meta:
+        required_db_features = {"supports_expression_defaults"}

--- a/tests/bulk_create/tests.py
+++ b/tests/bulk_create/tests.py
@@ -845,6 +845,7 @@ class BulkCreateTests(TestCase):
             ],
         )
 
+    @skipUnlessDBFeature("supports_expression_defaults")
     def test_db_default_field_excluded(self):
         # created_at is excluded when no db_default override is provided.
         with self.assertNumQueries(1) as ctx:
@@ -869,7 +870,9 @@ class BulkCreateTests(TestCase):
             2 if connection.features.can_return_rows_from_bulk_insert else 1,
         )
 
-    @skipUnlessDBFeature("can_return_rows_from_bulk_insert")
+    @skipUnlessDBFeature(
+        "can_return_rows_from_bulk_insert", "supports_expression_defaults"
+    )
     def test_db_default_primary_key(self):
         (obj,) = DbDefaultPrimaryKey.objects.bulk_create([DbDefaultPrimaryKey()])
         self.assertIsInstance(obj.id, datetime)


### PR DESCRIPTION
Oversights observed while testing with MongoDB.