### PR TITLE
Fixed #26756 -- permission names and verbose name

### DIFF
--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -28,6 +28,8 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_over_clause = True
     supports_frame_range_fixed_distance = True
     supports_update_conflicts = True
+    supports_update_conflicts_with_target = True
+
     can_rename_index = True
     delete_can_self_reference_subquery = False
     create_test_procedure_without_params_sql = """

--- a/docs/releases/6.0.txt
+++ b/docs/releases/6.0.txt
@@ -57,6 +57,9 @@ Minor features
 * The default iteration count for the PBKDF2 password hasher is increased from
   1,000,000 to 1,200,000.
 
+* Fixed a bug with model's permissions that would not change when modifying 
+  the verbose_name of some model.
+
 :mod:`django.contrib.contenttypes`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/auth_tests/test_management.py
+++ b/tests/auth_tests/test_management.py
@@ -1521,6 +1521,23 @@ class CreatePermissionsTests(TestCase):
             ).exists()
         )
 
+    def test_permission_name_changes_with_verbose_name(self):
+        """
+        #26756 -Simulate a case where verbose name changes for some model
+        and check if the changes reflected in permissions table.
+        """
+
+        old_perm = Permission.objects.get(codename="add_permission")
+
+        self.assertEqual(old_perm.name, "Can add permission")
+
+        Permission._meta.verbose_name_raw = "p"
+        create_permissions(self.app_config, verbosity=0)
+
+        new_perm = Permission.objects.get(codename="add_permission")
+
+        self.assertEqual(new_perm.name, "Can add p")
+
 
 class DefaultDBRouter:
     """Route all writes to default."""


### PR DESCRIPTION
#### Trac ticket number

ticket-26756


#### Branch description
Added "name" value to the values list when
fetching all permissions

Added update_conflicts=True flag that allows
to update the permissions with the same
contenttypes and codenames but different names,
instead of raising a error (related to uniqueness)

Test for the ticket

Created a test that asserts the permission name
before the verbose name change and after
if name verbose name changed and the permission
name changed accordingly, test is passed.

Added to documentation the bug fix


#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
