### PR TITLE
Fixed #36380 -- Deferred SQL formatting when running tests with --debug-sql.

### DIFF
--- a/django/db/backends/utils.py
+++ b/django/db/backends/utils.py
@@ -151,7 +151,7 @@ class CursorDebugWrapper(CursorWrapper):
             logger.debug(
                 "(%.3f) %s; args=%s; alias=%s",
                 duration,
-                self.db.ops.format_debug_sql(sql),
+                sql,
                 params,
                 self.db.alias,
                 extra={

--- a/tests/backends/tests.py
+++ b/tests/backends/tests.py
@@ -1,10 +1,10 @@
 """Tests related to django.db.backends that haven't been organized."""
 
 import datetime
+import logging
 import threading
 import unittest
 import warnings
-from unittest import mock
 
 from django.core.management.color import no_style
 from django.db import (
@@ -572,23 +572,39 @@ class BackendTestCase(TransactionTestCase):
             BaseDatabaseWrapper.queries_limit = old_queries_limit
             new_connection.close()
 
-    @mock.patch("django.db.backends.utils.logger")
     @override_settings(DEBUG=True)
-    def test_queries_logger(self, mocked_logger):
+    def test_queries_logger(self):
         sql = "select 1" + connection.features.bare_select_suffix
-        with connection.cursor() as cursor:
+        with (
+            connection.cursor() as cursor,
+            self.assertLogs("django.db.backends", "DEBUG") as handler,
+        ):
             cursor.execute(sql)
-        params, kwargs = mocked_logger.debug.call_args
-        self.assertIn("; alias=%s", params[0])
-        self.assertEqual(params[2], sql)
-        self.assertNotEqual(params[2], connection.ops.format_debug_sql(sql))
-        self.assertIsNone(params[3])
-        self.assertEqual(params[4], connection.alias)
-        self.assertEqual(
-            list(kwargs["extra"]),
-            ["duration", "sql", "params", "alias"],
+        self.assertGreaterEqual(
+            records_len := len(handler.records),
+            1,
+            f"Wrong number of calls for {handler=} in (expected at least 1, got "
+            f"{records_len}).",
         )
-        self.assertEqual(tuple(kwargs["extra"].values()), params[1:])
+        record = handler.records[-1]
+        # Log raw message, effective level and args are correct.
+        self.assertEqual(record.msg, "(%.3f) %s; args=%s; alias=%s")
+        self.assertEqual(record.levelno, logging.DEBUG)
+        self.assertEqual(len(record.args), 4)
+        duration, logged_sql, params, alias = record.args
+        # Duration is hard to test without mocking time, expect under 1 second.
+        self.assertIsInstance(duration, float)
+        self.assertLess(duration, 1)
+        self.assertEqual(duration, record.duration)
+        # SQL is correct and not formatted.
+        self.assertEqual(logged_sql, sql)
+        self.assertNotEqual(logged_sql, connection.ops.format_debug_sql(sql))
+        self.assertEqual(logged_sql, record.sql)
+        # Params is None and alias is connection.alias.
+        self.assertIsNone(params)
+        self.assertIsNone(record.params)
+        self.assertEqual(alias, connection.alias)
+        self.assertEqual(alias, record.alias)
 
     def test_queries_bare_where(self):
         sql = f"SELECT 1{connection.features.bare_select_suffix} WHERE 1=1"

--- a/tests/test_runner/test_debug_sql.py
+++ b/tests/test_runner/test_debug_sql.py
@@ -1,11 +1,183 @@
+import logging
 import unittest
 from io import StringIO
+from time import time
+from unittest import mock
 
-from django.db import connection
+from django.db import DEFAULT_DB_ALIAS, connection, connections
 from django.test import TestCase
-from django.test.runner import DiscoverRunner
+from django.test.runner import DiscoverRunner, QueryFormatter
 
 from .models import Person
+
+logger = logging.getLogger(__name__)
+
+
+class QueryFormatterTests(unittest.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.format_sql_calls = []
+
+    def new_format_sql(self, sql):
+        # Use time() to introduce some uniqueness.
+        formatted = "Formatted! %s at %s" % (sql.upper(), time())
+        self.format_sql_calls.append({sql: formatted})
+        return formatted
+
+    def make_handler(self, **formatter_kwargs):
+        formatter = QueryFormatter(**formatter_kwargs)
+
+        handler = logging.StreamHandler(StringIO())
+        handler.setLevel(logging.DEBUG)
+        handler.setFormatter(formatter)
+
+        original_level = logger.getEffectiveLevel()
+        logger.setLevel(logging.DEBUG)
+        self.addCleanup(logger.setLevel, original_level)
+        logger.addHandler(handler)
+        self.addCleanup(logger.removeHandler, handler)
+
+        return handler
+
+    def do_log(self, msg, *logger_args, alias=DEFAULT_DB_ALIAS, extra=None):
+        if extra is None:
+            extra = {}
+        if alias and "alias" not in extra:
+            extra["alias"] = alias
+        # Patch connection's format_debug_sql to ensure it was properly called.
+        with mock.patch.object(
+            connections[alias].ops, "format_debug_sql", side_effect=self.new_format_sql
+        ):
+            logger.info(msg, *logger_args, extra=extra)
+
+    def assertLogRecord(self, handler, expected):
+        handler.stream.seek(0)
+        self.assertEqual(handler.stream.read().strip(), expected)
+
+    def assertSQLFormatted(self, handler, sql, total_calls=1):
+        self.assertEqual(len(self.format_sql_calls), total_calls)
+        formatted_sql = self.format_sql_calls[0][sql]
+        expected = f"=> Executing query duration=3.142 sql={formatted_sql}"
+        self.assertLogRecord(handler, expected)
+
+    def test_formats_sql_bracket_format_style(self):
+        handler = self.make_handler(
+            fmt="{message} duration={duration:.3f} sql={sql}", style="{"
+        )
+        msg = "=> Executing query"
+        sql = "select * from foo"
+
+        self.do_log(msg, extra={"sql": sql, "duration": 3.1416})
+        self.assertSQLFormatted(handler, sql)
+
+    def test_formats_sql_named_fmt_format_style(self):
+        handler = self.make_handler(
+            fmt="%(message)s duration=%(duration).3f sql=%(sql)s"
+        )
+        msg = "=> Executing query"
+        sql = "select * from foo"
+
+        self.do_log(msg, extra={"sql": sql, "duration": 3.1416})
+        self.assertSQLFormatted(handler, sql)
+
+    def test_formats_sql_named_percent_format_style(self):
+        handler = self.make_handler()
+        msg = "=> Executing query duration=%(duration).3f sql=%(sql)s"
+        sql = "select * from foo"
+
+        self.do_log(msg, {"duration": 3.1416, "sql": sql})
+        self.assertSQLFormatted(handler, sql)
+
+    def test_formats_sql_default_percent_format_style(self):
+        handler = self.make_handler()
+        msg = "=> Executing query duration=%.3f sql=%s"
+        sql = "select * from foo"
+
+        self.do_log(msg, 3.1416, sql)
+        self.assertSQLFormatted(handler, sql)
+
+    def test_formats_sql_multiple_matching_sql(self):
+        handler = self.make_handler()
+        msg = "=> Executing query duration=%.3f sql=%s"
+        sql = "select * from foo"
+
+        self.do_log(msg, 3.1416, sql, extra={"duration": 3.1416, "sql": sql})
+        self.assertSQLFormatted(handler, sql)
+
+    def test_formats_sql_multiple_non_matching_sql(self):
+        handler = self.make_handler()
+        msg = "=> Executing query duration=%.3f sql=%s"
+        sql1 = "select * from foo"
+        sql2 = "select * from other"
+
+        self.do_log(msg, 3.1416, sql1, extra={"duration": 3.1416, "sql": sql2})
+        self.assertSQLFormatted(handler, sql1, total_calls=2)
+        # Second format call is triggered since the sql are different.
+        self.assertEqual(list(self.format_sql_calls[1].keys()), [sql2])
+
+    def test_log_record_no_args(self):
+        handler = self.make_handler()
+        msg = "=> Executing query no args"
+
+        self.do_log(msg)
+        self.assertEqual(self.format_sql_calls, [])
+        self.assertLogRecord(handler, msg)
+
+    def test_log_record_not_enough_args(self):
+        handler = self.make_handler()
+        msg = "=> Executing query one args %r"
+        args = "not formatted"
+
+        self.do_log(msg, args)
+        self.assertEqual(self.format_sql_calls, [])
+        self.assertLogRecord(handler, msg % args)
+
+    def test_log_record_not_key_in_dict_args(self):
+        handler = self.make_handler()
+        msg = "=> Executing query missing sql key %(foo)r"
+        args = {"foo": "bar"}
+
+        self.do_log(msg, args)
+        self.assertEqual(self.format_sql_calls, [])
+        self.assertLogRecord(handler, msg % args)
+
+    def test_log_record_no_alias(self):
+        handler = self.make_handler()
+        msg = "=> Executing query duration=%.3f sql=%s"
+        args = (3.1416, "select * from foo")
+
+        self.do_log(msg, *args, extra={"alias": "does not exist"})
+        self.assertEqual(self.format_sql_calls, [])
+        self.assertLogRecord(handler, msg % args)
+
+    def test_log_record_sql_arg_none(self):
+        handler = self.make_handler()
+        msg = "=> Executing query duration=%.3f sql=%s"
+        args = (3.1416, None)
+
+        self.do_log(msg, *args)
+        self.assertEqual(self.format_sql_calls, [])
+        self.assertLogRecord(handler, msg % args)
+
+    def test_log_record_sql_key_none(self):
+        handler = self.make_handler()
+        msg = "=> Executing query duration=%(duration).3f sql=%(sql)s"
+        args = {"duration": 3.1416, "sql": None}
+
+        self.do_log(msg, args)
+        self.assertEqual(self.format_sql_calls, [])
+        self.assertLogRecord(handler, msg % args)
+
+    def test_log_record_sql_extra_none(self):
+        handler = self.make_handler(
+            fmt="{message} duration={duration:.3f} sql={sql}", style="{"
+        )
+        msg = "=> Executing query"
+
+        self.do_log(msg, extra={"sql": None, "duration": 3.1416})
+        self.assertEqual(self.format_sql_calls, [])
+        self.assertLogRecord(handler, f"{msg} duration=3.142 sql=None")
 
 
 @unittest.skipUnless(


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36380

#### Branch description
Spin off from #19508 and #19509.

#### Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
