### PR TITLE
[4.2.x] Pinned flake8 and isort in GitHub actions.

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-      - run: python -m pip install flake8
+      - run: python -m pip install flake8==7.1.2
       - name: flake8
         # Pinned to v2.0.0.
         uses: liskin/gh-problem-matcher-wrap@d8afa2cfb66dd3f982b1950429e652bc14d0d7d2

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-      - run: python -m pip install isort
+      - run: python -m pip install "isort<6"
       - name: isort
         # Pinned to v2.0.0.
         uses: liskin/gh-problem-matcher-wrap@d8afa2cfb66dd3f982b1950429e652bc14d0d7d2


### PR DESCRIPTION
As there were some fixes for 7.2.0 of flake8 1ebb341854e63b6f97683a70d788f569c5e576cf
Makes sense to pin the GitHub actions of flake8 for 5.1 and 4.2 as they are still supported versions (with security releases)

One option is to pin to 6.1.0 as that would match the pre-commit config on this branch