### PR TITLE
Fixed #36528, Refs #34917 -- Removed role="button" from object-tools links.

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -129,7 +129,8 @@ a:not(
     [role="button"],
     #header a,
     #nav-sidebar a,
-    #content-main.app-list a
+    #content-main.app-list a,
+    .object-tools a,
 ) {
     text-decoration: underline;
 }

--- a/django/contrib/admin/templates/admin/change_form_object_tools.html
+++ b/django/contrib/admin/templates/admin/change_form_object_tools.html
@@ -2,7 +2,7 @@
 {% block object-tools-items %}
 <li>
     {% url opts|admin_urlname:'history' original.pk|admin_urlquote as history_url %}
-    <a role="button" href="{% add_preserved_filters history_url %}" class="historylink">{% translate "History" %}</a>
+    <a href="{% add_preserved_filters history_url %}" class="historylink">{% translate "History" %}</a>
 </li>
 {% if has_absolute_url %}<li><a href="{{ absolute_url }}" class="viewsitelink">{% translate "View on site" %}</a></li>{% endif %}
 {% endblock %}

--- a/django/contrib/admin/templates/admin/change_list_object_tools.html
+++ b/django/contrib/admin/templates/admin/change_list_object_tools.html
@@ -4,7 +4,7 @@
   {% if has_add_permission %}
   <li>
     {% url cl.opts|admin_urlname:'add' as add_url %}
-    <a role="button" href="{% add_preserved_filters add_url is_popup to_field %}" class="addlink">
+    <a href="{% add_preserved_filters add_url is_popup to_field %}" class="addlink">
       {% blocktranslate with cl.opts.verbose_name as name %}Add {{ name }}{% endblocktranslate %}
     </a>
   </li>

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -4086,7 +4086,7 @@ class AdminViewStringPrimaryKeyTest(TestCase):
         )
         self.assertContains(
             response,
-            '<a role="button" href="%s" class="historylink"' % escape(expected_link),
+            '<a href="%s" class="historylink"' % escape(expected_link),
         )
 
     def test_redirect_on_add_view_continue_button(self):
@@ -6957,6 +6957,34 @@ class SeleniumTests(AdminSeleniumTestCase):
             save_button.click()
 
     @screenshot_cases(["desktop_size", "mobile_size", "rtl", "dark", "high_contrast"])
+    def test_object_tools(self):
+        from selenium.webdriver.common.by import By
+
+        state = State.objects.create(name="Korea")
+        city = City.objects.create(state=state, name="Gwangju")
+        self.admin_login(
+            username="super", password="secret", login_url=reverse("admin:index")
+        )
+        self.selenium.get(
+            self.live_server_url + reverse("admin:admin_views_city_changelist")
+        )
+        object_tools = self.selenium.find_elements(
+            By.CSS_SELECTOR, "ul.object-tools li a"
+        )
+        self.assertEqual(len(object_tools), 1)
+        self.take_screenshot("changelist")
+
+        self.selenium.get(
+            self.live_server_url
+            + reverse("admin:admin_views_city_change", args=(city.pk,))
+        )
+        object_tools = self.selenium.find_elements(
+            By.CSS_SELECTOR, "ul.object-tools li a"
+        )
+        self.assertEqual(len(object_tools), 2)
+        self.take_screenshot("changeform")
+
+    @screenshot_cases(["desktop_size", "mobile_size", "rtl", "dark", "high_contrast"])
     def test_long_header_with_object_tools_layout(self):
         from selenium.webdriver.common.by import By
 
@@ -8415,7 +8443,7 @@ class AdminKeepChangeListFiltersTests(TestCase):
 
         # Check the history link.
         history_link = re.search(
-            '<a role="button" href="(.*?)" class="historylink">History</a>',
+            '<a href="(.*?)" class="historylink">History</a>',
             response.text,
         )
         self.assertURLEqual(history_link[1], self.get_history_url())


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36528

#### Branch description
Removed the underline that existed on the button rendered when `view_on_site` was True in `ModelAdmin`.

+++ 
This issue also occurs when customizing by overriding the object-tools block to add additional buttons.

### Before

<img width="1101" height="134" alt="Screenshot 2025-07-29 at 6 10 06 PM" src="https://github.com/user-attachments/assets/8be64a5b-83b6-4fd1-ac3f-1e055a716776" />


### After

<img width="835" height="183" alt="Screenshot 2025-07-29 at 6 06 03 PM" src="https://github.com/user-attachments/assets/87848a1d-5a3b-46fd-a650-ef7cdcf82a25" />

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
