### PR TITLE
Fixed #26583 -- Silenced individual clashing name warnings in collectstatic's default verbosity.

### DIFF
--- a/docs/releases/6.0.txt
+++ b/docs/releases/6.0.txt
@@ -470,6 +470,10 @@ Miscellaneous
 * The minimum supported version of ``asgiref`` is increased from 3.8.1 to
   3.9.1.
 
+* The :djadmin:`collectstatic` command now reports only a summary of skipped
+  files due to conflicts when ``--verbosity`` is 1. To see warnings for each
+  conflicting destination path, set the ``--verbosity`` flag to 2 or higher.
+
 .. _deprecated-features-6.0:
 
 Features deprecated in 6.0


### PR DESCRIPTION
#### Trac ticket number
ticket-26583

#### Branch description
Show summary instead of individual messages by default

Changed the collectstatic management command to suppress individual conflict messages at verbosity level 1 and instead show a summary count in the final output (e.g., "42 skipped due to conflict"). Individual conflict messages are still shown at verbosity level 2+.

This reduces noise when there are many duplicate files while still providing useful summary information about conflicts.

This is based on Simon's comment in an older unmerged PR [13683](https://github.com/django/django/pull/13683#pullrequestreview-530764272)
#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
