### PR TITLE
Changed RTD configuration to build htmlzip manually.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,6 +7,14 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.12"
+  jobs:
+    post_build:
+      # RTD's htmlzip uses the singlehtml sphinx builder which just generates
+      # a single giant HTML file. So we build our own zip instead based on the
+      # regular HTML builder.
+      - mkdir -p $READTHEDOCS_OUTPUT/htmlzip
+      - cd $READTHEDOCS_OUTPUT/html
+      - zip -r $READTHEDOCS_OUTPUT/htmlzip/$READTHEDOCS_PROJECT.zip . -x '_sources/*' .buildinfo objects.inv
 
 sphinx:
   configuration: docs/conf.py
@@ -16,4 +24,7 @@ python:
   install:
     - requirements: docs/requirements.txt
 
-formats: all
+# htmlzip is built manually in post_build
+formats:
+  - epub
+  - pdf


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

N/A

#### Branch description
This changes the configuration in `.readthedocs.yml` to build the `htmlzip` format manually so that we can use the regular `html` sphinx builder instead of the `singlehtml` one hardcoded in RTD.

This produces a zip file that contains index.html files and directories, rather than a single giant html file.

This will help offload the building of the zip to RTD's infrastructure, see https://github.com/django/djangoproject.com/pull/2032

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
