### PR TITLE
Fixed #36433--Model validation of constraints fails if condition's Q …

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1322,6 +1322,7 @@ class Model(AltersData, metaclass=ModelBase):
             if not value or not hasattr(value, "resolve_expression"):
                 value = Value(value, field)
             field_map[field.name] = value
+            field_map[field.attname] = value
         if "pk" not in exclude:
             field_map["pk"] = Value(self.pk, meta.pk)
         if generated_fields:

--- a/tests/constraints/tests.py
+++ b/tests/constraints/tests.py
@@ -361,6 +361,32 @@ class CheckConstraintTests(TestCase):
             constraint_with_pk.validate(ChildModel, ChildModel(id=1, age=1))
         constraint_with_pk.validate(ChildModel, ChildModel(pk=1, age=1), exclude={"pk"})
 
+    def test_validate_fk_attname(self):
+        with self.subTest("Failing Validation"):
+            constraint_with_fk = models.CheckConstraint(
+                condition=models.Q(uniqueconstraintproduct_ptr_id__isnull=False),
+                name="parent_ptr_present",
+            )
+
+            with self.assertRaisesMessage(
+                ValidationError, "Constraint “parent_ptr_present” is violated."
+            ):
+                constraint_with_fk.validate(
+                    ChildUniqueConstraintProduct, ChildUniqueConstraintProduct()
+                )
+        with self.subTest("Passing Validations"):
+            constraint_with_fk.validate(
+                ChildUniqueConstraintProduct,
+                ChildUniqueConstraintProduct(uniqueconstraintproduct_ptr_id=1),
+            )
+            constraint_with_fk.condition = models.Q(
+                uniqueconstraintproduct_ptr_id__isnull=True
+            )
+
+            constraint_with_fk.validate(
+                ChildUniqueConstraintProduct, ChildUniqueConstraintProduct()
+            )
+
     @skipUnlessDBFeature("supports_json_field")
     def test_validate_jsonfield_exact(self):
         data = {"release": "5.0.2", "version": "stable"}


### PR DESCRIPTION
#### Trac ticket number

ticket-36433

#### Branch description
added field.attname to field map in _get_field_expression_map() to allow lookup of foreign keys in contraints by _id (database column name)

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
