### PR TITLE
Fixed #36537 -- Ensured unique HTML IDs for geometry widget option scripts in the admin.

### DIFF
--- a/django/contrib/gis/static/gis/js/OLMapWidget.js
+++ b/django/contrib/gis/static/gis/js/OLMapWidget.js
@@ -266,8 +266,10 @@ function initMapWidgetInSection(section) {
         if (wrapper.id.includes('__prefix__')) {
             return;
         }
-        const options = JSON.parse(wrapper.querySelector("#mapwidget-options").textContent);
-        options.id = wrapper.querySelector("textarea").id;
+        const textarea_id = wrapper.querySelector("textarea").id;
+        const options_script = wrapper.querySelector(`script#${textarea_id}_mapwidget_options`);
+        const options = JSON.parse(options_script.textContent);
+        options.id = textarea_id;
         options.map_id = wrapper.querySelector(".dj_map").id;
         maps.push(new MapWidget(options));
     });

--- a/django/contrib/gis/templates/gis/openlayers.html
+++ b/django/contrib/gis/templates/gis/openlayers.html
@@ -6,5 +6,7 @@
     {% if widget.attrs.display_raw %}<p>{% translate "Debugging window (serialized value)" %}</p>{% endif %}
     <textarea id="{{ widget.attrs.id }}" class="vSerializedField required" cols="150" rows="10" name="{{ widget.name }}"
               {% if not widget.attrs.display_raw %} hidden{% endif %}>{{ serialized }}</textarea>
-    {{ widget.attrs|json_script:"mapwidget-options" }}
+    {% with script_id=widget.attrs.id|add:"_mapwidget_options" %}
+    {{ widget.attrs|json_script:script_id }}
+    {% endwith %}
 </div>

--- a/js_tests/gis/mapwidget.test.js
+++ b/js_tests/gis/mapwidget.test.js
@@ -142,7 +142,7 @@ QUnit.test('initMapWidgetInSection initializes widgets and skips __prefix__', fu
     wrapper1.innerHTML = `
         <textarea id="id_point"></textarea>
         <div class="dj_map" id="id_point_map"></div>
-        <script type="application/json" id="mapwidget-options">
+        <script type="application/json" id="id_point_mapwidget_options">
             { "geom_name": "Point" }
         </script>
     `;
@@ -154,7 +154,7 @@ QUnit.test('initMapWidgetInSection initializes widgets and skips __prefix__', fu
     wrapper2.innerHTML = `
         <textarea id="id_fake"></textarea>
         <div class="dj_map" id="id_fake_map"></div>
-        <script type="application/json" id="mapwidget-options">
+        <script type="application/json" id="id_fake_mapwidget_options">
             { "geom_name": "MultiPoint" }
         </script>
     `;

--- a/tests/gis_tests/test_geoforms.py
+++ b/tests/gis_tests/test_geoforms.py
@@ -214,7 +214,7 @@ class GeometryFieldTest(SimpleTestCase):
             "id": "id_p",
             "geom_name": "Point",
         }
-        expected = json_script(attrs, "mapwidget-options")
+        expected = json_script(attrs, "id_p_mapwidget_options")
         self.assertInHTML(expected, rendered)
 
 
@@ -305,7 +305,7 @@ class SpecializedFieldTest(SimpleTestCase):
                 "id": map_field.id_for_label,
                 "geom_name": geom_name,
             }
-            expected = json_script(attrs, "mapwidget-options")
+            expected = json_script(attrs, f"{map_field.id_for_label}_mapwidget_options")
             self.assertInHTML(expected, rendered)
         self.assertIn("gis/js/OLMapWidget.js", str(form_instance.media))
 
@@ -475,7 +475,7 @@ class OSMWidgetTest(SimpleTestCase):
             "id": "id_p",
             "geom_name": "Point",
         }
-        expected = json_script(attrs, "mapwidget-options")
+        expected = json_script(attrs, "id_p_mapwidget_options")
         self.assertInHTML(expected, rendered)
 
 


### PR DESCRIPTION

#### Trac ticket number

ticket-36537

#### Branch description

This amends the code from https://github.com/django/django/pull/18494 to avoid setting an URL for the script containing the widget configuration in JSON format. The ID generated by json_script would be non-unique when using the widget several times on the same page.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
