### PR TITLE
Fixed #36366 -- accessibility improvements to the admin pagination area using aria attributes.

### DIFF
--- a/django/contrib/admin/templates/admin/object_history.html
+++ b/django/contrib/admin/templates/admin/object_history.html
@@ -34,20 +34,21 @@
         {% endfor %}
         </tbody>
     </table>
-    <p class="paginator">
+    <nav class="paginator" aria-labelledby="pagination">
+      <h2 id="pagination" class="visually-hidden">Pagination</h2>
       {% if pagination_required %}
         {% for i in page_range %}
           {% if i == action_list.paginator.ELLIPSIS %}
             {{ action_list.paginator.ELLIPSIS }}
           {% elif i == action_list.number %}
-            <span class="this-page">{{ i }}</span>
+            <span class="this-page" aria-current="page">{{ i }}</span>
           {% else %}
-            <a role="button" href="?{{ page_var }}={{ i }}" {% if i == action_list.paginator.num_pages %} class="end" {% endif %}>{{ i }}</a>
+            <a role="button" href="?{{ page_var }}={{ i }}" aria-label="page {{ i }}" {% if i == action_list.paginator.num_pages %} class="end" {% endif %}>{{ i }}</a>
           {% endif %}
         {% endfor %}
       {% endif %}
       {{ action_list.paginator.count }} {% blocktranslate count counter=action_list.paginator.count %}entry{% plural %}entries{% endblocktranslate %}
-    </p>
+    </nav>
 {% else %}
     <p>{% translate 'This object doesn’t have a change history. It probably wasn’t added via this admin site.' %}</p>
 {% endif %}

--- a/django/contrib/admin/templates/admin/pagination.html
+++ b/django/contrib/admin/templates/admin/pagination.html
@@ -1,6 +1,7 @@
 {% load admin_list %}
 {% load i18n %}
-<p class="paginator">
+<nav class="paginator" aria-labelledby="pagination">
+    <h2 id="pagination" class="visually-hidden">Pagination</h2>
 {% if pagination_required %}
 {% for i in page_range %}
     {% paginator_number cl i %}
@@ -9,4 +10,4 @@
 {{ cl.result_count }} {% if cl.result_count == 1 %}{{ cl.opts.verbose_name }}{% else %}{{ cl.opts.verbose_name_plural }}{% endif %}
 {% if show_all_url %}<a href="{{ show_all_url }}" class="showall">{% translate 'Show all' %}</a>{% endif %}
 {% if cl.formset and cl.result_count %}<input type="submit" name="_save" class="default" value="{% translate 'Save' %}">{% endif %}
-</p>
+</nav>

--- a/django/contrib/admin/templatetags/admin_list.py
+++ b/django/contrib/admin/templatetags/admin_list.py
@@ -42,11 +42,12 @@ def paginator_number(cl, i):
     if i == cl.paginator.ELLIPSIS:
         return format_html("{} ", cl.paginator.ELLIPSIS)
     elif i == cl.page_num:
-        return format_html('<span class="this-page">{}</span> ', i)
+        return format_html('<span class="this-page" aria-current="page">{}</span> ', i)
     else:
         return format_html(
-            '<a role="button" href="{}"{}>{}</a> ',
+            '<a role="button" href="{}" aria-label="page {}" {}>{}</a> ',
             cl.get_query_string({PAGE_VAR: i}),
+            i,
             mark_safe(' class="end"' if i == cl.paginator.num_pages else ""),
             i,
         )


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36366

#### Branch description
Using aria attributes, I added descriptive information for screen readers when accessing the admin pagination area and its elements.

---

####  when accessing the pagination area...
<img width="841" alt="Screenshot 2025-05-08 at 7 30 52 PM" src="https://github.com/user-attachments/assets/4f709d2a-63ee-4fa4-94d2-c79b55a6a734" />


#### when accessing the pagination button...

<img width="814" alt="Screenshot 2025-05-08 at 7 39 46 PM" src="https://github.com/user-attachments/assets/65b9afff-93aa-469e-9b3d-66a69ce7516d" />

screen reader user's can identify the currently active page using `aria-current`.

<img width="799" alt="Screenshot 2025-05-08 at 7 41 07 PM" src="https://github.com/user-attachments/assets/ee66c018-8e97-440b-979b-7098f73bf08e" />

By adding "Page XX" to the buttons within the pagination, we clarify that they are used to navigate between pages.


#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
