### PR TITLE
Fixed #33091 -- Raised FieldError when updating a parent field using a child field reference.

### DIFF
--- a/django/db/models/sql/subqueries.py
+++ b/django/db/models/sql/subqueries.py
@@ -99,6 +99,19 @@ class UpdateQuery(Query):
                     "Cannot update model field %r (only non-relations and "
                     "foreign keys permitted)." % field
                 )
+            for field_name, *lookups in model._get_expr_references(val):
+                if (
+                    field_name not in self.annotations
+                    and field_name not in model._meta._local_concrete_field_names
+                ):
+                    if (
+                        model is not self.get_meta().model
+                        and field_name in self.get_meta()._field_names
+                    ):
+                        raise FieldError(
+                            "Cannot reference child model field %r when updating "
+                            "parent field %r." % (field_name, field)
+                        )
             if model is not self.get_meta().concrete_model:
                 self.add_related_update(model, field, val)
                 continue

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -458,6 +458,15 @@ class BasicExpressionsTests(TestCase):
         with self.assertRaisesMessage(FieldError, msg):
             RemoteEmployee.objects.update(adjusted_salary=F("salary") * 5)
 
+    def test_update_inherited_field_from_child(self):
+        update_field = RemoteEmployee._meta.get_field("salary")
+        msg = (
+            "Cannot reference child model field 'adjusted_salary' "
+            "when updating parent field %r."
+        ) % (update_field)
+        with self.assertRaisesMessage(FieldError, msg):
+            RemoteEmployee.objects.update(salary=F("adjusted_salary") / 5)
+
     def test_object_update_unsaved_objects(self):
         # F expressions cannot be used to update attributes on objects which do
         # not yet exist in the database

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -467,6 +467,17 @@ class BasicExpressionsTests(TestCase):
         with self.assertRaisesMessage(FieldError, msg):
             RemoteEmployee.objects.update(salary=F("adjusted_salary") / 5)
 
+    def test_save_inherited_field_from_child_field_value(self):
+        update_field = RemoteEmployee._meta.get_field("salary")
+        msg = (
+            "Cannot reference child model field 'adjusted_salary' "
+            "when saving parent field %r."
+        ) % (update_field)
+        employee = RemoteEmployee.objects.create(salary=1000, adjusted_salary=0)
+        employee.salary = F("adjusted_salary") / 5
+        with self.assertRaisesMessage(FieldError, msg):
+            employee.save()
+
     def test_object_update_unsaved_objects(self):
         # F expressions cannot be used to update attributes on objects which do
         # not yet exist in the database


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-33091

#### Branch description
Raises a specialised ``FieldError`` when trying to update an inherited field using a local field on the child model.

Previously, a general `FieldError` was raised "Cannot resolve keyword 'keyword' into field. Choices are ..."

I am not 100% confident about the perfomance implications of this patch. Unlike 9e5e5a657b95ee49923fe3d2691c5d73813b4c53 this patch seems to have some expensive checks, and I'm not quite sure they are fully paying their way here. However, I have not been able to find a better solution.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
