### PR TITLE
Fixed #36318 -- Fixed incorrect rollback exception attribution in nested atomic blocks.

### DIFF
--- a/django/db/transaction.py
+++ b/django/db/transaction.py
@@ -195,6 +195,7 @@ class Atomic(ContextDecorator):
             # Reset state when entering an outermost atomic block.
             connection.commit_on_exit = True
             connection.needs_rollback = False
+            connection.rollback_exc = None
             if not connection.get_autocommit():
                 # Pretend we're already in an atomic block to bypass the code
                 # that disables autocommit to enter a transaction, and make a
@@ -278,6 +279,9 @@ class Atomic(ContextDecorator):
                     # otherwise.
                     if sid is None:
                         connection.needs_rollback = True
+                        # Avoid shadowing an already assigned rollback exc.
+                        if connection.rollback_exc is None:
+                            connection.rollback_exc = exc_value
                     else:
                         try:
                             connection.savepoint_rollback(sid)


### PR DESCRIPTION

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36318

#### Branch description
Prevented rollback_exc from leaking exceptions between unrelated atomic blocks.
Ensures correct exception attribution in TransactionManagementError.

Thank you, @charettes, for your guidance.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
