### PR TITLE
Fixed #36522 -- Fixed a crash when filtering composite pk against tuple of expressions.

### DIFF
--- a/django/db/models/fields/tuple_lookups.py
+++ b/django/db/models/fields/tuple_lookups.py
@@ -103,7 +103,11 @@ class TupleLookupMixin:
     def process_rhs(self, compiler, connection):
         if self.rhs_is_direct_value():
             args = [
-                Value(val, output_field=col.output_field)
+                (
+                    val
+                    if hasattr(val, "as_sql")
+                    else Value(val, output_field=col.output_field)
+                )
                 for col, val in zip(self.lhs, self.rhs)
             ]
             return compiler.compile(Tuple(*args))
@@ -337,7 +341,11 @@ class TupleIn(TupleLookupMixin, In):
             result.append(
                 Tuple(
                     *[
-                        Value(val, output_field=col.output_field)
+                        (
+                            val
+                            if hasattr(val, "as_sql")
+                            else Value(val, output_field=col.output_field)
+                        )
                         for col, val in zip(lhs, vals)
                     ]
                 )

--- a/docs/releases/5.2.5.txt
+++ b/docs/releases/5.2.5.txt
@@ -12,3 +12,6 @@ Bugfixes
 * Fixed a regression in Django 5.2.1 that prevented the usage of ``UNNEST``
   PostgreSQL strategy of ``QuerySet.bulk_create()`` with foreign keys
   (:ticket:`36502`).
+
+* Fixed a crash in Django 5.2 when filtering against a composite primary key
+  using a tuple containing expressions (:ticket:`36522`).

--- a/tests/composite_pk/test_filter.py
+++ b/tests/composite_pk/test_filter.py
@@ -9,6 +9,7 @@ from django.db.models import (
     Q,
     Subquery,
     TextField,
+    Value,
     When,
 )
 from django.db.models.functions import Cast
@@ -548,6 +549,13 @@ class CompositePKFilterTests(TestCase):
                 ).filter(filtered_tokens=(1, 1)),
                 [self.tenant_1],
             )
+
+    def test_filter_by_tuple_containing_expression(self):
+        pk_lookup = (self.comment_1.tenant.id, (Value(self.comment_1.id) + 1) - 1)
+        for lookup in ({"pk": pk_lookup}, {"pk__in": [pk_lookup]}):
+            with self.subTest(lookup=lookup):
+                qs = Comment.objects.filter(**lookup)
+                self.assertEqual(qs.get(), self.comment_1)
 
 
 @skipUnlessDBFeature("supports_tuple_lookups")


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36522

#### Branch description

The previous logic assumed that only literal values would be provided.

Thanks @jacobtylerwalls for the report.
