### PR TITLE
feat: support disable transaction.atomic during loaddata

### DIFF
--- a/django/core/management/commands/loaddata.py
+++ b/django/core/management/commands/loaddata.py
@@ -62,6 +62,11 @@ class Command(BaseCommand):
             ),
         )
         parser.add_argument(
+            "--disable-atomic",
+            action="store_true",
+            help="do not use transaction.atomic duration save data",
+        )
+        parser.add_argument(
             "--app",
             dest="app_label",
             help="Only look for fixtures in the specified app.",
@@ -99,8 +104,11 @@ class Command(BaseCommand):
         )
         self.format = options["format"]
 
-        with transaction.atomic(using=self.using):
+        if options["disable_atomic"]:
             self.loaddata(fixture_labels)
+        else:
+            with transaction.atomic(using=self.using):
+                self.loaddata(fixture_labels)
 
         # Close the DB connection -- unless we're still in a transaction. This
         # is required as a workaround for an edge case in MySQL: if the same


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-N/A

#### Branch description
In one of my project, the loaddata will get stuck because of the transaction.atomic (I have lots of signals and each signal contains code like update_or_create which will create transaction again). So I need the disable the transaction.atomic during loaddata.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
