### PR TITLE
Fixed #36230 -- Improved color contrast for blockquote in admin.

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -245,7 +245,7 @@ blockquote {
     color: var(--body-quiet-color);
     margin-left: 2px;
     padding-left: 10px;
-    border-left: 5px solid var(--body-quiet-color);
+    border-left: 5px solid currentColor;
 }
 
 code, pre {

--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -245,7 +245,7 @@ blockquote {
     color: var(--body-quiet-color);
     margin-left: 2px;
     padding-left: 10px;
-    border-left: 5px solid #ddd;
+    border-left: 5px solid var(--body-quiet-color);
 }
 
 code, pre {

--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -242,7 +242,7 @@ details summary {
 
 blockquote {
     font-size: 0.6875rem;
-    color: #777;
+    color: var(--body-quiet-color);
     margin-left: 2px;
     padding-left: 10px;
     border-left: 5px solid #ddd;


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36230

#### Branch description
Updated hardcoded color for blockquote and its border to the variable color `--body-quiet-color`. This addresses accessibility issues. 

- Dark mode result:
<img width="391" height="306" alt="image" src="https://github.com/user-attachments/assets/5c12d492-90c1-4539-a4d4-a74271667fb4" />

- Light mode result:
<img width="352" height="305" alt="image" src="https://github.com/user-attachments/assets/899fe8b2-15a9-4446-bed7-0beac8dcd858" />


#### Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [X] I have attached screenshots in both light and dark modes for any UI changes.
