### PR TITLE
Fixed #36360 -- Fixed a queryset update() crash when using values() with annotations.

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1250,8 +1250,9 @@ class QuerySet(AltersData):
                 new_order_by.append(col)
         query.order_by = tuple(new_order_by)
 
-        # Clear any annotations so that they won't be present in subqueries.
-        query.annotations = {}
+        # Clear SELECT clause as all annotation references were inlined by
+        # add_update_values() already.
+        query.clear_select_clause()
         with transaction.mark_for_rollback_on_error(using=self.db):
             rows = query.get_compiler(self.db).execute_sql(ROW_COUNT)
         self._result_cache = None

--- a/docs/releases/5.2.1.txt
+++ b/docs/releases/5.2.1.txt
@@ -51,3 +51,7 @@ Bugfixes
 
 * Fixed a regression in Django 5.2 that caused a crash when serializing email
   alternatives or attachments due to named tuple mismatches (:ticket:`36309`).
+
+* Fixed a regression in Django 5.2 that caused a crash when using ``update()``
+  on a ``QuerySet`` filtered against a related model and including references
+  to annotations through ``values()`` (:ticket:`36360`).

--- a/tests/update/tests.py
+++ b/tests/update/tests.py
@@ -256,6 +256,13 @@ class AdvancedTests(TestCase):
         Bar.objects.annotate(abs_id=Abs("m2m_foo")).order_by("-abs_id").update(x=4)
         self.assertEqual(Bar.objects.get().x, 4)
 
+    def test_update_values_annotation(self):
+        RelatedPoint.objects.annotate(abs_id=Abs("id")).filter(
+            data__is_active=False
+        ).values("id", "abs_id").update(data=self.d0)
+        self.r1.refresh_from_db(fields=["data"])
+        self.assertEqual(self.r1.data, self.d0)
+
     def test_update_negated_f(self):
         DataPoint.objects.update(is_active=~F("is_active"))
         self.assertCountEqual(

--- a/tests/update/tests.py
+++ b/tests/update/tests.py
@@ -25,8 +25,8 @@ class SimpleTest(TestCase):
     def setUpTestData(cls):
         cls.a1 = A.objects.create()
         cls.a2 = A.objects.create()
+        B.objects.bulk_create(B(a=cls.a1) for _ in range(20))
         for x in range(20):
-            B.objects.create(a=cls.a1)
             D.objects.create(a=cls.a1)
 
     def test_nonempty_update(self):
@@ -292,8 +292,9 @@ class MySQLUpdateOrderByTest(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        UniqueNumber.objects.create(number=1)
-        UniqueNumber.objects.create(number=2)
+        UniqueNumber.objects.bulk_create(
+            [UniqueNumber(number=1), UniqueNumber(number=2)]
+        )
 
     def test_order_by_update_on_unique_constraint(self):
         tests = [


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36360

#### Branch description

Refs ticket-28900

Regression in 65ad4ade74dc9208b9d686a451cd6045df0c9c3a.

Thanks @gav-fyi for the detailed report.
