### PR TITLE
Refs #35844 -- Skipped argon2-cffi requirement in Windows for Python 3.14+.

### DIFF
--- a/tests/requirements/py3.txt
+++ b/tests/requirements/py3.txt
@@ -1,6 +1,6 @@
 aiosmtpd >= 1.4.5
 asgiref >= 3.8.1
-argon2-cffi >= 23.1.0
+argon2-cffi >= 23.1.0; sys.platform != 'win32' or python_version < '3.14'
 bcrypt >= 4.1.1
 black >= 25.1.0
 docutils >= 0.19


### PR DESCRIPTION
This is a temporary measure to workaround recent failures when installing dependencies in CI following the 3.14b1 Python release:

>  LINK : fatal error LNK1104: cannot open file 'python314t.lib'
>  ERROR: Failed building wheel for cffi

#### Branch description
Scheduled tests for Windows with Python 3.14 have been failing since the 3.14b1 release.