### PR TITLE
Fixed #36535 -- Ensured compatibility with docutils 0.19 through 0.22.

### DIFF
--- a/django/contrib/admindocs/utils.py
+++ b/django/contrib/admindocs/utils.py
@@ -13,6 +13,7 @@ try:
     import docutils.core
     import docutils.nodes
     import docutils.parsers.rst.roles
+    import docutils.writers
 except ImportError:
     docutils_is_available = False
 else:
@@ -78,11 +79,14 @@ def parse_rst(text, default_reference_context, thing_being_parsed=None):
 
 .. default-role::
 """
+    # In docutils < 0.22, the `writer` param must be an instance. Passing a
+    # string writer name like "html" is only supported in 0.22+.
+    writer_instance = docutils.writers.get_writer_class("html")()
     parts = docutils.core.publish_parts(
         source % text,
         source_path=thing_being_parsed,
         destination_path=None,
-        writer="html",
+        writer=writer_instance,
         settings_overrides=overrides,
     )
     return mark_safe(parts["fragment"])

--- a/docs/releases/5.2.5.txt
+++ b/docs/releases/5.2.5.txt
@@ -19,3 +19,5 @@ Bugfixes
 * Fixed a crash in Django 5.2 when validating a model that uses
   ``GeneratedField`` or constraints composed of ``Q`` and ``Case`` lookups
   (:ticket:`36518`).
+
+* Added compatibility for ``docutils`` 0.22 (:ticket:`36535`).


### PR DESCRIPTION
Regression in 5aefd005fc3dd35be6e9e4a24f9c2bc92b69df3b.

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36535

#### Branch description
This change ensures compatibility with both older and newer versions of Docutils, including recent version 0.22.

Docutils 0.22 includes [this change](https://github.com/docutils/docutils/commit/3e101823a2a748fdc30ab037c81e8d8803e082ef), which allows the writer parameter to be either a string or an instance. However, older versions only accept the writer name as a string passed via the writer_name argument (which was removed in 0.22). The good news is that older version already accepted an writer param which should be given a writer instance.

To support versions from 0.19 through 0.22 and beyond, this change updates the logic to create a writer instance explicitly, avoiding version-specific behavior.

#### Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have checked the "Has patch" ticket flag in the Trac system.
