### PR TITLE
Updated asgiref dependency.

### DIFF
--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -308,7 +308,7 @@ dependencies:
 
 * :pypi:`aiosmtpd` 1.4.5+
 * :pypi:`argon2-cffi` 23.1.0+
-* :pypi:`asgiref` 3.8.1+ (required)
+* :pypi:`asgiref` 3.9.1+ (required)
 * :pypi:`bcrypt` 4.1.1+
 * :pypi:`colorama` 0.4.6+
 * :pypi:`docutils` 0.19+

--- a/docs/releases/6.0.txt
+++ b/docs/releases/6.0.txt
@@ -392,6 +392,9 @@ Miscellaneous
   set the level to ``messages.SUCCESS`` to retain the previous icon and
   styling.
 
+* The minimum supported version of ``asgiref`` is increased from 3.8.1 to
+  3.9.1.
+
 .. _deprecated-features-6.0:
 
 Features deprecated in 6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "Django"
 dynamic = ["version"]
 requires-python = ">= 3.12"
 dependencies = [
-    "asgiref>=3.8.1",
+    "asgiref>=3.9.1",
     "sqlparse>=0.5.0",
     "tzdata; sys_platform == 'win32'",
 ]

--- a/tests/requirements/py3.txt
+++ b/tests/requirements/py3.txt
@@ -1,5 +1,5 @@
 aiosmtpd >= 1.4.5
-asgiref >= 3.8.1
+asgiref >= 3.9.1
 argon2-cffi >= 23.1.0; sys.platform != 'win32' or python_version < '3.14'
 bcrypt >= 4.1.1
 black >= 25.1.0


### PR DESCRIPTION
#### Trac ticket number

n/a

#### Branch description

Updated agsiref to at least 3.9.1. v3.9 fixed a number of issues in the v3.8 series, and fixed a reference cycle issue in `sync_to_async` that should significantly reduce memory overhead. It's worth bumping now to begin nudging environments to upgrade. Even with no other updates, this should be the minimum pin for the next Django version. 

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
