### PR TITLE
[5.1.x] Pinned flake8 == 7.1.2 in GitHub actions.

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.13'
-      - run: python -m pip install flake8
+      - run: python -m pip install flake8==7.1.2
       - name: flake8
         # Pinned to v3.0.0.
         uses: liskin/gh-problem-matcher-wrap@e7b7beaaafa52524748b31a381160759d68d61fb


### PR DESCRIPTION
As there were some fixes for 7.2.0 of flake8 1ebb341854e63b6f97683a70d788f569c5e576cf
Makes sense to pin the GitHub actions of flake8 for 5.1 and 4.2 as they are still supported versions (with security releases)

One option is to pin to 7.0.0 as that would match the pre-commit config on this branch