### PR TITLE
Fixed #36352 -- Fixed FieldError when chaining `values()` after `annotate()` with the same alias.

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -2519,10 +2519,13 @@ class Query(BaseExpression):
                         annotation_names.append(f)
                         selected[f] = f
                     elif f in self.annotations:
-                        raise FieldError(
-                            f"Cannot select the '{f}' alias. Use annotate() to "
-                            "promote it."
-                        )
+                        if f not in self.annotation_select:
+                            raise FieldError(
+                                f"Cannot select the '{f}' alias. Use annotate() to "
+                                "promote it."
+                            )
+                        annotation_names.append(f)
+                        selected[f] = f
                     else:
                         # Call `names_to_path` to ensure a FieldError including
                         # annotations about to be masked as valid choices if
@@ -2532,6 +2535,8 @@ class Query(BaseExpression):
                         selected[f] = len(field_names)
                         field_names.append(f)
             self.set_extra_mask(extra_names)
+            if self.annotation_select_mask:
+                annotation_names = set(annotation_names) | self.annotation_select_mask
             self.set_annotation_mask(annotation_names)
         else:
             field_names = [f.attname for f in self.model._meta.concrete_fields]


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36352

#### Branch description
Previously, chaining values() after annotate() with the same alias raised a FieldError,
even if the alias was already promoted. Now, already-promoted annotation aliases are
allowed in subsequent values() calls. 

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
