### PR TITLE
Clarified that only latest dependency versions are valid for security reports.

### DIFF
--- a/docs/faq/install.txt
+++ b/docs/faq/install.txt
@@ -58,7 +58,10 @@ Django version Python versions
 ============== ===============
 
 For each version of Python, only the latest micro release (A.B.C) is officially
-supported. You can find the latest micro version for each series on the `Python
+supported. Python versions that have reached end-of-life are no longer
+maintained by the Python project and therefore should not be used with Django.
+
+You can find the latest supported micro version for each series on the `Python
 download page <https://www.python.org/downloads/>`_.
 
 We will support a Python version up to and including the first Django LTS

--- a/docs/internals/security.txt
+++ b/docs/internals/security.txt
@@ -55,6 +55,17 @@ set up, run, and reproduce the issue.
 
 Please do not attach screenshots of code.
 
+Use supported versions of dependencies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Django only :ref:`officially supports <faq-python-version-support>` the latest
+micro release (A.B.C) of Python. Vulnerabilities must be reproducible when all
+relevant dependencies (not limited to Python) are at supported versions.
+
+For example, vulnerabilities that only occur when Django is run on a version of
+Python that is no longer receiving security updates ("end-of-life") are **not
+considered valid**, even if that version is listed as supported by Django.
+
 User input must be sanitized
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
#### Trac ticket number

N/A. As discussed in Security mailing list.

#### Branch description

Mention in our security policy that dependencies must be up to date and using the latest supported version.

For example, whilst Python 3.8 is still officially supported by Django 4.2, it is no longer supported upstream (ie by python.org), so vulnerabilities which only exist in Python 3.8 are no longer considered valid.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
