### PR TITLE
Fixed #36447 -- Only considered quality when selecting preferred media type.

### DIFF
--- a/django/http/request.py
+++ b/django/http/request.py
@@ -90,7 +90,7 @@ class HttpRequest:
 
     @cached_property
     def accepted_types(self):
-        """Return a list of MediaType instances, in order of preference."""
+        """Return a list of MediaType instances, in order of preference (quality)."""
         header_value = self.headers.get("Accept", "*/*")
         return sorted(
             (
@@ -98,19 +98,30 @@ class HttpRequest:
                 for token in header_value.split(",")
                 if token.strip() and (media_type := MediaType(token)).quality != 0
             ),
+            key=operator.attrgetter("quality", "specificity"),
+            reverse=True,
+        )
+
+    @cached_property
+    def accepted_types_by_precedence(self):
+        """
+        Return a list of MediaType instances, in order of precedence (specificity).
+        """
+        return sorted(
+            self.accepted_types,
             key=operator.attrgetter("specificity", "quality"),
             reverse=True,
         )
 
     def accepted_type(self, media_type):
         """
-        Return the preferred MediaType instance which matches the given media type.
+        Return the MediaType instance which best matches the given media type.
         """
         media_type = MediaType(media_type)
         return next(
             (
                 accepted_type
-                for accepted_type in self.accepted_types
+                for accepted_type in self.accepted_types_by_precedence
                 if media_type.match(accepted_type)
             ),
             None,
@@ -130,7 +141,7 @@ class HttpRequest:
         if not desired_types:
             return None
 
-        # Of the desired media types, select the one which is most desirable.
+        # Of the desired media types, select the one which is preferred.
         return min(desired_types, key=lambda t: self.accepted_types.index(t[0]))[1]
 
     def accepts(self, media_type):

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -478,7 +478,7 @@ Methods
         None
 
     (For further details on how content negotiation is performed, see
-    :rfc:`7231#section-5.3.2`.)
+    :rfc:`9110#section-12.5.1`.)
 
     Most browsers send ``Accept: */*`` by default, meaning they don't have a
     preference, in which case the first item in ``media_types`` would be

--- a/docs/releases/5.2.4.txt
+++ b/docs/releases/5.2.4.txt
@@ -9,4 +9,6 @@ Django 5.2.4 fixes several bugs in 5.2.3.
 Bugfixes
 ========
 
-* ...
+* Fixed a regression in Django 5.2.2 where :meth:`HttpRequest.get_preferred_type()
+  <django.http.HttpRequest.get_preferred_type>` incorrectly preferred more
+  specific media types with a lower quality (:ticket:`36447`).


### PR DESCRIPTION
#### Trac ticket number

ticket-36447

#### Branch description

When matching which entry in the `Accept` header should be used for a given media type, the specificity matters. However once those are resolved, only the quality matters when selecting preference.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
