### PR TITLE
Refs #36341 -- Added release notes for 5.1.9 and 4.2.21 for fix in 1e9db35836d42a3c72f3d1015c2f302eb6fee046.

### DIFF
--- a/docs/releases/4.2.21.txt
+++ b/docs/releases/4.2.21.txt
@@ -4,7 +4,7 @@ Django 4.2.21 release notes
 
 *Expected May 7, 2025*
 
-Django 4.2.21 fixes a data loss bug in 4.2.20.
+Django 4.2.21 fixes a data loss bug and a regression in 4.2.20.
 
 Bugfixes
 ========
@@ -13,3 +13,8 @@ Bugfixes
   ``allow_overwrite=True``, where leftover content from a previously larger
   file could remain after overwriting with a smaller one due to lack of
   truncation (:ticket:`36298`).
+
+* Fixed a regression in Django 4.2.20, introduced when fixing
+  :cve:`2025-26699`, where the :tfilter:`wordwrap` template filter did not
+  preserve empty lines between paragraphs after wrapping text
+  (:ticket:`36341`).

--- a/docs/releases/5.1.9.txt
+++ b/docs/releases/5.1.9.txt
@@ -4,7 +4,7 @@ Django 5.1.9 release notes
 
 *Expected May 7, 2025*
 
-Django 5.1.9 fixes a data loss bug in 5.1.8.
+Django 5.1.9 fixes a data loss bug and a regression in 5.1.8.
 
 Bugfixes
 ========
@@ -13,3 +13,7 @@ Bugfixes
   ``allow_overwrite=True``, where leftover content from a previously larger
   file could remain after overwriting with a smaller one due to lack of
   truncation (:ticket:`36298`).
+
+* Fixed a regression in Django 5.1.8, introduced when fixing :cve:`2025-26699`,
+  where the :tfilter:`wordwrap` template filter did not preserve empty lines
+  between paragraphs after wrapping text (:ticket:`36341`).


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36341

#### Branch description
1e9db35836d42a3c72f3d1015c2f302eb6fee046 fixed a regression that affects stable versions in extended support (5.1.x and 4.2.x) since the issue was introduced by [this CVE fix](55d89e25f4115c5674cdd9b9bcba2bb2bb6d820b.).