### PR TITLE
Sorted imports in django/templatetags/tz.py per isort.

### DIFF
--- a/django/templatetags/tz.py
+++ b/django/templatetags/tz.py
@@ -1,5 +1,5 @@
 import zoneinfo
-from datetime import datetime, tzinfo, UTC
+from datetime import UTC, datetime, tzinfo
 
 from django.template import Library, Node, TemplateSyntaxError
 from django.utils import timezone


### PR DESCRIPTION
Issue from https://github.com/django/django/pull/19358 
Somehow isort was skipped on the PR :thinking: 