### PR TITLE
 Refs #31223 -- Added __class_getitem__() to SetPasswordMixin.

### DIFF
--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -134,6 +134,9 @@ class SetPasswordMixin:
             user.save()
         return user
 
+    def __class_getitem__(cls, *args, **kwargs):
+        return cls
+
 
 class SetUnusablePasswordMixin:
     """

--- a/tests/auth_tests/test_forms.py
+++ b/tests/auth_tests/test_forms.py
@@ -350,6 +350,9 @@ class BaseUserCreationFormTest(TestDataMixin, TestCase):
                     form.fields[field_name].widget.attrs["autocomplete"], autocomplete
                 )
 
+    def test_user_creation_form_class_getitem(self):
+        self.assertIs(BaseUserCreationForm["MyCustomUser"], BaseUserCreationForm)
+
 
 class CustomUserCreationFormTest(TestDataMixin, TestCase):
 


### PR DESCRIPTION
#### Trac ticket number
Refs [ticket-31223](https://code.djangoproject.com/ticket/31223)

#### Branch description
This is similar to #12405 and #15571. 

We are struggling to monkeypatch these in django-stubs because this module import the User model.

This is quite valuable because users want to declare their custom `User` model when using these forms (for ex `SetPasswordForm[MyUser]`) to have accurate types.

See [related issue](https://github.com/typeddjango/django-stubs/issues/2697) in django-stubs and associated [mitigation PR](https://github.com/typeddjango/django-stubs/pull/2738)


#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
