### PR TITLE
Fixed #23557 -- Prevent silent extension of explicit GROUP BY when using order_by.

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -266,6 +266,9 @@ class BaseDatabaseFeatures:
     # delimiter along with DISTINCT.
     supports_aggregate_distinct_multiple_argument = True
 
+    # Does the database support SQL 2023 ORDER BY in grouped table?
+    supports_order_by_grouped_table = False
+
     # Does the database support SQL 2023 ANY_VALUE in GROUP BY?
     supports_any_value = False
 

--- a/django/db/backends/postgresql/features.py
+++ b/django/db/backends/postgresql/features.py
@@ -163,4 +163,5 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         operator.attrgetter("is_postgresql_15")
     )
 
+    supports_order_by_grouped_table = property(operator.attrgetter("is_postgresql_16"))
     supports_any_value = property(operator.attrgetter("is_postgresql_16"))

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -53,6 +53,7 @@ from django.test import TestCase
 from django.test.testcases import skipIfDBFeature, skipUnlessDBFeature
 from django.test.utils import Approximate, CaptureQueriesContext
 from django.utils import timezone
+from django.utils.deprecation import RemovedInDjango70Warning
 
 from .models import Author, Book, Employee, Publisher, Store
 
@@ -1619,6 +1620,30 @@ class AggregateTestCase(TestCase):
                     .values_list("pk", flat=True)
                 )
                 self.assertEqual(list(books_qs), expected_result)
+
+    @skipIfDBFeature("supports_order_by_grouped_table")
+    def test_order_by_grouped_table_deprecated(self):
+        books_qs = (
+            Book.objects.values("rating").annotate(Count("authors")).order_by("pubdate")
+        )
+        message = (
+            "Having columns in the ORDER BY clause that are not in the GROUP "
+            "BY clause is not supported on this database backend and will be "
+            "deprecated on Django 7.0."
+        )
+        # RemovedInDjango70Warning: When the deprecation ends, replace with:
+        # with self.assertRaisesMessage(NotSupportedError, message):
+        with self.assertWarnsMessage(RemovedInDjango70Warning, message):
+            # There are two GROUP BY clause (zero commas means at most one clause).
+            books_qs_str = str(books_qs.query)
+            group_by_idx = books_qs_str.index("GROUP BY")
+            order_by_idx = books_qs_str.index("ORDER BY")
+            self.assertGreater(group_by_idx, 0)
+            self.assertGreater(order_by_idx, 0)
+            self.assertEqual(
+                books_qs_str[group_by_idx : order_by_idx + 1].count(", "), 1
+            )
+            self.assertTrue("pubdate" in books_qs_str[group_by_idx : order_by_idx + 1])
 
     @skipUnlessDBFeature("supports_subqueries_in_group_by")
     def test_group_by_subquery_annotation(self):


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-23557

#### Branch description

Compares the results of `collapse_group_by()` with and without the expressions from order_by clause. Raises a deprecation warning if the results differ for database backends that do not support order by columns that are not present in the group by clause for grouped tables (SQL:2023 F868).

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
