### PR TITLE
Refs #35844, #35945 -- Used asgiref.sync.iscoroutinefunction() instead of deprecated asyncio.iscoroutinefunction().

### DIFF
--- a/django/core/paginator.py
+++ b/django/core/paginator.py
@@ -1,10 +1,9 @@
 import collections.abc
 import inspect
 import warnings
-from asyncio import iscoroutinefunction
 from math import ceil
 
-from asgiref.sync import sync_to_async
+from asgiref.sync import iscoroutinefunction, sync_to_async
 
 from django.utils.deprecation import RemovedInDjango70Warning
 from django.utils.functional import cached_property


### PR DESCRIPTION
Follow up to bd3b1dfa2422e02ced3a894adb7544e42540c97d.
Introduced in 2ae3044d9d4dfb8371055513e440e0384f211963.

Fixes `DeprecationWarning`:

```
'asyncio.iscoroutinefunction' is deprecated and slated for removal in Python 3.16; use inspect.iscoroutinefunction() instead.
```