### PR TITLE
Fixed #36368 -- Prevented duplicate locale paths and write_po_file calls in makemessages.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -739,6 +739,7 @@ answer newbie questions, and generally made Django that much better:
     Michal Chruszcz <troll@pld-linux.org>
     michal@plovarna.cz
     Michał Modzelewski <michal.modzelewski@gmail.com>
+    Michał Pokusa <https://github.com/michalpokusa>
     Mihai Damian <yang_damian@yahoo.com>
     Mihai Preda <mihai_preda@yahoo.com>
     Mikaël Barbero <mikael.barbero nospam at nospam free.fr>

--- a/django/core/management/commands/makemessages.py
+++ b/django/core/management/commands/makemessages.py
@@ -382,10 +382,15 @@ class Command(BaseCommand):
             self.invoked_for_django = True
         else:
             if self.settings_available:
-                self.locale_paths.extend(settings.LOCALE_PATHS)
+                for path in settings.LOCALE_PATHS:
+                    locale_path = os.path.abspath(path)
+                    if locale_path not in self.locale_paths:
+                        self.locale_paths.append(locale_path)
             # Allow to run makemessages inside an app dir
             if os.path.isdir("locale"):
-                self.locale_paths.append(os.path.abspath("locale"))
+                locale_path = os.path.abspath("locale")
+                if locale_path not in self.locale_paths:
+                    self.locale_paths.append(locale_path)
             if self.locale_paths:
                 self.default_locale_path = self.locale_paths[0]
                 os.makedirs(self.default_locale_path, exist_ok=True)
@@ -548,9 +553,10 @@ class Command(BaseCommand):
                         self.stdout.write("ignoring directory %s" % dirname)
                 elif dirname == "locale":
                     dirnames.remove(dirname)
-                    self.locale_paths.insert(
-                        0, os.path.join(os.path.abspath(dirpath), dirname)
-                    )
+                    locale_dir = os.path.join(os.path.abspath(dirpath), dirname)
+                    if locale_dir in self.locale_paths:
+                        self.locale_paths.remove(locale_dir)
+                    self.locale_paths.insert(0, locale_dir)
             for filename in filenames:
                 file_path = os.path.normpath(os.path.join(dirpath, filename))
                 file_ext = os.path.splitext(filename)[1]

--- a/tests/i18n/test_extraction.py
+++ b/tests/i18n/test_extraction.py
@@ -14,7 +14,10 @@ from django.core import management
 from django.core.management import execute_from_command_line
 from django.core.management.base import CommandError
 from django.core.management.commands.makemessages import Command as MakeMessagesCommand
-from django.core.management.commands.makemessages import write_pot_file
+from django.core.management.commands.makemessages import (
+    TranslatableFile,
+    write_pot_file,
+)
 from django.core.management.utils import find_command
 from django.test import SimpleTestCase, override_settings
 from django.test.utils import captured_stderr, captured_stdout
@@ -594,6 +597,79 @@ class BasicExtractorTests(ExtractorTests):
             pot_contents = fp.read()
             self.assertIn("Content-Type: text/plain; charset=UTF-8", pot_contents)
             self.assertIn("mañana; charset=CHARSET", pot_contents)
+
+    def test_no_duplicate_locale_paths(self):
+        for locale_paths in [
+            [],
+            [os.path.join(self.test_dir, "locale")],
+            [Path(self.test_dir, "locale")],
+        ]:
+            with self.subTest(locale_paths=locale_paths):
+                with override_settings(LOCALE_PATHS=locale_paths):
+                    cmd = MakeMessagesCommand()
+                    management.call_command(cmd, locale=["en", "ru"], verbosity=0)
+                    self.assertTrue(
+                        all(isinstance(path, str) for path in cmd.locale_paths)
+                    )
+                    self.assertEqual(len(cmd.locale_paths), len(set(cmd.locale_paths)))
+
+    def test_no_duplicate_write_po_file_calls(self):
+        with mock.patch.object(
+            MakeMessagesCommand, "write_po_file"
+        ) as mock_write_po_file:
+            cmd = MakeMessagesCommand()
+            management.call_command(cmd, locale=["en", "ru"], verbosity=0)
+            self.assertEqual(
+                len(mock_write_po_file.call_args_list),
+                len({call.args for call in mock_write_po_file.call_args_list}),
+            )
+
+    def test_correct_translatable_file_locale_dir(self):
+
+        class ReturnTrackingMock(mock.Mock):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.call_return_value_list = []
+
+            def __call__(self, *args, **kwargs):
+                value = super().__call__(*args, **kwargs)
+                self.call_return_value_list.append(value)
+                return value
+
+        for locale_paths in [
+            [],
+            [
+                os.path.join(self.test_dir, "app_with_locale", "locale"),
+            ],
+            [
+                os.path.join(self.test_dir, "locale"),
+                os.path.join(self.test_dir, "app_with_locale", "locale"),
+            ],
+        ]:
+            with self.subTest(locale_paths=locale_paths):
+                with override_settings(LOCALE_PATHS=locale_paths):
+                    cmd = MakeMessagesCommand()
+                    rtm = ReturnTrackingMock(wraps=cmd.find_files)
+
+                    with mock.patch.object(cmd, "find_files", new=rtm):
+                        management.call_command(cmd, locale=["en", "ru"], verbosity=0)
+                        self.assertEqual(len(rtm.call_args_list), 1)
+                        self.assertEqual(len(rtm.call_return_value_list), 1)
+
+                        for tf in rtm.call_return_value_list[0]:
+                            self.assertIsInstance(tf, TranslatableFile)
+                            abs_file_path = os.path.abspath(
+                                os.path.join(self.test_dir, tf.dirpath, tf.file)
+                            )
+                            max_common_path = max(
+                                [
+                                    os.path.commonpath([abs_file_path, locale_path])
+                                    for locale_path in cmd.locale_paths
+                                ],
+                                key=len,
+                            )
+                            correct_locale_dir = os.path.join(max_common_path, "locale")
+                            self.assertEqual(tf.locale_dir, correct_locale_dir)
 
 
 class JavaScriptExtractorTests(ExtractorTests):


### PR DESCRIPTION


#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36368

#### Branch description
In some cases the `makemessages` management command calls `write_po_file` method multiple times, due to duplicate locale paths and later duplicated potfile paths. This is caused by using `list`, which is necessary for preserving order, without checking if it already contains a path that is about to be added.

The above problem is solved by checking if given path is present in `self.locale_paths`, and adding it only if it is not, and in similar concept removing it before inserting it at a different position.

This alone is not enough as another case of duplicate locale paths could happen because paths are not converted to `str`, so if `settings.LOCALE_PATHS` contain a `Path` object, which is a common practise, the check would fail, and the same path could be present as `str` and `Path`. This is solved by explicitly converting all added locale paths to `str`.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
