### PR TITLE
Removed redundant redefinition of msg in tests/test_utils/tests.py.

### DIFF
--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -535,7 +535,6 @@ class AssertTemplateUsedContextManagerTests(SimpleTestCase):
             with self.assertTemplateUsed("template_used/base.html"):
                 render_to_string("template_used/alternative.html")
 
-        msg = "No templates used to render the response"
         with self.assertRaisesMessage(AssertionError, msg):
             response = self.client.get("/test_utils/no_template_used/")
             self.assertTemplateUsed(response, "template_used/base.html")


### PR DESCRIPTION
Already defined on line 521.

Maybe we may also want to move test with `msg2` to group all tests that use the same `msg`?
