### PR TITLE
Fixed #36341 -- Fixed utils.text.wrap not preserving empty lines.

### DIFF
--- a/django/utils/text.py
+++ b/django/utils/text.py
@@ -54,10 +54,19 @@ def wrap(text, width):
         width=width,
         break_long_words=False,
         break_on_hyphens=False,
+        replace_whitespace=False,
     )
     result = []
-    for line in text.splitlines(True):
-        result.extend(wrapper.wrap(line))
+    for line in text.splitlines():
+        wrapped = wrapper.wrap(line)
+        if not wrapped:
+            # If `line` contains only whitespaces that are dropped, restore it.
+            result.append(line)
+        else:
+            result.extend(wrapped)
+    if text.endswith("\n"):
+        # If `text` ends with a newline, preserve it.
+        result.append("")
     return "\n".join(result)
 
 

--- a/docs/releases/5.2.1.txt
+++ b/docs/releases/5.2.1.txt
@@ -44,3 +44,7 @@ Bugfixes
 * Fixed a regression in Django 5.2 that caused the ``object-tools`` block to be
   rendered twice when using custom admin templates with overridden blocks due
   to changes in the base admin page block structure (:ticket:`36331`).
+
+* Fixed a regression in Django 5.2, introduced when fixing :cve:`2025-26699`,
+  where the :tfilter:`wordwrap` template filter did not preserve empty lines
+  between paragraphs after wrapping text (:ticket:`36341`).

--- a/tests/template_tests/filter_tests/test_wordwrap.py
+++ b/tests/template_tests/filter_tests/test_wordwrap.py
@@ -89,3 +89,44 @@ class FunctionTests(SimpleTestCase):
             "I'm afraid",
             wordwrap(long_text, 10),
         )
+
+    def test_wrap_preserve_newlines(self):
+        cases = [
+            (
+                "this is a long paragraph of text that really needs to be wrapped\n\n"
+                "that is followed by another paragraph separated by an empty line\n",
+                "this is a long paragraph of\ntext that really needs to be\nwrapped\n\n"
+                "that is followed by another\nparagraph separated by an\nempty line\n",
+                30,
+            ),
+            ("\n\n\n", "\n\n\n", 5),
+            ("\n\n\n\n\n\n", "\n\n\n\n\n\n", 5),
+        ]
+        for text, expected, width in cases:
+            with self.subTest(text=text):
+                self.assertEqual(wordwrap(text, width), expected)
+
+    def test_wrap_preserve_whitespace(self):
+        width = 5
+        width_spaces = " " * width
+        cases = [
+            (
+                f"first line\n{width_spaces}\nsecond line",
+                f"first\nline\n{width_spaces}\nsecond\nline",
+            ),
+            (
+                "first line\n \t\t\t \nsecond line",
+                "first\nline\n \t\t\t \nsecond\nline",
+            ),
+            (
+                f"first line\n{width_spaces}\nsecond line\n\nthird{width_spaces}\n",
+                f"first\nline\n{width_spaces}\nsecond\nline\n\nthird\n",
+            ),
+            (
+                f"first line\n{width_spaces}{width_spaces}\nsecond line",
+                f"first\nline\n{width_spaces}{width_spaces}\nsecond\nline",
+            ),
+        ]
+        for text, expected in cases:
+            with self.subTest(text=text):
+                self.assertEqual(wordwrap(text, width), expected)


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36341

#### Branch description
The fix for CVE-2025-26699 altered behavior of `django.utils.text.wrap()` so that it no longer preserved empty lines. This re-adds functionality so that empty lines are preserved.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
