### PR TITLE
Fixed #36439 -- Optimized acheck_password by using sync_to_async on verify_password.

### DIFF
--- a/django/contrib/auth/hashers.py
+++ b/django/contrib/auth/hashers.py
@@ -6,6 +6,8 @@ import importlib
 import math
 import warnings
 
+from asgiref.sync import sync_to_async
+
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.signals import setting_changed
@@ -86,7 +88,10 @@ def check_password(password, encoded, setter=None, preferred="default"):
 
 async def acheck_password(password, encoded, setter=None, preferred="default"):
     """See check_password()."""
-    is_correct, must_update = verify_password(password, encoded, preferred=preferred)
+    is_correct, must_update = await sync_to_async(
+        verify_password,
+        thread_sensitive=False,
+    )(password, encoded, preferred=preferred)
     if setter and is_correct and must_update:
         await setter(password)
     return is_correct


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

[ticket-36439](https://code.djangoproject.com/ticket/36439)

#### Branch description

~~Conducted several [experiments/benchmarks](https://code.djangoproject.com/ticket/36439#comment:8) on the performance of the [`acheck_password`](https://docs.djangoproject.com/en/dev/topics/auth/passwords/#django.contrib.auth.hashers.acheck_password) that blocks asyncio's event-loop, which is causing a performance bottleneck. Adding a `ThreadPoolExecutor` significantly improved the performance gap compared to the test without using it.~~

~~Also, introduced the `CHECK_PASSWORD_EXECUTOR_MAX_WORKERS` for allowing developers to provide a configurable setting for the `ThreadPoolExecutor` instance. See the updated document on this PR.~~

EDIT:

Please check the new [experiments/benchmarks](https://code.djangoproject.com/ticket/36439#comment:13) on the performance of the [`acheck_password`](https://docs.djangoproject.com/en/dev/topics/auth/passwords/#django.contrib.auth.hashers.acheck_password) that blocks asyncio's event-loop, which is causing a performance bottleneck by using the `sync_to_async` on the `verify_password`.

EDIT 2:

Added a new benchmark via django-asv here: https://github.com/django/django-asv/pull/94

---

> **Note**: The idea was not mine but by **Robert Aistleitner** who proposed it which was later on picked up by me since it has no owner for 4 weeks.

This PR targets a patch for v5.2 as mentioned in the ticket.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
