### PR TITLE
Removed unneeded field_name checks within MigrationAutodetector.check_dependency().

### DIFF
--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -496,20 +496,14 @@ class MigrationAutodetector:
                 and operation.name_lower == dependency.model_name_lower
             )
         # Field being altered
-        elif (
-            dependency.field_name is not None
-            and dependency.type == OperationDependency.Type.ALTER
-        ):
+        elif dependency.type == OperationDependency.Type.ALTER:
             return (
                 isinstance(operation, operations.AlterField)
                 and operation.model_name_lower == dependency.model_name_lower
                 and operation.name_lower == dependency.field_name_lower
             )
         # order_with_respect_to being unset for a field
-        elif (
-            dependency.field_name is not None
-            and dependency.type == OperationDependency.Type.REMOVE_ORDER_WRT
-        ):
+        elif dependency.type == OperationDependency.Type.REMOVE_ORDER_WRT:
             return (
                 isinstance(operation, operations.AlterOrderWithRespectTo)
                 and operation.name_lower == dependency.model_name_lower
@@ -517,10 +511,7 @@ class MigrationAutodetector:
                 != dependency.field_name_lower
             )
         # Field is removed and part of an index/unique_together
-        elif (
-            dependency.field_name is not None
-            and dependency.type == OperationDependency.Type.ALTER_FOO_TOGETHER
-        ):
+        elif dependency.type == OperationDependency.Type.ALTER_FOO_TOGETHER:
             return (
                 isinstance(
                     operation,


### PR DESCRIPTION
While testing https://github.com/django/django/pull/19361, I was checking whether the elif check could be simplified to check test coverage and make sure we don't add anything unnecessary.

There are some `OperationDependency.Type` which are used for changes to both models and fields (such as `OperationDependency.Type.CREATE`) and some that are currently only used for changes to fields (such as `OperationDependency.Type.REMOVE_ORDER_WRT`).

I want to confirm if always checking whether the field name is or isn't None is something we want by design or whether a small refactor is worthwhile.
This might be just a personal preference decision but thought I would ask :+1: 

- [X] test 1
- [ x] test 2
- [x ] test 3
- [x] test 4
- [ X ] test 5