### PR TITLE
Fixed #36326 -- Allowed RawModelIterable to support CompositePrimaryK…

### DIFF
--- a/tests/composite_pk/tests.py
+++ b/tests/composite_pk/tests.py
@@ -158,6 +158,10 @@ class CompositePKTests(TestCase):
         users = User.objects.values_list("pk").order_by("pk")
         self.assertNotIn('AS "pk"', str(users.query))
 
+    def test_raw_query(self):
+        users = User.objects.raw("SELECT * FROM composite_pk_user")
+        self.assertEqual(len(users), 1)
+
     def test_only(self):
         users = User.objects.only("pk")
         self.assertSequenceEqual(users, (self.user,))


### PR DESCRIPTION
…ey models.

#### Trac ticket number
Trac ticket number: [#36326]  (https://code.djangoproject.com/ticket/36326)

ticket-36326

#### Branch description
RawModelIterable previously raised FieldDoesNotExist for models using CompositePrimaryKey, due to assuming a single-field primary key.

#### Checklist
- [ ] This PR targets the `main` branch.
- [ ] Checks if .pk is a CompositePrimaryKey and loops over its fields
- [ ] Ensures all attnames of the PK fields are included in the raw SQL result
- [ ] Adds a test to validate the fix
