### PR TITLE
Fixed #34746 -- Add a size limit for variable size when pretty printing e…

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -517,6 +517,7 @@ answer newbie questions, and generally made Django that much better:
     Jim Dalton <jim.dalton@gmail.com>
     Jimmy Song <jaejoon@gmail.com>
     Jiri Barton
+    Jitesh Nair <ja8zyjits@gmail.com>
     Joachim Jablon <ewjoachim@gmail.com>
     Joao Oliveira <joaoxsouls@gmail.com>
     Joao Pedro Silva <j.pedro004@gmail.com>
@@ -589,6 +590,7 @@ answer newbie questions, and generally made Django that much better:
     Katherine “Kati” Michel <kthrnmichel@gmail.com>
     Kathryn Killebrew <kathryn.killebrew@gmail.com>
     Katie Miller <katie@sub50.com>
+    Keerthi Vasan S A <keerthivasansa@outlook.com>
     Keith Bussell <kbussell@gmail.com>
     Kenneth Love <kennethlove@gmail.com>
     Kent Hauser <kent@khauser.net>

--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -7,7 +7,6 @@ from decimal import ROUND_HALF_UP, Context, Decimal, InvalidOperation, getcontex
 from functools import wraps
 from inspect import unwrap
 from operator import itemgetter
-from pprint import pformat
 from urllib.parse import quote
 
 from django.utils import formats
@@ -18,7 +17,7 @@ from django.utils.html import json_script as _json_script
 from django.utils.html import linebreaks, strip_tags
 from django.utils.html import urlize as _urlize
 from django.utils.safestring import SafeData, mark_safe
-from django.utils.text import Truncator, normalize_newlines, phone2numeric
+from django.utils.text import DebugRepr, Truncator, normalize_newlines, phone2numeric
 from django.utils.text import slugify as _slugify
 from django.utils.text import wrap
 from django.utils.timesince import timesince, timeuntil
@@ -28,6 +27,10 @@ from .base import VARIABLE_ATTRIBUTE_SEPARATOR
 from .library import Library
 
 register = Library()
+
+# The number of characters that will be printed
+# before trimming while printing an exception in reports.
+EXCEPTION_PRINT_LIMIT = 4096
 
 
 #######################
@@ -984,8 +987,13 @@ def phone2numeric_filter(value):
 
 @register.filter(is_safe=True)
 def pprint(value):
-    """A wrapper around pprint.pprint -- for debugging, really."""
+    """A wrapper with custom Repr implementation for debugging."""
+    repr_instance = DebugRepr(limit=EXCEPTION_PRINT_LIMIT)
+
     try:
-        return pformat(value)
+        value = repr_instance.repr(value)
+
     except Exception as e:
-        return "Error in formatting: %s: %s" % (e.__class__.__name__, e)
+        value = "Error in formatting: %s: %s" % (e.__class__.__name__, e)
+
+    return value

--- a/django/utils/text.py
+++ b/django/utils/text.py
@@ -1,3 +1,4 @@
+import builtins
 import gzip
 import re
 import secrets
@@ -9,6 +10,7 @@ from gzip import compress as gzip_compress
 from html import escape
 from html.parser import HTMLParser
 from io import BytesIO
+from itertools import islice
 
 from django.core.exceptions import SuspiciousFileOperation
 from django.utils.functional import (
@@ -486,3 +488,150 @@ def _format_lazy(format_string, *args, **kwargs):
 
 
 format_lazy = lazy(_format_lazy, str)
+
+
+class DebugRepr:
+    """
+    Modified Reprlib.Repr from Python 3.12 that includes fillvalue customization.
+    """
+
+    def __init__(self, limit):
+        self.indent = 0
+        self.maxlevel = 2
+        self.limit = limit
+
+    def repr(self, x):
+        return self.repr1(x, self.maxlevel)
+
+    def repr1(self, x, level):
+        typename = type(x).__name__
+        if " " in typename:
+            parts = typename.split()
+            typename = "_".join(parts)
+        if hasattr(self, "repr_" + typename):
+            return getattr(self, "repr_" + typename)(x, level)
+        else:
+            return self.repr_instance(x, level)
+
+    def _join(self, pieces, level):
+        if self.indent is None:
+            return ", ".join(pieces)
+        if not pieces:
+            return ""
+        indent = self.indent
+        if isinstance(indent, int):
+            if indent < 0:
+                raise ValueError(f"Repr.indent cannot be negative int (was {indent!r})")
+            indent *= " "
+        try:
+            sep = ", " + (self.maxlevel - level + 1) * indent
+        except TypeError as error:
+            raise TypeError(
+                f"Repr.indent must be a str, int or None, not {type(indent)}"
+            ) from error
+        return sep.join(("", *pieces))[1 : -len(indent) or None]
+
+    def _repr_iterable(self, x, level, left, right, maxiter, trail=""):
+        n = len(x)
+        fillvalue = self.gen_trim_msg(n)
+        if level <= 0 and n:
+            s = fillvalue
+        else:
+            newlevel = level - 1
+            repr1 = self.repr1
+            pieces = [repr1(elem, newlevel) for elem in islice(x, maxiter)]
+            if n > maxiter:
+                pieces.append(fillvalue)
+            s = self._join(pieces, level)
+            if n == 1 and trail and self.indent is None:
+                right = trail + right
+        return "%s%s%s" % (left, s, right)
+
+    def repr_tuple(self, x, level):
+        return self._repr_iterable(x, level, "(", ")", self.limit, ",")
+
+    def repr_list(self, x, level):
+        return self._repr_iterable(x, level, "[", "]", self.limit)
+
+    def repr_array(self, x, level):
+        if not x:
+            return "array('%s')" % x.typecode
+        header = "array('%s', [" % x.typecode
+        return self._repr_iterable(x, level, header, "])", self.limit)
+
+    def repr_set(self, x, level):
+        if not x:
+            return "set()"
+        x = _possibly_sorted(x)
+        return self._repr_iterable(x, level, "{", "}", self.limit)
+
+    def repr_frozenset(self, x, level):
+        if not x:
+            return "frozenset()"
+        x = _possibly_sorted(x)
+        return self._repr_iterable(x, level, "frozenset({", "})", self.limit)
+
+    def repr_deque(self, x, level):
+        return self._repr_iterable(x, level, "deque([", "])", self.limit)
+
+    def repr_dict(self, x, level):
+        n = len(x)
+        if n == 0:
+            return "{}"
+        fillvalue = self.gen_trim_msg(n)
+        if level <= 0:
+            return "{" + fillvalue + "}"
+        newlevel = level - 1
+        repr1 = self.repr1
+        pieces = []
+        for key in islice(_possibly_sorted(x), self.limit):
+            keyrepr = repr1(key, newlevel)
+            valrepr = repr1(x[key], newlevel)
+            pieces.append("%s: %s" % (keyrepr, valrepr))
+        if n > self.limit:
+            pieces.append(fillvalue)
+        s = self._join(pieces, level)
+        return "{%s}" % (s,)
+
+    def repr_int(self, x, level):
+        s = builtins.repr(x)
+        if len(s) > self.limit:
+            i = max(0, (self.limit - 3) // 2)
+            j = max(0, self.limit - 3 - i)
+            s = s[:i] + self.limit + s[len(s) - j :]
+        return s
+
+    def repr_instance(self, x, level):
+        try:
+            s = builtins.repr(x)
+            # Bugs in x.__repr__() can cause arbitrary
+            # exceptions -- then make up something
+        except Exception:
+            return "<%s instance at %#x>" % (x.__class__.__name__, id(x))
+        if len(s) > self.limit:
+            i = max(0, (self.limit - 3) // 2)
+            j = max(0, self.limit - 3 - i)
+            fillvalue = self.gen_trim_msg(len(s))
+            s = s[:i] + fillvalue + s[len(s) - j :]
+        return s
+
+    def repr_str(self, x, level):
+        return "'%s'" % (x[: self.limit] + self.gen_trim_msg(len(x)))
+
+    def print(self, value):
+        return self.repr(value)
+
+    def gen_trim_msg(self, length):
+        if length <= self.limit:
+            return ""
+        return "...<trimmed %d bytes string> " % (length - self.limit)
+
+
+def _possibly_sorted(x):
+    # Since not all sequences of items can be sorted and comparison
+    # functions may raise arbitrary exceptions, return an unsorted
+    # sequence in that case.
+    try:
+        return sorted(x)
+    except Exception:
+        return list(x)

--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -353,9 +353,6 @@ class ExceptionReporter:
                 frame_vars = []
                 for k, v in frame["vars"]:
                     v = pprint(v)
-                    # Trim large blobs of data
-                    if len(v) > 4096:
-                        v = "%s… <trimmed %d bytes string>" % (v[0:4096], len(v))
                     frame_vars.append((k, v))
                 frame["vars"] = frame_vars
             frames[i] = frame

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -18,12 +18,14 @@ from django.http import Http404, HttpRequest, HttpResponse
 from django.shortcuts import render
 from django.template import TemplateDoesNotExist
 from django.test import RequestFactory, SimpleTestCase, override_settings
+from django.template.defaultfilters import EXCEPTION_PRINT_LIMIT
 from django.test.utils import LoggingCaptureMixin
 from django.urls import path, reverse
 from django.urls.converters import IntConverter
 from django.utils.functional import SimpleLazyObject
 from django.utils.regex_helper import _lazy_re_compile
 from django.utils.safestring import mark_safe
+from django.utils.text import DebugRepr
 from django.views.debug import (
     CallableSettingWrapper,
     ExceptionCycleWarning,
@@ -1087,9 +1089,50 @@ class ExceptionReporterTests(SimpleTestCase):
         reporter = ExceptionReporter(None, exc_type, exc_value, tb)
         html = reporter.get_traceback_html()
         self.assertEqual(len(html) // 1024 // 128, 0)  # still fit in 128Kb
-        self.assertIn(
-            "&lt;trimmed %d bytes string&gt;" % (large + repr_of_str_adds,), html
+        trim_msg = "&lt;trimmed %d bytes string&gt;" % (
+            large - EXCEPTION_PRINT_LIMIT + repr_of_str_adds,
         )
+        self.assertIn(trim_msg, html)
+
+    def test_large_sizable_object(self):
+        """Large objects should not be rendered entirely"""
+        lg = list(range(1000 * 1000))
+        try:
+            lg["a"]
+        except TypeError:
+            exc_type, exc_value, tb = sys.exc_info()
+
+        reporter = ExceptionReporter(None, exc_type, exc_value, tb)
+        d = reporter.get_traceback_data()
+        vars = d["lastframe"]["vars"]
+
+        for k, v in vars:
+            if k == "lg":
+                i = v.index("...")
+
+                # Construct list with elements before trimming
+                ls = eval(v[:i] + "]")
+
+                # Check if length of trimmed list is our limit
+                self.assertEqual(len(ls), EXCEPTION_PRINT_LIMIT)
+                break
+
+    def test_non_sizable_object(self):
+        """Non-sizable variables be handled with builtin repr"""
+        num = 10000000
+        try:
+            num["a"]
+        except TypeError:
+            exc_type, exc_value, tb = sys.exc_info()
+
+        reporter = ExceptionReporter(None, exc_type, exc_value, tb)
+        d = reporter.get_traceback_data()
+        vars = d["lastframe"]["vars"]
+
+        for k, v in vars:
+            if k == "a":
+                self.assertEqual(v, str(num))
+                break
 
     def test_encoding_error(self):
         """
@@ -1244,6 +1287,40 @@ class ExceptionReporterTests(SimpleTestCase):
                 request = factory.get(url)
                 reporter = ExceptionReporter(request, None, None, None)
                 self.assertEqual(reporter._get_raw_insecure_uri(), expected)
+
+
+class DebugReprTests(SimpleTestCase):
+
+    limit_overflow = EXCEPTION_PRINT_LIMIT + 100
+    repr_instance = DebugRepr(limit=EXCEPTION_PRINT_LIMIT)
+
+    def test_string_trim(self):
+        """A string longer than limit is trimmed"""
+        long_str = "A" * self.limit_overflow
+        trimmed_str = self.repr_instance.print(long_str)
+        self.assertIn("trimmed 100 bytes string", trimmed_str)
+
+    def test_list_trim(self):
+        """A list longer than limit is trimmed"""
+        long_list = ["A"] * self.limit_overflow
+        trimmed_list = self.repr_instance.print(long_list)
+        self.assertIn("trimmed 100 bytes string", trimmed_list)
+
+    def test_set_trim(self):
+        """A set with elements more than limit is trimmed"""
+        long_set = set()
+        for i in range(self.limit_overflow):
+            long_set.add(i)
+        trimmed_set = self.repr_instance.print(long_set)
+        self.assertIn("trimmed 100 bytes string", trimmed_set)
+
+    def test_dict_trim(self):
+        """A dictionary with keys more than limit is trimmed"""
+        long_dict = {}
+        for i in range(self.limit_overflow):
+            long_dict[i] = 1
+        trimmed_dict = self.repr_instance.print(long_dict)
+        self.assertIn("trimmed 100 bytes string", trimmed_dict)
 
 
 class PlainTextReportTests(SimpleTestCase):


### PR DESCRIPTION
…xception report

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-34746

#### Branch description

 Fixed #34746  --  Add a size limit for variable size when pretty printing exception report
Thanks to  @keerthivasansa https://github.com/keerthivasansa for their pull request https://github.com/django/django/pull/17809

Since Django 6.x Python3.12 is the oldest version and hence the issue of difference of  behavior of https://docs.python.org/3/library/reprlib.html between python3.10 and python3.11 doesnt exist here.

https://github.com/django/django/pull/17809 PR

#### Checklist
- [ ] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
