### PR TITLE
Fixed #36442 -- Cloned FilteredRelation before rename_prefix_from_q.

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1723,6 +1723,7 @@ class Query(BaseExpression):
                     "relations deeper than the relation_name (got %r for "
                     "%r)." % (lookup, filtered_relation.relation_name)
                 )
+        filtered_relation = filtered_relation.clone()
         filtered_relation.condition = rename_prefix_from_q(
             filtered_relation.relation_name,
             alias,

--- a/tests/filtered_relation/tests.py
+++ b/tests/filtered_relation/tests.py
@@ -604,6 +604,28 @@ class FilteredRelationTests(TestCase):
             qs.filter(my_readers=borrower).values_list("name", flat=True), ["Alice"]
         )
 
+    def test_reuse_same_filtered_relation(self):
+        borrower = Borrower.objects.create(name="Jenny")
+        Reservation.objects.create(
+            borrower=borrower,
+            book=self.book1,
+            state=Reservation.STOPPED,
+        )
+        condition = Q(book__reservation__state=Reservation.STOPPED)
+        my_reserved_books = FilteredRelation("book__reservation", condition=condition)
+        first_query = list(
+            Author.objects.annotate(
+                my_reserved_books=my_reserved_books,
+            )
+        )
+        self.assertEqual(my_reserved_books.condition, condition)
+        second_query = list(
+            Author.objects.annotate(
+                my_reserved_books=my_reserved_books,
+            )
+        )
+        self.assertEqual(first_query, second_query)
+
     def test_deep_nested_foreign_key(self):
         qs = (
             Book.objects.annotate(


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36442

#### Branch description
Due to changes introduced in [django/django#16786](https://github.com/django/django/pull/16786), FilteredRelation now renames conditions, which unintentionally mutates the original FilteredRelation object, making it unusable in subsequent queries.

This change ensures that the FilteredRelation used in annotations is cloned before being modified in `add_filtered_relation`.

#### Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [X] I have attached screenshots in both light and dark modes for any UI changes.
