### PR TITLE
Refs #36138 -- Corrected global_settings comment for ADMINS.

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -22,7 +22,7 @@ DEBUG = False
 DEBUG_PROPAGATE_EXCEPTIONS = False
 
 # People who get code error notifications. In the format
-# [('Full Name', 'email@example.com'), ('Full Name', 'anotheremail@example.com')]
+# ["email@example.com", '"Full Name" <anotheremail@example.com>']
 ADMINS = []
 
 # List of IP addresses, as strings, that:


### PR DESCRIPTION
#### Trac ticket number
N/A

#### Branch description
ticket-36138 changed ADMINS and MANAGERS from lists of (name, email) tuples to lists of email address strings. Corrected a comment in global_settings.py that referenced the old format.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- n/a I have checked the "Has patch" ticket flag in the Trac system.
- n/a I have added or updated relevant tests.
- n/a I have added or updated relevant docs, including release notes if applicable.
- n/a I have attached screenshots in both light and dark modes for any UI changes.
