### PR TITLE
Updated new contributor github action to close toast PRs.

### DIFF
--- a/.github/workflows/new_contributor_pr.yml
+++ b/.github/workflows/new_contributor_pr.yml
@@ -8,7 +8,27 @@ permissions:
   pull-requests: write
 
 jobs:
+  check:
+    name: Close invalid PRs
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Close invalid PRs"
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            const isInvalid = /99999/.test(title);
+            if (isInvalid) {
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+                state: 'closed'
+              });
+            }
+
   build:
+    needs: check
     name: Hello new contributor
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
#### Trac ticket number

"N/A"

#### Branch description
Close toast PRs with a simple grep 👍

Closing toast PRs is annoying for some folks (context switching and notifications would be the biggest headache here).

This is mostly to demonstrate an alternative of using simple blacklist of words to grep as opposed to writing complex analysis code.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
