### PR TITLE
Fixed #35846 -- Improved reproducibility on staticfiles manifests.

### DIFF
--- a/django/contrib/staticfiles/storage.py
+++ b/django/contrib/staticfiles/storage.py
@@ -496,11 +496,12 @@ class ManifestFilesMixin(HashedFilesMixin):
             self.save_manifest()
 
     def save_manifest(self):
+        sorted_hashed_files = sorted(self.hashed_files.items())
         self.manifest_hash = self.file_hash(
-            None, ContentFile(json.dumps(sorted(self.hashed_files.items())).encode())
+            None, ContentFile(json.dumps(sorted_hashed_files).encode())
         )
         payload = {
-            "paths": self.hashed_files,
+            "paths": dict(sorted_hashed_files),
             "version": self.manifest_version,
             "hash": self.manifest_hash,
         }

--- a/docs/releases/6.0.txt
+++ b/docs/releases/6.0.txt
@@ -154,7 +154,9 @@ Minor features
 :mod:`django.contrib.staticfiles`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* ...
+* :class:`~django.contrib.staticfiles.storage.ManifestStaticFilesStorage` now
+  ensures consistent path ordering in manifest files, making them more
+  reproducible and reducing unnecessary diffs.
 
 :mod:`django.contrib.syndication`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/staticfiles_tests/test_storage.py
+++ b/tests/staticfiles_tests/test_storage.py
@@ -568,6 +568,20 @@ class TestCollectionManifestStorage(TestHashedFiles, CollectionTestCase):
         self.assertEqual(manifest_hash, "")
         self.assertEqual(manifest_content, {"dummy.txt": "dummy.txt"})
 
+    def test_manifest_file_consistent_content(self):
+        original_manifest_content = storage.staticfiles_storage.read_manifest()
+        hashed_files = storage.staticfiles_storage.hashed_files
+        # Force a change in the order of the hashed files.
+        with mock.patch.object(
+            storage.staticfiles_storage,
+            "hashed_files",
+            dict(reversed(hashed_files.items())),
+        ):
+            storage.staticfiles_storage.save_manifest()
+        manifest_file_content = storage.staticfiles_storage.read_manifest()
+        # The manifest file content should not change.
+        self.assertEqual(original_manifest_content, manifest_file_content)
+
 
 @override_settings(
     STATIC_URL="/",


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35846

#### Branch description
The ordering of the paths in staticfiles.json for the [ManifestStaticFilesStorage](https://docs.djangoproject.com/en/5.2/ref/contrib/staticfiles/#django.contrib.staticfiles.storage.ManifestStaticFilesStorage) backend is non-deterministic as it is determined by the order the files are returned by [os.scandir](https://docs.python.org/3/library/os.html#os.scandir), which is non-deterministic.

This causes problems for reproducible builds as the file content will not always be the same for the same set of static files.

This PR sorts the keys in the resulting JSON file to make the outputted file deterministic. I do not believe this change will have any backwards incompatible consequences.

The test written forces the order of the files in the list to be re-ordered and then assets that the newly generated JSON file matches the original.


#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
