### PR TITLE
Fixed #36456 -- Improved content type negotiation in technical 500 error response.

### DIFF
--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -65,9 +65,10 @@ def technical_500_response(request, exc_type, exc_value, tb, status_code=500):
     the values returned from sys.exc_info() and friends.
     """
     reporter = get_exception_reporter_class(request)(request, exc_type, exc_value, tb)
-    if request.accepts("text/html"):
+    preferred_type = request.get_preferred_type(["text/html", "text/plain"])
+    if preferred_type == "text/html":
         html = reporter.get_traceback_html()
-        return HttpResponse(html, status=status_code)
+        return HttpResponse(html, status=status_code, content_type="text/html")
     else:
         text = reporter.get_traceback_text()
         return HttpResponse(

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -261,6 +261,22 @@ class DebugViewTests(SimpleTestCase):
             status_code=500,
         )
 
+    def test_technical_500_content_type_negotiation(self):
+        for accepts, content_type in [
+            ("text/plain", "text/plain; charset=utf-8"),
+            ("text/html", "text/html"),
+            ("text/html,text/plain;q=0.9", "text/html"),
+            ("text/plain,text/html;q=0.9", "text/plain; charset=utf-8"),
+            ("text/*", "text/html"),
+        ]:
+            with self.subTest(accepts=accepts):
+                with self.assertLogs("django.request", "ERROR"):
+                    response = self.client.get(
+                        "/raises500/", headers={"accept": accepts}
+                    )
+                self.assertEqual(response.status_code, 500)
+                self.assertEqual(response["Content-Type"], content_type)
+
     def test_classbased_technical_500(self):
         with self.assertLogs("django.request", "ERROR"):
             response = self.client.get("/classbased500/")


### PR DESCRIPTION
### Summary

This PR ensures that technical_500_response() sets the Content-Type header correctly based on the client's preferred response type (text/html or text/plain). Previously, it returned an HTML response even if the header suggested plain text. This caused mismatches in content negotiation, especially in API clients or CLI tools.

Now, the function uses request.get_preferred_type() and sets the content_type explicitly. This ensures proper formatting and behavior for both browser and non-browser clients.

ticket-36456

