### PR TITLE
Documented use of update_fields with File.save()

### DIFF
--- a/docs/ref/files/file.txt
+++ b/docs/ref/files/file.txt
@@ -135,8 +135,9 @@ below) will also have a couple of extra methods:
 
     Saves a new file with the file name and contents provided. This will not
     replace the existing file, but will create a new file and update the object
-    to point to it. If ``save`` is ``True``, the model's ``save()`` method will
-    be called once the file is saved. That is, these two lines:
+    to point to it. If ``save`` is ``True``, the model's
+    :meth:`~django.db.models.Model.save` method will be called once the file is
+    saved. That is, these two lines:
 
     .. code-block:: pycon
 
@@ -152,6 +153,17 @@ below) will also have a couple of extra methods:
     Note that the ``content`` argument must be an instance of either
     :class:`File` or of a subclass of :class:`File`, such as
     :class:`~django.core.files.base.ContentFile`.
+
+    This method will not pass any additional arguments like ``update_fields``
+    to the model's :meth:`~django.db.models.Model.save` method. To provide
+    additional arguments to the model's :meth:`~django.db.models.Model.save`
+    method, set ``save`` to ``False`` and then call the model's ``save()``
+    method directly:
+
+    .. code-block:: pycon
+
+        >>> car.photo.save("myphoto.jpg", content, save=False)
+        >>> car.save(update_fields=["photo"])
 
 .. method:: File.delete(save=True)
 

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -425,6 +425,7 @@ reverter
 roadmap
 Roald
 rss
+runnable
 Sandvik
 savepoint
 savepoints
@@ -525,6 +526,7 @@ unapplied
 unapplying
 uncategorized
 unclaim
+unclosed
 uncopyable
 unencoded
 unencrypted


### PR DESCRIPTION
See discussion at https://github.com/django/new-features/issues/48 (no Trac ticket, tiny docs update).

#### Branch description

As discussed in the suggested new feature linked above, added some documentation that points out that no arguments are passed from `File.save()` to `Model.save()`, including the probably most common use case to wanting to pass through arguments (ie. `update_fields` to only update the file that is being saved).

I also ran `make spelling` as directed by the contribution docs and found some words that triggered the spellcheck, so I added them to the word list in a separate commit, included here. Happy to remove it or move it to a separate PR if you prefer.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
