### PR TITLE
Skipped test_no_logs_without_debug test when the runner is invoked with --debug-sql.

### DIFF
--- a/tests/backends/base/test_base.py
+++ b/tests/backends/base/test_base.py
@@ -9,6 +9,7 @@ from django.test import (
     TransactionTestCase,
     skipUnlessDBFeature,
 )
+from django.test.runner import DebugSQLTextTestResult
 from django.test.utils import CaptureQueriesContext, override_settings
 
 from ..models import Person, Square
@@ -134,6 +135,8 @@ class DatabaseWrapperLoggingTests(TransactionTestCase):
                 )
 
     def test_no_logs_without_debug(self):
+        if isinstance(self._outcome.result, DebugSQLTextTestResult):
+            self.skipTest("--debug-sql interferes with this test")
         with self.assertNoLogs("django.db.backends", "DEBUG"):
             with self.assertRaises(Exception), transaction.atomic():
                 Person.objects.create(first_name="first", last_name="last")


### PR DESCRIPTION
#### Branch description
As alluded to as an aside in ticket-36112, this command fails (since `--debug-sql` unconditionally logs SQL queries, and this test tests that sql queries are not logged when DEBUG=False):

```py
./runtests.py backends.base.test_base.DatabaseWrapperLoggingTests.test_no_logs_without_debug --debug-sql
```

(Let me know if I should `Refs #...`, but it seemed tangential.)

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
