### PR TITLE
Added GitHub Action to enforce stable branch commit message prefix.

### DIFF
--- a/.github/workflows/check-commit-messages.yml
+++ b/.github/workflows/check-commit-messages.yml
@@ -1,0 +1,63 @@
+name: Check commit prefix
+
+on:
+  pull_request:
+    types: [edited, opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-commit-prefix:
+    if: startsWith(github.event.pull_request.base.ref, 'stable/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Calculate commit prefix
+        id: vars
+        run: |
+          BASE="${{ github.event.pull_request.base.ref }}"
+          HEAD="${{ github.event.pull_request.head.ref }}"
+          echo "BASE=$BASE" >> $GITHUB_ENV
+          echo "HEAD=$HEAD" >> $GITHUB_ENV
+          VERSION="${BASE#stable/}"
+          echo "prefix=[$VERSION]" >> $GITHUB_OUTPUT
+
+      - name: Check PR title prefix
+        run: |
+          TITLE="${{ github.event.pull_request.title }}"
+          PREFIX="${{ steps.vars.outputs.prefix }}"
+          if [[ "$TITLE" != "$PREFIX"* ]]; then
+            echo "❌ PR title must start with the required prefix: $PREFIX"
+            exit 1
+          fi
+          echo "✅ PR title has the required prefix."
+
+      - name: Fetch base and head branches
+        run: |
+          git fetch origin $BASE
+          git fetch origin $HEAD
+
+      - name: Check commit messages prefix
+        run: |
+          PREFIX="${{ steps.vars.outputs.prefix }}"
+          COMMITS=$(git rev-list origin/${BASE}..origin/${HEAD})
+          echo "Checking commit messages for required prefix: $PREFIX"
+          FAIL=0
+          for SHA in $COMMITS; do
+            MSG=$(git log -1 --pretty=%s $SHA)
+            echo "Checking commit $SHA: $MSG"
+            if [[ "$MSG" != "$PREFIX"* ]]; then
+              echo "❌ Commit $SHA must start with the required prefix: $PREFIX"
+              FAIL=1
+            fi
+          done
+
+          if [[ $FAIL -eq 1 ]]; then
+            echo "One or more commit messages are missing the required prefix."
+            exit 1
+          fi
+
+          echo "✅ All commits have the required prefix."


### PR DESCRIPTION
#### Branch description
I've made the mistake of forgetting to include the `[A.B.x]` prefix in commit messages a few times when targeting `stable/A.B.x` branches. This new GitHub Actions check, designed to run only on branches starting with `stable/`, should help me and others avoid this in future merges.