### PR TITLE
When a request is closed, data is read from the buffer by fragment to prevent memory usage caused by reading all packets at a time

### DIFF
--- a/django/core/servers/basehttp.py
+++ b/django/core/servers/basehttp.py
@@ -158,7 +158,7 @@ class ServerHandler(simple_server.ServerHandler):
             """
             Block-based read prevents memory usage caused by large packets
             """
-            lefe_size = io_stream.limit
+            left_size = io_stream.limit
             while True:
                 if left_size <= chunk_size:
                     io_stream.read(left_size)


### PR DESCRIPTION
When a request is closed, data is read from the buffer by fragment to prevent memory usage caused by reading all packets at a time.

Trac ticket number
N/A

Branch description
In the original implementation, when an external attacker initiates a request using a large packet, the packet is not parsed in a timely manner. In addition, when the packet is closed, the input stream is loaded at a time. As a result, the memory usage exceeds the threshold and DDoS attacks occur.

#### Checklist
- [ ] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
