### PR TITLE
Fixed #36383 -- Improved migration serialization of partial objects.

### DIFF
--- a/django/db/migrations/serializer.py
+++ b/django/db/migrations/serializer.py
@@ -102,10 +102,20 @@ class DeconstructibleSerializer(BaseSerializer):
             arg_string, arg_imports = serializer_factory(arg).serialize()
             strings.append(arg_string)
             imports.update(arg_imports)
+        non_ident_kwargs = {}
         for kw, arg in sorted(kwargs.items()):
-            arg_string, arg_imports = serializer_factory(arg).serialize()
-            imports.update(arg_imports)
-            strings.append("%s=%s" % (kw, arg_string))
+            if kw.isidentifier():
+                arg_string, arg_imports = serializer_factory(arg).serialize()
+                imports.update(arg_imports)
+                strings.append("%s=%s" % (kw, arg_string))
+            else:
+                non_ident_kwargs[kw] = arg
+        if non_ident_kwargs:
+            # Serialize non-identifier keyword arguments as a dict.
+            kw_string, kw_imports = serializer_factory(non_ident_kwargs).serialize()
+            strings.append(f"**{kw_string}")
+            imports.update(kw_imports)
+
         return "%s(%s)" % (name, ", ".join(strings)), imports
 
     @staticmethod

--- a/django/db/migrations/serializer.py
+++ b/django/db/migrations/serializer.py
@@ -207,23 +207,11 @@ class FunctionTypeSerializer(BaseSerializer):
 
 class FunctoolsPartialSerializer(BaseSerializer):
     def serialize(self):
-        # Serialize functools.partial() arguments
-        func_string, func_imports = serializer_factory(self.value.func).serialize()
-        args_string, args_imports = serializer_factory(self.value.args).serialize()
-        keywords_string, keywords_imports = serializer_factory(
-            self.value.keywords
-        ).serialize()
-        # Add any imports needed by arguments
-        imports = {"import functools", *func_imports, *args_imports, *keywords_imports}
-        return (
-            "functools.%s(%s, *%s, **%s)"
-            % (
-                self.value.__class__.__name__,
-                func_string,
-                args_string,
-                keywords_string,
-            ),
-            imports,
+        partial_name = self.value.__class__.__name__
+        return DeconstructibleSerializer.serialize_deconstructed(
+            f"functools.{partial_name}",
+            (self.value.func, *self.value.args),
+            self.value.keywords,
         )
 
 

--- a/django/db/migrations/serializer.py
+++ b/django/db/migrations/serializer.py
@@ -93,10 +93,10 @@ class DecimalSerializer(BaseSerializer):
         return repr(self.value), {"from decimal import Decimal"}
 
 
-class DeconstructableSerializer(BaseSerializer):
+class DeconstructibleSerializer(BaseSerializer):
     @staticmethod
     def serialize_deconstructed(path, args, kwargs):
-        name, imports = DeconstructableSerializer._serialize_path(path)
+        name, imports = DeconstructibleSerializer._serialize_path(path)
         strings = []
         for arg in args:
             arg_string, arg_imports = serializer_factory(arg).serialize()
@@ -231,13 +231,13 @@ class IterableSerializer(BaseSerializer):
         return value % (", ".join(strings)), imports
 
 
-class ModelFieldSerializer(DeconstructableSerializer):
+class ModelFieldSerializer(DeconstructibleSerializer):
     def serialize(self):
         attr_name, path, args, kwargs = self.value.deconstruct()
         return self.serialize_deconstructed(path, args, kwargs)
 
 
-class ModelManagerSerializer(DeconstructableSerializer):
+class ModelManagerSerializer(DeconstructibleSerializer):
     def serialize(self):
         as_manager, manager_path, qs_path, args, kwargs = self.value.deconstruct()
         if as_manager:
@@ -397,7 +397,7 @@ def serializer_factory(value):
         return TypeSerializer(value)
     # Anything that knows how to deconstruct itself.
     if hasattr(value, "deconstruct"):
-        return DeconstructableSerializer(value)
+        return DeconstructibleSerializer(value)
     for type_, serializer_cls in Serializer._registry.items():
         if isinstance(value, type_):
             return serializer_cls(value)

--- a/docs/releases/6.0.txt
+++ b/docs/releases/6.0.txt
@@ -181,6 +181,9 @@ Migrations
 
 * Migrations now support serialization of :class:`zoneinfo.ZoneInfo` instances.
 
+* Serialization of deconstructible objects now supports keyword arguments with
+  names that are not valid Python identifiers.
+
 Models
 ~~~~~~
 

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -113,6 +113,7 @@ databrowse
 datafile
 datetimes
 declaratively
+deconstructible
 deduplicates
 deduplication
 deepcopy

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -300,6 +300,18 @@ class WriterTests(SimpleTestCase):
         self.assertEqual(value.null, new_value.null)
         self.assertEqual(value.unique, new_value.unique)
 
+    def assertSerializedFunctoolsPartialEqual(
+        self, value, expected_string, expected_imports
+    ):
+        string, imports = MigrationWriter.serialize(value)
+        self.assertEqual(string, expected_string)
+        self.assertEqual(imports, expected_imports)
+        result = self.serialize_round_trip(value)
+        self.assertEqual(result.func, value.func)
+        self.assertEqual(result.args, value.args)
+        self.assertEqual(result.keywords, value.keywords)
+        return result
+
     def test_serialize_numbers(self):
         self.assertSerializedEqual(1)
         self.assertSerializedEqual(1.2)
@@ -895,19 +907,59 @@ class WriterTests(SimpleTestCase):
         self.assertSerializedEqual(datetime.timedelta(minutes=42))
 
     def test_serialize_functools_partial(self):
+        value = functools.partial(datetime.timedelta)
+        string, imports = MigrationWriter.serialize(value)
+        self.assertSerializedFunctoolsPartialEqual(
+            value,
+            "functools.partial(datetime.timedelta, *(), **{})",
+            {"import datetime", "import functools"},
+        )
+
+    def test_serialize_functools_partial_posarg(self):
+        value = functools.partial(datetime.timedelta, 1)
+        string, imports = MigrationWriter.serialize(value)
+        self.assertSerializedFunctoolsPartialEqual(
+            value,
+            "functools.partial(datetime.timedelta, *(1,), **{})",
+            {"import datetime", "import functools"},
+        )
+
+    def test_serialize_functools_partial_kwarg(self):
+        value = functools.partial(datetime.timedelta, seconds=2)
+        string, imports = MigrationWriter.serialize(value)
+        self.assertSerializedFunctoolsPartialEqual(
+            value,
+            "functools.partial(datetime.timedelta, *(), **{'seconds': 2})",
+            {"import datetime", "import functools"},
+        )
+
+    def test_serialize_functools_partial_mixed(self):
         value = functools.partial(datetime.timedelta, 1, seconds=2)
-        result = self.serialize_round_trip(value)
-        self.assertEqual(result.func, value.func)
-        self.assertEqual(result.args, value.args)
-        self.assertEqual(result.keywords, value.keywords)
+        string, imports = MigrationWriter.serialize(value)
+        self.assertSerializedFunctoolsPartialEqual(
+            value,
+            "functools.partial(datetime.timedelta, *(1,), **{'seconds': 2})",
+            {"import datetime", "import functools"},
+        )
+
+    def test_serialize_functools_partial_non_identifier_keyword(self):
+        value = functools.partial(datetime.timedelta, **{"kebab-case": 1})
+        string, imports = MigrationWriter.serialize(value)
+        self.assertSerializedFunctoolsPartialEqual(
+            value,
+            "functools.partial(datetime.timedelta, *(), **{'kebab-case': 1})",
+            {"import datetime", "import functools"},
+        )
 
     def test_serialize_functools_partialmethod(self):
         value = functools.partialmethod(datetime.timedelta, 1, seconds=2)
-        result = self.serialize_round_trip(value)
+        string, imports = MigrationWriter.serialize(value)
+        result = self.assertSerializedFunctoolsPartialEqual(
+            value,
+            "functools.partialmethod(datetime.timedelta, *(1,), **{'seconds': 2})",
+            {"import datetime", "import functools"},
+        )
         self.assertIsInstance(result, functools.partialmethod)
-        self.assertEqual(result.func, value.func)
-        self.assertEqual(result.args, value.args)
-        self.assertEqual(result.keywords, value.keywords)
 
     def test_serialize_type_none(self):
         self.assertSerializedEqual(NoneType)

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -41,6 +41,13 @@ class DeconstructibleInstances:
         return ("DeconstructibleInstances", [], {})
 
 
+@deconstructible
+class DeconstructibleArbitrary:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+
 class Money(decimal.Decimal):
     def deconstruct(self):
         return (
@@ -1142,6 +1149,24 @@ class WriterTests(SimpleTestCase):
             string,
             "models.CharField(default=migrations.test_writer.DeconstructibleInstances)",
         )
+
+    def test_serialize_non_identifier_keyword_args(self):
+        instance = DeconstructibleArbitrary(
+            **{"kebab-case": 1, "my_list": [1, 2, 3], "123foo": {"456bar": set()}},
+            regular="kebab-case",
+            **{"simple": 1, "complex": 3.1416},
+        )
+        string, imports = MigrationWriter.serialize(instance)
+        self.assertEqual(
+            string,
+            "migrations.test_writer.DeconstructibleArbitrary(complex=3.1416, "
+            "my_list=[1, 2, 3], regular='kebab-case', simple=1, "
+            "**{'123foo': {'456bar': set()}, 'kebab-case': 1})",
+        )
+        self.assertEqual(imports, {"import migrations.test_writer"})
+        result = self.serialize_round_trip(instance)
+        self.assertEqual(result.args, instance.args)
+        self.assertEqual(result.kwargs, instance.kwargs)
 
     def test_register_serializer(self):
         class ComplexSerializer(BaseSerializer):

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -911,7 +911,7 @@ class WriterTests(SimpleTestCase):
         string, imports = MigrationWriter.serialize(value)
         self.assertSerializedFunctoolsPartialEqual(
             value,
-            "functools.partial(datetime.timedelta, *(), **{})",
+            "functools.partial(datetime.timedelta)",
             {"import datetime", "import functools"},
         )
 
@@ -920,7 +920,7 @@ class WriterTests(SimpleTestCase):
         string, imports = MigrationWriter.serialize(value)
         self.assertSerializedFunctoolsPartialEqual(
             value,
-            "functools.partial(datetime.timedelta, *(1,), **{})",
+            "functools.partial(datetime.timedelta, 1)",
             {"import datetime", "import functools"},
         )
 
@@ -929,7 +929,7 @@ class WriterTests(SimpleTestCase):
         string, imports = MigrationWriter.serialize(value)
         self.assertSerializedFunctoolsPartialEqual(
             value,
-            "functools.partial(datetime.timedelta, *(), **{'seconds': 2})",
+            "functools.partial(datetime.timedelta, seconds=2)",
             {"import datetime", "import functools"},
         )
 
@@ -938,7 +938,7 @@ class WriterTests(SimpleTestCase):
         string, imports = MigrationWriter.serialize(value)
         self.assertSerializedFunctoolsPartialEqual(
             value,
-            "functools.partial(datetime.timedelta, *(1,), **{'seconds': 2})",
+            "functools.partial(datetime.timedelta, 1, seconds=2)",
             {"import datetime", "import functools"},
         )
 
@@ -947,7 +947,7 @@ class WriterTests(SimpleTestCase):
         string, imports = MigrationWriter.serialize(value)
         self.assertSerializedFunctoolsPartialEqual(
             value,
-            "functools.partial(datetime.timedelta, *(), **{'kebab-case': 1})",
+            "functools.partial(datetime.timedelta, **{'kebab-case': 1})",
             {"import datetime", "import functools"},
         )
 
@@ -956,7 +956,7 @@ class WriterTests(SimpleTestCase):
         string, imports = MigrationWriter.serialize(value)
         result = self.assertSerializedFunctoolsPartialEqual(
             value,
-            "functools.partialmethod(datetime.timedelta, *(1,), **{'seconds': 2})",
+            "functools.partialmethod(datetime.timedelta, 1, seconds=2)",
             {"import datetime", "import functools"},
         )
         self.assertIsInstance(result, functools.partialmethod)


### PR DESCRIPTION
#### Trac ticket number

ticket-36383

#### Branch description

This PR:

1. Adjusts spelling of the `DeconstructibleSerializer` class.
2. Extends `DeconstructibleSerializer` to support non-identifier keyword arguments.
3. Improves the serialization of `functools.{partial,partialmethod}` objects by reusing `DeconstructibleSerializer.serialize_deconstructed()`.

See the ticket and commit messages for more details.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
