### PR TITLE
Fixed flakiness in file_storage.tests.CustomStorageTests.test_file_get_accessed_time.

### DIFF
--- a/tests/file_storage/tests.py
+++ b/tests/file_storage/tests.py
@@ -188,11 +188,12 @@ class FileStorageTests(SimpleTestCase):
         self.addCleanup(self.storage.delete, f_name)
         atime = self.storage.get_accessed_time(f_name)
 
-        self.assertEqual(
-            atime,
-            datetime.datetime.fromtimestamp(
+        self.assertLess(
+            atime
+            - datetime.datetime.fromtimestamp(
                 os.path.getatime(self.storage.path(f_name))
             ),
+            datetime.timedelta(seconds=1),
         )
         self.assertLess(
             timezone.now() - self.storage.get_accessed_time(f_name),


### PR DESCRIPTION
#### Trac ticket number

N/A

#### Branch description

Two separate calls to look up access time can result in sub-second differences which cause the test to fail.

When running the full test suite locally, this is consistently failing for me.

#### Checklist

- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.