### PR TITLE
Fixed #25251 -- Added --use-clones option to never run against test DB

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -773,6 +773,7 @@ answer newbie questions, and generally made Django that much better:
     Nasir Hussain <nasirhjafri@gmail.com>
     Natalia Bidart <nataliabidart@gmail.com>
     Nate Bragg <jonathan.bragg@alum.rpi.edu>
+    Nathan Florea <florean+django@gmail.com>
     Nathan Gaberel <nathan@gnab.fr>
     Neal Norwitz <nnorwitz@google.com>
     Nebojša Dorđević

--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -693,6 +693,7 @@ class DiscoverRunner:
         verbosity=1,
         interactive=True,
         failfast=False,
+        use_clones=False,
         keepdb=False,
         reverse=False,
         debug_mode=False,
@@ -715,7 +716,8 @@ class DiscoverRunner:
         self.verbosity = verbosity
         self.interactive = interactive
         self.failfast = failfast
-        self.keepdb = keepdb
+        self.use_clones = use_clones
+        self.keepdb = keepdb or use_clones
         self.reverse = reverse
         self.debug_mode = debug_mode
         self.debug_sql = debug_sql
@@ -768,6 +770,11 @@ class DiscoverRunner:
         )
         parser.add_argument(
             "--keepdb", action="store_true", help="Preserves the test DB between runs."
+        )
+        parser.add_argument(
+            "--use-clones",
+            action="store_true",
+            help="Runs all tests against fresh clones of the test DB. ",
         )
         parser.add_argument(
             "--shuffle",
@@ -1010,6 +1017,7 @@ class DiscoverRunner:
             keepdb=self.keepdb,
             debug_sql=self.debug_sql,
             parallel=self.parallel,
+            use_clones=self.use_clones,
             **kwargs,
         )
 

--- a/docs/man/django-admin.1
+++ b/docs/man/django-admin.1
@@ -1861,6 +1861,14 @@ subsequent run. Unless the \fI\%MIGRATE\fP test setting is
 before running the test suite.
 .INDENT 0.0
 .TP
+.B \-\-use-clones
+.UNINDENT
+.sp
+Similar to \fB\-\-keepdb\fP, but only runs tests against fresh clones of the
+test database. This ensures it will never be modified at the cost of additional
+database copies. Previous test copies will be automatically overwritten.
+.INDENT 0.0
+.TP
 .B \-\-shuffle [SEED]
 .UNINDENT
 .sp

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1472,6 +1472,12 @@ subsequent run. Unless the :setting:`MIGRATE <TEST_MIGRATE>` test setting is
 ``False``, any unapplied migrations will also be applied to the test database
 before running the test suite.
 
+.. django-admin-option:: --use-clones
+
+Similar to ``--keepdb``, but only runs tests against fresh clones of the
+test database. This ensures it will never be modified at the cost of additional
+database copies. Previous test copies will be automatically overwritten.
+
 .. django-admin-option:: --shuffle [SEED]
 
 Randomizes the order of tests before running them. This can help detect tests

--- a/docs/releases/6.0.txt
+++ b/docs/releases/6.0.txt
@@ -310,7 +310,8 @@ Templates
 Tests
 ~~~~~
 
-* ...
+* Django test runner now supports a ``--use-clones`` option to always run tests
+  against fresh clones of the test database.
 
 URLs
 ~~~~

--- a/docs/topics/testing/advanced.txt
+++ b/docs/topics/testing/advanced.txt
@@ -525,7 +525,7 @@ behavior. This class defines the ``run_tests()`` entry point, plus a
 selection of other methods that are used by ``run_tests()`` to set up, execute
 and tear down the test suite.
 
-.. class:: DiscoverRunner(pattern='test*.py', top_level=None, verbosity=1, interactive=True, failfast=False, keepdb=False, reverse=False, debug_mode=False, debug_sql=False, parallel=0, tags=None, exclude_tags=None, test_name_patterns=None, pdb=False, buffer=False, enable_faulthandler=True, timing=True, shuffle=False, logger=None, durations=None, **kwargs)
+.. class:: DiscoverRunner(pattern='test*.py', top_level=None, verbosity=1, interactive=True, failfast=False, keepdb=False, use_clones=False, reverse=False, debug_mode=False, debug_sql=False, parallel=0, tags=None, exclude_tags=None, test_name_patterns=None, pdb=False, buffer=False, enable_faulthandler=True, timing=True, shuffle=False, logger=None, durations=None, **kwargs)
 
     ``DiscoverRunner`` will search for tests in any file matching ``pattern``.
 
@@ -550,6 +550,10 @@ and tear down the test suite.
     If ``keepdb`` is ``True``, the test suite will use the existing database,
     or create one if necessary. If ``False``, a new database will be created,
     prompting the user to remove the existing one, if present.
+
+    If ``use_clones`` is ``True``, the test suite will only run tests against
+    fresh copies of the test database.  It is similar to ``keepdb``, but it
+    will automatically overwrite existing clones.
 
     If ``reverse`` is ``True``, test cases will be executed in the opposite
     order. This could be useful to debug tests that aren't properly isolated
@@ -763,7 +767,7 @@ utility methods in the ``django.test.utils`` module.
     Performs global post-test teardown, such as removing instrumentation from
     the template system and restoring normal email services.
 
-.. function:: setup_databases(verbosity, interactive, *, time_keeper=None, keepdb=False, debug_sql=False, parallel=0, aliases=None, serialized_aliases=None, **kwargs)
+.. function:: setup_databases(verbosity, interactive, *, time_keeper=None, keepdb=False, use_clones=False, debug_sql=False, parallel=0, aliases=None, serialized_aliases=None, **kwargs)
 
     Creates the test databases.
 

--- a/docs/topics/testing/overview.txt
+++ b/docs/topics/testing/overview.txt
@@ -158,8 +158,11 @@ when all the tests have been executed.
 
 You can prevent the test databases from being destroyed by using the
 :option:`test --keepdb` option. This will preserve the test database between
-runs. If the database does not exist, it will first be created. Any migrations
-will also be applied in order to keep it up to date.
+runs. You can prevent any changes to the test database by using
+the :option:`test --use-clones` option, which preserves the test database but
+destroys any clones and runs tests against fresh copies. If the database does
+not exist, it will first be created. Any migrations will also be applied in
+order to keep it up to date.
 
 As described in the previous section, if a test run is forcefully interrupted,
 the test database may not be destroyed. On the next run, you'll be asked
@@ -382,7 +385,10 @@ Preserving the test database
 
 The :option:`test --keepdb` option preserves the test database between test
 runs. It skips the create and destroy actions which can greatly decrease the
-time to run tests.
+time to run tests. The :option:`test --use-clones` option further prevents any
+changes to the test database at the cost of additional database copies. The
+increase in time is usually negligible and the :option:`test --timing` flag
+will show exactly how much time it adds.
 
 Avoiding disk access for media files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -364,6 +364,7 @@ def django_tests(
     interactive,
     failfast,
     keepdb,
+    use_clones,
     reverse,
     test_labels,
     debug_sql,
@@ -413,6 +414,7 @@ def django_tests(
         interactive=interactive,
         failfast=failfast,
         keepdb=keepdb,
+        use_clones=use_clones,
         reverse=reverse,
         debug_sql=debug_sql,
         parallel=parallel,
@@ -566,6 +568,11 @@ if __name__ == "__main__":
         "--keepdb",
         action="store_true",
         help="Tells Django to preserve the test database between runs.",
+    )
+    parser.add_argument(
+        "--use-clones",
+        action="store_true",
+        help="Runs all tests against fresh clones of the test DB.",
     )
     parser.add_argument(
         "--settings",
@@ -791,6 +798,7 @@ if __name__ == "__main__":
                 options.interactive,
                 options.failfast,
                 options.keepdb,
+                options.use_clones,
                 options.reverse,
                 options.modules,
                 options.debug_sql,


### PR DESCRIPTION
#### Trac ticket number
ticket-25251

#### Branch description
Added an option to the test runner to always run tests against fresh clones of the test database, ensuring that subsequent runs will always be consistent no matter what happens to the database under test.  This incidentally fixed ticket 25251, but there are a number of reasons beyond TransactionTestCases that could cause a test database to be altered, such as integration tests, other processes outside of a TestCase's immediate control, or bugs.

This solution simply piggybacked on to the existing parallel code path with two small changes that could not be expressed through previous options: it does not preserve clones, treating the original test database as the only source of truth, and it creates a clone even when not using --parallel.

#### Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [NA] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
- [NA] I have attached screenshots in both light and dark modes for any UI changes.
