### PR TITLE
Refs #35680 -- Sorted shell default autoimports to prevent isort mismatches.

### DIFF
--- a/django/core/management/commands/shell.py
+++ b/django/core/management/commands/shell.py
@@ -133,9 +133,9 @@ class Command(BaseCommand):
         [
             "django.conf.settings",
             "django.db.connection",
-            "django.db.reset_queries",
             "django.db.models",
             "django.db.models.functions",
+            "django.db.reset_queries",
             "django.utils.timezone",
             "django.contrib.sessions.models.Session",
             "django.contrib.contenttypes.models.ContentType",
@@ -149,9 +149,9 @@ class Command(BaseCommand):
         default_imports = [
             "django.conf.settings",
             "django.db.connection",
-            "django.db.reset_queries",
             "django.db.models",
             "django.db.models.functions",
+            "django.db.reset_queries",
             "django.utils.timezone",
         ]
         app_models_imports = default_imports + [

--- a/tests/shell/tests.py
+++ b/tests/shell/tests.py
@@ -355,7 +355,7 @@ class ShellCommandAutoImportsTestCase(SimpleTestCase):
             "  import shell\n"
             "  import django\n"
             "  from django.conf import settings\n"
-            "  from django.db import connection, reset_queries, models\n"
+            "  from django.db import connection, models, reset_queries\n"
             "  from django.db.models import functions\n"
             "  from django.utils import timezone\n"
             "  from django.contrib.contenttypes.models import ContentType\n"
@@ -411,7 +411,7 @@ class ShellCommandAutoImportsTestCase(SimpleTestCase):
             1: "6 objects imported automatically (use -v 2 for details).",
             2: "6 objects imported automatically:\n\n"
             "  from django.conf import settings\n"
-            "  from django.db import connection, reset_queries, models\n"
+            "  from django.db import connection, models, reset_queries\n"
             "  from django.db.models import functions\n"
             "  from django.utils import timezone",
         }


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35680

#### Branch description
Following a5cd84ad2002f9a43363ab9fd9d9f6e9dfa48c60, I started getting this test failure when running the tests:
```
======================================================================
FAIL: test_message_with_stdout_no_installed_apps (shell.tests.ShellCommandAutoImportsTestCase.test_message_with_stdout_no_installed_apps) [<object object at 0x74bfb52cb140>] (verbosity=2)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.13/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/usr/lib/python3.13/unittest/case.py", line 556, in subTest
    yield
  File "/home/nessita/fellowship/django/tests/shell/tests.py", line 422, in test_message_with_stdout_no_installed_apps
    self.assertEqual(stdout.getvalue().strip(), expected)
    ^^^
  File "/usr/lib/python3.13/unittest/case.py", line 907, in assertEqual
    assertion_func(first, second, msg=msg)
    ^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/unittest/case.py", line 1273, in assertMultiLineEqual
    self.fail(self._formatMessage(msg, standardMsg))
    ^^^^^^^^^^^
  File "/usr/lib/python3.13/unittest/case.py", line 732, in fail
    raise self.failureException(msg)
    ^^^^^^^^^^^^^^^
AssertionError: '6 ob[100 chars]ion, models, reset_queries\n  from django.db.m[55 chars]zone' != '6 ob[100 chars]ion, reset_queries, models\n  from django.db.m[55 chars]zone'
  6 objects imported automatically:
  
    from django.conf import settings
-   from django.db import connection, models, reset_queries
?                                    --------
+   from django.db import connection, reset_queries, models
?                                                  ++++++++
    from django.db.models import functions
    from django.utils import timezone
```
I have `isort` installed as some other Django developer do (but not all) to properly sort imports. The tests should not depend on whether `isort` is installed or not, so I'm proposing that the default list of utilities to auto import in the shell is also sorted, not only this feels cleaner and more polished, but it also prevents isort mismatches.