### PR TITLE
Add urls.py to app_template so startapp creates it automatically

### DIFF
--- a/django/conf/app_template/urls.py-tpl
+++ b/django/conf/app_template/urls.py-tpl
@@ -1,0 +1,5 @@
+from django.urls import path
+
+urlpatterns = [
+    # path('', views.home, name='home'),
+]


### PR DESCRIPTION
> This pull request adds a default `urls.py` file to the template used when running `python manage.py startapp`. The goal is to promote better app modularization by encouraging developers to define app-level URL configurations from the start.
>
> Currently, Django does not include this file by default, even though creating it is a common and repetitive step in nearly every app. By including it, we:
>
> * Encourage better separation of concerns between project-wide and app-specific routing.
> * Save time for developers, especially those working with reusable or pluggable apps.
> * Improve onboarding for new developers by giving them a structure to define routes from the beginning.
>
> The added `urls.py` file includes a minimal and clean scaffold:
>
> ```python
> from django.urls import path
>
> urlpatterns = [
>     # path('', views.home, name='home'),
> ]
> ```
>
> I believe this small addition aligns with Django’s philosophy of clarity and reusability. Let me know if there are any improvements or considerations needed — happy to iterate on the suggestion.
