### PR TITLE
Clarify MySQL mapping for PositiveIntegerField types

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -1487,27 +1487,66 @@ To query ``JSONField`` in the database, see :ref:`querying-jsonfield`.
 
 .. class:: PositiveBigIntegerField(**options)
 
-Like a :class:`PositiveIntegerField`, but only allows values under a certain
-(database-dependent) point. Values from ``0`` to ``9223372036854775807`` are
-safe in all databases supported by Django.
+Like a :class:`PositiveIntegerField`, but allows larger values depending
+on the database backend.
+
+**Portable safe range**:
+Values from ``0`` to ``9223372036854775807`` can be safely used across all
+database backends supported by Django.
+
+**Backend-specific notes**:
+
+- In MySQL, this field maps to ``UNSIGNED BIGINT``, allowing values from
+  ``0`` to ``18446744073709551615``.
+- Other databases, such as PostgreSQL and SQLite, do not natively support
+  unsigned integers. Django uses signed integer types internally, hence the
+  conservative safe range listed above.
 
 ``PositiveIntegerField``
 ------------------------
 
 .. class:: PositiveIntegerField(**options)
 
-Like an :class:`IntegerField`, but must be either positive or zero (``0``).
-Values from ``0`` to ``2147483647`` are safe in all databases supported by
-Django. The value ``0`` is accepted for backward compatibility reasons.
+Like an :class:`IntegerField`, but must be positive or zero (``0``).
+
+**Portable safe range**:
+Values from ``0`` to ``2147483647`` are consistently safe across all supported
+databases.
+
+**Backend-specific notes**:
+
+- In MySQL, this field maps to ``UNSIGNED INT``, supporting values from
+  ``0`` to ``4294967295``.
+- Databases like PostgreSQL and SQLite implement this using signed integers,
+  which limits the portable safe range to the value above.
 
 ``PositiveSmallIntegerField``
 -----------------------------
 
 .. class:: PositiveSmallIntegerField(**options)
 
-Like a :class:`PositiveIntegerField`, but only allows values under a certain
-(database-dependent) point. Values from ``0`` to ``32767`` are safe in all
-databases supported by Django.
+Like a :class:`PositiveIntegerField`, but intended for smaller integers.
+
+**Portable safe range**:
+Values from ``0`` to ``32767`` are safe and consistently supported across all
+databases.
+
+**Backend-specific notes**:
+
+- In MySQL, this field maps to ``UNSIGNED SMALLINT``, supporting values from
+  ``0`` to ``65535``.
+- Other database backends typically use signed small integers, restricting
+  the portable safe range accordingly.
+
+.. admonition:: About portable safe ranges
+
+    The "portable safe ranges" listed above represent values guaranteed to
+    behave consistently across all Django-supported databases.
+
+    Some backends, such as MySQL, internally use unsigned integer columns,
+    enabling larger maximum values. However, other backends like PostgreSQL
+    or SQLite use signed integer columns, restricting the universally safe
+    range.
 
 ``SlugField``
 -------------


### PR DESCRIPTION
#### Trac ticket number

[ticket-36425](https://code.djangoproject.com/ticket/36425)

#### Branch description

Clarifies the backend-specific mappings and safe value ranges for Positive*IntegerField types.

MySQL users in particular may find it unclear that these fields map to UNSIGNED column types supporting larger values than the documented "safe" range. This change makes such mappings explicit.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
