### PR TITLE
Refs #36052, #32234 -- Fixed inspectdb tests for CompositePrimaryKey on Oracle.

### DIFF
--- a/tests/inspectdb/models.py
+++ b/tests/inspectdb/models.py
@@ -157,7 +157,7 @@ class DbComment(models.Model):
         required_db_features = {"supports_comments"}
 
 
-class CompositePrimaryKeyModel(models.Model):
+class CompositePKModel(models.Model):
     pk = models.CompositePrimaryKey("column_1", "column_2")
     column_1 = models.IntegerField()
     column_2 = models.IntegerField()

--- a/tests/inspectdb/tests.py
+++ b/tests/inspectdb/tests.py
@@ -629,7 +629,7 @@ class InspectDBTransactionalTests(TransactionTestCase):
     def test_composite_primary_key(self):
         out = StringIO()
         field_type = connection.features.introspected_field_types["IntegerField"]
-        call_command("inspectdb", "inspectdb_compositeprimarykeymodel", stdout=out)
+        call_command("inspectdb", "inspectdb_compositepkmodel", stdout=out)
         output = out.getvalue()
         self.assertIn(
             "pk = models.CompositePrimaryKey('column_1', 'column_2')",
@@ -640,5 +640,5 @@ class InspectDBTransactionalTests(TransactionTestCase):
 
     def test_composite_primary_key_not_unique_together(self):
         out = StringIO()
-        call_command("inspectdb", "inspectdb_compositeprimarykeymodel", stdout=out)
+        call_command("inspectdb", "inspectdb_compositepkmodel", stdout=out)
         self.assertNotIn("unique_together", out.getvalue())


### PR DESCRIPTION
Table name had more than 30 characters.

Tests regression in 4c75858135589f3a00e32eb4d476074536371a32.

```
./runtests.py inspectdb.tests
Testing against Django installed in '/home/felixx/repo/django/django' with up to 8 processes
Found 27 test(s).
Creating test database for alias 'default'...
Creating test user...
System check identified no issues (2 silenced).
..ss...............s.sFs.s.
======================================================================
FAIL: test_composite_primary_key (inspectdb.tests.InspectDBTransactionalTests.test_composite_primary_key)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/workspace/django-oracle/database/oracle19/label/oracle/python/python3.13/tests/inspectdb/tests.py", line 634, in test_composite_primary_key
    self.assertIn(
    ~~~~~~~~~~~~~^
        "pk = models.CompositePrimaryKey('column_1', 'column_2')",
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        output,
        ^^^^^^^
    )
    ^
AssertionError: "pk = models.CompositePrimaryKey('column_1', 'column_2')" not found in "# This is an auto-generated Django model module.\n# You'll have to do the following manually to clean this up:\n#   * Rearrange models' order\n#   * Make sure each model has one field with primary_key=True\n#   * Make sure each ForeignKey and OneToOneField has `on_delete` set to the desired behavior\n#   * Remove `managed = False` lines if you wish to allow Django to create, modify, and delete the table\n# Feel free to rename the models, but don't rename db_table values or field names.\nfrom django.db import models\n# Unable to inspect table 'inspectdb_compositeprimarykeymodel'\n# The error was: 'COLUMN_1'\n"

----------------------------------------------------------------------
Ran 27 tests in 5.123s

FAILED (failures=1, skipped=6)
Destroying test database for alias 'default'...
Destroying test user...
Destroying test database tables...
```