### PR TITLE
Fixed #35333 -- Ensured that date and time filters honor the `unlocalize` tag

### DIFF
--- a/django/template/base.py
+++ b/django/template/base.py
@@ -748,12 +748,15 @@ class FilterExpression:
                     arg_vals.append(mark_safe(arg))
                 else:
                     arg_vals.append(arg.resolve(context))
+            kwargs = {}
             if getattr(func, "expects_localtime", False):
                 obj = template_localtime(obj, context.use_tz)
+                if func.__name__ in ("date", "time"):
+                    kwargs["use_l10n"] = context.use_l10n
             if getattr(func, "needs_autoescape", False):
-                new_obj = func(obj, autoescape=context.autoescape, *arg_vals)
+                new_obj = func(obj, autoescape=context.autoescape, *arg_vals, **kwargs)
             else:
-                new_obj = func(obj, *arg_vals)
+                new_obj = func(obj, *arg_vals, **kwargs)
             if getattr(func, "is_safe", False) and isinstance(obj, SafeData):
                 obj = mark_safe(new_obj)
             else:

--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -776,12 +776,12 @@ def get_digit(value, arg):
 
 
 @register.filter(expects_localtime=True, is_safe=False)
-def date(value, arg=None):
+def date(value, arg=None, use_l10n=None):
     """Format a date according to the given format."""
     if value in (None, ""):
         return ""
     try:
-        return formats.date_format(value, arg)
+        return formats.date_format(value, arg, use_l10n=use_l10n)
     except AttributeError:
         try:
             return format(value, arg)
@@ -790,12 +790,12 @@ def date(value, arg=None):
 
 
 @register.filter(expects_localtime=True, is_safe=False)
-def time(value, arg=None):
+def time(value, arg=None, use_l10n=None):
     """Format a time according to the given format."""
     if value in (None, ""):
         return ""
     try:
-        return formats.time_format(value, arg)
+        return formats.time_format(value, arg, use_l10n=use_l10n)
     except (AttributeError, TypeError):
         try:
             return time_format(value, arg)

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -1396,6 +1396,52 @@ class FormattingTests(SimpleTestCase):
                 self.assertEqual(template2.render(context), output2)
                 self.assertEqual(template3.render(context), output3)
 
+    def test_unlocalize_honor_date_settings(self):
+        filter_template = Template(
+            "{% load l10n %}Localized: {{ my_value }}. "
+            "Unlocalized: {{ my_value|unlocalize }}."
+        )
+        tag_template = Template(
+            "{% load l10n %}Localized: {{ my_value }}. {% localize off %}"
+            "Unlocalized: {{ my_value }}{% endlocalize %}."
+        )
+        filter_inside_unlocalize = Template(
+            "{% load l10n %}Localized: {{ my_value|date }}. {% localize off %}"
+            "Unlocalized: {{ my_value|date:'DATE_FORMAT' }}{% endlocalize %}."
+        )
+        context = Context({"my_value": datetime.date(2024, 12, 15)})
+        expected_result = "Localized: 15. Dezember 2024. Unlocalized: 15-12-2024."
+        for case in (filter_template, tag_template, filter_inside_unlocalize):
+            with (
+                self.subTest(case=str(case)),
+                translation.override("de", deactivate=True),
+                self.settings(DATE_FORMAT="j-m-Y"),
+            ):
+                self.assertEqual(case.render(context), expected_result)
+
+    def test_unlocalize_honor_time_settings(self):
+        filter_template = Template(
+            "{% load l10n %}Localized: {{ my_value }}. "
+            "Unlocalized: {{ my_value|unlocalize }}."
+        )
+        tag_template = Template(
+            "{% load l10n %}Localized: {{ my_value }}. {% localize off %}"
+            "Unlocalized: {{ my_value }}{% endlocalize %}."
+        )
+        filter_inside_unlocalize = Template(
+            "{% load l10n %}Localized: {{ my_value|time }}. {% localize off %}"
+            "Unlocalized: {{ my_value|time }}{% endlocalize %}."
+        )
+        context = Context({"my_value": datetime.time(1, 2, 3)})
+        expected_result = "Localized: 01:02. Unlocalized: 01h 02m."
+        for case in (filter_template, tag_template, filter_inside_unlocalize):
+            with (
+                self.subTest(case=str(case)),
+                translation.override("de", deactivate=True),
+                self.settings(TIME_FORMAT="H\\h i\\m"),
+            ):
+                self.assertEqual(case.render(context), expected_result)
+
     def test_localized_off_numbers(self):
         """A string representation is returned for unlocalized numbers."""
         template = Template(


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35333

#### Branch description
The date and time template filters now respect the localization context when used with the unlocalize tag or within a `{% localize off %}` block. This is achieved by passing the current localization context `(use_l10n flag)` from the template rendering context to the filter functions, allowing them to properly format dates and times according to the unlocalized settings when localization is disabled. Previously, these filters would ignore the localization context setting.

Special thanks to @claudep for the initial work on PR #18021 and to @nessita for guidance on the ticket.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
