### PR TITLE
Fixed #35852 -- Fixed inconsistent formatting of numbers in a locale-aware fashion.

### DIFF
--- a/django/contrib/humanize/templatetags/humanize.py
+++ b/django/contrib/humanize/templatetags/humanize.py
@@ -1,6 +1,6 @@
 import re
 from datetime import UTC, date, datetime
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 
 from django import template
 from django.template import defaultfilters
@@ -66,14 +66,15 @@ def ordinal(value):
 @register.filter(is_safe=True)
 def intcomma(value, use_l10n=True):
     """
-    Convert an integer to a string containing commas every three digits.
-    For example, 3000 becomes '3,000' and 45000 becomes '45,000'.
+    Convert an integer or float (or a string representation of either) to a
+    string containing commas every three digits. Format localization is
+    respected. For example, 3000 becomes '3,000' and 45000 becomes '45,000'.
     """
     if use_l10n:
         try:
             if not isinstance(value, (float, Decimal)):
-                value = int(value)
-        except (TypeError, ValueError):
+                value = Decimal(value)
+        except (TypeError, ValueError, InvalidOperation):
             return intcomma(value, False)
         else:
             return number_format(value, use_l10n=True, force_grouping=True)

--- a/tests/humanize_tests/tests.py
+++ b/tests/humanize_tests/tests.py
@@ -196,8 +196,8 @@ class HumanizeTests(SimpleTestCase):
             None,
             "1,234,567",
             "-1,234,567",
-            "１,２３４,５６７.１２",
-            "-１,２３４,５６７.１２",
+            "1,234,567.12",
+            "-1,234,567.12",
             "the quick brown fox jumped over the lazy dog",
         )
         with translation.override("en"):
@@ -238,7 +238,7 @@ class HumanizeTests(SimpleTestCase):
             "-１２３４５６７.１２",
             "the quick brown fox jumped over the lazy dog",
         )
-        result_list = (
+        result_list_en = (
             "100",
             "-100",
             "1,000",
@@ -268,13 +268,49 @@ class HumanizeTests(SimpleTestCase):
             None,
             "1,234,567",
             "-1,234,567",
-            "１,２３４,５６７.１２",
-            "-１,２３４,５６７.１２",
+            "1,234,567.12",
+            "-1,234,567.12",
+            "the quick brown fox jumped over the lazy dog",
+        )
+        result_list_de = (
+            "100",
+            "-100",
+            "1.000",
+            "-1.000",
+            "10.123",
+            "-10.123",
+            "10.311",
+            "-10.311",
+            "1.000.000",
+            "-1.000.000",
+            "1.234.567,25",
+            "-1.234.567,25",
+            "100",
+            "-100",
+            "1.000",
+            "-1.000",
+            "10.123",
+            "-10.123",
+            "10.311",
+            "-10.311",
+            "1.000.000",
+            "-1.000.000",
+            "1.234.567,1234567",
+            "-1.234.567,1234567",
+            "1.234.567,1234567",
+            "-1.234.567,1234567",
+            None,
+            "1.234.567",
+            "-1.234.567",
+            "1.234.567,12",
+            "-1.234.567,12",
             "the quick brown fox jumped over the lazy dog",
         )
         with self.settings(USE_THOUSAND_SEPARATOR=False):
             with translation.override("en"):
-                self.humanize_tester(test_list, result_list, "intcomma")
+                self.humanize_tester(test_list, result_list_en, "intcomma")
+            with translation.override("de"):
+                self.humanize_tester(test_list, result_list_de, "intcomma")
 
     def test_intcomma_without_number_grouping(self):
         # Regression for #17414


### PR DESCRIPTION
#### Trac ticket number

ticket-35852

#### Branch description

Currently, `intcomma` fails to apply appropriate internationalisation to string representations of numbers with decimals.

The cause of the bug is that, where it can, `intcomma` uses `number_format` to apply internationalisation. In the case that the value is not a float or a decimal, it (currently) casts that value to an integer before passing to `number_format`. This fails when the string representation contains a decimal, and in this scenario, `intcomma` applies its own naive (non-locale-aware) comma separation. The fix for this is to cast to a decimal instead of an integer.

This should actually have been picked up by the tests. The test-cases do cover this example. The problem here is that the test `test_l10n_intcomma` is using `en` as the locale, and so the error above was never surfaced. I've updated the test to use `de` instead.

I have also updated the docstring, so it matches [the documentation](https://docs.djangoproject.com/en/dev/ref/contrib/humanize/#intcomma).

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
