### PR TITLE
Added supports_expression_defaults check in DefaultTests.test_full_clean() test.

### DIFF
--- a/tests/field_defaults/tests.py
+++ b/tests/field_defaults/tests.py
@@ -179,6 +179,7 @@ class DefaultTests(TestCase):
         years = DBDefaultsFunction.objects.values_list("year", flat=True)
         self.assertCountEqual(years, [2000, timezone.now().year])
 
+    @skipUnlessDBFeature("supports_expression_defaults")
     def test_full_clean(self):
         obj = DBArticle()
         obj.full_clean()


### PR DESCRIPTION
`field_defaults_dbarticle` table doesn't exist if `supports_expression_defaults` is False.