### PR TITLE
Refs #35844 -- Skipped selenium and geoip2 requirement in Windows for Python 3.14+.

### DIFF
--- a/tests/requirements/py3.txt
+++ b/tests/requirements/py3.txt
@@ -4,7 +4,7 @@ argon2-cffi >= 23.1.0; sys.platform != 'win32' or python_version < '3.14'
 bcrypt >= 4.1.1
 black >= 25.1.0
 docutils >= 0.19
-geoip2 >= 4.8.0
+geoip2 >= 4.8.0; sys.platform != 'win32' or python_version < '3.14'
 jinja2 >= 2.11.0
 numpy >= 1.26.0; python_version < '3.14'
 Pillow >= 10.1.0; sys.platform != 'win32' or python_version < '3.14'
@@ -14,7 +14,7 @@ pymemcache >= 3.4.0
 pywatchman; sys_platform != 'win32'
 PyYAML >= 6.0.2
 redis >= 5.1.0
-selenium >= 4.23.0
+selenium >= 4.23.0; sys.platform != 'win32' or python_version < '3.14'
 sqlparse >= 0.5.0
 tblib >= 3.0.0
 tzdata


### PR DESCRIPTION
Follow up to d6925f0d6beb3c08ae24bdb8fd83ddb13d1756e4.

`cffi` is a depedency of `selenium`, we need to skip it.
`aiohttp` is a dependency of `geoip2`, we need to skip it as well.

[Test build on my fork](https://github.com/felixxm/django/pull/13).