### PR TITLE
Fixed #36430 -- Removed artificially low limit on single field bulk operations on SQLite.

### DIFF
--- a/django/db/backends/sqlite3/operations.py
+++ b/django/db/backends/sqlite3/operations.py
@@ -32,9 +32,6 @@ class DatabaseOperations(BaseDatabaseOperations):
         """
         SQLite has a variable limit defined by SQLITE_LIMIT_VARIABLE_NUMBER
         (reflected in max_query_params).
-
-        If there's only a single field to insert, the limit is 500
-        (SQLITE_MAX_COMPOUND_SELECT).
         """
         fields = list(
             chain.from_iterable(
@@ -46,9 +43,7 @@ class DatabaseOperations(BaseDatabaseOperations):
                 for field in fields
             )
         )
-        if len(fields) == 1:
-            return 500
-        elif len(fields) > 1:
+        if fields:
             return self.connection.features.max_query_params // len(fields)
         else:
             return len(objs)

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1182,10 +1182,8 @@ class QuerySet(AltersData):
             if not id_list:
                 return {}
             filter_key = "{}__in".format(field_name)
-            max_params = connections[self.db].features.max_query_params or 0
-            num_fields = len(opts.pk_fields) if field_name == "pk" else 1
-            batch_size = max_params // num_fields
             id_list = tuple(id_list)
+            batch_size = connections[self.db].ops.bulk_batch_size([opts.pk], id_list)
             # If the database has a limit on the number of query parameters
             # (e.g. SQLite), retrieve objects in batches if necessary.
             if batch_size and batch_size < len(id_list):

--- a/tests/backends/sqlite/test_operations.py
+++ b/tests/backends/sqlite/test_operations.py
@@ -93,7 +93,8 @@ class SQLiteOperationsTests(TestCase):
         first_name_field = Person._meta.get_field("first_name")
         last_name_field = Person._meta.get_field("last_name")
         self.assertEqual(
-            connection.ops.bulk_batch_size([first_name_field], [Person()]), 500
+            connection.ops.bulk_batch_size([first_name_field], [Person()]),
+            connection.features.max_query_params,
         )
         self.assertEqual(
             connection.ops.bulk_batch_size(

--- a/tests/composite_pk/tests.py
+++ b/tests/composite_pk/tests.py
@@ -147,20 +147,24 @@ class CompositePKTests(TestCase):
         result = Comment.objects.in_bulk([self.comment.pk])
         self.assertEqual(result, {self.comment.pk: self.comment})
 
-    @unittest.mock.patch.object(
-        type(connection.features), "max_query_params", new_callable=lambda: 10
-    )
-    def test_in_bulk_batching(self, mocked_max_query_params):
+    def test_in_bulk_batching(self):
         Comment.objects.all().delete()
-        num_requiring_batching = (connection.features.max_query_params // 2) + 1
-        comments = [
-            Comment(id=i, tenant=self.tenant, user=self.user)
-            for i in range(1, num_requiring_batching + 1)
-        ]
-        Comment.objects.bulk_create(comments)
-        id_list = list(Comment.objects.values_list("pk", flat=True))
-        with self.assertNumQueries(2):
-            comment_dict = Comment.objects.in_bulk(id_list=id_list)
+        batching_required = connection.features.max_query_params is not None
+        expected_queries = 2 if batching_required else 1
+        with unittest.mock.patch.object(
+            type(connection.features), "max_query_params", 10
+        ):
+            num_requiring_batching = (
+                connection.ops.bulk_batch_size([Comment._meta.pk], []) + 1
+            )
+            comments = [
+                Comment(id=i, tenant=self.tenant, user=self.user)
+                for i in range(1, num_requiring_batching + 1)
+            ]
+            Comment.objects.bulk_create(comments)
+            id_list = list(Comment.objects.values_list("pk", flat=True))
+            with self.assertNumQueries(expected_queries):
+                comment_dict = Comment.objects.in_bulk(id_list=id_list)
         self.assertQuerySetEqual(comment_dict, id_list)
 
     def test_iterator(self):


### PR DESCRIPTION
#### Trac ticket number
ticket-36430

#### Branch description
Thanks @laymonage for analysis on the ticket about why this limit should no longer be relevant.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
