### PR TITLE
Refs #35728 -- Added standard failure prefixes to assertion message tests.

### DIFF
--- a/tests/test_client_regress/tests.py
+++ b/tests/test_client_regress/tests.py
@@ -388,6 +388,46 @@ class AssertRedirectsTests(SimpleTestCase):
         with self.assertRaisesMessage(AssertionError, msg):
             self.assertRedirects(response, "/get_view/", msg_prefix="abc")
 
+    def test_followed_redirect_unexpected_initial_status_code(self):
+        response = self.client.get("/permanent_redirect_view/", follow=True)
+        msg = (
+            "301 != 302 : Initial response didn't redirect as expected: "
+            "Response code was 301 (expected 302)"
+        )
+        with self.assertRaisesMessage(AssertionError, msg):
+            self.assertRedirects(response, "/get_view/")
+
+        msg = (
+            "301 != 302 : abc: Initial response didn't redirect as expected: "
+            "Response code was 301 (expected 302)"
+        )
+        with self.assertRaisesMessage(AssertionError, msg):
+            self.assertRedirects(response, "/get_view/", msg_prefix="abc")
+
+    def test_followed_redirect_unexpected_final_status_code(self):
+        response = self.client.get("/redirect_view/", follow=True)
+        msg = (
+            "200 != 403 : Response didn't redirect as expected: Final Response "
+            "code was 200 (expected 403)"
+        )
+        with self.assertRaisesMessage(AssertionError, msg):
+            self.assertRedirects(
+                response, "/get_view/", status_code=302, target_status_code=403
+            )
+
+        msg = (
+            "200 != 403 : abc: Response didn't redirect as expected: Final "
+            "Response code was 200 (expected 403)"
+        )
+        with self.assertRaisesMessage(AssertionError, msg):
+            self.assertRedirects(
+                response,
+                "/get_view/",
+                status_code=302,
+                target_status_code=403,
+                msg_prefix="abc",
+            )
+
     def test_lost_query(self):
         """
         An assertion is raised if the redirect location doesn't preserve GET

--- a/tests/test_client_regress/tests.py
+++ b/tests/test_client_regress/tests.py
@@ -37,8 +37,8 @@ class TestDataMixin:
 
 @override_settings(ROOT_URLCONF="test_client_regress.urls")
 class AssertContainsTests(SimpleTestCase):
-    def test_contains(self):
-        "Responses can be inspected for content, including counting repeated substrings"
+
+    def test_basic_contains_not_contains(self):
         response = self.client.get("/no_template_view/")
 
         self.assertNotContains(response, "never")
@@ -48,154 +48,144 @@ class AssertContainsTests(SimpleTestCase):
         self.assertContains(response, "twice")
         self.assertContains(response, "twice", 2)
 
-        try:
+    def test_contains_with_wrong_status_code(self):
+        response = self.client.get("/no_template_view/")
+
+        msg = "Couldn't retrieve content: Response code was 200 (expected 999)"
+        with self.assertRaisesMessage(AssertionError, msg):
             self.assertContains(response, "text", status_code=999)
-        except AssertionError as e:
-            self.assertIn(
-                "Couldn't retrieve content: Response code was 200 (expected 999)",
-                str(e),
-            )
-        try:
+
+        msg = "abc: Couldn't retrieve content: Response code was 200 (expected 999)"
+        with self.assertRaisesMessage(AssertionError, msg):
             self.assertContains(response, "text", status_code=999, msg_prefix="abc")
-        except AssertionError as e:
-            self.assertIn(
-                "abc: Couldn't retrieve content: Response code was 200 (expected 999)",
-                str(e),
-            )
 
-        try:
+    def test_not_contains_with_wrong_status_code(self):
+        response = self.client.get("/no_template_view/")
+
+        msg = "Couldn't retrieve content: Response code was 200 (expected 999)"
+        with self.assertRaisesMessage(AssertionError, msg):
             self.assertNotContains(response, "text", status_code=999)
-        except AssertionError as e:
-            self.assertIn(
-                "Couldn't retrieve content: Response code was 200 (expected 999)",
-                str(e),
-            )
-        try:
+
+        msg = "abc: Couldn't retrieve content: Response code was 200 (expected 999)"
+        with self.assertRaisesMessage(AssertionError, msg):
             self.assertNotContains(response, "text", status_code=999, msg_prefix="abc")
-        except AssertionError as e:
-            self.assertIn(
-                "abc: Couldn't retrieve content: Response code was 200 (expected 999)",
-                str(e),
-            )
 
-        try:
+    def test_not_contains_failure(self):
+        response = self.client.get("/no_template_view/")
+
+        msg = (
+            "1 != 0 : 'once' unexpectedly found in the following response\n"
+            f"{response.content}"
+        )
+        with self.assertRaisesMessage(AssertionError, msg):
             self.assertNotContains(response, "once")
-        except AssertionError as e:
-            self.assertIn(
-                "'once' unexpectedly found in the following response\n"
-                f"{response.content}",
-                str(e),
-            )
-        try:
+
+        msg = (
+            "abc: 'once' unexpectedly found in the following response"
+            f"\n{response.content}"
+        )
+        with self.assertRaisesMessage(AssertionError, msg):
             self.assertNotContains(response, "once", msg_prefix="abc")
-        except AssertionError as e:
-            self.assertIn(
-                "abc: 'once' unexpectedly found in the following response\n"
-                f"{response.content}",
-                str(e),
-            )
 
-        try:
+    def test_count_mismatch(self):
+        response = self.client.get("/no_template_view/")
+
+        msg = (
+            "Found 0 instances of 'never' (expected 1) in the following response\n"
+            f"{response.content}"
+        )
+        with self.assertRaisesMessage(AssertionError, msg):
             self.assertContains(response, "never", 1)
-        except AssertionError as e:
-            self.assertIn(
-                "Found 0 instances of 'never' (expected 1) in the following response\n"
-                f"{response.content}",
-                str(e),
-            )
-        try:
+
+        msg = (
+            "abc: Found 0 instances of 'never' (expected 1) in the following response\n"
+            f"{response.content}"
+        )
+        with self.assertRaisesMessage(AssertionError, msg):
             self.assertContains(response, "never", 1, msg_prefix="abc")
-        except AssertionError as e:
-            self.assertIn(
-                "abc: Found 0 instances of 'never' (expected 1) in the following "
-                f"response\n{response.content}",
-                str(e),
-            )
 
-        try:
+    def test_unexpected_presence(self):
+        response = self.client.get("/no_template_view/")
+
+        msg = (
+            "1 != 0 : Found 1 instances of 'once' (expected 0) in the following "
+            f"response\n{response.content}"
+        )
+        with self.assertRaisesMessage(AssertionError, msg):
             self.assertContains(response, "once", 0)
-        except AssertionError as e:
-            self.assertIn(
-                "Found 1 instances of 'once' (expected 0) in the following response\n"
-                f"{response.content}",
-                str(e),
-            )
-        try:
+
+        msg = (
+            "1 != 0 : abc: Found 1 instances of 'once' (expected 0) in the following "
+            f"response\n{response.content}"
+        )
+        with self.assertRaisesMessage(AssertionError, msg):
             self.assertContains(response, "once", 0, msg_prefix="abc")
-        except AssertionError as e:
-            self.assertIn(
-                "abc: Found 1 instances of 'once' (expected 0) in the following "
-                f"response\n{response.content}",
-                str(e),
-            )
 
-        try:
+    def test_insufficient_count(self):
+        response = self.client.get("/no_template_view/")
+
+        msg = (
+            "Found 1 instances of 'once' (expected 2) in the following response\n"
+            f"{response.content}"
+        )
+        with self.assertRaisesMessage(AssertionError, msg):
             self.assertContains(response, "once", 2)
-        except AssertionError as e:
-            self.assertIn(
-                "Found 1 instances of 'once' (expected 2) in the following response\n"
-                f"{response.content}",
-                str(e),
-            )
-        try:
+
+        msg = (
+            "abc: Found 1 instances of 'once' (expected 2) in the following response\n"
+            f"{response.content}"
+        )
+        with self.assertRaisesMessage(AssertionError, msg):
             self.assertContains(response, "once", 2, msg_prefix="abc")
-        except AssertionError as e:
-            self.assertIn(
-                "abc: Found 1 instances of 'once' (expected 2) in the following "
-                f"response\n{response.content}",
-                str(e),
-            )
 
-        try:
+    def test_excessive_count(self):
+        response = self.client.get("/no_template_view/")
+
+        msg = (
+            "Found 2 instances of 'twice' (expected 1) in the following response\n"
+            f"{response.content}"
+        )
+        with self.assertRaisesMessage(AssertionError, msg):
             self.assertContains(response, "twice", 1)
-        except AssertionError as e:
-            self.assertIn(
-                "Found 2 instances of 'twice' (expected 1) in the following response\n"
-                f"{response.content}",
-                str(e),
-            )
-        try:
+
+        msg = (
+            "abc: Found 2 instances of 'twice' (expected 1) in the following response\n"
+            f"{response.content}"
+        )
+        with self.assertRaisesMessage(AssertionError, msg):
             self.assertContains(response, "twice", 1, msg_prefix="abc")
-        except AssertionError as e:
-            self.assertIn(
-                "abc: Found 2 instances of 'twice' (expected 1) in the following "
-                f"response\n{response.content}",
-                str(e),
-            )
 
-        try:
+    def test_missing_content(self):
+        response = self.client.get("/no_template_view/")
+
+        msg = f"Couldn't find 'thrice' in the following response\n{response.content}"
+        with self.assertRaisesMessage(AssertionError, msg):
             self.assertContains(response, "thrice")
-        except AssertionError as e:
-            self.assertIn(
-                f"Couldn't find 'thrice' in the following response\n{response.content}",
-                str(e),
-            )
-        try:
+
+        msg = (
+            f"abc: Couldn't find 'thrice' in the following response\n{response.content}"
+        )
+        with self.assertRaisesMessage(AssertionError, msg):
             self.assertContains(response, "thrice", msg_prefix="abc")
-        except AssertionError as e:
-            self.assertIn(
-                "abc: Couldn't find 'thrice' in the following response\n"
-                f"{response.content}",
-                str(e),
-            )
 
-        try:
+    def test_missing_content_with_count(self):
+        response = self.client.get("/no_template_view/")
+
+        msg = (
+            "0 != 3 : Found 0 instances of 'thrice' (expected 3) in the following "
+            f"response\n{response.content}"
+        )
+        with self.assertRaisesMessage(AssertionError, msg):
             self.assertContains(response, "thrice", 3)
-        except AssertionError as e:
-            self.assertIn(
-                "Found 0 instances of 'thrice' (expected 3) in the following response\n"
-                f"{response.content}",
-                str(e),
-            )
-        try:
-            self.assertContains(response, "thrice", 3, msg_prefix="abc")
-        except AssertionError as e:
-            self.assertIn(
-                "abc: Found 0 instances of 'thrice' (expected 3) in the following "
-                f"response\n{response.content}",
-                str(e),
-            )
 
+        msg = (
+            "0 != 3 : abc: Found 0 instances of 'thrice' (expected 3) in the following "
+            f"response\n{response.content}"
+        )
+        with self.assertRaisesMessage(AssertionError, msg):
+            self.assertContains(response, "thrice", 3, msg_prefix="abc")
+
+    def test_long_content(self):
         long_content = (
             b"This is a very very very very very very very very long message which "
             b"exceeds the max limit of truncation."
@@ -212,7 +202,10 @@ class AssertContainsTests(SimpleTestCase):
         with self.assertRaisesMessage(AssertionError, msg):
             self.assertContains(response, "This", 3)
 
-        msg = f"'very' unexpectedly found in the following response\n{long_content}"
+        msg = (
+            "8 != 0 : 'very' unexpectedly found in the following response\n"
+            f"{long_content}"
+        )
         with self.assertRaisesMessage(AssertionError, msg):
             self.assertNotContains(response, "very")
 

--- a/tests/test_client_regress/tests.py
+++ b/tests/test_client_regress/tests.py
@@ -367,27 +367,26 @@ class AssertTemplateUsedTests(TestDataMixin, TestCase):
 
 @override_settings(ROOT_URLCONF="test_client_regress.urls")
 class AssertRedirectsTests(SimpleTestCase):
-    def test_redirect_page(self):
-        "An assertion is raised if the original page couldn't be retrieved as expected"
+    def test_unexpected_status_code(self):
+        """
+        An assertion is raised if the original page couldn't be retrieved
+        as expected.
+        """
         # This page will redirect with code 301, not 302
         response = self.client.get("/permanent_redirect_view/")
-        try:
+        msg = (
+            "301 != 302 : Response didn't redirect as expected: Response code was "
+            "301 (expected 302)"
+        )
+        with self.assertRaisesMessage(AssertionError, msg):
             self.assertRedirects(response, "/get_view/")
-        except AssertionError as e:
-            self.assertIn(
-                "Response didn't redirect as expected: Response code was 301 "
-                "(expected 302)",
-                str(e),
-            )
 
-        try:
+        msg = (
+            "301 != 302 : abc: Response didn't redirect as expected: Response code "
+            "was 301 (expected 302)"
+        )
+        with self.assertRaisesMessage(AssertionError, msg):
             self.assertRedirects(response, "/get_view/", msg_prefix="abc")
-        except AssertionError as e:
-            self.assertIn(
-                "abc: Response didn't redirect as expected: Response code was 301 "
-                "(expected 302)",
-                str(e),
-            )
 
     def test_lost_query(self):
         """
@@ -431,26 +430,22 @@ class AssertRedirectsTests(SimpleTestCase):
         retrieved as expected.
         """
         response = self.client.get("/double_redirect_view/")
-        try:
+        msg = (
+            "301 != 200 : Couldn't retrieve redirection page "
+            "'/permanent_redirect_view/': response code was 301 (expected 200)"
+        )
+        with self.assertRaisesMessage(AssertionError, msg):
             # The redirect target responds with a 301 code, not 200
             self.assertRedirects(response, "http://testserver/permanent_redirect_view/")
-        except AssertionError as e:
-            self.assertIn(
-                "Couldn't retrieve redirection page '/permanent_redirect_view/': "
-                "response code was 301 (expected 200)",
-                str(e),
-            )
 
-        try:
+        msg = (
+            "301 != 200 : abc: Couldn't retrieve redirection page "
+            "'/permanent_redirect_view/': response code was 301 (expected 200)"
+        )
+        with self.assertRaisesMessage(AssertionError, msg):
             # The redirect target responds with a 301 code, not 200
             self.assertRedirects(
                 response, "http://testserver/permanent_redirect_view/", msg_prefix="abc"
-            )
-        except AssertionError as e:
-            self.assertIn(
-                "abc: Couldn't retrieve redirection page '/permanent_redirect_view/': "
-                "response code was 301 (expected 200)",
-                str(e),
             )
 
     def test_redirect_chain(self):

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -601,7 +601,7 @@ class AssertTemplateUsedContextManagerTests(SimpleTestCase):
             render_to_string("template_used/base.html")
 
         msg = (
-            "Template 'template_used/base.html' was expected to be rendered "
+            "2 != 3 : Template 'template_used/base.html' was expected to be rendered "
             "3 time(s) but was actually rendered 2 time(s)."
         )
         with self.assertRaisesMessage(AssertionError, msg):


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

Two additional commits I added while working on this:
1. Splitting monolithic `test_contains()` test into smaller focused tests (10+)
2. Adding missing tests for assertRedirects when following redirect chains.

ticket-35728