### PR TITLE
Refs #35784 -- Extended RedirectView to preserve the original HTTP method with status codes 307 and 308. 

### DIFF
--- a/django/views/generic/base.py
+++ b/django/views/generic/base.py
@@ -231,6 +231,7 @@ class RedirectView(View):
     """Provide a redirect on any GET request."""
 
     permanent = False
+    preserve_request = False
     url = None
     pattern_name = None
     query_string = False
@@ -257,9 +258,9 @@ class RedirectView(View):
         url = self.get_redirect_url(*args, **kwargs)
         if url:
             if self.permanent:
-                return HttpResponsePermanentRedirect(url)
+                return HttpResponsePermanentRedirect(url, preserve_request=self.preserve_request)
             else:
-                return HttpResponseRedirect(url)
+                return HttpResponseRedirect(url, preserve_request=self.preserve_request)
         else:
             logger.warning(
                 "Gone: %s", request.path, extra={"status_code": 410, "request": request}

--- a/docs/ref/class-based-views/base.txt
+++ b/docs/ref/class-based-views/base.txt
@@ -221,6 +221,7 @@ MRO is an acronym for Method Resolution Order.
 
         class ArticleCounterRedirectView(RedirectView):
             permanent = False
+            preserve_request = False
             query_string = True
             pattern_name = "article-detail"
 
@@ -268,6 +269,28 @@ MRO is an acronym for Method Resolution Order.
         the HTTP status code returned. If ``True``, then the redirect will use
         status code 301. If ``False``, then the redirect will use status code
         302. By default, ``permanent`` is ``False``.
+
+    .. attribute:: preserve_request
+
+       By default, a temporary redirect is issued with a 302 status code. If
+       ``permanent=True``, a permanent redirect is issued with a 301 status code.
+
+       If ``preserve_request=True``, the response instructs the user agent to
+       preserve the method and body of the original request when issuing the
+       redirect. In this case, temporary redirects use a 307 status code, and
+       permanent redirects use a 308 status code. This is better illustrated in the
+       following table:
+    
+       =========  ================ ================
+       permanent  preserve_request HTTP status code
+       =========  ================ ================
+       ``True``   ``False``        301
+       ``False``  ``False``        302
+       ``False``  ``True``         307
+       ``True``   ``True``         308
+       =========  ================ ================
+
+       By default, ``preserve_request`` is ``False``.
 
     .. attribute:: query_string
 


### PR DESCRIPTION
Analog to the [http shortcut redirect()](https://docs.djangoproject.com/en/5.2/topics/http/shortcuts/#redirect) also in the class-based view RedirectView the attribute preserve_request is useful in order to choose status code 301 or 308.

#### Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
