### PR TITLE
Fixed #36142 -- Made Http404 messages in *_or_404() shortcuts translatable.

### DIFF
--- a/django/shortcuts.py
+++ b/django/shortcuts.py
@@ -13,6 +13,7 @@ from django.http import (
 from django.template import loader
 from django.urls import NoReverseMatch, reverse
 from django.utils.functional import Promise
+from django.utils.translation import gettext as _
 
 
 def render(
@@ -90,7 +91,10 @@ def get_object_or_404(klass, *args, **kwargs):
         return queryset.get(*args, **kwargs)
     except queryset.model.DoesNotExist:
         raise Http404(
-            "No %s matches the given query." % queryset.model._meta.object_name
+            # Translators: %s is the name of a model, e.g. "No City matches the
+            # given query."
+            _("No %s matches the given query.")
+            % queryset.model._meta.object_name
         )
 
 
@@ -108,7 +112,9 @@ async def aget_object_or_404(klass, *args, **kwargs):
     try:
         return await queryset.aget(*args, **kwargs)
     except queryset.model.DoesNotExist:
-        raise Http404(f"No {queryset.model._meta.object_name} matches the given query.")
+        raise Http404(
+            _("No %s matches the given query.") % queryset.model._meta.object_name
+        )
 
 
 def get_list_or_404(klass, *args, **kwargs):
@@ -131,7 +137,7 @@ def get_list_or_404(klass, *args, **kwargs):
     obj_list = list(queryset.filter(*args, **kwargs))
     if not obj_list:
         raise Http404(
-            "No %s matches the given query." % queryset.model._meta.object_name
+            _("No %s matches the given query.") % queryset.model._meta.object_name
         )
     return obj_list
 
@@ -149,7 +155,9 @@ async def aget_list_or_404(klass, *args, **kwargs):
         )
     obj_list = [obj async for obj in queryset.filter(*args, **kwargs)]
     if not obj_list:
-        raise Http404(f"No {queryset.model._meta.object_name} matches the given query.")
+        raise Http404(
+            _("No %s matches the given query.") % queryset.model._meta.object_name
+        )
     return obj_list
 
 


### PR DESCRIPTION

#### Trac ticket number

[ticket-36142](https://code.djangoproject.com/ticket/36142)

#### Branch description

django.shortcuts.get_object_or_404 does not support translation for error messages (i18n)
Used gettext for Http 404 error text raised by shortcurts.

#### Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
