### PR TITLE
Corrected assertNumQueries() example in docs/topics/testing/tools.txt.

### DIFF
--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -1895,7 +1895,7 @@ your test suite.
     If a ``"using"`` key is present in ``kwargs`` it is used as the database
     alias for which to check the number of queries::
 
-        self.assertNumQueries(7, using="non_default_db")
+        self.assertNumQueries(7, my_function, using="non_default_db")
 
     If you wish to call a function with a ``using`` parameter you can do it by
     wrapping the call with a ``lambda`` to add an extra parameter::


### PR DESCRIPTION
#### Trac ticket number

N/A

#### Branch description

The `func` argument is missing from the first example in the `assertNumQueries` docs. It seems to me that `assertNumQueries` should be called with either a `func` or inside of a context block.

I used `my_function` because it's used in the example below.

#### Checklist
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
