### PR TITLE
Fixed #36479: Failing test for black formatter missing install simulation on a macOS

### DIFF
--- a/tests/user_commands/tests.py
+++ b/tests/user_commands/tests.py
@@ -565,11 +565,15 @@ class UtilsTests(SimpleTestCase):
         self.assertEqual(normalize_path_patterns(["foo/bar/*", "bar/*/"]), expected)
 
     def test_run_formatters_handles_oserror_for_black_path(self):
+        test_files_path = Path(__file__).parent / "test_files"
         cases = [
-            (FileNotFoundError, "nonexistent"),
+            (
+                FileNotFoundError,
+                str(test_files_path / "nonexistent"),
+            ),
             (
                 OSError if sys.platform == "win32" else PermissionError,
-                str(Path(__file__).parent / "test_files" / "black"),
+                str(test_files_path / "black"),
             ),
         ]
         for exception, location in cases:


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

[ticket-36479](https://code.djangoproject.com/ticket/36479)

#### Branch description

This branch added a simple fix for running `./runtests.py user_commands.tests.UtilsTests.test_run_formatters_handles_oserror_for_black_path` which fails on a `darwin` platform but passes on a `linux` platform due to different subclass results by `OSError` from different platforms. Please see the ticket for further details of the problem.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
