### PR TITLE
Docs: Add test suite tip to contributing guide

### DIFF
--- a/docs/internals/contributing/committing-code.txt
+++ b/docs/internals/contributing/committing-code.txt
@@ -205,6 +205,8 @@ Django's Git repository:
 
   (use the commit hash where the regression was introduced).
 
+  Tip: After installing the requirements from ``requirements/py3.txt``, you can run the full test suite using ``python tests/runtests.py``.
+
 Reverting commits
 =================
 


### PR DESCRIPTION
#### Trac ticket number
N/A

#### Branch description
This PR adds a useful tip at the end of the contributing guide to help new contributors run Django's test suite locally:

``Tip: After installing the requirements from ``requirements/py3.txt``, you can run the full test suite using ``python tests/runtests.py``.``

It improves onboarding clarity for first-time contributors.

#### Checklist
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense and ends with a period.
- [x] I have added or updated relevant docs, including release notes if applicable.