### PR TITLE
Fixed #36320 -- Ignored "duplicated_toc_entry" for ePub docs build.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -194,7 +194,7 @@ intersphinx_mapping = {
 intersphinx_cache_limit = 90  # days
 
 # The 'versionadded' and 'versionchanged' directives are overridden.
-suppress_warnings = ["app.add_directive"]
+suppress_warnings = ["app.add_directive", "epub.duplicated_toc_entry"]
 
 # -- Options for HTML output ---------------------------------------------------
 


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36320

#### Branch description
This PR adds sphinx configuration to ignore the warning that crashes the building of the ePub docs on readthedocs.org.

To test it you can run `make epub` from the `docs` directory.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
