### PR TITLE
Fixed #35581 -- Updated django.core.mail to Python's modern email API. 

### DIFF
--- a/django/core/mail/__init__.py
+++ b/django/core/mail/__init__.py
@@ -13,14 +13,10 @@ from django.core.exceptions import ImproperlyConfigured
 # backends and the subsequent reorganization (See #10355)
 from django.core.mail.message import (
     DEFAULT_ATTACHMENT_MIME_TYPE,
-    BadHeaderError,
     EmailAlternative,
     EmailAttachment,
     EmailMessage,
     EmailMultiAlternatives,
-    SafeMIMEMultipart,
-    SafeMIMEText,
-    forbid_multi_line_headers,
     make_msgid,
 )
 from django.core.mail.utils import DNS_NAME, CachedDnsName
@@ -33,12 +29,8 @@ __all__ = [
     "DNS_NAME",
     "EmailMessage",
     "EmailMultiAlternatives",
-    "SafeMIMEText",
-    "SafeMIMEMultipart",
     "DEFAULT_ATTACHMENT_MIME_TYPE",
     "make_msgid",
-    "BadHeaderError",
-    "forbid_multi_line_headers",
     "get_connection",
     "send_mail",
     "send_mass_mail",
@@ -46,6 +38,11 @@ __all__ = [
     "mail_managers",
     "EmailAlternative",
     "EmailAttachment",
+    # RemovedInDjango70Warning:
+    "BadHeaderError",
+    "SafeMIMEText",
+    "SafeMIMEMultipart",
+    "forbid_multi_line_headers",
 ]
 
 
@@ -192,3 +189,34 @@ def mail_managers(
         fail_silently=fail_silently,
         connection=connection,
     )
+
+
+# RemovedInDjango70Warning
+_deprecate_on_import = {
+    "BadHeaderError": "BadHeaderError is deprecated. Replace with ValueError.",
+    "SafeMIMEText": (
+        "SafeMIMEText is deprecated. The return value"
+        " of EmailMessage.message() is an email.message.EmailMessage."
+    ),
+    "SafeMIMEMultipart": (
+        "SafeMIMEMultipart is deprecated. The return value"
+        " of EmailMessage.message() is an email.message.EmailMessage."
+    ),
+    "forbid_multi_line_headers": (
+        "The internal API forbid_multi_line_headers() is deprecated."
+    ),
+}
+
+
+# RemovedInDjango70Warning
+# Issue deprecation warnings at time of import.
+def __getattr__(name):
+    try:
+        msg = _deprecate_on_import[name]
+    except KeyError:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None
+    else:
+        from django.core.mail import _deprecated
+
+        warnings.warn(msg, category=RemovedInDjango70Warning)
+        return getattr(_deprecated, name)

--- a/django/core/mail/_deprecated.py
+++ b/django/core/mail/_deprecated.py
@@ -1,0 +1,200 @@
+# RemovedInDjango70Warning: This entire file.
+import warnings
+from email import charset as Charset
+from email import generator
+from email.errors import HeaderParseError
+from email.header import Header
+from email.headerregistry import Address, parser
+from email.mime.message import MIMEMessage
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from email.utils import formataddr, getaddresses
+from io import BytesIO, StringIO
+
+from django.conf import settings
+from django.utils.deprecation import RemovedInDjango70Warning
+from django.utils.encoding import force_str, punycode
+
+# Don't BASE64-encode UTF-8 messages so that we avoid unwanted attention from
+# some spam filters.
+utf8_charset = Charset.Charset("utf-8")
+utf8_charset.body_encoding = None  # Python defaults to BASE64
+utf8_charset_qp = Charset.Charset("utf-8")
+utf8_charset_qp.body_encoding = Charset.QP
+
+RFC5322_EMAIL_LINE_LENGTH_LIMIT = 998
+
+
+# BadHeaderError must _be_ ValueError (not subclass it), so that existing code
+# with `except BadHeaderError` will catch the ValueError that Python's modern
+# email API raises for headers containing CR or NL.
+BadHeaderError = ValueError
+
+# Header names that contain structured address data (RFC 5322).
+ADDRESS_HEADERS = {
+    "from",
+    "sender",
+    "reply-to",
+    "to",
+    "cc",
+    "bcc",
+    "resent-from",
+    "resent-sender",
+    "resent-to",
+    "resent-cc",
+    "resent-bcc",
+}
+
+
+def forbid_multi_line_headers(name, val, encoding):
+    """Forbid multi-line headers to prevent header injection."""
+    warnings.warn(
+        "The internal API forbid_multi_line_headers() is deprecated."
+        " Python's modern email API (with email.message.EmailMessage or"
+        " email.policy.default) will reject multi-line headers.",
+        RemovedInDjango70Warning,
+    )
+
+    encoding = encoding or settings.DEFAULT_CHARSET
+    val = str(val)  # val may be lazy
+    if "\n" in val or "\r" in val:
+        raise BadHeaderError(
+            "Header values can't contain newlines (got %r for header %r)" % (val, name)
+        )
+    try:
+        val.encode("ascii")
+    except UnicodeEncodeError:
+        if name.lower() in ADDRESS_HEADERS:
+            val = ", ".join(
+                sanitize_address(addr, encoding) for addr in getaddresses((val,))
+            )
+        else:
+            val = Header(val, encoding).encode()
+    else:
+        if name.lower() == "subject":
+            val = Header(val).encode()
+    return name, val
+
+
+def sanitize_address(addr, encoding):
+    """
+    Format a pair of (name, address) or an email address string.
+    """
+    warnings.warn(
+        "The internal API sanitize_address() is deprecated."
+        " Python's modern email API (with email.message.EmailMessage or"
+        " email.policy.default) will handle most required validation and"
+        " encoding. Use Python's email.headerregistry.Address to construct"
+        " formatted addresses from component parts.",
+        RemovedInDjango70Warning,
+    )
+
+    address = None
+    if not isinstance(addr, tuple):
+        addr = force_str(addr)
+        try:
+            token, rest = parser.get_mailbox(addr)
+        except (HeaderParseError, ValueError, IndexError):
+            raise ValueError('Invalid address "%s"' % addr)
+        else:
+            if rest:
+                # The entire email address must be parsed.
+                raise ValueError(
+                    'Invalid address; only %s could be parsed from "%s"' % (token, addr)
+                )
+            nm = token.display_name or ""
+            localpart = token.local_part
+            domain = token.domain or ""
+    else:
+        nm, address = addr
+        if "@" not in address:
+            raise ValueError(f'Invalid address "{address}"')
+        localpart, domain = address.rsplit("@", 1)
+
+    address_parts = nm + localpart + domain
+    if "\n" in address_parts or "\r" in address_parts:
+        raise ValueError("Invalid address; address parts cannot contain newlines.")
+
+    # Avoid UTF-8 encode, if it's possible.
+    try:
+        nm.encode("ascii")
+        nm = Header(nm).encode()
+    except UnicodeEncodeError:
+        nm = Header(nm, encoding).encode()
+    try:
+        localpart.encode("ascii")
+    except UnicodeEncodeError:
+        localpart = Header(localpart, encoding).encode()
+    domain = punycode(domain)
+
+    parsed_address = Address(username=localpart, domain=domain)
+    return formataddr((nm, parsed_address.addr_spec))
+
+
+class MIMEMixin:
+    def as_string(self, unixfrom=False, linesep="\n"):
+        """Return the entire formatted message as a string.
+        Optional `unixfrom' when True, means include the Unix From_ envelope
+        header.
+
+        This overrides the default as_string() implementation to not mangle
+        lines that begin with 'From '. See bug #13433 for details.
+        """
+        fp = StringIO()
+        g = generator.Generator(fp, mangle_from_=False)
+        g.flatten(self, unixfrom=unixfrom, linesep=linesep)
+        return fp.getvalue()
+
+    def as_bytes(self, unixfrom=False, linesep="\n"):
+        """Return the entire formatted message as bytes.
+        Optional `unixfrom' when True, means include the Unix From_ envelope
+        header.
+
+        This overrides the default as_bytes() implementation to not mangle
+        lines that begin with 'From '. See bug #13433 for details.
+        """
+        fp = BytesIO()
+        g = generator.BytesGenerator(fp, mangle_from_=False)
+        g.flatten(self, unixfrom=unixfrom, linesep=linesep)
+        return fp.getvalue()
+
+
+class SafeMIMEMessage(MIMEMixin, MIMEMessage):
+    def __setitem__(self, name, val):
+        # message/rfc822 attachments must be ASCII
+        name, val = forbid_multi_line_headers(name, val, "ascii")
+        MIMEMessage.__setitem__(self, name, val)
+
+
+class SafeMIMEText(MIMEMixin, MIMEText):
+    def __init__(self, _text, _subtype="plain", _charset=None):
+        self.encoding = _charset
+        MIMEText.__init__(self, _text, _subtype=_subtype, _charset=_charset)
+
+    def __setitem__(self, name, val):
+        name, val = forbid_multi_line_headers(name, val, self.encoding)
+        MIMEText.__setitem__(self, name, val)
+
+    def set_payload(self, payload, charset=None):
+        if charset == "utf-8" and not isinstance(charset, Charset.Charset):
+            has_long_lines = any(
+                len(line.encode(errors="surrogateescape"))
+                > RFC5322_EMAIL_LINE_LENGTH_LIMIT
+                for line in payload.splitlines()
+            )
+            # Quoted-Printable encoding has the side effect of shortening long
+            # lines, if any (#22561).
+            charset = utf8_charset_qp if has_long_lines else utf8_charset
+        MIMEText.set_payload(self, payload, charset=charset)
+
+
+class SafeMIMEMultipart(MIMEMixin, MIMEMultipart):
+    def __init__(
+        self, _subtype="mixed", boundary=None, _subparts=None, encoding=None, **_params
+    ):
+        self.encoding = encoding
+        MIMEMultipart.__init__(self, _subtype, boundary, _subparts, **_params)
+
+    def __setitem__(self, name, val):
+        name, val = forbid_multi_line_headers(name, val, self.encoding)
+        MIMEMultipart.__setitem__(self, name, val)

--- a/django/core/mail/backends/smtp.py
+++ b/django/core/mail/backends/smtp.py
@@ -1,13 +1,16 @@
 """SMTP email backend class."""
 
+import email.policy
 import smtplib
 import ssl
 import threading
+from email.errors import HeaderParseError
+from email.headerregistry import Address, AddressHeader
 
 from django.conf import settings
 from django.core.mail.backends.base import BaseEmailBackend
-from django.core.mail.message import sanitize_address
 from django.core.mail.utils import DNS_NAME
+from django.utils.encoding import force_str, punycode
 from django.utils.functional import cached_property
 
 
@@ -145,18 +148,52 @@ class EmailBackend(BaseEmailBackend):
         """A helper method that does the actual sending."""
         if not email_message.recipients():
             return False
-        encoding = email_message.encoding or settings.DEFAULT_CHARSET
-        from_email = sanitize_address(email_message.from_email, encoding)
-        recipients = [
-            sanitize_address(addr, encoding) for addr in email_message.recipients()
-        ]
-        message = email_message.message()
+        from_email = self.prep_address(email_message.from_email)
+        recipients = [self.prep_address(addr) for addr in email_message.recipients()]
+        message = email_message.message(policy=email.policy.SMTP)
         try:
-            self.connection.sendmail(
-                from_email, recipients, message.as_bytes(linesep="\r\n")
-            )
+            self.connection.sendmail(from_email, recipients, message.as_bytes())
         except smtplib.SMTPException:
             if not self.fail_silently:
                 raise
             return False
         return True
+
+    def prep_address(self, address, force_ascii=True):
+        """
+        Return the addr-spec portion of an email address. Raises ValueError for
+        invalid addresses, including CR/NL injection.
+
+        If force_ascii is True, apply IDNA encoding to non-ASCII domains, and raise
+        ValueError for non-ASCII local-parts (which can't be encoded). Otherwise,
+        leave Unicode characters unencoded (e.g., for sending with SMTPUTF8).
+        """
+        address = force_str(address)
+        try:
+            parsed = AddressHeader.value_parser(address)
+        except (AssertionError, HeaderParseError, IndexError, TypeError, ValueError):
+            # (Don't include the parser error message. It's generally not helpful.)
+            raise ValueError(f"Invalid address {address!r}") from None
+        else:
+            defects = set(str(defect) for defect in parsed.all_defects)
+            # Local mailboxes like "From: webmaster" are allowed (#15042).
+            defects.discard("addr-spec local part with no domain")
+            if not force_ascii:
+                # Non-ASCII local-part is allowed with SMTPUTF8. (There's an
+                # extraneous ')' in this error through at least Python 3.13.)
+                defects.discard("local-part contains non-ASCII characters)")
+                defects.discard("local-part contains non-ASCII characters")
+            if defects:
+                raise ValueError(f"Invalid address {address!r}: {'; '.join(defects)}")
+
+        mailboxes = parsed.all_mailboxes
+        if len(mailboxes) != 1:
+            raise ValueError(f"Invalid address {address!r}: must be a single address")
+
+        mailbox = mailboxes[0]
+        if force_ascii and mailbox.domain and not mailbox.domain.isascii():
+            # Re-compose an addr-spec with the IDNA encoded domain.
+            domain = punycode(mailbox.domain)
+            return str(Address(username=mailbox.local_part, domain=domain))
+        else:
+            return mailbox.addr_spec

--- a/django/core/mail/message.py
+++ b/django/core/mail/message.py
@@ -1,195 +1,27 @@
+import email.message
+import email.policy
 import mimetypes
+import warnings
 from collections import namedtuple
-from email import charset as Charset
-from email import encoders as Encoders
-from email import generator, message_from_bytes
-from email.errors import HeaderParseError
-from email.header import Header
-from email.headerregistry import Address, parser
-from email.message import Message
+from datetime import datetime, timezone
+from email.headerregistry import Address, AddressHeader
 from email.mime.base import MIMEBase
-from email.mime.message import MIMEMessage
-from email.mime.multipart import MIMEMultipart
-from email.mime.text import MIMEText
-from email.utils import formataddr, formatdate, getaddresses, make_msgid
-from io import BytesIO, StringIO
+from email.utils import make_msgid
 from pathlib import Path
 
 from django.conf import settings
+from django.core.mail._deprecated import (  # NOQA: F401; RemovedInDjango70Warning
+    forbid_multi_line_headers,
+    sanitize_address,
+)
 from django.core.mail.utils import DNS_NAME
+from django.utils.deprecation import RemovedInDjango70Warning
 from django.utils.encoding import force_bytes, force_str, punycode
-
-# Don't BASE64-encode UTF-8 messages so that we avoid unwanted attention from
-# some spam filters.
-utf8_charset = Charset.Charset("utf-8")
-utf8_charset.body_encoding = None  # Python defaults to BASE64
-utf8_charset_qp = Charset.Charset("utf-8")
-utf8_charset_qp.body_encoding = Charset.QP
+from django.utils.timezone import get_current_timezone
 
 # Default MIME type to use on attachments (if it is not explicitly given
 # and cannot be guessed).
 DEFAULT_ATTACHMENT_MIME_TYPE = "application/octet-stream"
-
-RFC5322_EMAIL_LINE_LENGTH_LIMIT = 998
-
-
-class BadHeaderError(ValueError):
-    pass
-
-
-# Header names that contain structured address data (RFC 5322).
-ADDRESS_HEADERS = {
-    "from",
-    "sender",
-    "reply-to",
-    "to",
-    "cc",
-    "bcc",
-    "resent-from",
-    "resent-sender",
-    "resent-to",
-    "resent-cc",
-    "resent-bcc",
-}
-
-
-def forbid_multi_line_headers(name, val, encoding):
-    """Forbid multi-line headers to prevent header injection."""
-    encoding = encoding or settings.DEFAULT_CHARSET
-    val = str(val)  # val may be lazy
-    if "\n" in val or "\r" in val:
-        raise BadHeaderError(
-            "Header values can't contain newlines (got %r for header %r)" % (val, name)
-        )
-    try:
-        val.encode("ascii")
-    except UnicodeEncodeError:
-        if name.lower() in ADDRESS_HEADERS:
-            val = ", ".join(
-                sanitize_address(addr, encoding) for addr in getaddresses((val,))
-            )
-        else:
-            val = Header(val, encoding).encode()
-    else:
-        if name.lower() == "subject":
-            val = Header(val).encode()
-    return name, val
-
-
-def sanitize_address(addr, encoding):
-    """
-    Format a pair of (name, address) or an email address string.
-    """
-    address = None
-    if not isinstance(addr, tuple):
-        addr = force_str(addr)
-        try:
-            token, rest = parser.get_mailbox(addr)
-        except (HeaderParseError, ValueError, IndexError):
-            raise ValueError('Invalid address "%s"' % addr)
-        else:
-            if rest:
-                # The entire email address must be parsed.
-                raise ValueError(
-                    'Invalid address; only %s could be parsed from "%s"' % (token, addr)
-                )
-            nm = token.display_name or ""
-            localpart = token.local_part
-            domain = token.domain or ""
-    else:
-        nm, address = addr
-        if "@" not in address:
-            raise ValueError(f'Invalid address "{address}"')
-        localpart, domain = address.rsplit("@", 1)
-
-    address_parts = nm + localpart + domain
-    if "\n" in address_parts or "\r" in address_parts:
-        raise ValueError("Invalid address; address parts cannot contain newlines.")
-
-    # Avoid UTF-8 encode, if it's possible.
-    try:
-        nm.encode("ascii")
-        nm = Header(nm).encode()
-    except UnicodeEncodeError:
-        nm = Header(nm, encoding).encode()
-    try:
-        localpart.encode("ascii")
-    except UnicodeEncodeError:
-        localpart = Header(localpart, encoding).encode()
-    domain = punycode(domain)
-
-    parsed_address = Address(username=localpart, domain=domain)
-    return formataddr((nm, parsed_address.addr_spec))
-
-
-class MIMEMixin:
-    def as_string(self, unixfrom=False, linesep="\n"):
-        """Return the entire formatted message as a string.
-        Optional `unixfrom' when True, means include the Unix From_ envelope
-        header.
-
-        This overrides the default as_string() implementation to not mangle
-        lines that begin with 'From '. See bug #13433 for details.
-        """
-        fp = StringIO()
-        g = generator.Generator(fp, mangle_from_=False)
-        g.flatten(self, unixfrom=unixfrom, linesep=linesep)
-        return fp.getvalue()
-
-    def as_bytes(self, unixfrom=False, linesep="\n"):
-        """Return the entire formatted message as bytes.
-        Optional `unixfrom' when True, means include the Unix From_ envelope
-        header.
-
-        This overrides the default as_bytes() implementation to not mangle
-        lines that begin with 'From '. See bug #13433 for details.
-        """
-        fp = BytesIO()
-        g = generator.BytesGenerator(fp, mangle_from_=False)
-        g.flatten(self, unixfrom=unixfrom, linesep=linesep)
-        return fp.getvalue()
-
-
-class SafeMIMEMessage(MIMEMixin, MIMEMessage):
-    def __setitem__(self, name, val):
-        # Per RFC 2046 Section 5.2.1, message/rfc822 attachment headers must be ASCII.
-        name, val = forbid_multi_line_headers(name, val, "ascii")
-        MIMEMessage.__setitem__(self, name, val)
-
-
-class SafeMIMEText(MIMEMixin, MIMEText):
-    def __init__(self, _text, _subtype="plain", _charset=None):
-        self.encoding = _charset
-        MIMEText.__init__(self, _text, _subtype=_subtype, _charset=_charset)
-
-    def __setitem__(self, name, val):
-        name, val = forbid_multi_line_headers(name, val, self.encoding)
-        MIMEText.__setitem__(self, name, val)
-
-    def set_payload(self, payload, charset=None):
-        if charset == "utf-8" and not isinstance(charset, Charset.Charset):
-            has_long_lines = any(
-                len(line.encode(errors="surrogateescape"))
-                > RFC5322_EMAIL_LINE_LENGTH_LIMIT
-                for line in payload.splitlines()
-            )
-            # Quoted-Printable encoding has the side effect of shortening long
-            # lines, if any (#22561).
-            charset = utf8_charset_qp if has_long_lines else utf8_charset
-        MIMEText.set_payload(self, payload, charset=charset)
-
-
-class SafeMIMEMultipart(MIMEMixin, MIMEMultipart):
-    def __init__(
-        self, _subtype="mixed", boundary=None, _subparts=None, encoding=None, **_params
-    ):
-        self.encoding = encoding
-        MIMEMultipart.__init__(self, _subtype, boundary, _subparts, **_params)
-
-    def __setitem__(self, name, val):
-        name, val = forbid_multi_line_headers(name, val, self.encoding)
-        MIMEMultipart.__setitem__(self, name, val)
-
 
 EmailAlternative = namedtuple("EmailAlternative", ["content", "mimetype"])
 EmailAttachment = namedtuple("EmailAttachment", ["filename", "content", "mimetype"])
@@ -199,7 +31,10 @@ class EmailMessage:
     """A container for email information."""
 
     content_subtype = "plain"
-    mixed_subtype = "mixed"
+
+    # Undocumented charset to use for text/* message bodies
+    # and attachments. Defaults to settings.DEFAULT_CHARSET.
+    # (Should rename to `charset` if it will be documented.)
     encoding = None  # None => use settings default
 
     def __init__(
@@ -249,7 +84,8 @@ class EmailMessage:
         self.attachments = []
         if attachments:
             for attachment in attachments:
-                if isinstance(attachment, MIMEBase):
+                # RemovedInDjango70Warning: MIMEBase attachment support.
+                if isinstance(attachment, (MIMEBase, email.message.MIMEPart)):
                     self.attach(attachment)
                 else:
                     self.attach(*attachment)
@@ -263,12 +99,13 @@ class EmailMessage:
             self.connection = get_connection(fail_silently=fail_silently)
         return self.connection
 
-    def message(self):
-        encoding = self.encoding or settings.DEFAULT_CHARSET
-        msg = SafeMIMEText(self.body, self.content_subtype, encoding)
-        msg = self._create_message(msg)
-        msg["Subject"] = self.subject
-        msg["From"] = self.extra_headers.get("From", self.from_email)
+    def message(self, *, policy=email.policy.default):
+        msg = email.message.EmailMessage(policy=policy)
+        self._add_bodies(msg)
+        self._add_attachments(msg)
+
+        msg["Subject"] = str(self.subject)
+        msg["From"] = str(self.extra_headers.get("From", self.from_email))
         self._set_list_header_if_not_empty(msg, "To", self.to)
         self._set_list_header_if_not_empty(msg, "Cc", self.cc)
         self._set_list_header_if_not_empty(msg, "Reply-To", self.reply_to)
@@ -277,18 +114,19 @@ class EmailMessage:
         # accommodate that when doing comparisons.
         header_names = [key.lower() for key in self.extra_headers]
         if "date" not in header_names:
-            # formatdate() uses stdlib methods to format the date, which use
-            # the stdlib/OS concept of a timezone, however, Django sets the
-            # TZ environment variable based on the TIME_ZONE setting which
-            # will get picked up by formatdate().
-            msg["Date"] = formatdate(localtime=settings.EMAIL_USE_LOCALTIME)
+            if settings.EMAIL_USE_LOCALTIME:
+                tz = get_current_timezone()
+            else:
+                tz = timezone.utc
+            msg["Date"] = datetime.now(tz)
         if "message-id" not in header_names:
             # Use cached DNS_NAME for performance
             msg["Message-ID"] = make_msgid(domain=DNS_NAME)
         for name, value in self.extra_headers.items():
             # Avoid headers handled above.
             if name.lower() not in {"from", "to", "cc", "reply-to"}:
-                msg[name] = value
+                msg[name] = force_str(value, strings_only=True)
+        self._idna_encode_address_header_domains(msg)
         return msg
 
     def recipients(self):
@@ -318,7 +156,19 @@ class EmailMessage:
         specified as content, decode it as UTF-8. If that fails, set the
         mimetype to DEFAULT_ATTACHMENT_MIME_TYPE and don't decode the content.
         """
-        if isinstance(filename, MIMEBase):
+        if isinstance(filename, email.message.MIMEPart):
+            if content is not None or mimetype is not None:
+                raise ValueError(
+                    "content and mimetype must not be given when a MIMEPart "
+                    "instance is provided."
+                )
+            self.attachments.append(filename)
+        elif isinstance(filename, MIMEBase):
+            warnings.warn(
+                "MIMEBase attachments are deprecated."
+                " Use an email.message.MIMEPart instead.",
+                RemovedInDjango70Warning,
+            )
             if content is not None or mimetype is not None:
                 raise ValueError(
                     "content and mimetype must not be given when a MIMEBase "
@@ -362,68 +212,69 @@ class EmailMessage:
             content = file.read()
             self.attach(path.name, content, mimetype)
 
-    def _create_message(self, msg):
-        return self._create_attachments(msg)
-
-    def _create_attachments(self, msg):
-        if self.attachments:
+    def _add_bodies(self, msg):
+        if self.body or not self.attachments:
             encoding = self.encoding or settings.DEFAULT_CHARSET
-            body_msg = msg
-            msg = SafeMIMEMultipart(_subtype=self.mixed_subtype, encoding=encoding)
-            if self.body or body_msg.is_multipart():
-                msg.attach(body_msg)
+            body = force_str(
+                self.body or "", encoding=encoding, errors="surrogateescape"
+            )
+            msg.set_content(body, subtype=self.content_subtype, charset=encoding)
+
+    def _add_attachments(self, msg):
+        if self.attachments:
+            if hasattr(self, "mixed_subtype"):
+                # RemovedInDjango70Warning
+                raise AttributeError(
+                    "EmailMessage no longer supports the"
+                    " undocumented `mixed_subtype` attribute"
+                )
+            msg.make_mixed()
             for attachment in self.attachments:
-                if isinstance(attachment, MIMEBase):
+                if isinstance(attachment, email.message.MIMEPart):
+                    msg.attach(attachment)
+                elif isinstance(attachment, MIMEBase):
+                    # RemovedInDjango70Warning
                     msg.attach(attachment)
                 else:
-                    msg.attach(self._create_attachment(*attachment))
-        return msg
+                    self._add_attachment(msg, *attachment)
 
-    def _create_mime_attachment(self, content, mimetype):
-        """
-        Convert the content, mimetype pair into a MIME attachment object.
-
-        If the mimetype is message/rfc822, content may be an
-        email.Message or EmailMessage object, as well as a str.
-        """
-        basetype, subtype = mimetype.split("/", 1)
-        if basetype == "text":
-            encoding = self.encoding or settings.DEFAULT_CHARSET
-            attachment = SafeMIMEText(content, subtype, encoding)
-        elif basetype == "message" and subtype == "rfc822":
-            # Bug #18967: Per RFC 2046 Section 5.2.1, message/rfc822
-            # attachments must not be base64 encoded.
-            if isinstance(content, EmailMessage):
-                # convert content into an email.Message first
-                content = content.message()
-            elif not isinstance(content, Message):
-                # For compatibility with existing code, parse the message
-                # into an email.Message object if it is not one already.
-                content = message_from_bytes(force_bytes(content))
-
-            attachment = SafeMIMEMessage(content, subtype)
-        else:
-            # Encode non-text attachments with base64.
-            attachment = MIMEBase(basetype, subtype)
-            attachment.set_payload(content)
-            Encoders.encode_base64(attachment)
-        return attachment
-
-    def _create_attachment(self, filename, content, mimetype=None):
-        """
-        Convert the filename, content, mimetype triple into a MIME attachment
-        object.
-        """
-        attachment = self._create_mime_attachment(content, mimetype)
-        if filename:
-            try:
-                filename.encode("ascii")
-            except UnicodeEncodeError:
-                filename = ("utf-8", "", filename)
-            attachment.add_header(
-                "Content-Disposition", "attachment", filename=filename
+    def _add_attachment(self, msg, filename, content, mimetype):
+        encoding = self.encoding or settings.DEFAULT_CHARSET
+        if mimetype is None:
+            mimetype = DEFAULT_ATTACHMENT_MIME_TYPE
+        maintype, subtype = mimetype.split("/", 1)
+        # See email.contentmanager.set_content() docs for the cases here.
+        if maintype == "text":
+            # For text/*, content must be str, and maintype cannot be provided.
+            if isinstance(content, bytes):
+                content = content.decode()
+            msg.add_attachment(
+                content, subtype=subtype, filename=filename, charset=encoding
             )
-        return attachment
+        elif maintype == "message":
+            # For message/*, content must be email.message.EmailMessage (or
+            # legacy email.message.Message), and maintype cannot be provided.
+            if isinstance(content, EmailMessage):
+                # Django EmailMessage.
+                content = content.message(policy=msg.policy)
+            elif not isinstance(
+                content, (email.message.EmailMessage, email.message.Message)
+            ):
+                content = email.message_from_bytes(
+                    force_bytes(content), policy=msg.policy
+                )
+            msg.add_attachment(content, subtype=subtype, filename=filename)
+        else:
+            # For all other types, content must be bytes-like, and both
+            # maintype and subtype must be provided.
+            if not isinstance(content, (bytes, bytearray, memoryview)):
+                content = force_bytes(content)
+            msg.add_attachment(
+                content,
+                maintype=maintype,
+                subtype=subtype,
+                filename=filename,
+            )
 
     def _set_list_header_if_not_empty(self, msg, header, values):
         """
@@ -436,6 +287,34 @@ class EmailMessage:
             if values:
                 msg[header] = ", ".join(str(v) for v in values)
 
+    def _idna_encode_address_header_domains(self, msg):
+        """
+        If msg.policy does not permit utf8 in headers, IDNA encode all non-ASCII
+        domains in its address headers.
+        """
+        # Avoids a problem where Python's email incorrectly converts non-ASCII domains
+        # to RFC 2047 encoded-words: https://github.com/python/cpython/issues/83938.
+        # This applies to the domain only, not to the localpart (username). There is no
+        # RFC that permits any 7-bit encoding for non-ASCII characters before the '@'.
+        if not getattr(msg.policy, "utf8", False):
+            # Not using SMTPUTF8, so apply IDNA encoding in all address headers.
+            # (IDNA encoding does not alter domains that are already ASCII.)
+            for field, value in msg.items():
+                if isinstance(value, AddressHeader) and any(
+                    not addr.domain.isascii() for addr in value.addresses
+                ):
+                    msg.replace_header(
+                        field,
+                        [
+                            Address(
+                                display_name=addr.display_name,
+                                username=addr.username,
+                                domain=punycode(addr.domain),
+                            )
+                            for addr in value.addresses
+                        ],
+                    )
+
 
 class EmailMultiAlternatives(EmailMessage):
     """
@@ -443,8 +322,6 @@ class EmailMultiAlternatives(EmailMessage):
     messages. For example, including text and HTML versions of the text is
     made easier.
     """
-
-    alternative_subtype = "alternative"
 
     def __init__(
         self,
@@ -486,24 +363,28 @@ class EmailMultiAlternatives(EmailMessage):
             raise ValueError("Both content and mimetype must be provided.")
         self.alternatives.append(EmailAlternative(content, mimetype))
 
-    def _create_message(self, msg):
-        return self._create_attachments(self._create_alternatives(msg))
-
-    def _create_alternatives(self, msg):
-        encoding = self.encoding or settings.DEFAULT_CHARSET
+    def _add_bodies(self, msg):
+        if self.body or not self.alternatives:
+            super()._add_bodies(msg)
         if self.alternatives:
-            body_msg = msg
-            msg = SafeMIMEMultipart(
-                _subtype=self.alternative_subtype, encoding=encoding
-            )
-            if self.body:
-                msg.attach(body_msg)
-            for alternative in self.alternatives:
-                msg.attach(
-                    self._create_mime_attachment(
-                        alternative.content, alternative.mimetype
-                    )
+            if hasattr(self, "alternative_subtype"):
+                # RemovedInDjango70Warning
+                raise AttributeError(
+                    "EmailMultiAlternatives no longer supports the"
+                    " undocumented `alternative_subtype` attribute"
                 )
+            msg.make_alternative()
+            encoding = self.encoding or settings.DEFAULT_CHARSET
+            for alternative in self.alternatives:
+                maintype, subtype = alternative.mimetype.split("/", 1)
+                content = alternative.content
+                if maintype == "text":
+                    if isinstance(content, bytes):
+                        content = content.decode()
+                    msg.add_alternative(content, subtype=subtype, charset=encoding)
+                else:
+                    content = force_bytes(content, encoding=encoding, strings_only=True)
+                    msg.add_alternative(content, maintype=maintype, subtype=subtype)
         return msg
 
     def body_contains(self, text):

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -35,6 +35,13 @@ details on these changes.
   argument of ``django.core.paginator.Paginator`` and
   ``django.core.paginator.AsyncPaginator`` will no longer be allowed.
 
+* The ability to attach Python's legacy email ``MIMEBase`` objects
+  to a ``django.core.mail.EmailMessage`` will be removed.
+
+* The ``django.core.mail.BadHeaderError``, ``SafeMIMEText`` and
+  ``SafeMIMEMultipart`` classes will be removed, along with the undocumented
+  ``forbid_multi_line_headers()`` and ``sanitize_address()`` functions.
+
 .. _deprecation-removed-in-6.1:
 
 6.1

--- a/docs/releases/6.0.txt
+++ b/docs/releases/6.0.txt
@@ -136,7 +136,13 @@ Decorators
 Email
 ~~~~~
 
-* ...
+* ``EmailMessage.message()`` now uses Python's "modern email" API and returns
+  an instance of :class:`email.message.EmailMessage`. It accepts a new
+  ``policy`` argument.
+
+* ``EmailMessage.attach()`` now accepts a :class:`~email.message.MIMEPart`
+  object from Python's modern email API.
+
 
 Error Reporting
 ~~~~~~~~~~~~~~~
@@ -327,6 +333,21 @@ of each library are the first to add or confirm compatibility with Python 3.12:
 * ``sqlparse`` 0.5.0
 * ``tblib`` 3.0.0
 
+Email
+-----
+
+* The undocumented ``mixed_subtype`` and ``alternative_subtype`` properties
+  of :class:`~django.core.mail.EmailMessage` and
+  :class:`~django.core.mail.EmailMultiAlternatives` are no longer supported.
+
+* The undocumented ``encoding`` property of :class:`~django.core.mail.EmailMessage`
+  no longer supports Python legacy :py:class:`email.charset.Charset` objects.
+
+* The internal implementations of :class:`~django.core.mail.EmailMessage` and
+  :class:`~django.core.mail.EmailMultiAlternatives` have changed significantly.
+  Closely examine any custom EmailMessage subclasses that rely on overriding
+  undocumented, internal underscore methods.
+
 Miscellaneous
 -------------
 
@@ -346,6 +367,24 @@ Miscellaneous
 
 Features deprecated in 6.0
 ==========================
+
+Email
+-----
+
+* Passing Python's legacy email :class:`~email.mime.base.MIMEBase` object to
+  ``EmailMessage.attach()`` (or including one in the message's ``attachments``
+  list) is deprecated. For complex attachments requiring additional headers or
+  parameters, switch to the modern email API's :class:`~email.message.MIMEPart`.
+
+* ``BadHeaderError`` is deprecated. Python's modern email raises a
+  :exc:`!ValueError` for email headers containing prohibited characters.
+
+* ``django.core.mail.SafeMIMEText`` and ``SafeMIMEMultipart`` are deprecated.
+  (In earlier releases, they had been documented as the return types of
+  ``EmailMessage.message()``.)
+
+* The undocumented email APIs ``django.core.mail.forbid_multi_line_headers()``
+  and ``django.core.mail.message.sanitize_address()`` are deprecated.
 
 Miscellaneous
 -------------

--- a/docs/topics/email.txt
+++ b/docs/topics/email.txt
@@ -224,7 +224,7 @@ The Django email functions outlined above all protect against header injection
 by forbidding newlines in header values. If any ``subject``, ``from_email`` or
 ``recipient_list`` contains a newline (in either Unix, Windows or Mac style),
 the email function (e.g. :meth:`~django.core.mail.send_mail()`) will raise
-``django.core.mail.BadHeaderError`` (a subclass of ``ValueError``) and, hence,
+:exc:`ValueError` and, hence,
 will not send the email. It's your responsibility to validate all data before
 passing it to the email functions.
 
@@ -235,7 +235,7 @@ Here's an example view that takes a ``subject``, ``message`` and ``from_email``
 from the request's POST data, sends that to admin@example.com and redirects to
 "/contact/thanks/" when it's done::
 
-    from django.core.mail import BadHeaderError, send_mail
+    from django.core.mail import send_mail
     from django.http import HttpResponse, HttpResponseRedirect
 
 
@@ -246,13 +246,20 @@ from the request's POST data, sends that to admin@example.com and redirects to
         if subject and message and from_email:
             try:
                 send_mail(subject, message, from_email, ["admin@example.com"])
-            except BadHeaderError:
+            except ValueError:
                 return HttpResponse("Invalid header found.")
             return HttpResponseRedirect("/contact/thanks/")
         else:
             # In reality we'd use a form class
             # to get proper validation errors.
             return HttpResponse("Make sure all fields are entered and valid.")
+
+
+.. deprecated:: 6.0
+
+    Earlier releases raised a custom ``django.core.mail.BadHeaderError``
+    for some invalid headers. That has been replaced with :exc:`!ValueError`.
+
 
 .. _Header injection: http://www.nyphp.org/phundamentals/8_Preventing-Email-Header-Injection.html
 
@@ -317,15 +324,24 @@ All parameters are optional and can be set at any time prior to calling the
   connection is created when ``send()`` is called. This parameter is ignored
   when using :ref:`send_messages() <topics-sending-multiple-emails>`.
 
-* ``attachments``: A list of attachments to put on the message. These can
-  be instances of :class:`~email.mime.base.MIMEBase` or
+* ``attachments``: A list of attachments to put on the message. Each can
+  be an instance of :class:`~email.message.MIMEPart` or
   :class:`~django.core.mail.EmailAttachment`, or a tuple with attributes
   ``(filename, content, mimetype)``.
 
-  .. versionchanged:: 5.2
+.. versionchanged:: 5.2
 
     Support for :class:`~django.core.mail.EmailAttachment` items of
     ``attachments`` were added.
+
+.. versionchanged:: 6.0
+
+    Added support for attaching Python's :class:`~email.message.MIMEPart` items.
+
+.. deprecated:: 6.0
+
+    Attaching Python's legacy :class:`~email.mime.base.MIMEBase` objects
+    is deprecated. Use modern :class:`~email.message.MIMEPart` instead.
 
 * ``headers``: A dictionary of extra headers to put on the message. The
   keys are the header name, values are the header values. It's up to the
@@ -362,12 +378,18 @@ The class has the following methods:
   recipients will not raise an exception. It will return ``1`` if the message
   was sent successfully, otherwise ``0``.
 
-* ``message()`` constructs a ``django.core.mail.SafeMIMEText`` object (a
-  subclass of Python's :class:`~email.mime.text.MIMEText` class) or a
-  ``django.core.mail.SafeMIMEMultipart`` object holding the message to be
-  sent. If you ever need to extend the
-  :class:`~django.core.mail.EmailMessage` class, you'll probably want to
-  override this method to put the content you want into the MIME object.
+* ``message(policy=email.policy.default)`` constructs and returns a Python
+  :class:`email.message.EmailMessage` object using the specified policy,
+  representing the message to be sent.
+
+  If you ever need to extend Django's :class:`~django.core.mail.EmailMessage`
+  class, you'll probably want to override this method to put the content you
+  want into Python EmailMessage object.
+
+  .. versionchanged:: 6.0
+
+      Added the ``policy`` argument and updated the method to return
+      a modern Python :py:class:`~email.message.EmailMessage`.
 
 * ``recipients()`` returns a list of all the recipients of the message,
   whether they're recorded in the ``to``, ``cc`` or ``bcc`` attributes. This
@@ -376,15 +398,11 @@ The class has the following methods:
   is sent. If you add another way to specify recipients in your class, they
   need to be returned from this method as well.
 
-* ``attach()`` creates a new file attachment and adds it to the message.
+* ``attach()`` creates a new attachment and adds it to the message.
   There are two ways to call ``attach()``:
 
-  * You can pass it a single argument that is a
-    :class:`~email.mime.base.MIMEBase` instance. This will be inserted directly
-    into the resulting message.
-
-  * Alternatively, you can pass ``attach()`` three arguments:
-    ``filename``, ``content`` and ``mimetype``. ``filename`` is the name
+  * You can pass it three arguments: ``filename``, ``content``
+    and ``mimetype``. ``filename`` is the name
     of the file attachment as it will appear in the email, ``content`` is
     the data that will be contained inside the attachment and
     ``mimetype`` is the optional MIME type for the attachment. If you
@@ -395,21 +413,45 @@ The class has the following methods:
 
        message.attach("design.png", img_data, "image/png")
 
-    If you specify a ``mimetype`` of :mimetype:`message/rfc822`, it will also
-    accept :class:`django.core.mail.EmailMessage` and
-    :py:class:`email.message.Message`.
+    If you specify a ``mimetype`` of :mimetype:`message/rfc822`, ``content``
+    can be a :class:`django.core.mail.EmailMessage` or Python's
+    :class:`email.message.EmailMessage` or :class:`email.message.Message`.
+    (``filename`` can be ``None`` in this case.)
 
     For a ``mimetype`` starting with :mimetype:`text/`, content is expected to
     be a string. Binary data will be decoded using UTF-8, and if that fails,
     the MIME type will be changed to :mimetype:`application/octet-stream` and
     the data will be attached unchanged.
 
-    In addition, :mimetype:`message/rfc822` attachments will no longer be
-    base64-encoded in violation of :rfc:`2046#section-5.2.1`, which can cause
-    issues with displaying the attachments in `Evolution`__ and `Thunderbird`__.
+  * Or for attachments requiring additional headers or parameters, you can pass
+    ``attach()`` a single Python :class:`~email.message.MIMEPart` object.
+    This will be attached directly to the resulting message. For example,
+    to attach an inline image with a :mailheader:`Content-ID`::
 
-    __ https://bugzilla.gnome.org/show_bug.cgi?id=651197
-    __ https://bugzilla.mozilla.org/show_bug.cgi?id=333880
+        cid = email.utils.make_msgid()
+        inline_image = email.message.MIMEPart()
+        inline_image.set_content(
+            image_data_bytes,
+            maintype="image",
+            subtype="png",
+            disposition="inline",
+            cid=f"<{cid}>",
+        )
+        message.attach(inline_image)
+        message.attach_alternative(f'… <img src="cid:${cid}"> …', "text/html")
+
+    Python's :meth:`email.contentmanager.set_content` documentation describes
+    the supported arguments for ``MIMEPart.set_content()``.
+
+    .. versionchanged:: 6.0
+
+        Added support for Python's modern email :class:`~email.message.MIMEPart`
+        attachments
+
+    .. deprecated:: 6.0
+
+        Attaching Python's legacy :class:`email.mime.base.MIMEBase` objects
+        is deprecated. Use modern :class:`~email.message.MIMEPart` instead.
 
 * ``attach_file()`` creates a new attachment using a file from your
   filesystem. Call it with the path of the file to attach and, optionally,

--- a/tests/auth_tests/test_forms.py
+++ b/tests/auth_tests/test_forms.py
@@ -1366,13 +1366,13 @@ class PasswordResetFormTest(TestDataMixin, TestCase):
         self.assertTrue(
             re.match(
                 r"^http://example.com/reset/[\w/-]+",
-                message.get_payload(0).get_payload(),
+                message.get_payload(0).get_content(),
             )
         )
         self.assertTrue(
             re.match(
                 r'^<html><a href="http://example.com/reset/[\w/-]+/">Link</a></html>$',
-                message.get_payload(1).get_payload(),
+                message.get_payload(1).get_content(),
             )
         )
 

--- a/tests/mail/test_deprecated.py
+++ b/tests/mail/test_deprecated.py
@@ -1,0 +1,364 @@
+# RemovedInDjango70Warning: this entire file
+from email.mime.image import MIMEImage
+from email.mime.text import MIMEText
+from unittest import mock
+
+from django.core.mail import (
+    EmailAlternative,
+    EmailAttachment,
+    EmailMessage,
+    EmailMultiAlternatives,
+)
+from django.test import SimpleTestCase, ignore_warnings
+from django.utils.deprecation import RemovedInDjango70Warning
+
+from .tests import MailTestsMixin
+
+
+class DeprecationWarningTests(MailTestsMixin, SimpleTestCase):
+    def test_attach_mime_image(self):
+        """
+        EmailMessage.attach() docs: "You can pass it
+        a single argument that is a MIMEBase instance."
+        """
+        msg = (
+            "MIMEBase attachments are deprecated."
+            " Use an email.message.MIMEPart instead."
+        )
+        # This also verifies complex attachments with extra header fields.
+        email = EmailMessage()
+        image = MIMEImage(b"GIF89a...", "gif")
+        image["Content-Disposition"] = "inline"
+        image["Content-ID"] = "<content-id@example.org>"
+        with self.assertWarnsMessage(RemovedInDjango70Warning, msg):
+            email.attach(image)
+
+        attachments = self.get_raw_attachments(email)
+        self.assertEqual(len(attachments), 1)
+        image_att = attachments[0]
+        self.assertEqual(image_att.get_content_type(), "image/gif")
+        self.assertEqual(image_att.get_content_disposition(), "inline")
+        self.assertEqual(image_att["Content-ID"], "<content-id@example.org>")
+        self.assertEqual(image_att.get_content(), b"GIF89a...")
+        self.assertIsNone(image_att.get_filename())
+
+    def test_attach_mime_image_in_constructor(self):
+        msg = (
+            "MIMEBase attachments are deprecated."
+            " Use an email.message.MIMEPart instead."
+        )
+        image = MIMEImage(b"\x89PNG...", "png")
+        image["Content-Disposition"] = "attachment; filename=test.png"
+        with self.assertWarnsMessage(RemovedInDjango70Warning, msg):
+            email = EmailMessage(attachments=[image])
+
+        attachments = self.get_raw_attachments(email)
+        self.assertEqual(len(attachments), 1)
+        image_att = attachments[0]
+        self.assertEqual(image_att.get_content_type(), "image/png")
+        self.assertEqual(image_att.get_content(), b"\x89PNG...")
+        self.assertEqual(image_att.get_filename(), "test.png")
+
+    def test_deprecated_on_import(self):
+        """
+        These items are not typically called from user code,
+        so generate deprecation warnings immediately at the time
+        they are imported from django.core.mail.
+        """
+        cases = [
+            # name, msg
+            (
+                "BadHeaderError",
+                "BadHeaderError is deprecated. Replace with ValueError.",
+            ),
+            (
+                "SafeMIMEText",
+                "SafeMIMEText is deprecated. The return value of"
+                " EmailMessage.message() is an email.message.EmailMessage.",
+            ),
+            (
+                "SafeMIMEMultipart",
+                "SafeMIMEMultipart is deprecated. The return value of"
+                " EmailMessage.message() is an email.message.EmailMessage.",
+            ),
+            (
+                "forbid_multi_line_headers",
+                "The internal API forbid_multi_line_headers() is deprecated.",
+            ),
+        ]
+        for name, msg in cases:
+            with self.subTest(name=name):
+                with self.assertWarnsMessage(RemovedInDjango70Warning, msg):
+                    __import__("django.core.mail", fromlist=[name])
+
+    def test_sanitize_address_deprecated(self):
+        from django.core.mail.message import sanitize_address
+
+        msg = "The internal API sanitize_address() is deprecated."
+        with self.assertWarnsMessage(RemovedInDjango70Warning, msg):
+            sanitize_address("to@example.com", "ascii")
+
+    def test_forbid_multi_line_headers_deprecated(self):
+        # Import from _deprecated to avoid warning on import.
+        # This function also warns (with a more detailed message) on use.
+        from django.core.mail._deprecated import forbid_multi_line_headers
+
+        msg = "The internal API forbid_multi_line_headers() is deprecated."
+        with self.assertWarnsMessage(RemovedInDjango70Warning, msg):
+            forbid_multi_line_headers("To", "to@example.com", "ascii")
+
+
+class UndocumentedFeatureErrorTests(SimpleTestCase):
+    """
+    These undocumented features were removed without going through deprecation.
+    In case they were being used, they now raise errors.
+    """
+
+    def test_undocumented_mixed_subtype(self):
+        """
+        Trying to use the previously undocumented, now unsupported
+        EmailMessage.mixed_subtype causes an error.
+        """
+        msg = (
+            "EmailMessage no longer supports"
+            " the undocumented `mixed_subtype` attribute"
+        )
+        email = EmailMessage(
+            attachments=[EmailAttachment(None, b"GIF89a...", "image/gif")]
+        )
+        email.mixed_subtype = "related"
+        with self.assertRaisesMessage(AttributeError, msg):
+            email.message()
+
+    def test_undocumented_alternative_subtype(self):
+        """
+        Trying to use the previously undocumented, now unsupported
+        EmailMultiAlternatives.alternative_subtype causes an error.
+        """
+        msg = (
+            "EmailMultiAlternatives no longer supports"
+            " the undocumented `alternative_subtype` attribute"
+        )
+        email = EmailMultiAlternatives(
+            alternatives=[EmailAlternative("", "text/plain")]
+        )
+        email.alternative_subtype = "multilingual"
+        with self.assertRaisesMessage(AttributeError, msg):
+            email.message()
+
+
+@ignore_warnings(category=RemovedInDjango70Warning)
+class DeprecatedCompatibilityTests(SimpleTestCase):
+    def test_bad_header_error(self):
+        """
+        Existing code that catches deprecated BadHeaderError should be
+        compatible with modern email (which raises ValueError instead).
+        """
+        from django.core.mail import BadHeaderError
+
+        with self.assertRaises(BadHeaderError):
+            EmailMessage(subject="Bad\r\nHeader").message()
+
+    def test_attachments_mimebase_in_constructor(self):
+        txt = MIMEText("content1")
+        msg = EmailMessage(attachments=[txt])
+        payload = msg.message().get_payload()
+        self.assertEqual(payload[0], txt)
+
+
+@ignore_warnings(category=RemovedInDjango70Warning)
+class DeprecatedFeatureTests(SimpleTestCase):
+    """
+    Original test cases for the deprecated email features.
+    """
+
+    @mock.patch("django.core.mail._deprecated.MIMEText.set_payload")
+    def test_nonascii_as_string_with_ascii_charset(self, mock_set_payload):
+        """Line length check should encode the payload supporting `surrogateescape`.
+
+        Following https://github.com/python/cpython/issues/76511, newer
+        versions of Python (3.12.3 and 3.13) ensure that a message's
+        payload is encoded with the provided charset and `surrogateescape` is
+        used as the error handling strategy.
+
+        This test is heavily based on the test from the fix for the bug above.
+        Line length checks in SafeMIMEText's set_payload should also use the
+        same error handling strategy to avoid errors such as:
+
+        UnicodeEncodeError: 'utf-8' codec can't encode <...>: surrogates not allowed
+        """
+        from django.core.mail import SafeMIMEText
+
+        def simplified_set_payload(instance, payload, charset):
+            instance._payload = payload
+
+        mock_set_payload.side_effect = simplified_set_payload
+
+        text = (
+            "Text heavily based in Python's text for non-ascii messages: Föö bär"
+        ).encode("iso-8859-1")
+        body = text.decode("ascii", errors="surrogateescape")
+        message = SafeMIMEText(body, "plain", "ascii")
+        mock_set_payload.assert_called_once()
+        self.assertEqual(message.get_payload(decode=True), text)
+
+    def test_sanitize_address(self):
+        """Email addresses are properly sanitized."""
+        from django.core.mail.message import sanitize_address
+
+        for email_address, encoding, expected_result in (
+            # ASCII addresses.
+            ("to@example.com", "ascii", "to@example.com"),
+            ("to@example.com", "utf-8", "to@example.com"),
+            (("A name", "to@example.com"), "ascii", "A name <to@example.com>"),
+            (
+                ("A name", "to@example.com"),
+                "utf-8",
+                "A name <to@example.com>",
+            ),
+            ("localpartonly", "ascii", "localpartonly"),
+            # ASCII addresses with display names.
+            ("A name <to@example.com>", "ascii", "A name <to@example.com>"),
+            ("A name <to@example.com>", "utf-8", "A name <to@example.com>"),
+            ('"A name" <to@example.com>', "ascii", "A name <to@example.com>"),
+            ('"A name" <to@example.com>', "utf-8", "A name <to@example.com>"),
+            # Unicode addresses: IDNA encoded domain supported per RFC-5890.
+            # But an 'encoded-word' localpart is prohibited by RFC-2047, and not
+            # supported by any known mail service. This incorrect behavior
+            # is preserved in sanitize_address() for compatibility.
+            ("tó@example.com", "utf-8", "=?utf-8?b?dMOz?=@example.com"),
+            ("to@éxample.com", "utf-8", "to@xn--xample-9ua.com"),
+            (
+                ("Tó Example", "tó@example.com"),
+                "utf-8",
+                # (Not RFC-2047 compliant.)
+                "=?utf-8?q?T=C3=B3_Example?= <=?utf-8?b?dMOz?=@example.com>",
+            ),
+            # Unicode addresses with display names.
+            (
+                "Tó Example <tó@example.com>",
+                "utf-8",
+                # (Not RFC-2047 compliant.)
+                "=?utf-8?q?T=C3=B3_Example?= <=?utf-8?b?dMOz?=@example.com>",
+            ),
+            (
+                "To Example <to@éxample.com>",
+                "ascii",
+                "To Example <to@xn--xample-9ua.com>",
+            ),
+            (
+                "To Example <to@éxample.com>",
+                "utf-8",
+                "To Example <to@xn--xample-9ua.com>",
+            ),
+            # Addresses with two @ signs.
+            ('"to@other.com"@example.com', "utf-8", r'"to@other.com"@example.com'),
+            (
+                '"to@other.com" <to@example.com>',
+                "utf-8",
+                '"to@other.com" <to@example.com>',
+            ),
+            (
+                ("To Example", "to@other.com@example.com"),
+                "utf-8",
+                'To Example <"to@other.com"@example.com>',
+            ),
+            # Addresses with long unicode display names.
+            (
+                "Tó Example very long" * 4 + " <to@example.com>",
+                "utf-8",
+                "=?utf-8?q?T=C3=B3_Example_very_longT=C3=B3_Example_very_longT"
+                "=C3=B3_Example_?=\n"
+                " =?utf-8?q?very_longT=C3=B3_Example_very_long?= "
+                "<to@example.com>",
+            ),
+            (
+                ("Tó Example very long" * 4, "to@example.com"),
+                "utf-8",
+                "=?utf-8?q?T=C3=B3_Example_very_longT=C3=B3_Example_very_longT"
+                "=C3=B3_Example_?=\n"
+                " =?utf-8?q?very_longT=C3=B3_Example_very_long?= "
+                "<to@example.com>",
+            ),
+            # Address with long display name and unicode domain.
+            (
+                ("To Example very long" * 4, "to@exampl€.com"),
+                "utf-8",
+                "To Example very longTo Example very longTo Example very longT"
+                "o Example very\n"
+                " long <to@xn--exampl-nc1c.com>",
+            ),
+        ):
+            with self.subTest(email_address=email_address, encoding=encoding):
+                self.assertEqual(
+                    sanitize_address(email_address, encoding), expected_result
+                )
+
+    def test_sanitize_address_invalid(self):
+        from django.core.mail.message import sanitize_address
+
+        for email_address in (
+            # Invalid address with two @ signs.
+            "to@other.com@example.com",
+            # Invalid address without the quotes.
+            "to@other.com <to@example.com>",
+            # Other invalid addresses.
+            "@",
+            "to@",
+            "@example.com",
+            ("", ""),
+        ):
+            with self.subTest(email_address=email_address):
+                with self.assertRaisesMessage(ValueError, "Invalid address"):
+                    sanitize_address(email_address, encoding="utf-8")
+
+    def test_sanitize_address_header_injection(self):
+        from django.core.mail.message import sanitize_address
+
+        msg = "Invalid address; address parts cannot contain newlines."
+        tests = [
+            "Name\nInjection <to@example.com>",
+            ("Name\nInjection", "to@xample.com"),
+            "Name <to\ninjection@example.com>",
+            ("Name", "to\ninjection@example.com"),
+        ]
+        for email_address in tests:
+            with self.subTest(email_address=email_address):
+                with self.assertRaisesMessage(ValueError, msg):
+                    sanitize_address(email_address, encoding="utf-8")
+
+
+class PythonGlobalState(SimpleTestCase):
+    """
+    Tests for #12422 -- Django smarts (#2472/#11212) with charset of utf-8 text
+    parts shouldn't pollute global email Python package charset registry when
+    django.mail.message is imported.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        # Make sure code that creates custom email charsets has been run.
+        from django.core.mail._deprecated import (  # NOQA: F401
+            utf8_charset,
+            utf8_charset_qp,
+        )
+
+    def test_utf8(self):
+        txt = MIMEText("UTF-8 encoded body", "plain", "utf-8")
+        self.assertIn("Content-Transfer-Encoding: base64", txt.as_string())
+
+    def test_7bit(self):
+        txt = MIMEText("Body with only ASCII characters.", "plain", "utf-8")
+        self.assertIn("Content-Transfer-Encoding: base64", txt.as_string())
+
+    def test_8bit_latin(self):
+        txt = MIMEText("Body with latin characters: àáä.", "plain", "utf-8")
+        self.assertIn("Content-Transfer-Encoding: base64", txt.as_string())
+
+    def test_8bit_non_latin(self):
+        txt = MIMEText(
+            "Body with non latin characters: А Б В Г Д Е Ж Ѕ З И І К Л М Н О П.",
+            "plain",
+            "utf-8",
+        )
+        self.assertIn("Content-Transfer-Encoding: base64", txt.as_string())

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -1,18 +1,20 @@
+import ast
 import mimetypes
 import os
 import pickle
+import re
 import shutil
 import socket
 import sys
 import tempfile
-from email import charset, message_from_binary_file
+from datetime import datetime, timezone
+from email import message_from_binary_file
 from email import message_from_bytes as _message_from_bytes
 from email import policy
 from email.headerregistry import Address
 from email.message import EmailMessage as PyEmailMessage
 from email.message import Message as PyMessage
-from email.mime.image import MIMEImage
-from email.mime.text import MIMEText
+from email.message import MIMEPart
 from io import StringIO
 from pathlib import Path
 from smtplib import SMTP, SMTPException
@@ -24,7 +26,6 @@ from django.core import mail
 from django.core.exceptions import ImproperlyConfigured
 from django.core.mail import (
     DNS_NAME,
-    BadHeaderError,
     EmailAlternative,
     EmailAttachment,
     EmailMessage,
@@ -35,7 +36,6 @@ from django.core.mail import (
     send_mass_mail,
 )
 from django.core.mail.backends import console, dummy, filebased, locmem, smtp
-from django.core.mail.message import sanitize_address
 from django.test import SimpleTestCase, override_settings
 from django.test.utils import requires_tz_support
 from django.utils.deprecation import RemovedInDjango70Warning
@@ -189,40 +189,6 @@ class MailTests(MailTestsMixin, SimpleTestCase):
         self.assertEqual(message.get_payload(), "Content\n")
         self.assertEqual(message["From"], "from@example.com")
         self.assertEqual(message["To"], "to@example.com")
-
-    # The following test is specific to Python's legacy MIMEText, and can be safely
-    # removed when EmailMessage.message() uses Python's modern email API.
-    # (Using surrogateescape for non-utf8 is also covered in test_encoding().)
-    @mock.patch("django.core.mail.message.MIMEText.set_payload")
-    def test_nonascii_as_string_with_ascii_charset(self, mock_set_payload):
-        """Line length check should encode the payload supporting `surrogateescape`.
-
-        Following https://github.com/python/cpython/issues/76511, newer
-        versions of Python (3.12.3 and 3.13) ensure that a message's
-        payload is encoded with the provided charset and `surrogateescape` is
-        used as the error handling strategy.
-
-        This test is heavily based on the test from the fix for the bug above.
-        Line length checks in SafeMIMEText's set_payload should also use the
-        same error handling strategy to avoid errors such as:
-
-        UnicodeEncodeError: 'utf-8' codec can't encode <...>: surrogates not allowed
-
-        """
-
-        def simplified_set_payload(instance, payload, charset):
-            instance._payload = payload
-
-        mock_set_payload.side_effect = simplified_set_payload
-
-        text = (
-            "Text heavily based in Python's text for non-ascii messages: Föö bär"
-        ).encode("iso-8859-1")
-        body = text.decode("ascii", errors="surrogateescape")
-        email = EmailMessage("Subject", body, "from@example.com", ["to@example.com"])
-        message = email.message()
-        mock_set_payload.assert_called_once()
-        self.assertEqual(message.get_payload(decode=True), text)
 
     def test_multiple_recipients(self):
         email = EmailMessage(
@@ -415,7 +381,7 @@ class MailTests(MailTestsMixin, SimpleTestCase):
             EmailMessage(reply_to="reply_to@example.com")
 
     def test_header_injection(self):
-        msg = "Header values can't contain newlines "
+        msg = "Header values may not contain linefeed or carriage return characters"
         cases = [
             {"subject": "Subject\nInjection Test"},
             {"subject": gettext_lazy("Lazy Subject\nInjection Test")},
@@ -424,7 +390,7 @@ class MailTests(MailTestsMixin, SimpleTestCase):
         for kwargs in cases:
             with self.subTest(case=kwargs):
                 email = EmailMessage(**kwargs)
-                with self.assertRaisesMessage(BadHeaderError, msg):
+                with self.assertRaisesMessage(ValueError, msg):
                     email.message()
 
     def test_folding_white_space(self):
@@ -437,12 +403,9 @@ class MailTests(MailTestsMixin, SimpleTestCase):
         )
         message = email.message()
         msg_bytes = message.as_bytes()
-        # Python's legacy email wraps this more than strictly necessary
-        # (but uses FWS properly at each wrap). Modern email wraps it better.
         self.assertIn(
             b"Subject: Long subject lines that get wrapped should contain a space\n"
-            b" continuation\n"
-            b" character to comply with RFC 822",
+            b" continuation character to comply with RFC 822",
             msg_bytes,
         )
 
@@ -461,6 +424,19 @@ class MailTests(MailTestsMixin, SimpleTestCase):
                 ("date", "Fri, 09 Nov 2001 01:08:47 -0000"),
             },
         )
+
+    def test_datetime_in_date_header(self):
+        """
+        A datetime in headers should be passed through to Python email intact,
+        so that it uses the email header date format.
+        """
+        email = EmailMessage(
+            headers={"Date": datetime(2001, 11, 9, 1, 8, 47, tzinfo=timezone.utc)},
+        )
+        message = email.message()
+        self.assertEqual(message["Date"], "Fri, 09 Nov 2001 01:08:47 +0000")
+        # Not the default ISO format from force_str(strings_only=False).
+        self.assertNotEqual(message["Date"], "2001-11-09 01:08:47+00:00")
 
     def test_from_header(self):
         """
@@ -706,7 +682,9 @@ class MailTests(MailTestsMixin, SimpleTestCase):
     def test_none_body(self):
         msg = EmailMessage("subject", None, "from@example.com", ["to@example.com"])
         self.assertEqual(msg.body, "")
-        self.assertEqual(msg.message().get_payload(), "")
+        # The modern email API forces trailing newlines on all text/* parts,
+        # even an empty body.
+        self.assertEqual(msg.message().get_payload(), "\n")
 
     @mock.patch("socket.getfqdn", return_value="漢字")
     def test_non_ascii_dns_non_unicode_email(self, mocked_getfqdn):
@@ -849,8 +827,10 @@ class MailTests(MailTestsMixin, SimpleTestCase):
         self.assertEqual(payload[0].get_content_type(), "multipart/alternative")
         self.assertEqual(payload[1].get_content_type(), "application/pdf")
 
-    def test_decoded_attachments_MIMEText(self):
-        txt = MIMEText("content1")
+    def test_decoded_attachment_text_MIMEPart(self):
+        # (See also test_attach_mime_part() and test_attach_mime_part_in_constructor().)
+        txt = MIMEPart()
+        txt.set_content("content1")
         msg = EmailMessage(attachments=[txt])
         payload = msg.message().get_payload()
         self.assertEqual(payload[0], txt)
@@ -973,16 +953,21 @@ class MailTests(MailTestsMixin, SimpleTestCase):
         self.assertEqual(attached_message["Content-Transfer-Encoding"], "8bit")
         self.assertEqual(attached_message.get_content_type(), "text/plain")
 
-    def test_attach_mime_image(self):
+    def test_attach_mime_part(self):
         """
         EmailMessage.attach() docs: "You can pass it
-        a single argument that is a MIMEBase instance."
+        a single argument that is a MIMEPart object."
         """
         # This also verifies complex attachments with extra header fields.
         email = EmailMessage()
-        image = MIMEImage(b"GIF89a...", "gif")
-        image["Content-Disposition"] = "inline"
-        image["Content-ID"] = "<content-id@example.org>"
+        image = MIMEPart()
+        image.set_content(
+            b"GIF89a...",
+            maintype="image",
+            subtype="gif",
+            disposition="inline",
+            cid="<content-id@example.org>",
+        )
         email.attach(image)
 
         attachments = self.get_raw_attachments(email)
@@ -994,9 +979,11 @@ class MailTests(MailTestsMixin, SimpleTestCase):
         self.assertEqual(image_att.get_content(), b"GIF89a...")
         self.assertIsNone(image_att.get_filename())
 
-    def test_attach_mime_image_in_constructor(self):
-        image = MIMEImage(b"\x89PNG...", "png")
-        image["Content-Disposition"] = "attachment; filename=test.png"
+    def test_attach_mime_part_in_constructor(self):
+        image = MIMEPart()
+        image.set_content(
+            b"\x89PNG...", maintype="image", subtype="png", filename="test.png"
+        )
         email = EmailMessage(attachments=[image])
 
         attachments = self.get_raw_attachments(email)
@@ -1064,11 +1051,12 @@ class MailTests(MailTestsMixin, SimpleTestCase):
                 self.assertEqual(child_cte, "7bit")
                 self.assertEqual(attached_message.get_content_type(), "text/plain")
 
-    def test_attach_mimebase_prohibits_other_params(self):
+    def test_attach_mimepart_prohibits_other_params(self):
         email_msg = EmailMessage()
-        txt = MIMEText("content")
+        txt = MIMEPart()
+        txt.set_content("content")
         msg = (
-            "content and mimetype must not be given when a MIMEBase instance "
+            "content and mimetype must not be given when a MIMEPart instance "
             "is provided."
         )
         with self.assertRaisesMessage(ValueError, msg):
@@ -1219,9 +1207,7 @@ class MailTests(MailTestsMixin, SimpleTestCase):
         self.assertIn(b"Content-Transfer-Encoding: 8bit", s)
 
         # Long body lines that require folding should use quoted-printable or base64,
-        # whichever is shorter. However, Python's legacy email API avoids re-folding
-        # non-ASCII text and just uses CTE 8bit. (The modern API would correctly choose
-        # base64 here. Any of these is deliverable.)
+        # whichever is shorter.
         msg = EmailMessage(
             body=(
                 "Body with non latin characters: А Б В Г Д Е Ж Ѕ З И І К Л М Н О П.\n"
@@ -1230,157 +1216,7 @@ class MailTests(MailTestsMixin, SimpleTestCase):
             ),
         )
         s = msg.message().as_bytes()
-        self.assertIn(b"Content-Transfer-Encoding: 8bit", s)
-
-    def test_custom_utf8_encoding(self):
-        """A UTF-8 charset with a custom body encoding is respected."""
-        # The tests that the undocumented EmailMessage.encoding property allows
-        # a custom, legacy email.charset.Charset object. Modern email doesn't
-        # support that, and this test will be removed. (A str charset name like
-        # `msg.encoding = "iso-8859-1"` will still work, and is tested elsewhere.)
-        body = "Body with latin characters: àáä.\n"
-        msg = EmailMessage("Subject", body, "bounce@example.com", ["to@example.com"])
-        encoding = charset.Charset("utf-8")
-        encoding.body_encoding = charset.QP
-        msg.encoding = encoding
-        message = msg.message()
-        self.assertMessageHasHeaders(
-            message,
-            {
-                ("MIME-Version", "1.0"),
-                ("Content-Type", 'text/plain; charset="utf-8"'),
-                ("Content-Transfer-Encoding", "quoted-printable"),
-            },
-        )
-        self.assertEqual(message.get_payload(), encoding.body_encode(body))
-
-    def test_sanitize_address(self):
-        """Email addresses are properly sanitized."""
-        # This is a unit test for the internal sanitize_address() function.
-        # Many of these cases are now duplicated in test_address_header_handling(),
-        # which verifies headers in the generated message.
-        for email_address, encoding, expected_result in (
-            # ASCII addresses.
-            ("to@example.com", "ascii", "to@example.com"),
-            ("to@example.com", "utf-8", "to@example.com"),
-            (("A name", "to@example.com"), "ascii", "A name <to@example.com>"),
-            (
-                ("A name", "to@example.com"),
-                "utf-8",
-                "A name <to@example.com>",
-            ),
-            ("localpartonly", "ascii", "localpartonly"),
-            # ASCII addresses with display names.
-            ("A name <to@example.com>", "ascii", "A name <to@example.com>"),
-            ("A name <to@example.com>", "utf-8", "A name <to@example.com>"),
-            ('"A name" <to@example.com>', "ascii", "A name <to@example.com>"),
-            ('"A name" <to@example.com>', "utf-8", "A name <to@example.com>"),
-            # Unicode addresses: IDNA encoded domain supported per RFC-5890.
-            ("to@éxample.com", "utf-8", "to@xn--xample-9ua.com"),
-            # The next three cases should be removed when fixing #35713.
-            # (An 'encoded-word' localpart is prohibited by RFC-2047, and not
-            # supported by any known mail service.)
-            ("tó@example.com", "utf-8", "=?utf-8?b?dMOz?=@example.com"),
-            (
-                ("Tó Example", "tó@example.com"),
-                "utf-8",
-                "=?utf-8?q?T=C3=B3_Example?= <=?utf-8?b?dMOz?=@example.com>",
-            ),
-            (
-                "Tó Example <tó@example.com>",
-                "utf-8",
-                "=?utf-8?q?T=C3=B3_Example?= <=?utf-8?b?dMOz?=@example.com>",
-            ),
-            # IDNA addresses with display names.
-            (
-                "To Example <to@éxample.com>",
-                "ascii",
-                "To Example <to@xn--xample-9ua.com>",
-            ),
-            (
-                "To Example <to@éxample.com>",
-                "utf-8",
-                "To Example <to@xn--xample-9ua.com>",
-            ),
-            # Addresses with two @ signs.
-            ('"to@other.com"@example.com', "utf-8", r'"to@other.com"@example.com'),
-            (
-                '"to@other.com" <to@example.com>',
-                "utf-8",
-                '"to@other.com" <to@example.com>',
-            ),
-            (
-                ("To Example", "to@other.com@example.com"),
-                "utf-8",
-                'To Example <"to@other.com"@example.com>',
-            ),
-            # Addresses with long unicode display names.
-            (
-                "Tó Example very long" * 4 + " <to@example.com>",
-                "utf-8",
-                "=?utf-8?q?T=C3=B3_Example_very_longT=C3=B3_Example_very_longT"
-                "=C3=B3_Example_?=\n"
-                " =?utf-8?q?very_longT=C3=B3_Example_very_long?= "
-                "<to@example.com>",
-            ),
-            (
-                ("Tó Example very long" * 4, "to@example.com"),
-                "utf-8",
-                "=?utf-8?q?T=C3=B3_Example_very_longT=C3=B3_Example_very_longT"
-                "=C3=B3_Example_?=\n"
-                " =?utf-8?q?very_longT=C3=B3_Example_very_long?= "
-                "<to@example.com>",
-            ),
-            # Address with long display name and unicode domain.
-            (
-                ("To Example very long" * 4, "to@exampl€.com"),
-                "utf-8",
-                "To Example very longTo Example very longTo Example very longT"
-                "o Example very\n"
-                " long <to@xn--exampl-nc1c.com>",
-            ),
-        ):
-            with self.subTest(email_address=email_address, encoding=encoding):
-                self.assertEqual(
-                    sanitize_address(email_address, encoding), expected_result
-                )
-
-    def test_sanitize_address_invalid(self):
-        # This is a unit test for the internal sanitize_address() function.
-        # Note that Django's EmailMessage.message() will _not_ catch these cases,
-        # as it only calls sanitize_address() if an address also includes non-ASCII
-        # chars. Django detects these cases in the SMTP EmailBackend during sending.
-        # See SMTPBackendTests.test_avoids_sending_to_invalid_addresses() below.
-        for email_address in (
-            # Invalid address with two @ signs.
-            "to@other.com@example.com",
-            # Invalid address without the quotes.
-            "to@other.com <to@example.com>",
-            # Other invalid addresses.
-            "@",
-            "to@",
-            "@example.com",
-            ("", ""),
-        ):
-            with self.subTest(email_address=email_address):
-                with self.assertRaisesMessage(ValueError, "Invalid address"):
-                    sanitize_address(email_address, encoding="utf-8")
-
-    def test_sanitize_address_header_injection(self):
-        # This is a unit test for the internal sanitize_address() function.
-        # These cases are also duplicated in test_address_header_handling(),
-        # which verifies headers in the generated message.
-        msg = "Invalid address; address parts cannot contain newlines."
-        tests = [
-            "Name\nInjection <to@example.com>",
-            ("Name\nInjection", "to@xample.com"),
-            "Name <to\ninjection@example.com>",
-            ("Name", "to\ninjection@example.com"),
-        ]
-        for email_address in tests:
-            with self.subTest(email_address=email_address):
-                with self.assertRaisesMessage(ValueError, msg):
-                    sanitize_address(email_address, encoding="utf-8")
+        self.assertIn(b"Content-Transfer-Encoding: quoted-printable", s)
 
     def test_address_header_handling(self):
         # This verifies the modern email API's address header handling.
@@ -1449,8 +1285,7 @@ class MailTests(MailTestsMixin, SimpleTestCase):
                 self.assertEqual(actual, expected)
 
     def test_address_header_injection(self):
-        # (This error message comes from Django's internal forbid_multi_line_headers().)
-        msg = "Header values can't contain newlines"
+        msg = "Header values may not contain linefeed or carriage return characters"
         cases = [
             "Name\nInjection <to@example.com>",
             '"Name\nInjection" <to@example.com>',
@@ -1720,10 +1555,12 @@ class MailTests(MailTestsMixin, SimpleTestCase):
         email.to = ["new-to@example.com"]
         email.bcc = ["new-bcc@example.com"]
         email.connection = new_connection
+        image = MIMEPart()
+        image.set_content(b"GIF89a...", "image", "gif")
         email.attachments = [
             ("new1.txt", "new attachment 1\n", "text/plain"),  # plain tuple
             EmailAttachment("new2.txt", "new attachment 2\n", "text/csv"),
-            MIMEImage(b"GIF89a...", "gif"),
+            image,
         ]
         email.extra_headers = {"X-Header": "new header"}
         email.cc = ["new-cc@example.com"]
@@ -1752,6 +1589,72 @@ class MailTests(MailTestsMixin, SimpleTestCase):
         self.assertIs(email.get_connection(), new_connection)
         self.assertNotIn("original", message.as_string())
 
+    def test_message_is_python_email_message(self):
+        """
+        EmailMessage.message() docs: "returns a Python
+        email.message.EmailMessage object."
+        """
+        email = EmailMessage()
+        message = email.message()
+        self.assertIsInstance(message, PyMessage)
+        self.assertEqual(message.policy, policy.default)
+
+    def test_message_policy_smtputf8(self):
+        # With SMTPUTF8, the message uses utf-8 directly in headers (not RFC 2047
+        # encoded-words). Note this is the only spec-compliant way to send to
+        # a non-ASCII localpart.
+        email = EmailMessage(
+            subject="Detta ämne innehåller icke-ASCII-tecken",
+            to=["nøn-åscîi@example.com"],
+        )
+        message = email.message(policy=policy.SMTPUTF8)
+        self.assertEqual(message.policy, policy.SMTPUTF8)
+        msg_bytes = message.as_bytes()
+        self.assertIn(
+            "Subject: Detta ämne innehåller icke-ASCII-tecken".encode(), msg_bytes
+        )
+        self.assertIn("To: nøn-åscîi@example.com".encode(), msg_bytes)
+        self.assertNotIn(b"=?utf-8?", msg_bytes)  # encoded-word prefix
+
+    def test_message_policy_cte_7bit(self):
+        """
+        Allows a policy that requires 7bit encodings.
+        """
+        email = EmailMessage(body="Detta innehåller icke-ASCII-tecken")
+        email.attach("file.txt", "يحتوي هذا المرفق على أحرف غير ASCII")
+
+        # Uses 8bit by default. (Test pre-condition.)
+        self.assertIn(b"Content-Transfer-Encoding: 8bit", email.message().as_bytes())
+
+        # Uses something 7bit compatible when policy requires it. Should pick
+        # the shorter of quoted-printable (for this body) or base64 (for this
+        # attachment), but must not use 8bit. (Decoding to "ascii" verifies that.)
+        policy_7bit = policy.default.clone(cte_type="7bit")
+        msg_bytes = email.message(policy=policy_7bit).as_bytes()
+        msg_ascii = msg_bytes.decode("ascii")
+        self.assertIn("Content-Transfer-Encoding: quoted-printable", msg_ascii)
+        self.assertIn("Content-Transfer-Encoding: base64", msg_ascii)
+        self.assertNotIn("Content-Transfer-Encoding: 8bit", msg_ascii)
+
+    def test_message_policy_compat32(self):
+        """
+        Although EmailMessage.message() doesn't support policy=compat32
+        (because compat32 doesn't support modern APIs), compat32 _can_ be
+        used with as_bytes() or as_string() on the resulting message.
+        """
+        # This subject results in different (but equivalent) RFC 2047 encoding
+        # with compat32 vs. email.policy.default.
+        email = EmailMessage(subject="Detta ämne innehåller icke-ASCII-tecken")
+        message = email.message()
+        self.assertIn(
+            b"Subject: =?utf-8?q?Detta_=C3=A4mne_inneh=C3=A5ller_icke-ASCII-tecken?=\n",
+            message.as_bytes(policy=policy.compat32),
+        )
+        self.assertIn(
+            "Subject: =?utf-8?q?Detta_=C3=A4mne_inneh=C3=A5ller_icke-ASCII-tecken?=\n",
+            message.as_string(policy=policy.compat32),
+        )
+
 
 @requires_tz_support
 class MailTimeZoneTests(MailTestsMixin, SimpleTestCase):
@@ -1763,7 +1666,9 @@ class MailTimeZoneTests(MailTestsMixin, SimpleTestCase):
         EMAIL_USE_LOCALTIME=False creates a datetime in UTC.
         """
         email = EmailMessage()
-        self.assertEndsWith(email.message()["Date"], "-0000")
+        # Per RFC 2822/5322 section 3.3, "The form '+0000' SHOULD be used
+        # to indicate a time zone at Universal Time."
+        self.assertEndsWith(email.message()["Date"], "+0000")
 
     @override_settings(
         EMAIL_USE_LOCALTIME=True, USE_TZ=True, TIME_ZONE="Africa/Algiers"
@@ -1775,34 +1680,6 @@ class MailTimeZoneTests(MailTestsMixin, SimpleTestCase):
         email = EmailMessage()
         # Africa/Algiers is UTC+1 year round.
         self.assertEndsWith(email.message()["Date"], "+0100")
-
-
-class PythonGlobalState(SimpleTestCase):
-    """
-    Tests for #12422 -- Django smarts (#2472/#11212) with charset of utf-8 text
-    parts shouldn't pollute global email Python package charset registry when
-    django.mail.message is imported.
-    """
-
-    def test_utf8(self):
-        txt = MIMEText("UTF-8 encoded body", "plain", "utf-8")
-        self.assertIn("Content-Transfer-Encoding: base64", txt.as_string())
-
-    def test_7bit(self):
-        txt = MIMEText("Body with only ASCII characters.", "plain", "utf-8")
-        self.assertIn("Content-Transfer-Encoding: base64", txt.as_string())
-
-    def test_8bit_latin(self):
-        txt = MIMEText("Body with latin characters: àáä.", "plain", "utf-8")
-        self.assertIn("Content-Transfer-Encoding: base64", txt.as_string())
-
-    def test_8bit_non_latin(self):
-        txt = MIMEText(
-            "Body with non latin characters: А Б В Г Д Е Ж Ѕ З И І К Л М Н О П.",
-            "plain",
-            "utf-8",
-        )
-        self.assertIn("Content-Transfer-Encoding: base64", txt.as_string())
 
 
 class BaseEmailBackendTests(MailTestsMixin):
@@ -1842,7 +1719,7 @@ class BaseEmailBackendTests(MailTestsMixin):
         self.assertEqual(num_sent, 1)
         message = self.get_the_message()
         self.assertEqual(message["subject"], "Subject")
-        self.assertEqual(message.get_payload(), "Content\n")
+        self.assertEqual(message.get_content(), "Content\n")
         self.assertEqual(message["from"], "from@example.com")
         self.assertEqual(message.get_all("to"), ["to@example.com"])
 
@@ -1866,11 +1743,9 @@ class BaseEmailBackendTests(MailTestsMixin):
         or base64 (whichever is shorter), to avoid having to insert newlines
         in a way that alters the intended text.
         """
-        # Django with Python's legacy email API uses quoted-printable for both cases
-        # below. Python's modern API would prefer shorter base64 for the first case.
         cases = [
             # (body, expected_cte)
-            ("В южных морях " * 60, "quoted-printable"),
+            ("В южных морях " * 60, "base64"),
             ("I de sørlige hav " * 58, "quoted-printable"),
         ]
         for body, expected_cte in cases:
@@ -2201,10 +2076,7 @@ class LocmemBackendTests(BaseEmailBackendTests, SimpleTestCase):
     email_backend = "django.core.mail.backends.locmem.EmailBackend"
 
     def get_mailbox_content(self):
-        # Reparse as modern messages to work with shared BaseEmailBackendTests.
-        # (Once EmailMessage.message() uses Python's modern email API, this
-        # can be changed back to `[m.message() for m in mail.outbox]`.)
-        return [message_from_bytes(m.message().as_bytes()) for m in mail.outbox]
+        return [m.message() for m in mail.outbox]
 
     def flush_mailbox(self):
         mail.outbox = []
@@ -2226,7 +2098,7 @@ class LocmemBackendTests(BaseEmailBackendTests, SimpleTestCase):
 
     def test_validate_multiline_headers(self):
         # Ticket #18861 - Validate emails when using the locmem backend
-        with self.assertRaises(BadHeaderError):
+        with self.assertRaises(ValueError):
             send_mail(
                 "Subject\nMultiline", "Content", "from@example.com", ["to@example.com"]
             )
@@ -2745,6 +2617,27 @@ class SMTPBackendTests(BaseEmailBackendTests, SMTPBackendTestsBase):
             ],
         )
 
+    def test_rejects_non_ascii_local_part(self):
+        """
+        The SMTP EmailBackend does not currently support non-ASCII local-parts.
+        (That would require using the RFC 6532 SMTPUTF8 extension.) #35713.
+        """
+        backend = smtp.EmailBackend()
+        backend.connection = mock.Mock(spec=object())
+        email = EmailMessage(to=["nø@example.dk"])
+        with self.assertRaisesMessage(
+            ValueError,
+            "Invalid address 'nø@example.dk': local-part contains non-ASCII characters",
+        ):
+            backend.send_messages([email])
+
+    def test_prep_address_without_force_ascii(self):
+        # A subclass implementing SMTPUTF8 could use prep_address(force_ascii=False).
+        backend = smtp.EmailBackend()
+        for case in ["åh@example.dk", "oh@åh.example.dk", "åh@åh.example.dk"]:
+            with self.subTest(case=case):
+                self.assertEqual(backend.prep_address(case, force_ascii=False), case)
+
 
 @skipUnless(HAS_AIOSMTPD, "No aiosmtpd library detected.")
 class SMTPBackendStoppedServerTests(SMTPBackendTestsBase):
@@ -2774,6 +2667,76 @@ class SMTPBackendStoppedServerTests(SMTPBackendTestsBase):
             self.backend.open()
         self.backend.fail_silently = True
         self.backend.open()
+
+
+class LegacyAPINotUsedTests(SimpleTestCase):
+    """
+    Check django.core.mail does not directly import Python legacy email APIs
+    (other than in _deprecated.py), with a few specific exceptions.
+    """
+
+    # From "Legacy API:" in https://docs.python.org/3/library/email.html.
+    legacy_email_apis = {
+        "email.message.Message",
+        "email.mime",
+        "email.header",
+        "email.charset",
+        "email.encoders",
+        "email.utils",
+        "email.iterators",
+    }
+
+    allowed_exceptions = {
+        # Compatibility in EmailMessage.attachments special cases:
+        "email.message.Message",
+        "email.mime.base.MIMEBase",
+        # No replacement in modern email API:
+        "email.utils.make_msgid",
+    }
+
+    def test_no_legacy_apis_imported(self):
+        django_core_mail_path = Path(mail.__file__).parent
+        django_path = django_core_mail_path.parent.parent.parent
+        for abs_path in django_core_mail_path.glob("**/*.py"):
+            if abs_path.name == "_deprecated.py":
+                continue
+            path = abs_path.relative_to(django_path)
+            with self.subTest(path=str(path)):
+                collector = self.ImportCollector(abs_path.read_text())
+                used_apis = collector.get_matching_imports(self.legacy_email_apis)
+                used_apis -= self.allowed_exceptions
+                self.assertEqual(
+                    "\n".join(sorted(used_apis)),
+                    "",
+                    f"Python legacy email APIs used in {path}",
+                )
+
+    class ImportCollector(ast.NodeVisitor):
+        """
+        Collect all imports from an AST as a set of fully-qualified dotted names.
+        """
+
+        def __init__(self, source=None):
+            self.imports = set()
+            if source:
+                tree = ast.parse(source)
+                self.visit(tree)
+
+        def get_matching_imports(self, base_names):
+            """
+            Return the set of collected imports that start with any
+            of the fully-qualified dotted names in iterable base_names.
+            """
+            matcher = re.compile(
+                r"\b(" + r"|".join(re.escape(name) for name in base_names) + r")\b"
+            )
+            return set(name for name in self.imports if matcher.match(name))
+
+        def visit_Import(self, node):
+            self.imports.update(alias.name for alias in node.names)
+
+        def visit_ImportFrom(self, node):
+            self.imports.update(f"{node.module}.{alias.name}" for alias in node.names)
 
 
 # Check whether python/cpython#128110 has been fixed by seeing if space


### PR DESCRIPTION
Rebased version of https://github.com/django/django/pull/18966 with Python workarounds dropped.