### PR TITLE
Fixed aggregation tests crash on databases that don't support JSONFields.

### DIFF
--- a/tests/aggregation/models.py
+++ b/tests/aggregation/models.py
@@ -47,3 +47,6 @@ class Store(models.Model):
 
 class Employee(models.Model):
     work_day_preferences = models.JSONField()
+
+    class Meta:
+        required_db_features = {"supports_json_field"}


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

N/A

#### Branch description

I'm testing https://github.com/django/django-docker-box/pull/50 again while working on https://code.djangoproject.com/ticket/36143 and noticed that since #18361, the tests cannot be run if SQLite doesn't have the JSON extension enabled.

To test, you can check out that branch and run the following:

```shell
SQLITE_VERSION=3.31.0 SQLITE_CFLAGS="-DSQLITE_ENABLE_DESERIALIZE" docker compose run --rm sqlite
```

##### Before

<img width="698" alt="image" src="https://github.com/user-attachments/assets/97d33a4d-849a-4de0-84d1-3463d783c388" />


##### After

<img width="698" alt="image" src="https://github.com/user-attachments/assets/11bec75c-d953-4cee-aff2-95251500064b" />

<img width="698" alt="image" src="https://github.com/user-attachments/assets/0071363c-7df5-4c8d-978e-3f27b10d13f8" />

(tests failures are currently expected)

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
