### PR TITLE
Fixed #36295 -- Added support for overriding `GenericForeignKey` in abstract models

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -34,6 +34,7 @@ answer newbie questions, and generally made Django that much better:
     Ahmad Alhashemi <trans@ahmadh.com>
     Ahmad Al-Ibrahim
     Ahmed Eltawela <https://github.com/ahmedabt>
+    Ahmed Nassar <https://ahmednassar7.github.io/>
     ajs <adi@sieker.info>
     Akash Agrawal <akashrocksha@gmail.com>
     Akash Kumar Sen <akashkumarsen4@gmail.com>

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -348,7 +348,7 @@ class ModelBase(type):
                 new_class._meta.parents.update(base_parents)
 
             # Inherit private fields (like GenericForeignKey) from the parent
-            # class
+            # class if they are not overridden.
             for field in base._meta.private_fields:
                 if field.name in field_names:
                     if not base._meta.abstract:
@@ -361,7 +361,10 @@ class ModelBase(type):
                                 base.__name__,
                             )
                         )
-                else:
+                elif (
+                    field.name not in new_class.__dict__
+                    and field.name not in inherited_attributes
+                ):
                     field = copy.deepcopy(field)
                     if not base._meta.abstract:
                         field.mti_inherited = True

--- a/tests/model_inheritance/test_abstract_inheritance.py
+++ b/tests/model_inheritance/test_abstract_inheritance.py
@@ -184,6 +184,32 @@ class AbstractInheritanceTests(SimpleTestCase):
             ExtendModelAbstract._meta.get_field("field"), GenericRelation
         )
 
+    def test_override_private_field_with_attr(self):
+        class AbstractBase(models.Model):
+            content_type = models.ForeignKey(
+                ContentType, on_delete=models.SET_NULL, null=True, blank=True
+            )
+            object_id = models.PositiveIntegerField(null=True, blank=True)
+            related_object = GenericForeignKey("content_type", "object_id")
+
+            class Meta:
+                abstract = True
+
+        class Descendant(AbstractBase):
+            related_object = None
+
+        class Mixin:
+            related_object = None
+
+        class MultiDescendant(Mixin, AbstractBase):
+            pass
+
+        with self.assertRaises(FieldDoesNotExist):
+            Descendant._meta.get_field("related_object")
+
+        with self.assertRaises(FieldDoesNotExist):
+            MultiDescendant._meta.get_field("related_object")
+
     def test_cannot_override_indirect_abstract_field(self):
         class AbstractBase(models.Model):
             name = models.CharField(max_length=30)


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36295 

#### Branch description
`GenericForeignKey` fields can now be overridden by setting them to `None` in abstract models, similar to how regular model fields work. Previously, attempting to override a GenericForeignKey by setting it to None in an abstract derived model would not work, despite Django's documentation stating this should be possible.

This aligns the behavior of GenericForeignKey with regular model fields and follows Django's documented behavior for field overriding in abstract models.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
