### PR TITLE
Fix build error on Linux with Python 3.12+ by excluding pylibmc

### DIFF
--- a/tests/requirements/py3.txt
+++ b/tests/requirements/py3.txt
@@ -8,8 +8,8 @@ geoip2 >= 4.8.0; sys.platform != 'win32' or python_version < '3.14'
 jinja2 >= 2.11.0
 numpy >= 1.26.0; python_version < '3.14'
 Pillow >= 10.1.0; sys.platform != 'win32' or python_version < '3.14'
-# pylibmc/libmemcached can't be built on Windows.
-pylibmc; sys_platform != 'win32'
+# pylibmc/libmemcached isn't available on Windows or Python 3.12+, use pymemcache instead
+pylibmc; sys_platform != 'win32' and python_version < '3.12'
 pymemcache >= 3.4.0
 pywatchman; sys_platform != 'win32'
 PyYAML >= 6.0.2


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36427

#### Branch description
Running Django’s test suite on Python 3.12+ in non-Windows environments (e.g., Linux CI agents or local dev containers) currently fails due to pylibmc installation errors. This is caused by missing libmemcached development headers and incomplete Python 3.12 support in pylibmc. Since Django’s test suite does not depend on pylibmc for core test execution, these failures are unnecessary blockers for contributors working on modern setups.

This change limits pylibmc to Python versions < 3.12 in the test requirements. It avoids test setup failures while discussions around its complete removal continue.

#### Checklist
- [ ] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
