### PR TITLE
Refs #10785 -- Add missing __hash__ method to custom pk test model.

### DIFF
--- a/tests/custom_pk/fields.py
+++ b/tests/custom_pk/fields.py
@@ -19,6 +19,9 @@ class MyWrapper:
             return self.value == other.value
         return self.value == other
 
+    def __hash__(self):
+        return hash(self.value)
+
 
 class MyWrapperField(models.CharField):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Without a `__hash__()` method, deleting instances of this test model fails.

```diff
diff --git a/tests/custom_pk/tests.py b/tests/custom_pk/tests.py
index 5f865b680a..bf4a1a3988 100644
--- a/tests/custom_pk/tests.py
+++ b/tests/custom_pk/tests.py
@@ -198,6 +198,8 @@ class CustomPKTests(TestCase):
         self.assertEqual(f, new_foo)
         self.assertEqual(f.bar, new_bar)
 
+        new_bar.delete()
+
     # SQLite lets objects be saved with an empty primary key, even though an
     # integer is expected. So we can't check for an error being raised in that
     # case for SQLite. Remove it from the suite for this next bit.
```

```py
  File "/Users/.../django/django/db/models/deletion.py", line 130, in add
    if obj not in instances:
       ^^^^^^^^^^^^^^^^^^^^
  File "/Users/.../django/django/db/models/base.py", line 628, in __hash__
    return hash(self.pk)
TypeError: unhashable type: 'MyWrapper'
```