### PR TITLE
Fixed #36390 -- Deprecated RemoteUserMiddleware subclasses missing aprocess_request().

### DIFF
--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -55,6 +55,10 @@ details on these changes.
   ``django.contrib.postgres.aggregates.JSONBAgg``, and
   ``django.contrib.postgres.aggregates.StringAgg`` will be removed.
 
+* Support for subclasses of ``RemoteUserMiddleware`` that override
+  ``process_request()`` without overriding ``aprocess_request()`` will be
+  removed.
+
 .. _deprecation-removed-in-6.0:
 
 6.0

--- a/docs/releases/5.2.2.txt
+++ b/docs/releases/5.2.2.txt
@@ -18,3 +18,7 @@ Bugfixes
 
 * Fixed a regression in Django 5.2 that caused a crash when no arguments were
   passed into ``QuerySet.union()`` (:ticket:`36388`).
+
+* Fixed a regression in Django 5.2 where subclasses of ``RemoteUserMiddleware``
+  that had overridden ``process_request()`` were no longer supported
+  (:ticket:`36390`).

--- a/docs/releases/5.2.txt
+++ b/docs/releases/5.2.txt
@@ -488,3 +488,7 @@ Miscellaneous
   ``django.contrib.postgres.aggregates.JSONBAgg``, and
   ``django.contrib.postgres.aggregates.StringAgg`` is deprecated in favor
   of the ``order_by`` argument.
+
+* Support for subclasses of ``RemoteUserMiddleware`` that override
+  ``process_request()`` without overriding ``aprocess_request()`` is
+  deprecated.


### PR DESCRIPTION
Regression in 50f89ae850f6b4e35819fe725a08c7e579bfd099. Thank you to shamoon for the report.

#### Trac ticket number

ticket-36390

#### Branch description
Provide a concise overview of the issue or rationale behind the proposed changes.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
