### PR TITLE
Fixed #36143 -- Made max_query_params respect SQLITE_LIMIT_VARIABLE_NUMBER.

### DIFF
--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -1,4 +1,5 @@
 import operator
+import sqlite3
 
 from django.db import transaction
 from django.db.backends.base.features import BaseDatabaseFeatures
@@ -13,7 +14,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     test_db_allows_multiple_connections = False
     supports_unspecified_pk = True
     supports_timezones = False
-    max_query_params = 999
     supports_transactions = True
     atomic_transactions = False
     can_rollback_ddl = True
@@ -146,6 +146,16 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             "GenericIPAddressField": "CharField",
             "SmallAutoField": "AutoField",
         }
+
+    @property
+    def max_query_params(self):
+        """
+        SQLite has a variable limit per query. The limit can be changed using
+        the SQLITE_MAX_VARIABLE_NUMBER compile-time option (which defaults to
+        999 in versions < 3.32.0 or 32766 in newer versions) or lowered per
+        connection at run-time with setlimit(SQLITE_LIMIT_VARIABLE_NUMBER, N).
+        """
+        return self.connection.connection.getlimit(sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER)
 
     @cached_property
     def supports_json_field(self):

--- a/django/db/backends/sqlite3/operations.py
+++ b/django/db/backends/sqlite3/operations.py
@@ -30,8 +30,8 @@ class DatabaseOperations(BaseDatabaseOperations):
 
     def bulk_batch_size(self, fields, objs):
         """
-        SQLite has a compile-time default (SQLITE_LIMIT_VARIABLE_NUMBER) of
-        999 variables per query.
+        SQLite has a variable limit defined by SQLITE_LIMIT_VARIABLE_NUMBER
+        (reflected in max_query_params).
 
         If there's only a single field to insert, the limit is 500
         (SQLITE_MAX_COMPOUND_SELECT).

--- a/tests/backends/sqlite/test_features.py
+++ b/tests/backends/sqlite/test_features.py
@@ -1,3 +1,4 @@
+import sqlite3
 from unittest import mock, skipUnless
 
 from django.db import OperationalError, connection
@@ -17,3 +18,14 @@ class FeaturesTests(TestCase):
         ):
             with self.assertRaisesMessage(OperationalError, msg):
                 connection.features.supports_json_field
+
+    def test_max_query_params_respects_variable_limit(self):
+        limit_name = sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER
+        current_limit = connection.features.max_query_params
+        new_limit = min(42, current_limit)
+        try:
+            connection.connection.setlimit(limit_name, new_limit)
+            self.assertEqual(connection.features.max_query_params, new_limit)
+        finally:
+            connection.connection.setlimit(limit_name, current_limit)
+        self.assertEqual(connection.features.max_query_params, current_limit)

--- a/tests/backends/sqlite/test_operations.py
+++ b/tests/backends/sqlite/test_operations.py
@@ -1,3 +1,4 @@
+import sqlite3
 import unittest
 
 from django.core.management.color import no_style
@@ -107,4 +108,33 @@ class SQLiteOperationsTests(TestCase):
                 [composite_pk, first_name_field], [Person()]
             ),
             connection.features.max_query_params // 3,
+        )
+
+    def test_bulk_batch_size_respects_variable_limit(self):
+        first_name_field = Person._meta.get_field("first_name")
+        last_name_field = Person._meta.get_field("last_name")
+        limit_name = sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER
+        current_limit = connection.features.max_query_params
+        self.assertEqual(
+            connection.ops.bulk_batch_size(
+                [first_name_field, last_name_field], [Person()]
+            ),
+            current_limit // 2,
+        )
+        new_limit = min(42, current_limit)
+        try:
+            connection.connection.setlimit(limit_name, new_limit)
+            self.assertEqual(
+                connection.ops.bulk_batch_size(
+                    [first_name_field, last_name_field], [Person()]
+                ),
+                new_limit // 2,
+            )
+        finally:
+            connection.connection.setlimit(limit_name, current_limit)
+        self.assertEqual(
+            connection.ops.bulk_batch_size(
+                [first_name_field, last_name_field], [Person()]
+            ),
+            current_limit // 2,
         )

--- a/tests/bulk_create/tests.py
+++ b/tests/bulk_create/tests.py
@@ -294,6 +294,14 @@ class BulkCreateTests(TestCase):
             Country.objects.bulk_create(objs, batch_size=max_batch_size + 1)
 
     @skipUnlessDBFeature("has_bulk_insert")
+    def test_max_batch_size(self):
+        objs = [Country(name=f"Country {i}") for i in range(1000)]
+        fields = ["name", "iso_two_letter", "description"]
+        max_batch_size = connection.ops.bulk_batch_size(fields, objs)
+        with self.assertNumQueries(ceil(len(objs) / max_batch_size)):
+            Country.objects.bulk_create(objs)
+
+    @skipUnlessDBFeature("has_bulk_insert")
     def test_bulk_insert_expressions(self):
         Restaurant.objects.bulk_create(
             [


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36143. @thepsalmist and I worked on this during the Djangonaut Space program, and I added the tests during the DjangoCon Europe 2025 sprints.

#### Branch description

As mentioned in the ticket, this changes `DatabaseFeatures.max_query_params` to make use of the actual limit set on the SQLite installation/connection as defined by `SQLITE_LIMIT_VARIABLE_NUMBER`.

The upper bound of the limit is set during compile time, but it can be lowered per-connection at runtime using the C API exposed by Python (3.11+) via the `getlimit()` and `setlimit()` methods.

To always ensure the right limit is used, we should use a `property` instead of `cached_property`, but that does mean calling `getlimit()` whenever the property is accessed (which may or may not execute a query to the database, I'm not sure). ~~However, the tradeoff between helping users set a lower limit on the connection vs the performance implications doesn't seem worth it, considering how uncommon it is to do. Besides, if users really want to do so, they can always clear the `cached_property` before/after calling `setlimit()` to ensure the new limit is used.~~

Edit: apparently the `getlimit()` function is quite efficient, so I've changed the implementation to use `property` instead of `cached_property`: https://github.com/django/django/pull/19427#discussion_r2062729205

~~I'm not super confident about the tests, in particular how they need to dig into the internals of the implementation a bit, e.g. with how `bulk_batch_size()` is called for `bulk_update()`.~~

Edit: I've removed the SQLite-specific `bulk_update()` and `bulk_insert()` tests to instead rely on the `max_query_params`/`bulk_batch_size` abstractions.

#### Experiments

I made an experiment in https://github.com/laymonage/django-sqlite-bulk-optimization to showcase an example of a performance optimization as a result of this change. Right now there's only [one test](https://github.com/laymonage/django-sqlite-bulk-optimization/blob/358e6ce2c48145d829621c5f830d376c10144563/app/tests.py#L16-L18): doing a `bulk_create()` for 4096 instances of a model with two fields (three including PK) originally took 9 queries `ceil(2 * 4096/999)` with the hardcoded `999` parameter limit. Now, it only takes one query (with the default limit set by Ubuntu's SQLite compilation flags, which is 250000 on both [Debian](https://sources.debian.org/src/sqlite3/3.46.1-3/debian/rules/#L62) and [Ubuntu](https://git.launchpad.net/ubuntu/+source/sqlite3/tree/debian/rules?h=applied/ubuntu/focal#n47))

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
