### PR TITLE
Refs #35444 -- Adjusted multi-args distinct aggregate test ordering expectations.

### DIFF
--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -576,7 +576,7 @@ class AggregateTestCase(TestCase):
         books = Book.objects.aggregate(
             ratings=StringAgg(Cast(F("rating"), CharField()), Value(","), distinct=True)
         )
-        self.assertEqual(books["ratings"], "3,4,4.5,5")
+        self.assertCountEqual(books["ratings"].split(","), ["3", "4", "4.5", "5"])
 
     @skipIfDBFeature("supports_aggregate_distinct_multiple_argument")
     def test_raises_error_on_multiple_argument_distinct(self):


### PR DESCRIPTION

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35444

#### Branch description

Unless an explicit `order_by` is specified for the aggregate the ordering of the aggregation results is undefined.

Discovered when testing #19495 on Oracle locally using `django-docker-box`

---

Failure on Oracle without this change

```
======================================================================
FAIL: test_distinct_on_stringagg (aggregation.tests.AggregateTestCase.test_distinct_on_stringagg)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/django/source/tests/aggregation/tests.py", line 579, in test_distinct_on_stringagg
    self.assertEqual(books["ratings"], "3,4,4.5,5")
AssertionError: '4.5,3,4,5' != '3,4,4.5,5'
- 4.5,3,4,5
+ 3,4,4.5,5
```
