### PR TITLE
Repairs translations for error message #36378

### DIFF
--- a/django/contrib/auth/password_validation.py
+++ b/django/contrib/auth/password_validation.py
@@ -113,14 +113,12 @@ class MinimumLengthValidator:
             )
 
     def get_error_message(self):
-        return (
-            ngettext(
-                "This password is too short. It must contain at least %d character.",
-                "This password is too short. It must contain at least %d characters.",
-                self.min_length,
-            )
-            % self.min_length
-        )
+        return ngettext(
+            "This password is too short. It must contain at least %(min_length)d character.",
+            "This password is too short. It must contain at least %(min_length)d characters.",
+            self.min_length,
+        ) % {"min_length": self.min_length}
+
 
     def get_help_text(self):
         return ngettext(

--- a/django/contrib/auth/password_validation.py
+++ b/django/contrib/auth/password_validation.py
@@ -114,11 +114,12 @@ class MinimumLengthValidator:
 
     def get_error_message(self):
         return ngettext(
-            "This password is too short. It must contain at least %(min_length)d character.",
-            "This password is too short. It must contain at least %(min_length)d characters.",
+            "This password is too short. "
+            "It must contain at least %(min_length)d character.",
+            "This password is too short. "
+            "It must contain at least %(min_length)d characters.",
             self.min_length,
         ) % {"min_length": self.min_length}
-
 
     def get_help_text(self):
         return ngettext(

--- a/tests/auth_tests/test_validators.py
+++ b/tests/auth_tests/test_validators.py
@@ -155,8 +155,8 @@ class MinimumLengthValidatorTest(SimpleTestCase):
         with self.subTest("get_error_message"):
             MinimumLengthValidator().get_error_message()
             mock_ngettext.assert_called_with(
-                "This password is too short. It must contain at least %d character.",
-                "This password is too short. It must contain at least %d characters.",
+                "This password is too short. It must contain at least %(min_length)d character.",
+                "This password is too short. It must contain at least %(min_length)d characters.",
                 8,
             )
         mock_ngettext.reset()

--- a/tests/auth_tests/test_validators.py
+++ b/tests/auth_tests/test_validators.py
@@ -155,16 +155,18 @@ class MinimumLengthValidatorTest(SimpleTestCase):
         with self.subTest("get_error_message"):
             MinimumLengthValidator().get_error_message()
             mock_ngettext.assert_called_with(
-                "This password is too short. It must contain at least %(min_length)d character.",
-                "This password is too short. It must contain at least %(min_length)d characters.",
+                "This password is too short. "
+                "It must contain at least %(min_length)d character.",
+                "This password is too short. "
+                "It must contain at least %(min_length)d characters.",
                 8,
             )
         mock_ngettext.reset()
         with self.subTest("get_help_text"):
             MinimumLengthValidator().get_help_text()
             mock_ngettext.assert_called_with(
-                "Your password must contain at least %(min_length)d " "character.",
-                "Your password must contain at least %(min_length)d " "characters.",
+                "Your password must contain at least %(min_length)d character.",
+                "Your password must contain at least %(min_length)d characters.",
                 8,
             )
 


### PR DESCRIPTION
#### Trac ticket number
ticket-36378

#### Branch description

The translation files did not match the code:
- The code in django.contrib.auth.password_validation.MinimumLengthValidator.get_error_message expects a digit: "This password is too short. It must contain at least %d characters."
- The translation file contains a named variable: "This password is too short. It must contain at least %(min_length)d characters."

This did not match, so the error message was not translated.

The tests do not need further updates, because there is one to verify that the method is called and another one to verify it handles the parameters correctly. The issue was that the connection between them did not match.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
