### PR TITLE
Fixed AttributeError for enterContext() on Python < 3.11.

### DIFF
--- a/tests/composite_pk/test_filter.py
+++ b/tests/composite_pk/test_filter.py
@@ -14,6 +14,7 @@ from django.db.models import (
 from django.db.models.functions import Cast
 from django.db.models.lookups import Exact
 from django.test import TestCase, skipUnlessDBFeature
+from django.utils.version import PY311
 
 from .models import Comment, Tenant, User
 
@@ -556,4 +557,10 @@ class CompositePKFilterTupleLookupFallbackTests(CompositePKFilterTests):
         feature_patch = patch.object(
             connection.features, "supports_tuple_lookups", False
         )
-        self.enterContext(feature_patch)
+        if PY311:
+            self.enterContext(feature_patch)
+        else:
+            # unittest.TestCase.enterContext() was added in Python 3.11.
+            from django.test.testcases import _enter_context
+
+            _enter_context(feature_patch, self.addCleanup)


### PR DESCRIPTION
On Jenkins with Python 3.10:

Traceback (most recent call last):
  File "[...]/python3.10/tests/composite_pk/test_filter.py", line 559, in setUp
    self.enterContext(feature_patch)
AttributeError: 'CompositePKFilterTupleLookupFallbackTests' object has no attribute 'enterContext'

#### Branch description
The Django 5.2 Jenkins jobs has failures for Python 3.10 as follows:
```
======================================================================
ERROR [0.001s]: test_cannot_cast_pk (composite_pk.test_filter.CompositePKFilterTupleLookupFallbackTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/workspace/django-5.2/database/postgis/label/focal/python/python3.10/tests/composite_pk/test_filter.py", line 559, in setUp
    self.enterContext(feature_patch)
AttributeError: 'CompositePKFilterTupleLookupFallbackTests' object has no attribute 'enterContext'
```