### PR TITLE
Fixed #36388 -- Made QuerySet.union() return self when called with no arguments.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -239,6 +239,7 @@ answer newbie questions, and generally made Django that much better:
     Claude Paroz <claude@2xlibre.net>
     Clifford Gama <cliffygamy@gmail.com>
     Clint Ecker
+    Colleen Dunlap <https://medium.com/@colleen85052>
     colin@owlfish.com
     Colin Wood <cwood06@gmail.com>
     Collin Anderson <cmawebsite@gmail.com>

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1550,6 +1550,8 @@ class QuerySet(AltersData):
             if len(qs) == 1:
                 return qs[0]
             return qs[0]._combinator_query("union", *qs[1:], all=all)
+        elif not other_qs:
+            return self
         return self._combinator_query("union", *other_qs, all=all)
 
     def intersection(self, *other_qs):

--- a/docs/releases/5.2.2.txt
+++ b/docs/releases/5.2.2.txt
@@ -15,3 +15,6 @@ Bugfixes
 * Fixed a bug in Django 5.2 where subqueries using ``"pk"`` to reference models
   with a ``CompositePrimaryKey`` failed to raise ``ValueError`` when too many
   or too few columns were selected (:ticket:`36392`).
+
+* Fixed a regression in Django 5.2 that caused a crash when no arguments were
+  passed into ``QuerySet.union()`` (:ticket:`36388`).

--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -88,6 +88,13 @@ class QuerySetSetOperationTests(TestCase):
         qs3 = qs1.union(qs2)
         self.assertNumbersEqual(qs3[:1], [0])
 
+    def test_union_empty_slice(self):
+        qs = Number.objects.union()
+        self.assertNumbersEqual(qs[:1], [0])
+        qs = Number.objects.union(all=True)
+        self.assertNumbersEqual(qs[:1], [0])
+        self.assertNumbersEqual(qs.order_by("num")[0:], list(range(0, 10)))
+
     def test_union_all_none_slice(self):
         qs = Number.objects.filter(id__in=[])
         with self.assertNumQueries(0):


### PR DESCRIPTION
Fixed regression from Django 5.1-5.2
Can call union without second queryset again

#### Trac ticket number

ticket-36388

#### Branch description
Fixed a regression from Django 5.1 to 5.2 where Model.objects.union() with no input began breaking. Error being thrown was `AttributeError: 'NoneType' object has no attribute 'elide_empty' and no __dict__ for setting new attributes` This PR fixes it.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
