### PR TITLE
Removed verbose "which" from migrations topic

### DIFF
--- a/docs/topics/migrations.txt
+++ b/docs/topics/migrations.txt
@@ -13,19 +13,17 @@ migrations, when to run them, and the common problems you might run into.
 The Commands
 ============
 
-There are several commands which you will use to interact with migrations
+There are several commands you will use to interact with migrations
 and Django's handling of database schema:
 
-* :djadmin:`migrate`, which is responsible for applying and unapplying
-  migrations.
+* :djadmin:`migrate`: applies and reverts migrations.
 
-* :djadmin:`makemigrations`, which is responsible for creating new migrations
-  based on the changes you have made to your models.
+* :djadmin:`makemigrations`: creates new migrations based on the changes
+  you have made to your models.
 
-* :djadmin:`sqlmigrate`, which displays the SQL statements for a migration.
+* :djadmin:`sqlmigrate`: displays the SQL statements for a migration.
 
-* :djadmin:`showmigrations`, which lists a project's migrations and their
-  status.
+* :djadmin:`showmigrations`: lists a project's migrations and their status.
 
 You should think of migrations as a version control system for your database
 schema. ``makemigrations`` is responsible for packaging up your model changes


### PR DESCRIPTION
#### Branch description
Trivial changes to migrations topic in docs. Removed  "which" and "which is" phrases, where they are overly verbose. This change is intended to make the migrations topic a bit more concise and easier to read.

Also fixes a very minor (preexisting) spelling error.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
