### PR TITLE
Fixed #36311 -- Standardized spelling in documentation

### DIFF
--- a/docs/intro/tutorial03.txt
+++ b/docs/intro/tutorial03.txt
@@ -391,13 +391,13 @@ Removing hardcoded URLs in templates
 ====================================
 
 Remember, when we wrote the link to a question in the ``polls/index.html``
-template, the link was partially hardcoded like this:
+template, the link was partially hard-coded like this:
 
 .. code-block:: html+django
 
     <li><a href="/polls/{{ question.id }}/">{{ question.question_text }}</a></li>
 
-The problem with this hardcoded, tightly-coupled approach is that it becomes
+The problem with this hard-coded, tightly-coupled approach is that it becomes
 challenging to change URLs on projects with a lot of templates. However, since
 you defined the ``name`` argument in the :func:`~django.urls.path` functions in
 the ``polls.urls`` module, you can remove a reliance on specific URL paths

--- a/docs/intro/tutorial04.txt
+++ b/docs/intro/tutorial04.txt
@@ -141,7 +141,7 @@ This code includes a few things we haven't covered yet in this tutorial:
 
 * We are using the :func:`~django.urls.reverse` function in the
   :class:`~django.http.HttpResponseRedirect` constructor in this example.
-  This function helps avoid having to hardcode a URL in the view function.
+  This function helps avoid having to hard-code a URL in the view function.
   It is given the name of the view that we want to pass control to and the
   variable portion of the URL pattern that points to that view. In this
   case, using the URLconf we set up in :doc:`Tutorial 3 </intro/tutorial03>`,

--- a/docs/intro/tutorial05.txt
+++ b/docs/intro/tutorial05.txt
@@ -400,7 +400,7 @@ With that ready, we can ask the client to do some work for us:
     >>> response.status_code
     404
     >>> # on the other hand we should expect to find something at '/polls/'
-    >>> # we'll use 'reverse()' rather than a hardcoded URL
+    >>> # we'll use 'reverse()' rather than a hard-coded URL
     >>> from django.urls import reverse
     >>> response = client.get(reverse("polls:index"))
     >>> response.status_code

--- a/docs/ref/contrib/flatpages.txt
+++ b/docs/ref/contrib/flatpages.txt
@@ -65,7 +65,7 @@ associates a flatpage with a site.
 Using the URLconf
 -----------------
 
-There are several ways to include the flat pages in your URLconf. You can
+There are several ways to include the flatpages in your URLconf. You can
 dedicate a particular path to flat pages::
 
     urlpatterns = [
@@ -88,8 +88,8 @@ to place the pattern at the end of the other urlpatterns::
     in the catchall pattern or flatpages without a trailing slash will not be
     matched.
 
-Another common setup is to use flat pages for a limited set of known pages and
-to hard code their URLs in the :doc:`URLconf </topics/http/urls>`::
+Another common setup is to use flatpages for a limited set of known pages and
+to hard-code their URLs in the :doc:`URLconf </topics/http/urls>`::
 
     from django.contrib.flatpages import views
 
@@ -162,7 +162,7 @@ For more on middleware, read the :doc:`middleware docs
     raising an exception instead, the response will become an HTTP 500
     ("Internal Server Error") and the
     :class:`~django.contrib.flatpages.middleware.FlatpageFallbackMiddleware`
-    will not attempt to serve a flat page.
+    will not attempt to serve a flatpage.
 
 .. currentmodule:: django.contrib.flatpages.models
 

--- a/docs/ref/contrib/syndication.txt
+++ b/docs/ref/contrib/syndication.txt
@@ -611,7 +611,7 @@ This example illustrates all possible attributes and methods for a
             instances).
             """
 
-        # Hardcoded stylesheets.
+        # Hard-coded stylesheets.
         stylesheets = ["/stylesheet1.xsl", "stylesheet2.xsl"]
 
         # ITEMS -- One of the following three is required. The framework looks
@@ -715,7 +715,7 @@ This example illustrates all possible attributes and methods for a
             Takes an item, as returned by items(), and returns a boolean.
             """
 
-        item_guid_is_permalink = False  # Hard coded value
+        item_guid_is_permalink = False  # Hard-coded value
 
         # ITEM AUTHOR NAME -- One of the following three is optional. The
         # framework looks for them in this order.
@@ -1138,7 +1138,7 @@ formats.
 You can add this to your RSS feed by setting the ``stylesheets`` attribute on
 the feed class.
 
-This can be a hardcoded URL::
+This can be a Hard-coded URL::
 
     from django.contrib.syndication.views import Feed
 

--- a/docs/ref/templates/api.txt
+++ b/docs/ref/templates/api.txt
@@ -668,7 +668,7 @@ processors::
 In addition to these, :class:`RequestContext` always enables
 ``'django.template.context_processors.csrf'``.  This is a security related
 context processor required by the admin and other contrib apps, and, in case
-of accidental misconfiguration, it is deliberately hardcoded in and cannot be
+of accidental misconfiguration, it is deliberately hard-coded in and cannot be
 turned off in the ``context_processors`` option.
 
 Each processor is applied in order. That means, if one processor adds a

--- a/docs/releases/1.10.3.txt
+++ b/docs/releases/1.10.3.txt
@@ -6,12 +6,12 @@ Django 1.10.3 release notes
 
 Django 1.10.3 fixes two security issues and several bugs in 1.10.2.
 
-User with hardcoded password created when running tests on Oracle
-=================================================================
+User with hard-coded password created when running tests on Oracle
+==================================================================
 
 When running tests with an Oracle database, Django creates a temporary database
 user. In older versions, if a password isn't manually specified in the database
-settings ``TEST`` dictionary, a hardcoded password is used. This could allow
+settings ``TEST`` dictionary, a hard-coded password is used. This could allow
 an attacker with network access to the database server to connect.
 
 This user is usually dropped after the test suite completes, but not when using

--- a/docs/releases/1.8.16.txt
+++ b/docs/releases/1.8.16.txt
@@ -6,12 +6,12 @@ Django 1.8.16 release notes
 
 Django 1.8.16 fixes two security issues in 1.8.15.
 
-User with hardcoded password created when running tests on Oracle
-=================================================================
+User with hard-coded password created when running tests on Oracle
+==================================================================
 
 When running tests with an Oracle database, Django creates a temporary database
 user. In older versions, if a password isn't manually specified in the database
-settings ``TEST`` dictionary, a hardcoded password is used. This could allow
+settings ``TEST`` dictionary, a hard-coded password is used. This could allow
 an attacker with network access to the database server to connect.
 
 This user is usually dropped after the test suite completes, but not when using

--- a/docs/releases/1.9.11.txt
+++ b/docs/releases/1.9.11.txt
@@ -6,12 +6,12 @@ Django 1.9.11 release notes
 
 Django 1.9.11 fixes two security issues in 1.9.10.
 
-User with hardcoded password created when running tests on Oracle
-=================================================================
+User with hard-coded password created when running tests on Oracle
+==================================================================
 
 When running tests with an Oracle database, Django creates a temporary database
 user. In older versions, if a password isn't manually specified in the database
-settings ``TEST`` dictionary, a hardcoded password is used. This could allow
+settings ``TEST`` dictionary, a hard-coded password is used. This could allow
 an attacker with network access to the database server to connect.
 
 This user is usually dropped after the test suite completes, but not when using

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -153,7 +153,7 @@ Minor features
 * The URL of the admin change view has been changed (was at
   ``/admin/<app>/<model>/<pk>/`` by default and is now at
   ``/admin/<app>/<model>/<pk>/change/``). This should not affect your
-  application unless you have hardcoded admin URLs. In that case, replace those
+  application unless you have hard-coded admin URLs. In that case, replace those
   links by :ref:`reversing admin URLs <admin-reverse-urls>` instead. Note that
   the old URL still redirects to the new one for backwards compatibility, but
   it may be removed in a future version.

--- a/docs/releases/security.txt
+++ b/docs/releases/security.txt
@@ -876,7 +876,7 @@ Versions affected
 November 1, 2016 - :cve:`2016-9013`
 -----------------------------------
 
-User with hardcoded password created when running tests on Oracle. `Full
+User with hard-coded password created when running tests on Oracle. `Full
 description <https://www.djangoproject.com/weblog/2016/nov/01/security-releases/>`__
 
 Versions affected

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -191,9 +191,9 @@ Greenhill
 gunicorn
 GZip
 gzipped
-hardcode
-hardcoded
-hardcoding
+hard-code
+hard-coded
+hard-coding
 hashable
 hasher
 hashers

--- a/docs/topics/http/shortcuts.txt
+++ b/docs/topics/http/shortcuts.txt
@@ -154,7 +154,7 @@ You can use the :func:`redirect` function in a number of ways.
             ...
             return redirect("some-view-name", foo="bar")
 
-#. By passing a hardcoded URL to redirect to:
+#. By passing a hard-coded URL to redirect to:
    ::
 
         def my_view(request):

--- a/docs/topics/testing/advanced.txt
+++ b/docs/topics/testing/advanced.txt
@@ -357,7 +357,7 @@ Advanced features of ``TransactionTestCase``
                 self.assertEqual(lion.pk, 1)
 
     Unless you are explicitly testing primary keys sequence numbers, it is
-    recommended that you do not hard code primary key values in tests.
+    recommended that you do not hard-code primary key values in tests.
 
     Using ``reset_sequences = True`` will slow down the test, since the primary
     key reset is a relatively expensive database operation.


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36311

#### Branch description
Standardized documentation spelling across Django docs:
  - Changed "hardcode"/"hard code" to "hard-code" (with hyphen) in documentation text
  - Maintained "lookup" (one word) for noun/adjective usage
  - Used "look up" (two words) for verb usage
  - Kept "flatpage" (one word) when referring to Django's feature
  - Used "flat page" (two words) only for general concept references

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
