### PR TITLE
Fixed #36314 -- Fixed MinimumLengthValidator error message translation.

### DIFF
--- a/django/contrib/auth/password_validation.py
+++ b/django/contrib/auth/password_validation.py
@@ -106,15 +106,20 @@ class MinimumLengthValidator:
 
     def validate(self, password, user=None):
         if len(password) < self.min_length:
-            raise ValidationError(self.get_error_message(), code="password_too_short")
+            raise ValidationError(
+                self.get_error_message(),
+                code="password_too_short",
+                params={"min_length": self.min_length},
+            )
 
     def get_error_message(self):
-        return ngettext(
-            "This password is too short. It must contain at least %d character."
-            % self.min_length,
-            "This password is too short. It must contain at least %d characters."
-            % self.min_length,
-            self.min_length,
+        return (
+            ngettext(
+                "This password is too short. It must contain at least %d character.",
+                "This password is too short. It must contain at least %d characters.",
+                self.min_length,
+            )
+            % self.min_length
         )
 
     def get_help_text(self):

--- a/docs/releases/5.2.1.txt
+++ b/docs/releases/5.2.1.txt
@@ -36,3 +36,7 @@ Bugfixes
 * Fixed a regression in Django 5.2 that caused improper values to be returned
   from ``QuerySet.values_list()`` when duplicate field names were specified
   (:ticket:`36288`).
+
+* Fixed a regression in Django 5.2 where the password validation error message
+  from ``MinimumLengthValidator`` was not translated when using non-English
+  locales (:ticket:`36314`).


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36314

#### Branch description
The `MinimumLengthValidator` error message was not being translated properly
because string formatting was applied before translation. Changed to use named
parameters `(%(min_length)d)` and moved string formatting after the ngettext
call, matching the pattern used in `get_help_text()`.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
