### PR TITLE
Refs #35038 -- Optimized away AlterConstraint operation after CreateModel.

### DIFF
--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -346,6 +346,21 @@ class CreateModel(ModelOperation):
                         },
                     ),
                 ]
+            elif isinstance(operation, AlterConstraint):
+                options_constraints = [
+                    constraint
+                    for constraint in self.options.get("constraints", [])
+                    if constraint.name != operation.name
+                ] + [operation.constraint]
+                return [
+                    replace(
+                        self,
+                        options={
+                            **self.options,
+                            "constraints": options_constraints,
+                        },
+                    ),
+                ]
             elif isinstance(operation, RemoveConstraint):
                 options_constraints = [
                     constraint

--- a/tests/migrations/test_optimizer.py
+++ b/tests/migrations/test_optimizer.py
@@ -1434,6 +1434,54 @@ class OptimizerTests(OptimizerTestBase):
             ],
         )
 
+    def test_create_model_alter_constraint(self):
+        original_constraint = models.CheckConstraint(
+            condition=models.Q(weight__gt=0), name="pony_weight_gt_0"
+        )
+        altered_constraint = models.CheckConstraint(
+            condition=models.Q(weight__gt=0),
+            name="pony_weight_gt_0",
+            violation_error_message="incorrect weight",
+        )
+        self.assertOptimizesTo(
+            [
+                migrations.CreateModel(
+                    name="Pony",
+                    fields=[
+                        ("weight", models.IntegerField()),
+                    ],
+                    options={
+                        "constraints": [
+                            original_constraint,
+                            models.UniqueConstraint(
+                                "weight", name="pony_weight_unique"
+                            ),
+                        ],
+                    },
+                ),
+                migrations.AlterConstraint(
+                    "Pony", "pony_weight_gt_0", altered_constraint
+                ),
+            ],
+            [
+                migrations.CreateModel(
+                    name="Pony",
+                    fields=[
+                        ("weight", models.IntegerField()),
+                    ],
+                    options={
+                        "constraints": [
+                            models.UniqueConstraint(
+                                "weight",
+                                name="pony_weight_unique",
+                            ),
+                            altered_constraint,
+                        ]
+                    },
+                ),
+            ],
+        )
+
     def test_create_model_remove_constraint(self):
         self.assertOptimizesTo(
             [


### PR DESCRIPTION
ticket-35038 added optimizations to reduce `AlterConstraint` between `AddConstraint`, `AlterConstraint`, and `RemoveConstraint`, but we missed `CreateModel`.