### PR TITLE
Fixed #36380 -- Kept query formatting lazy.

### DIFF
--- a/django/db/backends/utils.py
+++ b/django/db/backends/utils.py
@@ -10,6 +10,7 @@ from hashlib import md5
 from django.apps import apps
 from django.db import NotSupportedError
 from django.utils.dateparse import parse_time
+from django.utils.functional import lazy
 
 logger = logging.getLogger("django.db.backends")
 
@@ -151,7 +152,7 @@ class CursorDebugWrapper(CursorWrapper):
             logger.debug(
                 "(%.3f) %s; args=%s; alias=%s",
                 duration,
-                self.db.ops.format_debug_sql(sql),
+                lazy(self.db.ops.format_debug_sql)(sql),
                 params,
                 self.db.alias,
                 extra={


### PR DESCRIPTION
#### Trac ticket number
ticket-36380

#### Branch description
Before, queries were formatted for logging regardless of the logging configuration (albeit still obeying the guard for `DEBUG = True`). For my views with large SQL strings running with `DEBUG = True`, I attributed a 10x slowdown to this eager formatting.

Now, queries are not formatted for logging until the logging infrastructure actually formats the string.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
