### PR TITLE
Fixed #36424 -- Documented model name collisions in shell auto-imports.

### DIFF
--- a/docs/howto/custom-shell.txt
+++ b/docs/howto/custom-shell.txt
@@ -54,6 +54,44 @@ Running this customized ``shell`` command with ``verbosity=2`` would show:
       from django.contrib.sessions.models import Session
       from django.urls import resolve, reverse
 
+.. _handling-model-name-collisions:
+
+Handling model name collisions
+------------------------------
+
+If multiple apps define models with the same name, the model from the app listed earlier in 
+:setting:`INSTALLED_APPS` will be imported, overwriting any previously imported model with 
+the same name. For example, if both ``apps.cart.models`` and ``apps.order.models`` define a 
+``Line`` model, and ``apps.cart`` is listed before ``apps.order`` in :setting:`INSTALLED_APPS`, 
+only the ``Line`` model from ``apps.cart.models`` will be available in the shell.
+
+This behavior can be confusing, especially when using ``--verbosity=2`` with ``isort`` installed, 
+as the displayed import order may not match the actual import precedence. The model from the app 
+listed earlier in :setting:`INSTALLED_APPS` always takes precedence, regardless of the order shown 
+in the verbose output.
+
+To handle model name collisions, you can:
+
+1. Use the ``--no-imports`` flag to disable automatic imports and manually import the models you need.
+2. Create a custom shell command that overrides ``get_auto_imports()`` to provide aliases for colliding models:
+
+   .. code-block:: python
+       :caption: ``myapp/management/commands/shell.py``
+
+       from django.core.management.commands import shell
+
+
+       class Command(shell.Command):
+           def get_auto_imports(self):
+               # Get all default imports
+               imports = super().get_auto_imports()
+               # Add aliases for colliding models
+               imports.extend([
+                   "apps.cart.models.Line as CartLine",
+                   "apps.order.models.Line as OrderLine",
+               ])
+               return imports
+
 If an overridden ``shell`` command includes paths that cannot be imported,
 these errors are shown when ``verbosity`` is set to ``1`` or higher. Duplicate
 imports are automatically handled.

--- a/docs/howto/custom-shell.txt
+++ b/docs/howto/custom-shell.txt
@@ -86,10 +86,12 @@ To handle model name collisions, you can:
                # Get all default imports
                imports = super().get_auto_imports()
                # Add aliases for colliding models
-               imports.extend([
-                   "apps.cart.models.Line as CartLine",
-                   "apps.order.models.Line as OrderLine",
-               ])
+               imports.extend(
+                   [
+                       "apps.cart.models.Line as CartLine",
+                       "apps.order.models.Line as OrderLine",
+                   ]
+               )
                return imports
 
 If an overridden ``shell`` command includes paths that cannot be imported,

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1072,7 +1072,9 @@ objects will be listed. To disable automatic importing entirely, use the
 ``--no-imports`` flag.
 
 See the guide on :ref:`customizing this behavior
-<customizing-shell-auto-imports>` to add or remove automatic imports.
+<customizing-shell-auto-imports>` to add or remove automatic imports, and
+:ref:`handling model name collisions <handling-model-name-collisions>` for
+dealing with identically named models from different apps.
 
 .. versionchanged:: 5.2
 

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1065,16 +1065,15 @@ Mails the email addresses specified in :setting:`ADMINS` using
 
 Starts the Python interactive interpreter.
 
-All models from installed apps are automatically imported into the shell
-environment. Models from apps listed earlier in :setting:`INSTALLED_APPS` take
-precedence. For a ``--verbosity`` of 2 or higher, the automatically imported
-objects will be listed. To disable automatic importing entirely, use the
-``--no-imports`` flag.
+All models from installed apps are automatically imported into the shell environment.
+When multiple models share the same name, the one from the app listed earlier in
+:setting:`INSTALLED_APPS` takes precedence. See
+:ref:`handling-model-name-collisions` for details.
 
-See the guide on :ref:`customizing this behavior
-<customizing-shell-auto-imports>` to add or remove automatic imports, and
-:ref:`handling model name collisions <handling-model-name-collisions>` for
-dealing with identically named models from different apps.
+If ``--verbosity`` is ``2`` or higher, the imported objects will be listed.
+To disable automatic importing, use the :option:`--no-imports <shell --no-imports>` flag.
+
+See :ref:`customizing-shell-auto-imports` for guidance on adding or removing automatic imports.
 
 .. versionchanged:: 5.2
 


### PR DESCRIPTION
#### Trac ticket number

ticket-36424

#### Branch description
This change improves the Django documentation by adding detailed explanations about how the shell management command handles model name collisions when multiple apps define models with the same name. It clarifies that models from apps listed earlier in INSTALLED_APPS take precedence, which can lead to confusion. The update also documents how to resolve or avoid these collisions by using the --no-imports flag or by overriding the get_auto_imports() method to provide explicit aliases for conflicting models.

#### Checklist
- [x]  This PR targets the main branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
