### PR TITLE
Fixed #36405 -- Fixed Aggregate.order_by using OuterRef.

### DIFF
--- a/django/db/models/aggregates.py
+++ b/django/db/models/aggregates.py
@@ -120,11 +120,6 @@ class Aggregate(Func):
     ):
         # Aggregates are not allowed in UPDATE queries, so ignore for_save
         c = super().resolve_expression(query, allow_joins, reuse, summarize)
-        c.order_by = (
-            c.order_by.resolve_expression(query, allow_joins, reuse, summarize)
-            if c.order_by
-            else None
-        )
         if summarize:
             # Summarized aggregates cannot refer to summarized aggregates.
             for ref in c.get_refs():

--- a/docs/releases/5.2.2.txt
+++ b/docs/releases/5.2.2.txt
@@ -25,3 +25,7 @@ Bugfixes
 
 * Fixed a regression in Django 5.2 that caused a crash when using ``OuterRef``
   in the ``filter`` argument of an ``Aggregate`` expression (:ticket:`36404`).
+
+* Fixed a regression in Django 5.2 that caused a crash when using ``OuterRef``
+  in PostgreSQL aggregate functions ``ArrayAgg``, ``StringAgg``, and
+  ``JSONBAgg`` (:ticket:`36405`).

--- a/tests/postgres_tests/test_aggregates.py
+++ b/tests/postgres_tests/test_aggregates.py
@@ -364,6 +364,18 @@ class TestGeneralAggregate(PostgreSQLTestCase):
                         [[], [], [], []],
                     )
 
+    def test_array_agg_with_order_by_outer_ref(self):
+        StatTestModel.objects.annotate(
+            atm_ids=Subquery(
+                AggregateTestModel.objects.annotate(
+                    ids=ArrayAgg(
+                        "id",
+                        order_by=[OuterRef("int1")],
+                    )
+                ).values("ids")[:1]
+            )
+        )
+
     def test_bit_and_general(self):
         values = AggregateTestModel.objects.filter(integer_field__in=[0, 1]).aggregate(
             bitand=BitAnd("integer_field")


### PR DESCRIPTION
#### Trac ticket number

ticket-36404, ticket-36405

#### Branch description

Three commits:

1. Fix the regression for `filter`, ticket-36404.
2. Fix a latent issue exposed by the above fix, described in comment on file.
3. Fix the regression for `order_by`, ticket-36405.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
