### PR TITLE
Fixed #36435 -- Made CaptureQueriesContext restore reset_queries conditionally.

### DIFF
--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -728,12 +728,13 @@ class CaptureQueriesContext:
         self.connection.ensure_connection()
         self.initial_queries = len(self.connection.queries_log)
         self.final_queries = None
-        request_started.disconnect(reset_queries)
+        self.reset_queries_disconnected = request_started.disconnect(reset_queries)
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.connection.force_debug_cursor = self.force_debug_cursor
-        request_started.connect(reset_queries)
+        if self.reset_queries_disconnected:
+            request_started.connect(reset_queries)
         if exc_type is not None:
             return
         self.final_queries = len(self.connection.queries_log)

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -435,6 +435,14 @@ class CaptureQueriesContextManagerTests(TestCase):
         self.assertIn(self.person_pk, captured_queries[0]["sql"])
         self.assertIn(self.person_pk, captured_queries[1]["sql"])
 
+    def test_with_client_nested(self):
+        with CaptureQueriesContext(connection) as captured_queries:
+            Person.objects.count()
+            with CaptureQueriesContext(connection):
+                pass
+            self.client.get(self.url)
+        self.assertEqual(2, len(captured_queries))
+
 
 @override_settings(ROOT_URLCONF="test_utils.urls")
 class AssertNumQueriesContextManagerTests(TestCase):
@@ -473,6 +481,13 @@ class AssertNumQueriesContextManagerTests(TestCase):
 
         with self.assertNumQueries(2):
             self.client.get(self.url)
+            self.client.get(self.url)
+
+    def test_with_client_nested(self):
+        with self.assertNumQueries(2):
+            Person.objects.count()
+            with self.assertNumQueries(0):
+                pass
             self.client.get(self.url)
 
 


### PR DESCRIPTION
#### Trac ticket number

ticket-36435

#### Branch description

`CaptureQueriesContext.__exit__()`, as used by `assertNumQueries()`, unconditionally restores the `reset_queries` signal receiver. This behaviour can lead to missed queries when the context manager is nested and a request is made after the inner context manager exits.

The solution is to restore the signal receiver in `__exit__()` only if it was removed in `__enter__()`.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
