### PR TITLE
Fixed #36464 -- Fixed tuple in subquery lookup when missing native support.

### DIFF
--- a/django/db/models/fields/tuple_lookups.py
+++ b/django/db/models/fields/tuple_lookups.py
@@ -1,9 +1,10 @@
 import itertools
 
 from django.core.exceptions import EmptyResultSet
-from django.db.models import Field
+from django.db import models
 from django.db.models.expressions import (
     ColPairs,
+    Exists,
     Func,
     ResolvedOuterRef,
     Subquery,
@@ -25,7 +26,7 @@ from django.db.models.sql.where import AND, OR, WhereNode
 class Tuple(Func):
     allows_composite_expressions = True
     function = ""
-    output_field = Field()
+    output_field = models.Field()
 
     def __len__(self):
         return len(self.source_expressions)
@@ -351,7 +352,21 @@ class TupleIn(TupleLookupMixin, In):
         rhs = self.rhs
         if not rhs:
             raise EmptyResultSet
-        if not self.rhs_is_direct_value():
+        if isinstance(rhs, Query):
+            rhs_exprs = itertools.chain.from_iterable(
+                (
+                    select_expr
+                    if isinstance((select_expr := select[0]), ColPairs)
+                    else [select_expr]
+                )
+                for select in rhs.get_compiler(connection=connection).get_select()[0]
+            )
+            rhs = rhs.clone()
+            rhs.add_q(
+                models.Q(*[Exact(col, val) for col, val in zip(self.lhs, rhs_exprs)])
+            )
+            return compiler.compile(Exists(rhs))
+        elif not self.rhs_is_direct_value():
             return super(TupleLookupMixin, self).as_sql(compiler, connection)
 
         # e.g.: (a, b, c) in [(x1, y1, z1), (x2, y2, z2)] as SQL:

--- a/docs/releases/5.2.4.txt
+++ b/docs/releases/5.2.4.txt
@@ -16,3 +16,7 @@ Bugfixes
 * Fixed a regression in Django 5.2.3 where ``Value(None, JSONField())`` used in
   a :class:`~django.db.models.expressions.When` condition was incorrectly
   serialized as SQL ``NULL`` instead of JSON ``null`` (:ticket:`36453`).
+
+* Fixed a crash in Django 5.2 when performing an ``__in`` lookup involving a
+  composite primary key and a subquery on backends that lack native support for
+  tuple lookups (:ticket:`36464`).


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36464

#### Branch description

When native support is missing it can be emulated with an EXISTS clause.

The mishandling of subquery right-hand-side was likely missed because the only core backend we happen to test with the `supports_tuple_lookups` feature disabled (Oracle < 23.4) supports it natively.

Thanks @NandanaRaol for the report [against SQL Server](https://github.com/microsoft/mssql-django/pull/445/).
