### PR TITLE
Fixed #36509 -- Missing label on input fields in tables

### DIFF
--- a/django/contrib/admin/templates/admin/change_list_results.html
+++ b/django/contrib/admin/templates/admin/change_list_results.html
@@ -18,7 +18,7 @@
          <a href="{{ header.url_toggle }}" class="toggle {{ header.ascending|yesno:'ascending,descending' }}" title="{% translate "Toggle sorting" %}"></a>
        </div>
    {% endif %}
-   <div class="text">{% if header.sortable %}<a role="button" href="{{ header.url_primary }}">{{ header.text|capfirst }}</a>{% else %}<span>{{ header.text|capfirst }}</span>{% endif %}</div>
+   <div class="text" id="{{ header.id }}">{% if header.sortable %}<a role="button" href="{{ header.url_primary }}">{{ header.text|capfirst }}</a>{% else %}<span>{{ header.text|capfirst }}</span>{% endif %}</div>
    <div class="clear"></div>
 </th>{% endfor %}
 </tr>

--- a/django/contrib/admin/templatetags/admin_list.py
+++ b/django/contrib/admin/templatetags/admin_list.py
@@ -220,6 +220,9 @@ def items_for_result(cl, result, form):
         link_to_changelist = link_in_col(first, field_name, cl)
         try:
             f, attr, value = lookup_field(field_name, result, cl.model_admin)
+            label, label_attr = label_for_field(
+                field_name, cl.model, model_admin=cl.model_admin, return_attr=True
+            )
         except ObjectDoesNotExist:
             result_repr = empty_value_display
         else:
@@ -306,6 +309,8 @@ def items_for_result(cl, result, form):
                 )
             ):
                 bf = form[field_name]
+                if not label_attr:
+                    bf.field.widget.attrs["aria-labelledby"] = slugify(label)
                 result_repr = mark_safe(str(bf.errors) + str(bf))
             yield format_html("<td{}>{}</td>", row_class, result_repr)
     if form and not form[cl.model._meta.pk.name].is_hidden:

--- a/django/contrib/admin/templatetags/admin_list.py
+++ b/django/contrib/admin/templatetags/admin_list.py
@@ -26,7 +26,7 @@ from django.urls import NoReverseMatch
 from django.utils import formats, timezone
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
-from django.utils.text import capfirst
+from django.utils.text import capfirst, slugify
 from django.utils.translation import gettext as _
 
 from .base import InclusionAdminNode
@@ -167,6 +167,7 @@ def result_headers(cl):
 
         yield {
             "text": text,
+            "id": slugify(text),
             "sortable": True,
             "sorted": is_sorted,
             "ascending": order_type == "asc",

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -430,7 +430,7 @@ class ChangeListTests(TestCase):
 
         # make sure that list editable fields are rendered in divs correctly
         editable_name_field = (
-            '<input name="form-0-name" value="name" class="vTextField" '
+            '<input name="form-0-name" value="name" class="vTextField" aria-labelledby="name" '
             'maxlength="30" type="text" id="id_form-0-name">'
         )
         self.assertInHTML(

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -430,8 +430,8 @@ class ChangeListTests(TestCase):
 
         # make sure that list editable fields are rendered in divs correctly
         editable_name_field = (
-            '<input name="form-0-name" value="name" class="vTextField" aria-labelledby="name" '
-            'maxlength="30" type="text" id="id_form-0-name">'
+            '<input name="form-0-name" value="name" class="vTextField" '
+            'maxlength="30" type="text" id="id_form-0-name" aria-labelledby="name">'
         )
         self.assertInHTML(
             '<td class="field-name">%s</td>' % editable_name_field,


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36509

#### Branch description

Some of the editable fields (dropdown, date selection) in the Admin tables do not have any `aria` attributes to help users using assisting technologies like screen readers. This PR aims at fixing this by adding the following:
- Create and add an `id` attribute to the table headers
- Add a `aria-labelledby` attribute to the fields referring to this header id.

This seems to be a failure of [​WCAG SC 4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/quickref/#name-role-value)
#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
