### PR TITLE
Fixed #36516, Refs #36366 -- Fixed changelist footer layout with list_editable and list_filter.

### DIFF
--- a/django/contrib/admin/static/admin/css/changelists.css
+++ b/django/contrib/admin/static/admin/css/changelists.css
@@ -25,8 +25,8 @@
     min-height: 400px;
 }
 
-.change-list .filtered .results, .change-list .filtered .paginator,
-.filtered #toolbar, .filtered div.xfull {
+.change-list .filtered .results, .filtered #toolbar,
+.filtered div.xfull {
     width: auto;
 }
 

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -6907,6 +6907,24 @@ class SeleniumTests(AdminSeleniumTestCase):
                 self.assertEqual(message.get_attribute("innerText"), f"Test {level}")
                 self.take_screenshot(level)
 
+    @screenshot_cases(["desktop_size", "mobile_size", "rtl", "dark", "high_contrast"])
+    def test_list_editable_with_filter(self):
+        from selenium.webdriver.common.by import By
+
+        Person.objects.create(name="Tom", gender=1)
+        self.admin_login(
+            username="super", password="secret", login_url=reverse("admin:index")
+        )
+        self.selenium.get(
+            self.live_server_url + reverse("admin:admin_views_person_changelist")
+        )
+        save_button = self.selenium.find_element(By.NAME, "_save")
+        self.assertTrue(save_button.is_displayed())
+        self.take_screenshot("list_editable")
+
+        with self.wait_page_loaded():
+            save_button.click()
+
 
 @override_settings(ROOT_URLCONF="admin_views.urls")
 class ReadonlyTest(AdminFieldExtractionMixin, TestCase):


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36516

#### Branch description
3f59711 --> This commit improved pagination accessibility but did not maintain the original layout. `justify-content: space-between` property should have been added 😥

<img width="1808" height="740" alt="refs_36366" src="https://github.com/user-attachments/assets/040ccfb0-5761-491d-a1e9-d100645a4f7d" />

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
