### PR TITLE
Fixed #36502 -- Restored UNNEST strategy for foreign key bulk inserts on PostgreSQL.

### DIFF
--- a/django/db/backends/postgresql/compiler.py
+++ b/django/db/backends/postgresql/compiler.py
@@ -40,7 +40,8 @@ class SQLInsertCompiler(BaseSQLInsertCompiler):
             # unnest'able (e.g. array and geometry types are known to be
             # problematic).
             or any(
-                field.get_internal_type() not in self.connection.data_types
+                (field.target_field if field.is_relation else field).get_internal_type()
+                not in self.connection.data_types
                 for field in fields
             )
             # Compilable cannot be combined in an array of literal values.

--- a/docs/releases/5.2.5.txt
+++ b/docs/releases/5.2.5.txt
@@ -9,4 +9,6 @@ Django 5.2.5 fixes several bugs in 5.2.4.
 Bugfixes
 ========
 
-* ...
+* Fixed a regression in Django 5.2.1 that prevented the usage of ``UNNEST``
+  PostgreSQL strategy of ``QuerySet.bulk_create()`` with foreign keys
+  (:ticket:`36502`).

--- a/tests/backends/postgresql/test_compilation.py
+++ b/tests/backends/postgresql/test_compilation.py
@@ -1,10 +1,11 @@
 import unittest
+from datetime import date
 
 from django.db import connection
 from django.db.models.expressions import RawSQL
 from django.test import TestCase
 
-from ..models import Square
+from ..models import Article, Reporter, Square
 
 
 @unittest.skipUnless(connection.vendor == "postgresql", "PostgreSQL tests")
@@ -33,3 +34,17 @@ class BulkCreateUnnestTests(TestCase):
             squares = Square.objects.bulk_create([Square(root=3), Square(root=3)])
         self.assertIn("UNNEST", ctx[0]["sql"])
         self.assertEqual([square.square for square in squares], [9, 9])
+
+    def test_unnest_eligible_foreign_keys(self):
+        reporter = Reporter.objects.create()
+        with self.assertNumQueries(1) as ctx:
+            articles = Article.objects.bulk_create(
+                [
+                    Article(pub_date=date.today(), reporter=reporter),
+                    Article(pub_date=date.today(), reporter=reporter),
+                ]
+            )
+        self.assertIn("UNNEST", ctx[0]["sql"])
+        self.assertEqual(
+            [article.reporter for article in articles], [reporter, reporter]
+        )


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36502

#### Branch description
Regression in 764af7a3d6c0b543dcf659a2c327f214da768fe4.

Refs ticket-36289.

Thanks @canardoFR for the report.
