### PR TITLE
Fixed typo in ReverseManyToOneDescriptor docstring.

### DIFF
--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -602,7 +602,7 @@ class ReverseManyToOneDescriptor:
     ``Parent.children`` is a ``ReverseManyToOneDescriptor`` instance.
 
     Most of the implementation is delegated to a dynamically defined manager
-    class built by ``create_forward_many_to_many_manager()`` defined below.
+    class built by ``create_reverse_many_to_one_manager()`` defined below.
     """
 
     def __init__(self, rel):


### PR DESCRIPTION
ReverseManyToOneDescriptor is delegated to create_reverse_many_to_one_manager()!

#### Trac ticket number
N/A

#### Branch description
Just correcting a wrong commentary!
