### PR TITLE
Fixed #33312 -- Raised explicit exception when copying deferred model instances.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -859,6 +859,7 @@ class Model(AltersData, metaclass=ModelBase):
             not force_insert
             and deferred_non_generated_fields
             and using == self._state.db
+            and self._is_pk_set()
         ):
             field_names = set()
             pk_fields = self._meta.pk_fields

--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -220,9 +220,10 @@ class DeferredAttribute:
             # might be able to reuse the already loaded value. Refs #18343.
             val = self._check_parent_chain(instance)
             if val is None:
-                if not instance._is_pk_set() and self.field.generated:
+                if not instance._is_pk_set():
                     raise AttributeError(
-                        "Cannot read a generated field from an unsaved model."
+                        f"Cannot retrieve deferred field {field_name!r} "
+                        "from an unsaved model."
                     )
                 instance.refresh_from_db(fields=[field_name])
             else:

--- a/docs/topics/db/queries.txt
+++ b/docs/topics/db/queries.txt
@@ -1590,6 +1590,21 @@ For example, assuming ``entry`` is already duplicated as above::
     detail.entry = entry
     detail.save()
 
+Note that it is not possible to copy instances of models with deferred fields
+using this pattern unless values are assigned to them:
+
+.. code-block:: pycon
+
+    >>> blog = Blog.objects.defer("name")[0]
+    >>> blog.pk = None
+    >>> blog._state.adding = True
+    >>> blog.save()
+    Traceback (most recent call last):
+        ...
+    AttributeError: Cannot retrieve deferred field 'name' from an unsaved model.
+    >>> blog.name = "Another Blog"
+    >>> blog.save()
+
 .. _topics-db-queries-update:
 
 Updating multiple objects at once

--- a/tests/model_fields/test_generatedfield.py
+++ b/tests/model_fields/test_generatedfield.py
@@ -180,7 +180,7 @@ class GeneratedFieldTestMixin:
 
     def test_unsaved_error(self):
         m = self.base_model(a=1, b=2)
-        msg = "Cannot read a generated field from an unsaved model."
+        msg = "Cannot retrieve deferred field 'field' from an unsaved model."
         with self.assertRaisesMessage(AttributeError, msg):
             m.field
 


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-33312

#### Branch description

Previously `save()` would crash with an attempted forced update message, and both `save(force_insert=True)` and `bulk_create()` would crash with `DoesNotExist` errors when trying to retrieve a row with `pk IS NULL`.

Implementing deferred field model instance copying might be doable in certain cases (e.g. when all the deferred fields are db generated) but that's not trivial to implement in a backward compatible way.

Thanks @adamsol for the report and test.
