### PR TITLE
Fixed #29177: FKs accessible in subsequent migrations for unmanaged models

### DIFF
--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -149,7 +149,7 @@ class MigrationAutodetector:
         self.renamed_fields = {}
 
         # Prepare some old/new state and model lists, separating
-        # proxy models and ignoring unmigrated apps.
+        # proxy models and unmanaged models(for later usage?).
         self.old_model_keys = set()
         self.old_proxy_keys = set()
         self.old_unmanaged_keys = set()
@@ -242,14 +242,14 @@ class MigrationAutodetector:
         self.through_users = {}
         self.old_field_keys = {
             (app_label, model_name, field_name)
-            for app_label, model_name in self.kept_model_keys
+            for app_label, model_name in self.kept_model_keys | self.kept_unmanaged_keys
             for field_name in self.from_state.models[
                 app_label, self.renamed_models.get((app_label, model_name), model_name)
             ].fields
         }
         self.new_field_keys = {
             (app_label, model_name, field_name)
-            for app_label, model_name in self.kept_model_keys
+            for app_label, model_name in self.kept_model_keys | self.kept_unmanaged_keys
             for field_name in self.to_state.models[app_label, model_name].fields
         }
 
@@ -754,11 +754,6 @@ class MigrationAutodetector:
                 dependencies=dependencies,
                 beginning=True,
             )
-
-            # Don't add operations which modify the database for unmanaged
-            # models
-            if not model_state.options.get("managed", True):
-                continue
 
             # Generate operations for each related field
             for name, field in sorted(related_fields.items()):

--- a/tests/migrations/migrations_test_apps/unmanaged_model_with_fk/models.py
+++ b/tests/migrations/migrations_test_apps/unmanaged_model_with_fk/models.py
@@ -1,0 +1,13 @@
+from django.db import models
+
+
+class Foo(models.Model):
+    class Meta:
+        managed = True
+
+
+class Boo(models.Model):
+    foo = models.ForeignKey("Foo", on_delete=models.CASCADE)
+
+    class Meta:
+        managed = False

--- a/tests/migrations/test_autodetector_unmanaged.py
+++ b/tests/migrations/test_autodetector_unmanaged.py
@@ -27,8 +27,7 @@ class AutodetectorUnmanagedModelTest(MigrationTestBase, TransactionTestCase):
             call_command("makemigrations", "unmanaged_model_with_fk", verbosity=0)
             call_command("migrate", "unmanaged_model_with_fk", verbosity=0)
             with open(Path(tmp_dir) / "0002_custom.py", "w") as custom_migration_file:
-                custom_migration_content = textwrap.dedent(
-                    """
+                custom_migration_content = textwrap.dedent("""
                 from django.db import migrations
 
 
@@ -49,8 +48,7 @@ class AutodetectorUnmanagedModelTest(MigrationTestBase, TransactionTestCase):
                             reverse_code=migrations.RunPython.noop
                         ),
                     ]
-                """
-                )
+                """)
                 custom_migration_file.write(custom_migration_content)
             try:
                 call_command("migrate", "unmanaged_model_with_fk", stdout=out)
@@ -65,8 +63,7 @@ class AutodetectorUnmanagedModelTest(MigrationTestBase, TransactionTestCase):
     )
     def test_add_field_operation_is_detected(self):
         out = io.StringIO()
-        initial_migration_content = textwrap.dedent(
-            """
+        initial_migration_content = textwrap.dedent("""
             from django.db import migrations, models
 
 
@@ -113,8 +110,7 @@ class AutodetectorUnmanagedModelTest(MigrationTestBase, TransactionTestCase):
                         },
                     ),
                 ]
-            """
-        )
+            """)
         with self.temporary_migration_module("unmanaged_model_with_fk") as tmp_dir:
             with open(Path(tmp_dir) / "0001_initial.py", "w") as initial_migration_file:
                 initial_migration_file.write(initial_migration_content)
@@ -140,8 +136,7 @@ class AutodetectorUnmanagedModelTest(MigrationTestBase, TransactionTestCase):
     )
     def test_remove_field_operation_is_detected(self):
         out = io.StringIO()
-        initial_migration_content = textwrap.dedent(
-            """
+        initial_migration_content = textwrap.dedent("""
             from django.db import migrations, models
 
 
@@ -202,8 +197,7 @@ class AutodetectorUnmanagedModelTest(MigrationTestBase, TransactionTestCase):
                         },
                     ),
                 ]
-            """
-        )
+            """)
         with self.temporary_migration_module("unmanaged_model_with_fk") as tmp_dir:
             with open(Path(tmp_dir) / "0001_initial.py", "w") as initial_migration_file:
                 initial_migration_file.write(initial_migration_content)

--- a/tests/migrations/test_autodetector_unmanaged.py
+++ b/tests/migrations/test_autodetector_unmanaged.py
@@ -1,0 +1,228 @@
+import io
+import textwrap
+from pathlib import Path
+
+from migrations.test_base import MigrationTestBase
+
+from django.core.exceptions import FieldError
+from django.core.management import call_command
+from django.test import TransactionTestCase
+from django.test.utils import override_settings
+
+
+class AutodetectorUnmanagedModelTest(MigrationTestBase, TransactionTestCase):
+    """Regression test for bug #29177 in autodetector with
+    FK to managed=False model."""
+
+    # Consider also other cases to test, but the
+    # 'test_create_model_migrate_crashes_on_missing_fk' is the proove of a bug
+
+    @override_settings(
+        DEFAULT_AUTO_FIELD="django.db.models.AutoField",
+        INSTALLED_APPS=["migrations.migrations_test_apps.unmanaged_model_with_fk"],
+    )
+    def test_create_model_migrate_crashes_on_missing_fk(self):
+        out = io.StringIO()
+        with self.temporary_migration_module("unmanaged_model_with_fk") as tmp_dir:
+            call_command("makemigrations", "unmanaged_model_with_fk", verbosity=0)
+            call_command("migrate", "unmanaged_model_with_fk", verbosity=0)
+            with open(Path(tmp_dir) / "0002_custom.py", "w") as custom_migration_file:
+                custom_migration_content = textwrap.dedent(
+                    """
+                from django.db import migrations
+
+
+                def forwards_func(apps, schema_editor):
+                    klass_Boo = apps.get_model("unmanaged_model_with_fk", "Boo")
+                    klass_Boo.objects.filter(foo=1)
+
+
+                class Migration(migrations.Migration):
+
+                    dependencies = [
+                        ('unmanaged_model_with_fk', '0001_initial'),
+                    ]
+
+                    operations = [
+                        migrations.RunPython(
+                            forwards_func,
+                            reverse_code=migrations.RunPython.noop
+                        ),
+                    ]
+                """
+                )
+                custom_migration_file.write(custom_migration_content)
+            try:
+                call_command("migrate", "unmanaged_model_with_fk", stdout=out)
+            except FieldError:
+                # it can not find FK in managed=False model
+                pass
+            self.assertIn("OK", out.getvalue())
+
+    @override_settings(
+        DEFAULT_AUTO_FIELD="django.db.models.AutoField",
+        INSTALLED_APPS=["migrations.migrations_test_apps.unmanaged_model_with_fk"],
+    )
+    def test_add_field_operation_is_detected(self):
+        out = io.StringIO()
+        initial_migration_content = textwrap.dedent(
+            """
+            from django.db import migrations, models
+
+
+            class Migration(migrations.Migration):
+
+                initial = True
+
+                dependencies = [
+                ]
+
+                operations = [
+                    migrations.CreateModel(
+                        name='Foo',
+                        fields=[
+                            (
+                                'id',
+                                models.AutoField(
+                                    auto_created=True,
+                                    primary_key=True,
+                                    serialize=False,
+                                    verbose_name='ID'
+                                )
+                            ),
+                        ],
+                        options={
+                            'managed': True,
+                        },
+                    ),
+                    migrations.CreateModel(
+                        name='Boo',
+                        fields=[
+                            (
+                                'id',
+                                models.AutoField(
+                                    auto_created=True,
+                                    primary_key=True,
+                                    serialize=False,
+                                    verbose_name='ID'
+                                )
+                            ),
+                        ],
+                        options={
+                            'managed': False,
+                        },
+                    ),
+                ]
+            """
+        )
+        with self.temporary_migration_module("unmanaged_model_with_fk") as tmp_dir:
+            with open(Path(tmp_dir) / "0001_initial.py", "w") as initial_migration_file:
+                initial_migration_file.write(initial_migration_content)
+            call_command(
+                "makemigrations",
+                "unmanaged_model_with_fk",
+                dry_run=True,
+                verbosity=3,
+                stdout=out,
+            )
+        # explanation: currently as a side effect of a bug in #29177,
+        #              there is: "No changes detected in app...", but
+        #              AddField( ... name='foo' ...) should be there
+        migration_content = out.getvalue()
+        add_field_content = migration_content[migration_content.find("AddField") :]
+        add_field_content = add_field_content[: add_field_content.find(")") + 1]
+        self.assertIn("AddField", add_field_content)
+        self.assertIn("name='foo'", add_field_content)
+
+    @override_settings(
+        DEFAULT_AUTO_FIELD="django.db.models.AutoField",
+        INSTALLED_APPS=["migrations.migrations_test_apps.unmanaged_model_with_fk"],
+    )
+    def test_remove_field_operation_is_detected(self):
+        out = io.StringIO()
+        initial_migration_content = textwrap.dedent(
+            """
+            from django.db import migrations, models
+
+
+            class Migration(migrations.Migration):
+
+                initial = True
+
+                dependencies = [
+                ]
+
+                operations = [
+                    migrations.CreateModel(
+                        name='Foo',
+                        fields=[
+                            (
+                                'id',
+                                models.AutoField(
+                                    auto_created=True,
+                                    primary_key=True,
+                                    serialize=False,
+                                    verbose_name='ID'
+                                )
+                            ),
+                        ],
+                        options={
+                            'managed': True,
+                        },
+                    ),
+                    migrations.CreateModel(
+                        name='Boo',
+                        fields=[
+                            (
+                                'id',
+                                models.AutoField(
+                                    auto_created=True,
+                                    primary_key=True,
+                                    serialize=False,
+                                    verbose_name='ID'
+                                )
+                            ),
+                            (
+                                'foo',
+                                models.ForeignKey(
+                                    on_delete=models.deletion.CASCADE,
+                                    to='unmanaged_models.foo',
+                                )
+                            ),
+                            (
+                                'fk_foo',
+                                models.ForeignKey(
+                                    on_delete=models.deletion.CASCADE,
+                                    to='unmanaged_models.foo',
+                                )
+                            ),
+                        ],
+                        options={
+                            'managed': False,
+                        },
+                    ),
+                ]
+            """
+        )
+        with self.temporary_migration_module("unmanaged_model_with_fk") as tmp_dir:
+            with open(Path(tmp_dir) / "0001_initial.py", "w") as initial_migration_file:
+                initial_migration_file.write(initial_migration_content)
+            call_command(
+                "makemigrations",
+                "unmanaged_model_with_fk",
+                dry_run=True,
+                verbosity=3,
+                stdout=out,
+            )
+        # explanation: currently as a side effect of a bug in #29177,
+        #              there is: "No changes detected in app...", but
+        #              RemoveField( ... name='fk_foo' ...) should be there
+        migration_content = out.getvalue()
+        remove_field_content = migration_content[
+            migration_content.find("RemoveField") :
+        ]
+        remove_field_content = remove_field_content[
+            : remove_field_content.find(")") + 1
+        ]
+        self.assertIn("RemoveField", remove_field_content)
+        self.assertIn("name='fk_foo'", remove_field_content)


### PR DESCRIPTION
#### Work done
1. I added regression tests for the scenario described in ticket #29177 in the test_autodetector_unmanaged module.
2. I implemented a fix in django.db.migrations.autodetector.
3. Finally, I added also unittests for Autodetector covering problems with unmanaged models and foreign keys

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-29177

#### Branch description
Provide a concise overview of the issue or rationale behind the proposed changes.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
