### PR TITLE
Fixed #36350 -- Respected Field.db_check() when deciding whether to recreate constraint

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -923,13 +923,11 @@ class BaseDatabaseSchemaEditor:
     def _field_db_check(self, field, field_db_params):
         # Always check constraints with the same mocked column name to avoid
         # recreating constrains when the column is renamed.
-        check_constraints = self.connection.data_type_check_constraints
+        if (constraint := field.db_check(self.connection)) is None:
+            return None
         data = field.db_type_parameters(self.connection)
         data["column"] = "__column_name__"
-        try:
-            return check_constraints[field.get_internal_type()] % data
-        except KeyError:
-            return None
+        return constraint % data
 
     def _alter_field(
         self,


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36350

#### Branch description
This PR changes the logic in `BaseDatabaseSchemaEditor._field_db_check()` to make use of `Field.db_check()` instead of looking up constraints in `connection.data_type_check_constraints`. This re-enable custom fields being able to manage their own constraints.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
