### PR TITLE
Refs CVE-2025-48432 -- Ensured `log_response` is used anywhere a response is logged

### DIFF
--- a/docs/releases/4.2.23.txt
+++ b/docs/releases/4.2.23.txt
@@ -1,10 +1,10 @@
-==========================
-Django 5.2.3 release notes
-==========================
+===========================
+Django 4.2.23 release notes
+===========================
 
 *June 10, 2025*
 
-Django 5.2.3 fixes several bugs in 5.2.2.
+Django 4.2.23 fixes a potential log injection issue in 4.2.22.
 
 Bugfixes
 ========

--- a/docs/releases/5.1.11.txt
+++ b/docs/releases/5.1.11.txt
@@ -1,10 +1,10 @@
-==========================
-Django 5.2.3 release notes
-==========================
+===========================
+Django 5.1.11 release notes
+===========================
 
 *June 10, 2025*
 
-Django 5.2.3 fixes several bugs in 5.2.2.
+Django 5.1.11 fixes a potential log injection issue in 5.1.10.
 
 Bugfixes
 ========

--- a/docs/releases/index.txt
+++ b/docs/releases/index.txt
@@ -42,6 +42,7 @@ versions of the documentation contain the release notes for any later releases.
 .. toctree::
    :maxdepth: 1
 
+   5.1.11
    5.1.10
    5.1.9
    5.1.8
@@ -81,6 +82,7 @@ versions of the documentation contain the release notes for any later releases.
 .. toctree::
    :maxdepth: 1
 
+   4.2.23
    4.2.22
    4.2.21
    4.2.20

--- a/tests/generic_views/test_base.py
+++ b/tests/generic_views/test_base.py
@@ -1,4 +1,7 @@
+import logging
 import time
+
+from logging_tests.tests import LoggingAssertionMixin
 
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponse
@@ -63,7 +66,7 @@ class InstanceView(View):
         return self
 
 
-class ViewTest(SimpleTestCase):
+class ViewTest(LoggingAssertionMixin, SimpleTestCase):
     rf = RequestFactory()
 
     def _assert_simple(self, response):
@@ -297,6 +300,25 @@ class ViewTest(SimpleTestCase):
         response = view.dispatch(self.rf.head("/"))
         self.assertEqual(response.status_code, 405)
 
+    def test_method_not_allowed_response_logged(self):
+        for path, escaped in [
+            ("/foo/", "/foo/"),
+            (r"/%1B[1;31mNOW IN RED!!!1B[0m/", r"/\x1b[1;31mNOW IN RED!!!1B[0m/"),
+        ]:
+            with self.subTest(path=path):
+                request = self.rf.get(path, REQUEST_METHOD="BOGUS")
+                with self.assertLogs("django.request", "WARNING") as handler:
+                    response = SimpleView.as_view()(request)
+
+                self.assertLogRecord(
+                    handler,
+                    f"Method Not Allowed (BOGUS): {escaped}",
+                    logging.WARNING,
+                    405,
+                    request,
+                )
+                self.assertEqual(response.status_code, 405)
+
 
 @override_settings(ROOT_URLCONF="generic_views.urls")
 class TemplateViewTest(SimpleTestCase):
@@ -425,7 +447,7 @@ class TemplateViewTest(SimpleTestCase):
 
 
 @override_settings(ROOT_URLCONF="generic_views.urls")
-class RedirectViewTest(SimpleTestCase):
+class RedirectViewTest(LoggingAssertionMixin, SimpleTestCase):
     rf = RequestFactory()
 
     def test_no_url(self):
@@ -548,6 +570,20 @@ class RedirectViewTest(SimpleTestCase):
         view = RedirectView()
         response = view.dispatch(self.rf.head("/foo/"))
         self.assertEqual(response.status_code, 410)
+
+    def test_gone_response_logged(self):
+        for path, escaped in [
+            ("/foo/", "/foo/"),
+            (r"/%1B[1;31mNOW IN RED!!!1B[0m/", r"/\x1b[1;31mNOW IN RED!!!1B[0m/"),
+        ]:
+            with self.subTest(path=path):
+                request = self.rf.get(path)
+                with self.assertLogs("django.request", "WARNING") as handler:
+                    RedirectView().dispatch(request)
+
+                self.assertLogRecord(
+                    handler, f"Gone: {escaped}", logging.WARNING, 410, request
+                )
 
 
 class GetContextDataTest(SimpleTestCase):

--- a/tests/logging_tests/tests.py
+++ b/tests/logging_tests/tests.py
@@ -618,6 +618,15 @@ class SecurityLoggerTest(LoggingAssertionMixin, SimpleTestCase):
         self.assertEqual(len(mail.outbox), 1)
         self.assertIn("SuspiciousOperation at /suspicious/", mail.outbox[0].body)
 
+    def test_response_logged(self):
+        with self.assertLogs("django.security.SuspiciousOperation", "ERROR") as handler:
+            response = self.client.get("/suspicious/")
+
+        self.assertLogRecord(
+            handler, "dubious", logging.ERROR, 400, request=response.wsgi_request
+        )
+        self.assertEqual(response.status_code, 400)
+
 
 class SettingsCustomLoggingTest(AdminScriptTestCase):
     """

--- a/tests/logging_tests/tests.py
+++ b/tests/logging_tests/tests.py
@@ -98,23 +98,28 @@ class LoggingAssertionMixin:
     def assertLogRecord(
         self,
         logger_cm,
-        level,
         msg,
+        levelno,
         status_code,
+        request=None,
         exc_class=None,
     ):
         self.assertEqual(
             records_len := len(logger_cm.records),
             1,
-            f"Wrong number of calls for {logger_cm=} in {level=} (expected 1, got "
+            f"Wrong number of calls for {logger_cm=} in {levelno=} (expected 1, got "
             f"{records_len}).",
         )
         record = logger_cm.records[0]
         self.assertEqual(record.getMessage(), msg)
+        self.assertEqual(record.levelno, levelno)
         self.assertEqual(record.status_code, status_code)
+        if request is not None:
+            self.assertEqual(record.request, request)
         if exc_class:
             self.assertIsNotNone(record.exc_info)
             self.assertEqual(record.exc_info[0], exc_class)
+        return record
 
     def assertLogsRequest(
         self, url, level, msg, status_code, logger="django.request", exc_class=None
@@ -124,7 +129,9 @@ class LoggingAssertionMixin:
                 self.client.get(url)
             except views.UncaughtException:
                 pass
-            self.assertLogRecord(cm, level, msg, status_code, exc_class)
+            self.assertLogRecord(
+                cm, msg, getattr(logging, level), status_code, exc_class=exc_class
+            )
 
 
 @override_settings(DEBUG=True, ROOT_URLCONF="logging_tests.urls")
@@ -156,21 +163,17 @@ class HandlerLoggingTests(
         )
 
     async def test_async_page_not_found_warning(self):
-        logger = "django.request"
-        level = "WARNING"
-        with self.assertLogs(logger, level) as cm:
+        with self.assertLogs("django.request", "WARNING") as cm:
             await self.async_client.get("/does_not_exist/")
 
-        self.assertLogRecord(cm, level, "Not Found: /does_not_exist/", 404)
+        self.assertLogRecord(cm, "Not Found: /does_not_exist/", logging.WARNING, 404)
 
     async def test_async_control_chars_escaped(self):
-        logger = "django.request"
-        level = "WARNING"
-        with self.assertLogs(logger, level) as cm:
+        with self.assertLogs("django.request", "WARNING") as cm:
             await self.async_client.get(r"/%1B[1;31mNOW IN RED!!!1B[0m/")
 
         self.assertLogRecord(
-            cm, level, r"Not Found: /\x1b[1;31mNOW IN RED!!!1B[0m/", 404
+            cm, r"Not Found: /\x1b[1;31mNOW IN RED!!!1B[0m/", logging.WARNING, 404
         )
 
     def test_page_not_found_raised(self):
@@ -707,23 +710,9 @@ class LogFormattersTests(SimpleTestCase):
             )
 
 
-class LogResponseRealLoggerTests(TestCase):
+class LogResponseRealLoggerTests(LoggingAssertionMixin, TestCase):
 
     request = RequestFactory().get("/test-path/")
-
-    def assertResponseLogged(self, logger_cm, msg, levelno, status_code, request):
-        self.assertEqual(
-            records_len := len(logger_cm.records),
-            1,
-            f"Unexpected number of records for {logger_cm=} in {levelno=} (expected 1, "
-            f"got {records_len}).",
-        )
-        record = logger_cm.records[0]
-        self.assertEqual(record.getMessage(), msg)
-        self.assertEqual(record.levelno, levelno)
-        self.assertEqual(record.status_code, status_code)
-        self.assertEqual(record.request, request)
-        return record
 
     def test_missing_response_raises_attribute_error(self):
         with self.assertRaises(AttributeError):
@@ -733,7 +722,7 @@ class LogResponseRealLoggerTests(TestCase):
         response = HttpResponse(status=403)
         with self.assertLogs("django.request", level="INFO") as cm:
             log_response(msg := "Missing request", response=response, request=None)
-        self.assertResponseLogged(cm, msg, logging.WARNING, 403, request=None)
+        self.assertLogRecord(cm, msg, logging.WARNING, 403, request=None)
 
     def test_logs_5xx_as_error(self):
         response = HttpResponse(status=508)
@@ -741,7 +730,7 @@ class LogResponseRealLoggerTests(TestCase):
             log_response(
                 msg := "Server error occurred", response=response, request=self.request
             )
-        self.assertResponseLogged(cm, msg, logging.ERROR, 508, self.request)
+        self.assertLogRecord(cm, msg, logging.ERROR, 508, self.request)
 
     def test_logs_4xx_as_warning(self):
         response = HttpResponse(status=418)
@@ -749,13 +738,13 @@ class LogResponseRealLoggerTests(TestCase):
             log_response(
                 msg := "This is a teapot!", response=response, request=self.request
             )
-        self.assertResponseLogged(cm, msg, logging.WARNING, 418, self.request)
+        self.assertLogRecord(cm, msg, logging.WARNING, 418, self.request)
 
     def test_logs_2xx_as_info(self):
         response = HttpResponse(status=201)
         with self.assertLogs("django.request", level="INFO") as cm:
             log_response(msg := "OK response", response=response, request=self.request)
-        self.assertResponseLogged(cm, msg, logging.INFO, 201, self.request)
+        self.assertLogRecord(cm, msg, logging.INFO, 201, self.request)
 
     def test_custom_log_level(self):
         response = HttpResponse(status=403)
@@ -766,14 +755,14 @@ class LogResponseRealLoggerTests(TestCase):
                 request=self.request,
                 level="debug",
             )
-        self.assertResponseLogged(cm, msg, logging.DEBUG, 403, self.request)
+        self.assertLogRecord(cm, msg, logging.DEBUG, 403, self.request)
 
     def test_logs_only_once_per_response(self):
         response = HttpResponse(status=500)
         with self.assertLogs("django.request", level="ERROR") as cm:
             log_response("First log", response=response, request=self.request)
             log_response("Second log", response=response, request=self.request)
-        self.assertResponseLogged(cm, "First log", logging.ERROR, 500, self.request)
+        self.assertLogRecord(cm, "First log", logging.ERROR, 500, self.request)
 
     def test_exc_info_output(self):
         response = HttpResponse(status=500)
@@ -787,9 +776,7 @@ class LogResponseRealLoggerTests(TestCase):
                     request=self.request,
                     exception=exc,
                 )
-        self.assertResponseLogged(
-            cm, "With exception", logging.ERROR, 500, self.request
-        )
+        self.assertLogRecord(cm, "With exception", logging.ERROR, 500, self.request)
         self.assertIn("ValueError", "\n".join(cm.output))  # Stack trace included
 
     def test_format_args_are_applied(self):
@@ -803,7 +790,7 @@ class LogResponseRealLoggerTests(TestCase):
                 request=self.request,
             )
         msg = "Something went wrong: DB error (42)"
-        self.assertResponseLogged(cm, msg, logging.ERROR, 500, self.request)
+        self.assertLogRecord(cm, msg, logging.ERROR, 500, self.request)
 
     def test_logs_with_custom_logger(self):
         handler = logging.StreamHandler(log_stream := StringIO())
@@ -877,7 +864,7 @@ class LogResponseRealLoggerTests(TestCase):
                 response = HttpResponse(status=318)
                 log_response(msg, case, response=response, level="error")
 
-                record = self.assertResponseLogged(
+                record = self.assertLogRecord(
                     cm,
                     msg % expected,
                     levelno=logging.ERROR,


### PR DESCRIPTION
#### Trac ticket number

CVE-2025-48432

#### Branch description

There were a few places which were missed as part of the fix in a07ebec5591e233d8bbb38b7d63f35c5479eef0e. This PR updates a places, and ensures anywhere (probably) a request is logged, that `log_response` is used, to ensure the parameters are properly cleaned.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
