### PR TITLE
Fixed #36009 -- Added support for PostGIS 3.5

### DIFF
--- a/docs/ref/contrib/gis/install/geolibs.txt
+++ b/docs/ref/contrib/gis/install/geolibs.txt
@@ -12,7 +12,7 @@ Program                   Description                           Required        
 `PROJ`_                   Cartographic Projections library      Yes (PostgreSQL and SQLite only)  9.x, 8.x, 7.x, 6.x
 :doc:`GDAL <../gdal>`     Geospatial Data Abstraction Library   Yes                               3.10, 3.9, 3.8, 3.7, 3.6, 3.5, 3.4, 3.3, 3.2, 3.1
 :doc:`GeoIP <../geoip2>`  IP-based geolocation library          No                                2
-`PostGIS`__               Spatial extensions for PostgreSQL     Yes (PostgreSQL only)             3.4, 3.3, 3.2, 3.1
+`PostGIS`__               Spatial extensions for PostgreSQL     Yes (PostgreSQL only)             3.5, 3.4, 3.3, 3.2, 3.1
 `SpatiaLite`__            Spatial extensions for SQLite         Yes (SQLite only)                 5.1, 5.0, 4.3
 ========================  ====================================  ================================  =================================================
 
@@ -41,6 +41,7 @@ totally fine with GeoDjango. Your mileage may vary.
     PostGIS 3.2.0 2021-12-18
     PostGIS 3.3.0 2022-08-27
     PostGIS 3.4.0 2023-08-15
+    PostGIS 3.5.0 2024-09-25
     PROJ 9.0.0 2022-03-01
     PROJ 8.0.0 2021-03-01
     PROJ 8.0.0 2021-03-01

--- a/tests/gis_tests/geoapp/tests.py
+++ b/tests/gis_tests/geoapp/tests.py
@@ -578,7 +578,12 @@ class GeoLookupTest(TestCase):
         # Testing within relation mask.
         ks = State.objects.get(name="Kansas")
         self.assertEqual(
-            "Lawrence", City.objects.get(point__relate=(ks.poly, within_mask)).name
+            "Lawrence",
+            # Remove ".filter(name="Lawrence")" once PostGIS 3.5.4 is released.
+            # https://lists.osgeo.org/pipermail/postgis-devel/2025-July/030581.html
+            City.objects.filter(name="Lawrence")
+            .get(point__relate=(ks.poly, within_mask))
+            .name,
         )
 
         # Testing intersection relation mask.


### PR DESCRIPTION
Ticket : ticket-36009

This patch aims to resolve the test failure seen with PostGIS 3.5 and GEOS 3.13+. Details on the ticket.

https://github.com/smithdc1/django/pull/7 helps show what is going on here.

In the PR linked above I added a `relate()` function so that I can annotate the outcome of the [`ST_Relate()`](https://postgis.net/docs/ST_Relate.html). This shows that witih GEOS 3.13+ the outcome of `ST_Relate()` (when a pattern is provided) is different depending upon how many rows are in the queryset. This is quite surprising to me!



