### PR TITLE
Triggered window resize to fix layout issues.

### DIFF
--- a/django/contrib/admin/tests.py
+++ b/django/contrib/admin/tests.py
@@ -148,6 +148,14 @@ class AdminSeleniumTestCase(SeleniumTestCase, StaticLiveServerTestCase):
 
         self.wait_page_ready(timeout=timeout)
 
+    def trigger_resize(self):
+        width = self.selenium.get_window_size()["width"]
+        height = self.selenium.get_window_size()["height"]
+        self.selenium.set_window_size(width + 1, height)
+        self.wait_page_ready()
+        self.selenium.set_window_size(width, height)
+        self.wait_page_ready()
+
     def admin_login(self, username, password, login_url="/admin/"):
         """
         Log in to the admin.

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -6204,6 +6204,7 @@ class SeleniumTests(AdminSeleniumTestCase):
         user = User.objects.create_user(username="new", password="newuser")
         url = self.live_server_url + reverse("admin:auth_user_change", args=[user.id])
         self.selenium.get(url)
+        self.trigger_resize()
 
         # Scroll to the User permissions section.
         user_permissions = self.selenium.find_element(
@@ -6243,9 +6244,8 @@ class SeleniumTests(AdminSeleniumTestCase):
             ).perform()
 
         # Move focus to other element.
-        self.selenium.find_element(
-            By.CSS_SELECTOR, "#id_user_permissions_selected_input"
-        ).click()
+        body = self.selenium.find_element(By.TAG_NAME, "body")
+        body.send_keys(Keys.TAB)
         self.take_screenshot("selectbox-chosen-perms-some-selected")
 
     @screenshot_cases(["desktop_size", "mobile_size", "rtl", "dark", "high_contrast"])

--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -1541,6 +1541,7 @@ class HorizontalVerticalFilterSeleniumTests(AdminWidgetSeleniumTestCase):
             )
 
             self.wait_page_ready()
+            self.trigger_resize()
             self.execute_basic_operations("vertical", "students")
             self.execute_basic_operations("horizontal", "alumni")
 


### PR DESCRIPTION
#### Branch description
The following tests consistently fail:
```
./runtests.py --selenium=chrome admin_views.tests.SeleniumTests.test_selectbox_selected_rows --headless

./runtests.py --selenium=chrome admin_widgets.tests.HorizontalVerticalFilterSeleniumTests.test_basic --headless
```

These are screenshots of the failing screens:
`admin_views.tests.SeleniumTests.test_selectbox_selected_rows`
<img width="780" height="493" alt="test_selectbox_selected_rows" src="https://github.com/user-attachments/assets/08858f28-3e41-4d32-8c71-f8ff806afdd0" />

`admin_widgets.tests.HorizontalVerticalFilterSeleniumTests.test_basic`
<img width="1024" height="681" alt="test_basic" src="https://github.com/user-attachments/assets/896bc213-a459-40e6-8e64-21eb21ed2d19" />


Resizing the page generally recalculates the layout
Apparently headless mode is a bit sensitive with windows resizing and may not always work

See the selenium daily runs for failures: https://github.com/django/django/actions/workflows/schedule_tests.yml