### PR TITLE
Cleaned up CVE-2025-32873 security archive description.

### DIFF
--- a/docs/releases/security.txt
+++ b/docs/releases/security.txt
@@ -39,7 +39,7 @@ process. These are listed below.
 May 7, 2025 - :cve:`2025-32873`
 -------------------------------
 
-Denial-of-service possibility in `strip_tags()`.
+Denial-of-service possibility in ``strip_tags()``.
 `Full description
 <https://www.djangoproject.com/weblog/2025/may/07/security-releases/>`__
 


### PR DESCRIPTION
Missed while doing the security release.