### PR TITLE
Fixed #36419 -- Made bulk_update() convert top-level None to SQL NULL for JSONField.

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -297,7 +297,7 @@ class BaseExpression:
         c.is_summary = summarize
         source_expressions = [
             (
-                expr.resolve_expression(query, allow_joins, reuse, summarize)
+                expr.resolve_expression(query, allow_joins, reuse, summarize, for_save)
                 if expr is not None
                 else None
             )

--- a/docs/releases/5.2.3.txt
+++ b/docs/releases/5.2.3.txt
@@ -13,3 +13,7 @@ Bugfixes
 * Fixed a log injection possibility by migrating remaining response logging
   to ``django.utils.log.log_response()``, which safely escapes arguments such
   as the request path to prevent unsafe log output (:cve:`2025-48432`).
+
+* Fixed a regression in Django 5.2 that caused :meth:`.QuerySet.bulk_update` to
+  incorrectly convert ``None`` to JSON ``null`` instead of SQL ``NULL`` for
+  ``JSONField`` (:ticket:`36419`).


### PR DESCRIPTION


#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36419

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
