### PR TITLE
Fixed #36446 -- Restored "q" in internal MediaType.params property.

### DIFF
--- a/django/http/request.py
+++ b/django/http/request.py
@@ -694,13 +694,13 @@ class QueryDict(MultiValueDict):
 
 class MediaType:
     def __init__(self, media_type_raw_line):
-        full_type, self._params = parse_header_parameters(
+        full_type, self.params = parse_header_parameters(
             media_type_raw_line if media_type_raw_line else ""
         )
         self.main_type, _, self.sub_type = full_type.partition("/")
 
     def __str__(self):
-        params_str = "".join("; %s=%s" % (k, v) for k, v in self._params.items())
+        params_str = "".join("; %s=%s" % (k, v) for k, v in self.params.items())
         return "%s%s%s" % (
             self.main_type,
             ("/%s" % self.sub_type) if self.sub_type else "",
@@ -711,8 +711,8 @@ class MediaType:
         return "<%s: %s>" % (self.__class__.__qualname__, self)
 
     @cached_property
-    def params(self):
-        params = self._params.copy()
+    def range_params(self):
+        params = self.params.copy()
         params.pop("q", None)
         return params
 
@@ -735,20 +735,19 @@ class MediaType:
             if this_type != other_type and this_type != "*" and other_type != "*":
                 return False
 
-        if bool(self.params) == bool(other.params):
+        if bool(self.range_params) == bool(other.range_params):
             # If both have params or neither have params, they must be identical.
-            result = self.params == other.params
+            result = self.range_params == other.range_params
         else:
             # If self has params and other does not, it's a match.
             # If other has params and self does not, don't match.
-            result = bool(self.params or not other.params)
-
+            result = bool(self.range_params or not other.range_params)
         return result
 
     @cached_property
     def quality(self):
         try:
-            quality = float(self._params.get("q", 1))
+            quality = float(self.params.get("q", 1))
         except ValueError:
             # Discard invalid values.
             return 1
@@ -768,7 +767,7 @@ class MediaType:
             return 0
         elif self.sub_type == "*":
             return 1
-        elif not self.params:
+        elif not self.range_params:
             return 2
         return 3
 

--- a/docs/releases/5.2.3.txt
+++ b/docs/releases/5.2.3.txt
@@ -17,3 +17,6 @@ Bugfixes
 * Fixed a regression in Django 5.2 that caused :meth:`.QuerySet.bulk_update` to
   incorrectly convert ``None`` to JSON ``null`` instead of SQL ``NULL`` for
   ``JSONField`` (:ticket:`36419`).
+
+* Fixed a regression in Django 5.2.2 where the ``q`` parameter was removed from
+  the internal ``django.http.MediaType.params`` property (:ticket:`36446`).


### PR DESCRIPTION
Despite undocumented and internal, the "q" key was removed from the MediaType.params while fixing Refs #36411.

Thanks Anders Kaseorg for the report.

Regression in c075508b4de8edf9db553b409f8a8ed2f26ecead.

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36446

#### Branch description
Restore original `params` and add a new `range_params` following [this previous PR conversation](https://github.com/django/django/pull/19507/files#r2130422564).

I chose a slightly different name for the new property: range_params. I think this name matches better the spec, and also "MediaType.type_params" felt a bit redundant.