### PR TITLE
Fixed #36055 -- Prevented overlap of object-tools buttons and page header in the admin.

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -808,19 +808,19 @@ a.deletelink:focus, a.deletelink:hover {
 /* OBJECT TOOLS */
 
 .object-tools {
-    font-size: 0.625rem;
-    font-weight: bold;
-    padding-left: 0;
-    float: right;
-    position: relative;
-    margin-top: -48px;
+    padding: 0;
+    overflow: hidden;
+    text-align: right;
+    margin: 0 0 15px;
 }
 
 .object-tools li {
-    display: block;
-    float: left;
-    margin-left: 5px;
-    height: 1rem;
+    display: inline-block;
+    height: auto;
+}
+
+.object-tools li + li {
+    margin-left: 15px;
 }
 
 .object-tools a {

--- a/django/contrib/admin/static/admin/css/responsive.css
+++ b/django/contrib/admin/static/admin/css/responsive.css
@@ -442,19 +442,7 @@ input[type="submit"], button {
     }
 
     .object-tools {
-        float: none;
-        margin: 0 0 15px;
-        padding: 0;
-        overflow: hidden;
-    }
-
-    .object-tools li {
-        height: auto;
-        margin-left: 0;
-    }
-
-    .object-tools li + li {
-        margin-left: 15px;
+        text-align: left;
     }
 
     /* Forms */

--- a/django/contrib/admin/static/admin/css/responsive_rtl.css
+++ b/django/contrib/admin/static/admin/css/responsive_rtl.css
@@ -34,15 +34,6 @@
         background-position: calc(100% - 8px) 9px;
     }
 
-    [dir="rtl"] .object-tools li {
-        float: right;
-    }
-
-    [dir="rtl"] .object-tools li + li {
-        margin-left: 0;
-        margin-right: 15px;
-    }
-
     [dir="rtl"] .dashboard .module table td a {
         padding-left: 0;
         padding-right: 16px;
@@ -72,6 +63,11 @@
         margin-left: 0;
         margin-right: 0;
     }
+
+    [dir="rtl"] .object-tools {
+        text-align: right;
+    }
+
     [dir="rtl"] .aligned .vCheckboxLabel {
         padding: 1px 5px 0 0;
     }

--- a/django/contrib/admin/static/admin/css/rtl.css
+++ b/django/contrib/admin/static/admin/css/rtl.css
@@ -26,7 +26,12 @@ th {
 }
 
 .object-tools {
-    float: left;
+    text-align: left;
+}
+
+.object-tools li + li {
+    margin-right: 15px;
+    margin-left: 0;
 }
 
 thead th:first-child,

--- a/tests/admin_views/models.py
+++ b/tests/admin_views/models.py
@@ -973,6 +973,9 @@ class Restaurant(models.Model):
     city = models.ForeignKey(City, models.CASCADE)
     name = models.CharField(max_length=100)
 
+    class Meta:
+        verbose_name = "very l%sng name" % ("o" * 100)
+
     def get_absolute_url(self):
         return "/dummy/%s/" % self.pk
 


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36055

#### Branch description
Fixed an issue where object-tools would overlap the object’s string representation when it was a very long string.

### Before

<img width="879" height="207" alt="Screenshot 2025-07-19 at 5 37 38 PM" src="https://github.com/user-attachments/assets/96ecbf32-c109-4b31-9b3a-be32c24c23f4" />

### After

<img width="820" height="236" alt="Screenshot 2025-07-19 at 5 38 11 PM" src="https://github.com/user-attachments/assets/8dc22835-453a-4c71-9942-8304ca3c9756" />


#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
