### PR TITLE
Bumped versions in pre-commit and npm configurations.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,10 +17,10 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/PyCQA/flake8
-    rev: 7.1.1
+    rev: 7.2.0
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v9.19.0
+    rev: v9.24.0
     hooks:
       - id: eslint

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "npm": ">=1.3.0"
   },
   "devDependencies": {
-    "eslint": "^9.19.0",
-    "puppeteer": "^24.1.1",
-    "globals": "^15.14.0",
+    "eslint": "^9.24.0",
+    "puppeteer": "^24.6.1",
+    "globals": "^16.0.0",
     "grunt": "^1.6.1",
     "grunt-cli": "^1.5.0",
     "grunt-contrib-qunit": "^10.1.1",


### PR DESCRIPTION
Note that I haven't bumped isort as we still have it pinned under 6.0.0 (see 0671a461c44ba4cf97e84b6c88413bed332df314)
