### PR TITLE
Fixed #36448 -- Fixed GeoDjango spelling in test_commands.py docstrings.

### DIFF
--- a/tests/gis_tests/gis_migrations/test_commands.py
+++ b/tests/gis_tests/gis_migrations/test_commands.py
@@ -5,7 +5,7 @@ from django.test import TransactionTestCase
 
 class MigrateTests(TransactionTestCase):
     """
-    Tests running the migrate command in Geodjango.
+    Tests running the migrate command in GeoDjango.
     """
 
     available_apps = ["gis_tests.gis_migrations"]
@@ -24,7 +24,7 @@ class MigrateTests(TransactionTestCase):
 
     def test_migrate_gis(self):
         """
-        Tests basic usage of the migrate command when a model uses Geodjango
+        Tests basic usage of the migrate command when a model uses GeoDjango
         fields (#22001).
 
         It's also used to showcase an error in migrations where spatialite is


### PR DESCRIPTION
## Description
This PR fixes the spelling of "Geodjango" to "GeoDjango" in the docstrings of `tests/gis_tests/gis_migrations/test_commands.py`. This change ensures consistency with Django's official documentation and naming conventions.

Fixes #36448.

## Changes Made
- Corrected "Geodjango" to "GeoDjango" in the class docstring
- Corrected "Geodjango" to "GeoDjango" in the `test_migrate_gis` method docstring

## Why This Change Is Needed
The term "GeoDjango" is the official spelling used throughout Django's documentation and codebase. Maintaining consistent spelling helps with documentation clarity and searchability.

## Testing
No functional changes were made. Only documentation strings were updated.

## Checklist
- [x] Code follows Django's coding style
- [x] Tests are not needed (documentation only change)
- [x] Documentation is not needed (internal docstring only)
- [x] Commit message is clear and follows guidelines
- [x] Changes are minimal and focused