### PR TITLE
Fixed #35675 - avoid backtracking in Template parsing

### DIFF
--- a/django/template/base.py
+++ b/django/template/base.py
@@ -86,7 +86,7 @@ UNKNOWN_SOURCE = "<unknown source>"
 # Match BLOCK_TAG_*, VARIABLE_TAG_*, and COMMENT_TAG_* tags and capture the
 # entire tag, including start/end delimiters. Using re.compile() is faster
 # than instantiating SimpleLazyObject with _lazy_re_compile().
-tag_re = re.compile(r"({%.*?%}|{{.*?}}|{#.*?#})")
+tag_re = re.compile(r"({%(?=.*%}).*?%}|{{(?=.*}}).*?}}|{#(?=.*#}).*?#})")
 
 logger = logging.getLogger("django.template")
 


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35675

#### Branch description
This branch adds lookaheads to the regex pattern used by `Templates` to avoid the excessive backtracking described by [35675](https://code.djangoproject.com/ticket/35675). I will post the script I used to test the performance and results in a follow-up comment.

#### Checklist
- [ ] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
