### PR TITLE
Disabled Google password manager pop-up interfering with selenium tests.

### DIFF
--- a/django/test/selenium.py
+++ b/django/test/selenium.py
@@ -81,6 +81,10 @@ class SeleniumTestCaseBase(type(LiveServerTestCase)):
 
     def create_options(self):
         options = self.import_options(self.browser)()
+        if self.browser == "chrome":
+            # Disable Google Password Manager "Data Breach" alert pop-ups.
+            options.add_argument("--guest")
+            options.add_argument("--disable-infobars")
         if self.headless:
             match self.browser:
                 case "chrome" | "edge":


### PR DESCRIPTION
https://issues.chromium.org/issues/42323769

Version 122 of Chrome driver has a "check your password" data breach pop up which can interfere with the selenium tests

![image](https://github.com/user-attachments/assets/da262688-0b41-4708-95da-81b1aa67bff7)

