### PR TITLE
Refs #25706 -- Avoided adding an unneeded and potentially non-unique ID.

### DIFF
--- a/django/contrib/gis/static/gis/js/OLMapWidget.js
+++ b/django/contrib/gis/static/gis/js/OLMapWidget.js
@@ -266,7 +266,7 @@ function initMapWidgetInSection(section) {
         if (wrapper.id.includes('__prefix__')) {
             return;
         }
-        const options = JSON.parse(wrapper.querySelector("#mapwidget-options").textContent);
+        const options = JSON.parse(wrapper.querySelector("script").textContent);
         options.id = wrapper.querySelector("textarea").id;
         options.map_id = wrapper.querySelector(".dj_map").id;
         maps.push(new MapWidget(options));

--- a/django/contrib/gis/templates/gis/openlayers.html
+++ b/django/contrib/gis/templates/gis/openlayers.html
@@ -6,5 +6,5 @@
     {% if widget.attrs.display_raw %}<p>{% translate "Debugging window (serialized value)" %}</p>{% endif %}
     <textarea id="{{ widget.attrs.id }}" class="vSerializedField required" cols="150" rows="10" name="{{ widget.name }}"
               {% if not widget.attrs.display_raw %} hidden{% endif %}>{{ serialized }}</textarea>
-    {{ widget.attrs|json_script:"mapwidget-options" }}
+    {{ widget.attrs|json_script }}
 </div>

--- a/js_tests/gis/mapwidget.test.js
+++ b/js_tests/gis/mapwidget.test.js
@@ -142,7 +142,7 @@ QUnit.test('initMapWidgetInSection initializes widgets and skips __prefix__', fu
     wrapper1.innerHTML = `
         <textarea id="id_point"></textarea>
         <div class="dj_map" id="id_point_map"></div>
-        <script type="application/json" id="mapwidget-options">
+        <script type="application/json">
             { "geom_name": "Point" }
         </script>
     `;
@@ -154,7 +154,7 @@ QUnit.test('initMapWidgetInSection initializes widgets and skips __prefix__', fu
     wrapper2.innerHTML = `
         <textarea id="id_fake"></textarea>
         <div class="dj_map" id="id_fake_map"></div>
-        <script type="application/json" id="mapwidget-options">
+        <script type="application/json">
             { "geom_name": "MultiPoint" }
         </script>
     `;

--- a/tests/gis_tests/test_geoforms.py
+++ b/tests/gis_tests/test_geoforms.py
@@ -212,7 +212,7 @@ class GeometryFieldTest(SimpleTestCase):
             "id": "id_p",
             "geom_name": "Point",
         }
-        expected = json_script(attrs, "mapwidget-options")
+        expected = json_script(attrs)
         self.assertInHTML(expected, rendered)
 
 
@@ -303,7 +303,7 @@ class SpecializedFieldTest(SimpleTestCase):
                 "id": map_field.id_for_label,
                 "geom_name": geom_name,
             }
-            expected = json_script(attrs, "mapwidget-options")
+            expected = json_script(attrs)
             self.assertInHTML(expected, rendered)
         self.assertIn("gis/js/OLMapWidget.js", str(form_instance.media))
 
@@ -473,7 +473,7 @@ class OSMWidgetTest(SimpleTestCase):
             "id": "id_p",
             "geom_name": "Point",
         }
-        expected = json_script(attrs, "mapwidget-options")
+        expected = json_script(attrs)
         self.assertInHTML(expected, rendered)
 
 


### PR DESCRIPTION
This amends the code from https://github.com/django/django/pull/18494 to avoid setting an URL for the script containing the widget configuration in JSON format. The ID generated by json_script would be non-unique when using the widget several times on the same page.

This is a minor change without any real consequence, but I think it shows a slightly better pattern for shipping JSON configuration to custom widgets by avoiding the element ID.

cc @claudep 

#### Checklist

- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
