### PR TITLE
Fixed #36388 -- Handle empty combinator arguments in QuerySet methods

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1558,6 +1558,8 @@ class QuerySet(AltersData):
         # If any query is an EmptyQuerySet, return it.
         if isinstance(self, EmptyQuerySet):
             return self
+        if not other_qs:
+            return self
         for other in other_qs:
             if isinstance(other, EmptyQuerySet):
                 return other
@@ -1566,6 +1568,8 @@ class QuerySet(AltersData):
     def difference(self, *other_qs):
         # If the query is an EmptyQuerySet, return it.
         if isinstance(self, EmptyQuerySet):
+            return self
+        if not other_qs:
             return self
         return self._combinator_query("difference", *other_qs)
 

--- a/docs/releases/5.2.2.txt
+++ b/docs/releases/5.2.2.txt
@@ -20,6 +20,9 @@ Bugfixes
 * Fixed a regression in Django 5.2 that caused a crash when no arguments were
   passed into ``QuerySet.union()`` (:ticket:`36388`).
 
+* Fixed a regression in Django 5.2 that caused a crash when no arguments were
+  passed into ``QuerySet.intersection()`` and ``QuerySet.difference()``.
+
 * Fixed a regression in Django 5.2 where subclasses of ``RemoteUserMiddleware``
   that had overridden ``process_request()`` were no longer supported
   (:ticket:`36390`).

--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -95,6 +95,17 @@ class QuerySetSetOperationTests(TestCase):
         self.assertNumbersEqual(qs[:1], [0])
         self.assertNumbersEqual(qs.order_by("num")[0:], list(range(0, 10)))
 
+    @skipUnlessDBFeature("supports_select_intersection")
+    def test_intersection_empty_slice(self):
+        qs = Number.objects.intersection()
+        self.assertNumbersEqual(qs[:1], [0])
+
+    @skipUnlessDBFeature("supports_select_difference")
+    def test_difference_empty_slice(self):
+        qs = Number.objects.difference()
+        self.assertNumbersEqual(qs[:1], [0])
+        self.assertNumbersEqual(qs.order_by("num")[0:], list(range(0, 10)))
+
     def test_union_all_none_slice(self):
         qs = Number.objects.filter(id__in=[])
         with self.assertNumQueries(0):


### PR DESCRIPTION
#### Trac ticket number
ticket-36388

#### Branch description
This change restores the pre-5.2 behavior for the three combinator methods (union(), intersection(), and difference()) so that calling them with no arguments returns a valid QuerySet (either self or an empty result) instead of crashing.

#### Checklist
- [ ] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
