### PR TITLE
Fixed #36445 -- Ensured Value(None, output_field=JSONField()) is saved as JSON null in bulk_update()

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -1174,6 +1174,9 @@ class Value(SQLiteNumericMixin, Expression):
             if hasattr(output_field, "get_placeholder"):
                 return output_field.get_placeholder(val, compiler, connection), [val]
         if val is None:
+            if output_field.__class__.__name__ == "JSONField":
+                # Return JSON null in case the field is JSONField.
+                return "'null'", []
             # oracledb does not always convert None to the appropriate
             # NULL type (like in case expressions using numbers), so we
             # use a literal SQL NULL

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -939,7 +939,10 @@ class QuerySet(AltersData):
                 for obj in batch_objs:
                     attr = getattr(obj, field.attname)
                     if not hasattr(attr, "resolve_expression"):
-                        attr = Value(attr, output_field=field)
+                        if attr is None:
+                            attr = Value(None)
+                        else:
+                            attr = Value(attr, output_field=field)
                     when_statements.append(When(pk=obj.pk, then=attr))
                 case_statement = Case(*when_statements, output_field=field)
                 if requires_casting:


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

[ticket-36445](https://code.djangoproject.com/ticket/36445)

#### Branch description

-  Made changes in the query conversion logic to ensure 
- Provide a concise overview of the issue or rationale behind the proposed changes. `Value(None, output_field=JSONField())` is saved as JSON null
- None was being interpreted as Value(None, output_field=JSONField()). Made changes to ensure that doesn't happen. (Did this because according to this testfunc- `def test_json_field_sql_null` direct None assignment must be treated as SQL null.
- Added test to verify the changes

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
