### PR TITLE
Fixed #36358 -- Fixed composite integer primary key introspection on SQLite.

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -287,10 +287,6 @@ class BaseDatabaseFeatures:
     create_test_procedure_without_params_sql = None
     create_test_procedure_with_int_param_sql = None
 
-    # SQL to create a table with a composite primary key for use by the Django
-    # test suite.
-    create_test_table_with_composite_primary_key = None
-
     # Does the backend support keyword parameters for cursor.callproc()?
     supports_callproc_kwargs = False
 

--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -44,13 +44,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             SET V_I = P_I;
         END;
     """
-    create_test_table_with_composite_primary_key = """
-        CREATE TABLE test_table_composite_pk (
-            column_1 INTEGER NOT NULL,
-            column_2 INTEGER NOT NULL,
-            PRIMARY KEY(column_1, column_2)
-        )
-    """
     # Neither MySQL nor MariaDB support partial indexes.
     supports_partial_indexes = False
     # COLLATE must be wrapped in parentheses because MySQL treats COLLATE as an

--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -60,13 +60,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             V_I := P_I;
         END;
     """
-    create_test_table_with_composite_primary_key = """
-        CREATE TABLE test_table_composite_pk (
-            column_1 NUMBER(11) NOT NULL,
-            column_2 NUMBER(11) NOT NULL,
-            PRIMARY KEY (column_1, column_2)
-        )
-    """
     supports_callproc_kwargs = True
     supports_over_clause = True
     supports_frame_range_fixed_distance = True

--- a/django/db/backends/postgresql/features.py
+++ b/django/db/backends/postgresql/features.py
@@ -52,13 +52,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             V_I := P_I;
         END;
     $$ LANGUAGE plpgsql;"""
-    create_test_table_with_composite_primary_key = """
-        CREATE TABLE test_table_composite_pk (
-            column_1 INTEGER NOT NULL,
-            column_2 INTEGER NOT NULL,
-            PRIMARY KEY(column_1, column_2)
-        )
-    """
     requires_casted_case_in_updates = True
     supports_over_clause = True
     supports_frame_exclusion = True

--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -53,13 +53,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         # Date/DateTime fields and timedeltas.
         "expressions.tests.FTimeDeltaTests.test_mixed_comparisons1",
     }
-    create_test_table_with_composite_primary_key = """
-        CREATE TABLE test_table_composite_pk (
-            column_1 INTEGER NOT NULL,
-            column_2 INTEGER NOT NULL,
-            PRIMARY KEY(column_1, column_2)
-        )
-    """
     insert_test_table_with_defaults = 'INSERT INTO {} ("null") VALUES (1)'
     supports_default_keyword_in_insert = False
     supports_unlimited_charfield = True

--- a/docs/releases/5.2.1.txt
+++ b/docs/releases/5.2.1.txt
@@ -55,3 +55,7 @@ Bugfixes
 * Fixed a regression in Django 5.2 that caused a crash when using ``update()``
   on a ``QuerySet`` filtered against a related model and including references
   to annotations through ``values()`` (:ticket:`36360`).
+
+* Fixed a bug in composite primary key introspection that caused
+  ``IntegerField`` to be wrongly identified as ``AutoField`` on SQLite
+  (:ticket:`36358`).

--- a/tests/inspectdb/models.py
+++ b/tests/inspectdb/models.py
@@ -155,3 +155,9 @@ class DbComment(models.Model):
     class Meta:
         db_table_comment = "Custom table comment"
         required_db_features = {"supports_comments"}
+
+
+class CompositePrimaryKeyModel(models.Model):
+    pk = models.CompositePrimaryKey("column_1", "column_2")
+    column_1 = models.IntegerField()
+    column_2 = models.IntegerField()

--- a/tests/inspectdb/tests.py
+++ b/tests/inspectdb/tests.py
@@ -628,10 +628,7 @@ class InspectDBTransactionalTests(TransactionTestCase):
 
     def test_composite_primary_key(self):
         out = StringIO()
-        if connection.vendor == "sqlite":
-            field_type = connection.features.introspected_field_types["AutoField"]
-        else:
-            field_type = connection.features.introspected_field_types["IntegerField"]
+        field_type = connection.features.introspected_field_types["IntegerField"]
         call_command("inspectdb", "inspectdb_compositeprimarykeymodel", stdout=out)
         output = out.getvalue()
         self.assertIn(
@@ -639,8 +636,4 @@ class InspectDBTransactionalTests(TransactionTestCase):
             output,
         )
         self.assertIn(f"column_1 = models.{field_type}()", output)
-        self.assertIn(
-            "column_2 = models.%s()"
-            % connection.features.introspected_field_types["IntegerField"],
-            output,
-        )
+        self.assertIn(f"column_2 = models.{field_type}()", output)

--- a/tests/inspectdb/tests.py
+++ b/tests/inspectdb/tests.py
@@ -626,17 +626,13 @@ class InspectDBTransactionalTests(TransactionTestCase):
         self.assertIn(foreign_table_model, output)
         self.assertIn(foreign_table_managed, output)
 
-    @skipUnlessDBFeature("create_test_table_with_composite_primary_key")
     def test_composite_primary_key(self):
-        table_name = "test_table_composite_pk"
-        cursor_execute(connection.features.create_test_table_with_composite_primary_key)
-        self.addCleanup(cursor_execute, "DROP TABLE %s" % table_name)
         out = StringIO()
         if connection.vendor == "sqlite":
             field_type = connection.features.introspected_field_types["AutoField"]
         else:
             field_type = connection.features.introspected_field_types["IntegerField"]
-        call_command("inspectdb", table_name, stdout=out)
+        call_command("inspectdb", "inspectdb_compositeprimarykeymodel", stdout=out)
         output = out.getvalue()
         self.assertIn(
             "pk = models.CompositePrimaryKey('column_1', 'column_2')",


### PR DESCRIPTION
#### Trac ticket number

ticket-36358

#### Branch description

The previous logic was wrongly assuming that the integer first member of a composite primary key was always an `AutoField`.