### PR TITLE
Refs #36419 -- Fixed BulkUpdateTests.test_json_field_sql_null() crash on Oracle.

### DIFF
--- a/tests/queries/test_bulk_update.py
+++ b/tests/queries/test_bulk_update.py
@@ -3,7 +3,7 @@ from math import ceil
 
 from django.core.exceptions import FieldDoesNotExist
 from django.db import connection
-from django.db.models import F
+from django.db.models import F, IntegerField, Value
 from django.db.models.functions import Coalesce, Lower
 from django.db.utils import IntegrityError
 from django.test import TestCase, override_settings, skipUnlessDBFeature
@@ -305,7 +305,11 @@ class BulkUpdateTests(TestCase):
         obj = JSONFieldNullable.objects.create(json_field={})
         test_cases = [
             ("direct_none_assignment", None),
-            ("expression_none_assignment", Coalesce(None, None)),
+            ("value_none_assignment", Value(None)),
+            (
+                "expression_none_assignment",
+                Coalesce(None, None, output_field=IntegerField()),
+            ),
         ]
         for label, value in test_cases:
             with self.subTest(case=label):


### PR DESCRIPTION
Follow up to c1fa3fdd040718356e5a3b9a0fe699d73f47a940.

Logs:
```
Traceback (most recent call last):
  File "/home/jenkins/workspace/django-oracle/database/oracle19/label/oracle/python/python3.13/tests/queries/test_bulk_update.py", line 313, in test_json_field_sql_null
    JSONFieldNullable.objects.bulk_update([obj], fields=["json_field"])
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jenkins/workspace/django-oracle/database/oracle19/label/oracle/python/python3.13/django/db/models/manager.py", line 87, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/jenkins/workspace/django-oracle/database/oracle19/label/oracle/python/python3.13/django/db/models/query.py", line 953, in bulk_update
    rows_updated += queryset.filter(pk__in=pks).update(**update_kwargs)
                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/jenkins/workspace/django-oracle/database/oracle19/label/oracle/python/python3.13/django/db/models/query.py", line 1292, in update
    rows = query.get_compiler(self.db).execute_sql(ROW_COUNT)
  File "/home/jenkins/workspace/django-oracle/database/oracle19/label/oracle/python/python3.13/django/db/models/sql/compiler.py", line 2102, in execute_sql
    row_count = super().execute_sql(result_type)
  File "/home/jenkins/workspace/django-oracle/database/oracle19/label/oracle/python/python3.13/django/db/models/sql/compiler.py", line 1610, in execute_sql
    sql, params = self.as_sql()
                  ~~~~~~~~~~~^^
  File "/home/jenkins/workspace/django-oracle/database/oracle19/label/oracle/python/python3.13/django/db/models/sql/compiler.py", line 2074, in as_sql
    sql, params = self.compile(val)
                  ~~~~~~~~~~~~^^^^^
  File "/home/jenkins/workspace/django-oracle/database/oracle19/label/oracle/python/python3.13/django/db/models/sql/compiler.py", line 577, in compile
    sql, params = node.as_sql(self, self.connection)
                  ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jenkins/workspace/django-oracle/database/oracle19/label/oracle/python/python3.13/django/db/models/expressions.py", line 1710, in as_sql
    case_sql, case_params = compiler.compile(case)
                            ~~~~~~~~~~~~~~~~^^^^^^
  File "/home/jenkins/workspace/django-oracle/database/oracle19/label/oracle/python/python3.13/django/db/models/sql/compiler.py", line 577, in compile
    sql, params = node.as_sql(self, self.connection)
                  ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jenkins/workspace/django-oracle/database/oracle19/label/oracle/python/python3.13/django/db/models/expressions.py", line 1633, in as_sql
    result_sql, result_params = compiler.compile(self.result)
                                ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/home/jenkins/workspace/django-oracle/database/oracle19/label/oracle/python/python3.13/django/db/models/sql/compiler.py", line 575, in compile
    sql, params = vendor_impl(self, self.connection)
                  ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jenkins/workspace/django-oracle/database/oracle19/label/oracle/python/python3.13/django/db/models/functions/comparison.py", line 91, in as_oracle
    if self.output_field.get_internal_type() == "TextField":
       ^^^^^^^^^^^^^^^^^
  File "/home/jenkins/workspace/django-oracle/database/oracle19/label/oracle/python/python3.13/django/utils/functional.py", line 47, in __get__
    res = instance.__dict__[self.name] = self.func(instance)
                                         ~~~~~~~~~^^^^^^^^^^
  File "/home/jenkins/workspace/django-oracle/database/oracle19/label/oracle/python/python3.13/django/db/models/expressions.py", line 329, in output_field
    raise OutputFieldIsNoneError(
        "Cannot resolve expression type, unknown output_field"
    )
django.db.models.expressions.OutputFieldIsNoneError: Cannot resolve expression type, unknown output_field
```