### PR TITLE
Fixed writer_name deprecation warning in docutils 0.22+.

### DIFF
--- a/django/contrib/admindocs/utils.py
+++ b/django/contrib/admindocs/utils.py
@@ -82,7 +82,7 @@ def parse_rst(text, default_reference_context, thing_being_parsed=None):
         source % text,
         source_path=thing_being_parsed,
         destination_path=None,
-        writer_name="html",
+        writer="html",
         settings_overrides=overrides,
     )
     return mark_safe(parts["fragment"])


### PR DESCRIPTION
https://pypi.org/project/docutils/0.22/