### PR TITLE
Fixed #36346 -- Removed outdated section about the threaded option in Oracle driver.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -996,6 +996,7 @@ answer newbie questions, and generally made Django that much better:
     Taavi Teska <taaviteska@gmail.com>
     Tai Lee <real.human@mrmachine.net>
     Takashi Matsuo <matsuo.takashi@gmail.com>
+    Tan Yawei <tanyawei1991@gmail.com>
     Tareque Hossain <http://www.codexn.com>
     Taylor Mitchell <taylor.mitchell@gmail.com>
     tell-k <ffk2005@gmail.com>

--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -1139,19 +1139,6 @@ alternatively set ``"pool"`` to be a dict::
 
 .. _`create_pool()`: https://python-oracledb.readthedocs.io/en/latest/user_guide/connection_handling.html#connection-pooling
 
-Threaded option
----------------
-
-If you plan to run Django in a multithreaded environment (e.g. Apache using the
-default MPM module on any modern operating system), then you **must** set
-the ``threaded`` option of your Oracle database configuration to ``True``::
-
-    "OPTIONS": {
-        "threaded": True,
-    }
-
-Failure to do this may result in crashes and other odd behavior.
-
 INSERT ... RETURNING INTO
 -------------------------
 


### PR DESCRIPTION
Fixed #36346 -- Removed outdated information about the threaded option for Oracle database configuration in multithreaded environments.

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36346

#### Branch description
Removed outdated information about the threaded option in Oracle database configuration. The threaded option is no longer supported in python-oracledb 2.0 and higher, as threading is always enabled. Updated the documentation to reflect this change.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
