### PR TITLE
Fixed incorrect spacing in docs/ref/contrib/postgres/fields.txt.

### DIFF
--- a/docs/ref/contrib/postgres/fields.txt
+++ b/docs/ref/contrib/postgres/fields.txt
@@ -47,8 +47,8 @@ may be a good choice for the :ref:`range fields <range-fields>` and
         with the exception of those handling relational data
         (:class:`~django.db.models.ForeignKey`,
         :class:`~django.db.models.OneToOneField` and
-        :class:`~django.db.models.ManyToManyField`) and file fields (
-        :class:`~django.db.models.FileField` and
+        :class:`~django.db.models.ManyToManyField`) and file fields
+        (:class:`~django.db.models.FileField` and
         :class:`~django.db.models.ImageField`).
 
         It is possible to nest array fields - you can specify an instance of


### PR DESCRIPTION
Remove the extra whitespace inside the parens at the end of the sentence [here](https://docs.djangoproject.com/en/dev/ref/contrib/postgres/fields/#django.contrib.postgres.fields.ArrayField.base_field)