### PR TITLE
Fixed #36500 -- Removed separate line length for docstrings/comments.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,6 @@ trim_trailing_whitespace = true
 end_of_line = lf
 charset = utf-8
 
-# Docstrings and comments use max_line_length = 79
 [*.py]
 max_line_length = 88
 

--- a/docs/internals/contributing/writing-code/coding-style.txt
+++ b/docs/internals/contributing/writing-code/coding-style.txt
@@ -52,12 +52,12 @@ Python style
   that :pep:`8` is only a guide, so respect the style of the surrounding code
   as a primary goal.
 
-  An exception to :pep:`8` is our rules on line lengths. Don't limit lines of
-  code to 79 characters if it means the code looks significantly uglier or is
-  harder to read. We allow up to 88 characters as this is the line length used
-  by ``black``. This check is included when you run ``flake8``. Documentation,
-  comments, and docstrings should be wrapped at 79 characters, even though
-  :pep:`8` suggests 72.
+  An exception to :pep:`8` is our rules on line lengths. We allow up to 88
+  characters as this is the line length used by ``black``. This check is
+  included when you run ``flake8``.
+
+  Documentation source files (in the docs directory) should be wrapped at 79
+  characters.
 
 * String variable interpolation may use
   :py:ref:`%-formatting <old-string-formatting>`, :py:ref:`f-strings


### PR DESCRIPTION
(This is "option 1" from https://forum.djangoproject.com/t/enforce-or-eliminate-comment-docstring-line-length-limit/41760.)

#### Trac ticket number
ticket-36500

#### Branch description
Updated coding-style docs to remove smaller 79 character maximum line length for docstrings and comments. (This was left over from the pre-black era when code could be 119 characters long, but had been sporadically enforced. Much of Django's existing code includes comments and docstrings 80-88 characters wide.)

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- n/a I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- n/a I have attached screenshots in both light and dark modes for any UI changes.
