### PR TITLE
Fixed #36332 -- Corrected mixed up examples for get_full_path() and get_full_path_info() in docs and clarified misleading tests.

### DIFF
--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -351,14 +351,14 @@ Methods
 
     Returns the ``path``, plus an appended query string, if applicable.
 
-    Example: ``"/music/bands/the_beatles/?print=true"``
+    Example: ``"/minfo/music/bands/the_beatles/?print=true"``
 
 .. method:: HttpRequest.get_full_path_info()
 
     Like :meth:`get_full_path`, but uses :attr:`path_info` instead of
     :attr:`path`.
 
-    Example: ``"/minfo/music/bands/the_beatles/?print=true"``
+    Example: ``"/music/bands/the_beatles/?print=true"``
 
 .. method:: HttpRequest.build_absolute_uri(location=None)
 

--- a/tests/requests_tests/tests.py
+++ b/tests/requests_tests/tests.py
@@ -53,20 +53,20 @@ class RequestsTests(SimpleTestCase):
 
     def test_httprequest_full_path(self):
         request = HttpRequest()
-        request.path = "/;some/?awful/=path/foo:bar/"
-        request.path_info = "/prefix" + request.path
+        request.path_info = "/;some/?awful/=path/foo:bar/"
+        request.path = "/prefix" + request.path_info
         request.META["QUERY_STRING"] = ";some=query&+query=string"
         expected = "/%3Bsome/%3Fawful/%3Dpath/foo:bar/?;some=query&+query=string"
-        self.assertEqual(request.get_full_path(), expected)
-        self.assertEqual(request.get_full_path_info(), "/prefix" + expected)
+        self.assertEqual(request.get_full_path_info(), expected)
+        self.assertEqual(request.get_full_path(), "/prefix" + expected)
 
     def test_httprequest_full_path_with_query_string_and_fragment(self):
         request = HttpRequest()
-        request.path = "/foo#bar"
-        request.path_info = "/prefix" + request.path
+        request.path_info = "/foo#bar"
+        request.path = "/prefix" + request.path_info
         request.META["QUERY_STRING"] = "baz#quux"
-        self.assertEqual(request.get_full_path(), "/foo%23bar?baz#quux")
-        self.assertEqual(request.get_full_path_info(), "/prefix/foo%23bar?baz#quux")
+        self.assertEqual(request.get_full_path_info(), "/foo%23bar?baz#quux")
+        self.assertEqual(request.get_full_path(), "/prefix/foo%23bar?baz#quux")
 
     def test_httprequest_repr(self):
         request = HttpRequest()


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36332

#### Branch description
Documentation examples for `HttpRequest.get_full_path()` and `HttpRequest.get_full_path_info()` were mixed up, creating confusion about which one includes script prefix part and which one does not. Unit tests for these methods were written in a way promoting such confusion as well.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
