### PR TITLE
Fixed #36053 -- Corrected DOM structure for FilteredSelectMultiple widget label in admin

### DIFF
--- a/django/contrib/admin/static/admin/js/SelectFilter2.js
+++ b/django/contrib/admin/static/admin/js/SelectFilter2.js
@@ -33,7 +33,12 @@ Requires core.js and SelectBox.js.
             const selector_div = quickElement('div', from_box.parentNode);
             // Make sure the selector div is at the beginning so that the
             // add link would be displayed to the right of the widget.
-            from_box.parentNode.prepend(selector_div);
+            const label = from_box.parentNode.querySelector('label');
+            if (label) {
+                label.after(selector_div);
+            } else {
+                from_box.parentNode.insertBefore(selector_div, from_box);
+            }
             selector_div.className = is_stacked ? 'selector stacked' : 'selector';
 
             // <div class="selector-available">
@@ -106,7 +111,7 @@ Requires core.js and SelectBox.js.
                 interpolate(gettext('Remove %s by selecting them and then select the "Remove" arrow button.'), [field_name]),
                 'class', 'helptext'
             );
-            
+
             const filter_selected_p = quickElement('p', selector_chosen, '', 'id', field_id + '_filter_selected');
             filter_selected_p.className = 'selector-filter';
 


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36053

#### Branch description
The label for `FilteredSelectMultiple` was rendering to the right due to JavaScript modifying the DOM order incorrectly. This patch updates `SelectFilter2.js` to insert the `selector_div` after the input box, preserving the correct label-widget structure. The fix ensures that widget containers are inserted after the label element in the DOM rather than being prepended at the start. Supersedes PR #19156.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
