### PR TITLE
Fixed #35728 -- Computed error messages in assertions only on test failures.

### DIFF
--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -989,6 +989,11 @@ class SimpleTestCase(unittest.TestCase):
             self, haystack, None, "Second argument is not valid HTML:"
         )
         real_count = parsed_haystack.count(parsed_needle)
+
+        if (count is None and real_count > 0) or count == real_count:
+            # Shortcut.
+            return
+
         if msg_prefix:
             msg_prefix += ": "
         haystack_repr = safe_repr(haystack)

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -545,7 +545,9 @@ class SimpleTestCase(unittest.TestCase):
             return safe_repr(content)
         return "'%s'" % str(content)
 
-    def _assert_contains(self, response, text, status_code, msg_prefix, html):
+    def _assert_contains(
+        self, response, text, status_code, msg_prefix, html, count=None
+    ):
         # If the response supports deferred rendering and hasn't been rendered
         # yet, then ensure that it does get rendered before proceeding further.
         if (
@@ -581,8 +583,12 @@ class SimpleTestCase(unittest.TestCase):
             text = assert_and_parse_html(
                 self, text, None, "Second argument is not valid HTML:"
             )
-        real_count = content.count(text)
-        return real_count, msg_prefix, response_content
+        if (count is None or count == 0) and html:
+            # Does text exist in content, regardless of count?
+            real_count = int(text in content)
+            return real_count, msg_prefix, response_content
+
+        return content.count(text), msg_prefix, response_content
 
     def assertContains(
         self, response, text, count=None, status_code=200, msg_prefix="", html=False
@@ -595,7 +601,7 @@ class SimpleTestCase(unittest.TestCase):
         if the text occurs at least once in the response.
         """
         real_count, msg_prefix, response_content = self._assert_contains(
-            response, text, status_code, msg_prefix, html
+            response, text, status_code, msg_prefix, html, count=count
         )
 
         if count is not None:
@@ -624,7 +630,7 @@ class SimpleTestCase(unittest.TestCase):
         ``text`` doesn't occur in the content of the response.
         """
         real_count, msg_prefix, response_content = self._assert_contains(
-            response, text, status_code, msg_prefix, html
+            response, text, status_code, msg_prefix, html, count=0
         )
 
         if real_count != 0:
@@ -988,8 +994,12 @@ class SimpleTestCase(unittest.TestCase):
         parsed_haystack = assert_and_parse_html(
             self, haystack, None, "Second argument is not valid HTML:"
         )
-        real_count = parsed_haystack.count(parsed_needle)
 
+        if count is None or count == 0:
+            # Does needle exist regardless of count?
+            real_count = int(parsed_needle in parsed_haystack)
+        else:
+            real_count = parsed_haystack.count(parsed_needle)
         if (count is None and real_count > 0) or count == real_count:
             # Shortcut.
             return

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -645,27 +645,45 @@ class SimpleTestCase(unittest.TestCase):
                 "the Django test Client."
             )
 
-    def _assert_form_error(self, form, field, errors, msg_prefix, form_repr):
+    def _assert_form_error(
+        self, form, field, errors, msg_prefix, formset=None, form_index=None
+    ):
+
+        def form_repr():
+            # Lazily compute messages.
+            if formset is None:
+                return f"form {form!r}"
+            return f"form {form_index} of formset {formset!r}"
+
         if not form.is_bound:
             self.fail(
-                f"{msg_prefix}The {form_repr} is not bound, it will never have any "
-                f"errors."
+                "%sThe %s is not bound, it will never have any errors."
+                % (msg_prefix, form_repr())
             )
 
         if field is not None and field not in form.fields:
             self.fail(
-                f"{msg_prefix}The {form_repr} does not contain the field {field!r}."
+                "%sThe %s does not contain the field %r."
+                % (msg_prefix, form_repr(), field)
             )
         if field is None:
             field_errors = form.non_field_errors()
-            failure_message = f"The non-field errors of {form_repr} don't match."
         else:
             field_errors = form.errors.get(field, [])
-            failure_message = (
-                f"The errors of field {field!r} on {form_repr} don't match."
-            )
 
-        self.assertEqual(field_errors, errors, msg_prefix + failure_message)
+        # Skip assertion if errors already match.
+        if field_errors == errors:
+            return
+
+        # Use assertListEqual to show detailed diff if errors don't match.
+        if field is None:
+            failure_message = "The non-field errors of %s don't match." % (form_repr(),)
+        else:
+            failure_message = "The errors of field %r on %s don't match." % (
+                field,
+                form_repr(),
+            )
+        self.assertListEqual(field_errors, errors, msg_prefix + failure_message)
 
     def assertFormError(self, form, field, errors, msg_prefix=""):
         """
@@ -680,7 +698,7 @@ class SimpleTestCase(unittest.TestCase):
         if msg_prefix:
             msg_prefix += ": "
         errors = to_list(errors)
-        self._assert_form_error(form, field, errors, msg_prefix, f"form {form!r}")
+        self._assert_form_error(form, field, errors, msg_prefix)
 
     def assertFormSetError(self, formset, form_index, field, errors, msg_prefix=""):
         """
@@ -712,13 +730,22 @@ class SimpleTestCase(unittest.TestCase):
                 f"{form_or_forms}."
             )
         if form_index is not None:
-            form_repr = f"form {form_index} of formset {formset!r}"
             self._assert_form_error(
-                formset.forms[form_index], field, errors, msg_prefix, form_repr
+                formset.forms[form_index],
+                field,
+                errors,
+                msg_prefix,
+                formset=formset,
+                form_index=form_index,
             )
         else:
+            formset_errors = formset.non_form_errors()
+            if formset_errors == errors:
+                # Skip assertion if errors already match.
+                return
+
             failure_message = f"The non-form errors of formset {formset!r} don't match."
-            self.assertEqual(
+            self.assertListEqual(
                 formset.non_form_errors(), errors, msg_prefix + failure_message
             )
 

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -536,6 +536,15 @@ class SimpleTestCase(unittest.TestCase):
             msg_prefix + "Expected '%s' to equal '%s'." % (url1, url2),
         )
 
+    def _text_repr(self, content, force_string):
+        """
+        Helper method for converting content or text to a helpful representation.
+        Used by _assert_contains().
+        """
+        if isinstance(content, bytes) and not force_string:
+            return safe_repr(content)
+        return "'%s'" % str(content)
+
     def _assert_contains(self, response, text, status_code, msg_prefix, html):
         # If the response supports deferred rendering and hasn't been rendered
         # yet, then ensure that it does get rendered before proceeding further.
@@ -560,13 +569,11 @@ class SimpleTestCase(unittest.TestCase):
             content = b"".join(response.streaming_content)
         else:
             content = response.content
-        content_repr = safe_repr(content)
+        response_content = content
         if not isinstance(text, bytes) or html:
             text = str(text)
             content = content.decode(response.charset)
-            text_repr = "'%s'" % text
-        else:
-            text_repr = repr(text)
+
         if html:
             content = assert_and_parse_html(
                 self, content, None, "Response's content is not valid HTML:"
@@ -575,7 +582,7 @@ class SimpleTestCase(unittest.TestCase):
                 self, text, None, "Second argument is not valid HTML:"
             )
         real_count = content.count(text)
-        return text_repr, real_count, msg_prefix, content_repr
+        return real_count, msg_prefix, response_content
 
     def assertContains(
         self, response, text, count=None, status_code=200, msg_prefix="", html=False
@@ -587,27 +594,26 @@ class SimpleTestCase(unittest.TestCase):
         If ``count`` is None, the count doesn't matter - the assertion is true
         if the text occurs at least once in the response.
         """
-        text_repr, real_count, msg_prefix, content_repr = self._assert_contains(
+        real_count, msg_prefix, response_content = self._assert_contains(
             response, text, status_code, msg_prefix, html
         )
 
         if count is not None:
-            self.assertEqual(
-                real_count,
-                count,
-                (
+            if real_count != count:
+                text_repr = self._text_repr(text, force_string=html)
+                self.fail(
                     f"{msg_prefix}Found {real_count} instances of {text_repr} "
-                    f"(expected {count}) in the following response\n{content_repr}"
-                ),
-            )
+                    f"(expected {count}) in the following response\n"
+                    f"{response_content!r}"
+                )
+
         else:
-            self.assertTrue(
-                real_count != 0,
-                (
+            if real_count == 0:
+                text_repr = self._text_repr(text, force_string=html)
+                self.fail(
                     f"{msg_prefix}Couldn't find {text_repr} in the following response\n"
-                    f"{content_repr}"
+                    f"{response_content!r}"
                 ),
-            )
 
     def assertNotContains(
         self, response, text, status_code=200, msg_prefix="", html=False
@@ -617,18 +623,16 @@ class SimpleTestCase(unittest.TestCase):
         successfully, (i.e., the HTTP status code was as expected) and that
         ``text`` doesn't occur in the content of the response.
         """
-        text_repr, real_count, msg_prefix, content_repr = self._assert_contains(
+        real_count, msg_prefix, response_content = self._assert_contains(
             response, text, status_code, msg_prefix, html
         )
 
-        self.assertEqual(
-            real_count,
-            0,
-            (
+        if real_count != 0:
+            text_repr = self._text_repr(text, force_string=html)
+            self.fail(
                 f"{msg_prefix}{text_repr} unexpectedly found in the following response"
-                f"\n{content_repr}"
+                f"\n{response_content!r}"
             ),
-        )
 
     def _check_test_client_response(self, response, attribute, method_name):
         """


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-XXXXX

#### Branch description
There are two main approaches used.
1. Return early if the assertion will pass; if not compute error messages and pass them on to unittest's assertions. Passing on to unittest's assertions has the benefit of sometimes providing more helpful error messages, e.g. when asserting sequence equality, the difference is shown in the report. But sometimes this is just prepends `False is not true` to an error message.
2. Compute the error message in the failing conditional branch, for `self.fail(msg)`.

An additional commit makes sure that we use `__contains__` for checking existence of an element in HTML assertions. This has the benefit of using `Element._count(elem, count=False)` under the hood, and short-circuiting when a single match is found.

```python
from django.test.html import parse_html

parsed_needle = parse_html("<span>Hello</span>")
parsed_haystack = parse_html(
    "<div>" + ("<span>Other</span>" * 100) +
    "<span>Hello</span>" * 2 +
    ("<span>Other</span>" * 100) + "</div>"
)

%timeit parsed_needle in parsed_haystack 
%timeit parsed_haystack.count(parsed_needle)  # Double the time.

```
#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
