### PR TITLE
Fixed #36470 -- Potential log injection in development server (runserver) logging

### DIFF
--- a/django/core/servers/basehttp.py
+++ b/django/core/servers/basehttp.py
@@ -18,6 +18,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.handlers.wsgi import LimitedStream
 from django.core.wsgi import get_wsgi_application
 from django.db import connections
+from django.utils.log import log_message
 from django.utils.module_loading import import_string
 
 __all__ = ("WSGIServer", "WSGIRequestHandler")
@@ -182,35 +183,27 @@ class WSGIRequestHandler(simple_server.WSGIRequestHandler):
         return self.client_address[0]
 
     def log_message(self, format, *args):
-        extra = {
-            "request": self.request,
-            "server_time": self.log_date_time_string(),
-        }
-        if args[1][0] == "4":
+        if args[1][0] == "4" and args[0].startswith("\x16\x03"):
             # 0x16 = Handshake, 0x03 = SSL 3.0 or TLS 1.x
-            if args[0].startswith("\x16\x03"):
-                extra["status_code"] = 500
-                logger.error(
-                    "You're accessing the development server over HTTPS, but "
-                    "it only supports HTTP.",
-                    extra=extra,
-                )
-                return
-
-        if args[1].isdigit() and len(args[1]) == 3:
+            format = (
+                "You're accessing the development server over HTTPS, but it only "
+                "supports HTTP."
+            )
+            status_code = 500
+            args = ()
+        elif args[1].isdigit() and len(args[1]) == 3:
             status_code = int(args[1])
-            extra["status_code"] = status_code
-
-            if status_code >= 500:
-                level = logger.error
-            elif status_code >= 400:
-                level = logger.warning
-            else:
-                level = logger.info
         else:
-            level = logger.info
+            status_code = None
 
-        level(format, *args, extra=extra)
+        log_message(
+            logger,
+            format,
+            *args,
+            request=self.request,
+            status_code=status_code,
+            server_time=self.log_date_time_string(),
+        )
 
     def get_environ(self):
         # Strip all headers with underscores in the name before constructing

--- a/tests/servers/test_basehttp.py
+++ b/tests/servers/test_basehttp.py
@@ -50,6 +50,21 @@ class WSGIRequestHandlerTestCase(SimpleTestCase):
                             cm.records[0].levelname, wrong_level.upper()
                         )
 
+    def test_log_message_escapes_control_sequences(self):
+        request = WSGIRequest(self.request_factory.get("/").environ)
+        request.makefile = lambda *args, **kwargs: BytesIO()
+        handler = WSGIRequestHandler(request, "192.168.0.2", None)
+
+        malicious_path = "\x1b[31mALERT\x1b[0m"
+
+        with self.assertLogs("django.server", "WARNING") as cm:
+            handler.log_message("GET %s %s", malicious_path, "404")
+
+        log = cm.output[0]
+
+        self.assertNotIn("\x1b[31m", log)
+        self.assertIn("\\x1b[31mALERT\\x1b[0m", log)
+
     def test_https(self):
         request = WSGIRequest(self.request_factory.get("/").environ)
         request.makefile = lambda *args, **kwargs: BytesIO()


### PR DESCRIPTION
Fixed #36470 -- Potential log injection in development server (runserver) logging

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36470

#### Branch description
Fixed a log injection issue in Django's development server by escaping all control characters in user inputs passed to log_message(), and verified this behavior through tests.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
