### PR TITLE
Add run_extra_validation() hook to AuthenticationForm for custom validations (e.g., CAPTCHA)

### DIFF
--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -371,8 +371,18 @@ class AuthenticationForm(forms.Form):
             else:
                 self.confirm_login_allowed(self.user_cache)
 
-        return self.cleaned_data
+        self.run_extra_validation()
 
+        return self.cleaned_data
+    def run_extra_validation(self):
+        """
+        Hook method for extra validation (e.g., CAPTCHA).
+        Override this in subclasses.
+        """
+        pass
+
+
+    
     def confirm_login_allowed(self, user):
         """
         Controls whether the given User may log in. This is a policy setting,


### PR DESCRIPTION
## Summary

This PR introduces a new hook method `run_extra_validation()` in the `AuthenticationForm` class to allow developers to easily plug in custom validations (such as Google reCAPTCHA) without modifying the core logic of the form.

## Motivation

Currently, adding reCAPTCHA or similar checks requires overriding the `clean()` method entirely. With this hook, developers can simply subclass and override `run_extra_validation()` for their custom logic.

## Usage Example

```python
class CaptchaLoginForm(AuthenticationForm):
    captcha = ReCaptchaField(widget=ReCaptchaV2Checkbox())

    def run_extra_validation(self):
        if not self.cleaned_data.get("captcha"):
            raise forms.ValidationError("CAPTCHA validation failed.")
