### PR TITLE
Fixed incorrectly concatenated string in SimpleBlockTagTests.test_simple_block_tag_with_context_missing_content().

### DIFF
--- a/tests/template_tests/test_custom.py
+++ b/tests/template_tests/test_custom.py
@@ -514,9 +514,11 @@ class SimpleBlockTagTests(TagTestCase):
 
     def test_simple_block_tag_with_context_missing_content(self):
         # The 'content' parameter must be present when takes_context is True
-        msg = "'simple_block_tag_with_context_without_content' is decorated with "
-        "takes_context=True so it must have a first argument of 'context' and a "
-        "second argument of 'content'"
+        msg = (
+            "'simple_block_tag_with_context_without_content' is decorated with "
+            "takes_context=True so it must have a first argument of 'context' and a "
+            "second argument of 'content'"
+        )
         with self.assertRaisesMessage(TemplateSyntaxError, msg):
             self.engine.from_string(
                 "{% load custom %}{% simple_block_tag_with_context_without_content %}"


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

N/A

#### Branch description
test_simple_block_tag_with_context_missing_content() incorrectly attempts to concatenate a `msg` string.

(Maybe an error during black conversion? Discovered while experimenting with flake8 max-doc-length option.)

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, ~~mentions the ticket number,~~ and ends with a period.
- n/a I have checked the "Has patch" ticket flag in the Trac system.
- n/a I have added or updated relevant tests.
- n/a I have added or updated relevant docs, including release notes if applicable.
- n/a I have attached screenshots in both light and dark modes for any UI changes.
