### PR TITLE
Removed @skipIfDBFeature silencing of nonexistent features.

### DIFF
--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -1582,9 +1582,7 @@ def _deferredSkip(condition, reason, name):
 def skipIfDBFeature(*features):
     """Skip a test if a database has at least one of the named features."""
     return _deferredSkip(
-        lambda: any(
-            getattr(connection.features, feature, False) for feature in features
-        ),
+        lambda: any(getattr(connection.features, feature) for feature in features),
         "Database has feature(s) %s" % ", ".join(features),
         "skipIfDBFeature",
     )

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -133,10 +133,10 @@ class SkippingTestCase(SimpleTestCase):
             raise ValueError
 
         self._assert_skipping(test_func, unittest.SkipTest)
-        self._assert_skipping(test_func2, ValueError)
+        self._assert_skipping(test_func2, AttributeError)
         self._assert_skipping(test_func3, unittest.SkipTest)
         self._assert_skipping(test_func4, unittest.SkipTest)
-        self._assert_skipping(test_func5, ValueError)
+        self._assert_skipping(test_func5, AttributeError)
 
         class SkipTestCase(SimpleTestCase):
             @skipIfDBFeature("missing")


### PR DESCRIPTION
Follow up to f5df7ed7e62585c7d0289a88a327dab8d608efcf.

(missed in https://github.com/django/django/pull/19581)