### PR TITLE
Fixed #36392 -- Raised ValueError when subquery referencing composite pk selects too many columns.

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1227,7 +1227,10 @@ class Query(BaseExpression):
     @property
     def _subquery_fields_len(self):
         if self.has_select_fields:
-            return len(self.selected)
+            return sum(
+                len(self.model._meta.pk_fields) if field == "pk" else 1
+                for field in self.selected
+            )
         return len(self.model._meta.pk_fields)
 
     def resolve_expression(self, query, *args, **kwargs):

--- a/docs/releases/5.2.2.txt
+++ b/docs/releases/5.2.2.txt
@@ -11,3 +11,7 @@ Bugfixes
 
 * Fixed a crash when using ``select_related`` against a ``ForeignObject``
   originating from a model with a ``CompositePrimaryKey`` (:ticket:`36373`).
+
+* Fixed a bug in Django 5.2 where subqueries using ``"pk"`` to reference models
+  with a ``CompositePrimaryKey`` failed to raise ``ValueError`` when too many
+  or too few columns were selected (:ticket:`36392`).

--- a/tests/composite_pk/test_filter.py
+++ b/tests/composite_pk/test_filter.py
@@ -206,6 +206,14 @@ class CompositePKFilterTests(TestCase):
             [self.comment_1],
         )
 
+    def test_filter_by_pk_in_subquery_invalid_selected_columns(self):
+        msg = (
+            "The QuerySet value for the 'in' lookup must have 2 selected "
+            "fields (received 3)"
+        )
+        with self.assertRaisesMessage(ValueError, msg):
+            Comment.objects.filter(pk__in=Comment.objects.values("pk", "text"))
+
     def test_filter_by_pk_in_none(self):
         with self.assertNumQueries(0):
             self.assertSequenceEqual(


### PR DESCRIPTION
#### Trac ticket number
ticket-36392

#### Branch description
Before, subqueries referencing composite pks (via `"pk"`) evaded the check for an incorrect number of selected columns, failing at the db layer instead of with `ValueError`.

Now, such subqueries selecting too many or too few columns raise `ValueError`.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
