### PR TITLE
Fixed #36465 -- Disallowed '+' and '-' characters in template variable names.

### DIFF
--- a/django/template/base.py
+++ b/django/template/base.py
@@ -852,6 +852,13 @@ class Variable:
                         "Variables and attributes may "
                         "not begin with underscores: '%s'" % var
                     )
+                # Disallow characters that are allowed in numbers but not in a
+                # variable name.
+                for c in ["+", "-"]:
+                    if c in var:
+                        raise TemplateSyntaxError(
+                            "Invalid character ('%s') in variable name: '%s'" % (c, var)
+                        )
                 self.lookups = tuple(var.split(VARIABLE_ATTRIBUTE_SEPARATOR))
 
     def resolve(self, context):

--- a/tests/template_tests/test_base.py
+++ b/tests/template_tests/test_base.py
@@ -78,9 +78,6 @@ class VariableTests(SimpleTestCase):
 
     def test_nonliterals(self):
         """Variable names that aren't resolved as literals."""
-        var_names = []
-        for var in ("inf", "infinity", "iNFiniTy", "nan"):
-            var_names.extend((var, "-" + var, "+" + var))
-        for var in var_names:
+        for var in ["inf", "infinity", "iNFiniTy", "nan"]:
             with self.subTest(var=var):
                 self.assertIsNone(Variable(var).literal)


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36465

#### Branch description
The [PR](#19213) that fixed ticket [35816](https://code.djangoproject.com/ticket/35816) also introduced unwanted behavior which was to allow variables with '-' in the name. e.g. `my-variable-name`. This PR undoes that behavior by throwing an exception on initialization if the value is not numeric and contains one of the characters only valid for a number ('-' or '+'). 

Note that this behavior IS slightly different than it was before - "variable-name" would previously be interpreted by the parser as a variable named "variable", followed by something unparsable, and throw a "TemplateSyntaxError: Could not parse the remainder: '-name' from 'variable-name'. Now it interprets it as a variable named "variable-name" and explicitly disallows it, throwing a "TemplateSyntaxError: Invalid character ('-') in variable name: 'variable-name'". This error is thrown from the `Variable` itself, rather than from `FilterExpression`, so `Variable("variable-name")` will also fail where previously it would not.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
