### PR TITLE
Fixed not showing error message for inactive user in AuthenticationForm

### DIFF
--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -343,15 +343,18 @@ class AuthenticationForm(forms.Form):
         password = self.cleaned_data.get("password")
 
         if username is not None and password:
-            self.user_cache = authenticate(
-                self.request, username=username, password=password
-            )
-            if self.user_cache is None:
-                raise self.get_invalid_login_error()
-            else:
-                self.confirm_login_allowed(self.user_cache)
+            user = UserModel.objects.filter(**{UserModel.USERNAME_FIELD: username}).first()
+            if user:
+                password_check = user.check_password(password)
+                if password_check:
+                    self.user_cache = authenticate(
+                    self.request, username=username, password=password
+                    )
+                    if self.user_cache is None:
+                        self.confirm_login_allowed(user)
 
-        return self.cleaned_data
+                    return self.cleaned_data
+        raise self.get_invalid_login_error()
 
     def confirm_login_allowed(self, user):
         """


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

N/A

#### Branch description
In the AuthenticationForm class from Django, if the user is inactive in the database, the form raises the invalid login error message, which is supposed to indicate that the authentication data (credentials) is incorrect. This happens because the authenticate method from django.contrib.auth returns None for inactive users — even when the submitted credentials are actually valid — causing the following logic:

if self.user_cache is None:
    raise self.get_invalid_login_error()
else:
    self.confirm_login_allowed(self.user_cache)

to fail at the self.user_cache is None check.

As a result, instead of raising an appropriate "inactive user" error (via confirm_login_allowed), the form incorrectly raises an "invalid login" error, misleading the user into thinking their credentials are wrong, when in fact their account is merely inactive.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
