### PR TITLE
Fixed #36436 -- Prevent access to signer in messages CookieStorage

### DIFF
--- a/django/contrib/messages/storage/cookie.py
+++ b/django/contrib/messages/storage/cookie.py
@@ -89,7 +89,7 @@ class CookieStorage(BaseStorage):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.signer = signing.get_cookie_signer(salt=self.key_salt)
+        self._signer = signing.get_cookie_signer(salt=self.key_salt)
 
     def _get(self, *args, **kwargs):
         """
@@ -181,7 +181,7 @@ class CookieStorage(BaseStorage):
         also contains a hash to ensure that the data was not tampered with.
         """
         if messages or encode_empty:
-            return self.signer.sign_object(
+            return self._signer.sign_object(
                 messages, serializer=MessagePartGatherSerializer, compress=True
             )
 
@@ -205,7 +205,7 @@ class CookieStorage(BaseStorage):
         if not data:
             return None
         try:
-            return self.signer.unsign_object(data, serializer=MessageSerializer)
+            return self._signer.unsign_object(data, serializer=MessageSerializer)
         except (signing.BadSignature, binascii.Error, json.JSONDecodeError):
             pass
         # Mark the data as used (so it gets removed) since something was wrong

--- a/tests/messages_tests/test_cookie.py
+++ b/tests/messages_tests/test_cookie.py
@@ -206,6 +206,18 @@ class CookieTests(BaseTests, SimpleTestCase):
                     self.encode_decode("message", extra_tags=extra_tags).extra_tags,
                     extra_tags,
                 )
+                
+    def test_signer_is_not_accessible(self):
+        """
+        The signer is not accessible through the template context.
+        """
+        storage = self.get_storage()
+        # Verify that the signer is a private attribute
+        self.assertTrue(hasattr(storage, '_signer'))
+        self.assertFalse(hasattr(storage, 'signer'))
+        # Verify that the signer key is not accessible
+        with self.assertRaises(AttributeError):
+            storage.signer.key
 
     def test_signer_is_not_accessible(self):
         """

--- a/tests/messages_tests/test_cookie.py
+++ b/tests/messages_tests/test_cookie.py
@@ -206,18 +206,6 @@ class CookieTests(BaseTests, SimpleTestCase):
                     self.encode_decode("message", extra_tags=extra_tags).extra_tags,
                     extra_tags,
                 )
-                
-    def test_signer_is_not_accessible(self):
-        """
-        The signer is not accessible through the template context.
-        """
-        storage = self.get_storage()
-        # Verify that the signer is a private attribute
-        self.assertTrue(hasattr(storage, '_signer'))
-        self.assertFalse(hasattr(storage, 'signer'))
-        # Verify that the signer key is not accessible
-        with self.assertRaises(AttributeError):
-            storage.signer.key
 
     def test_signer_is_not_accessible(self):
         """

--- a/tests/messages_tests/test_cookie.py
+++ b/tests/messages_tests/test_cookie.py
@@ -207,6 +207,18 @@ class CookieTests(BaseTests, SimpleTestCase):
                     extra_tags,
                 )
 
+    def test_signer_is_not_accessible(self):
+        """
+        The signer is not accessible through the template context.
+        """
+        storage = self.get_storage()
+        # Verify that the signer is a private attribute
+        self.assertTrue(hasattr(storage, "_signer"))
+        self.assertFalse(hasattr(storage, "signer"))
+        # Verify that the signer key is not accessible
+        with self.assertRaises(AttributeError):
+            storage.signer.key
+
 
 class BisectTests(TestCase):
     def test_bisect_keep_left(self):


### PR DESCRIPTION
#### Trac ticket number

ticket-36436

#### Branch description
This PR addresses a security concern in the Django messages framework. Specifically, it ensures that the signer used in CookieStorage is not accessible via the template context, which could inadvertently expose the secret key used for signing.

A test test_signer_is_not_accessible() was added to confirm that:

- The signer is a private attribute (_signer) and not publicly accessible.

- Attempting to access storage.signer.key raises an AttributeError.

This change improves encapsulation and prevents potential misuse or security leaks via template introspection.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
