### PR TITLE
Fixed #36079 -- Fixed text size of TabularInline object titles.

### DIFF
--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -429,7 +429,6 @@ body.popup .submit-row {
 .inline-group .tabular tr td.original {
     padding: 2px 0 0 0;
     width: 0;
-    _position: relative;
 }
 
 .inline-group .tabular th.original {
@@ -437,16 +436,19 @@ body.popup .submit-row {
     padding: 0;
 }
 
+.inline-group .tabular td {
+    font-size: 1rem;
+}
+
 .inline-group .tabular td.original p {
     position: absolute;
     left: 0;
-    height: 1.1em;
+    height: 1.2em;
     padding: 2px 9px;
     overflow: hidden;
-    font-size: 0.5625rem;
+    font-size: 0.875rem;
     font-weight: bold;
     color: var(--body-quiet-color);
-    _width: 700px;
 }
 
 .inline-group div.add-row,

--- a/tests/admin_inlines/admin.py
+++ b/tests/admin_inlines/admin.py
@@ -358,6 +358,7 @@ class BinaryTreeAdmin(admin.TabularInline):
 # admin for #19524
 class SightingInline(admin.TabularInline):
     model = Sighting
+    show_change_link = True
 
 
 # admin and form for #18263
@@ -517,7 +518,7 @@ site.register(ParentModelWithCustomPk, inlines=[ChildModel1Inline, ChildModel2In
 site.register(BinaryTree, inlines=[BinaryTreeAdmin])
 site.register(ExtraTerrestrial, inlines=[SightingInline])
 site.register(SomeParentModel, inlines=[SomeChildModelInline])
-site.register([Question, Inner4Stacked, Inner4Tabular])
+site.register([Question, Inner4Stacked, Inner4Tabular, Sighting])
 site.register(Teacher, TeacherAdmin)
 site.register(Chapter, inlines=[FootNoteNonEditableInlineCustomForm])
 site.register(OutfitItem, inlines=[WeaknessInlineCustomForm])

--- a/tests/admin_inlines/models.py
+++ b/tests/admin_inlines/models.py
@@ -324,6 +324,9 @@ class Sighting(models.Model):
     et = models.ForeignKey(ExtraTerrestrial, models.CASCADE)
     place = models.CharField(max_length=100)
 
+    def __str__(self):
+        return self.place
+
 
 # Models for #18263
 class SomeParentModel(models.Model):

--- a/tests/admin_inlines/tests.py
+++ b/tests/admin_inlines/tests.py
@@ -2532,3 +2532,19 @@ class SeleniumTests(AdminSeleniumTestCase):
             delete.get_attribute("innerHTML"),
         )
         self.take_screenshot("loaded")
+
+    @screenshot_cases(["desktop_size", "mobile_size", "rtl", "dark", "high_contrast"])
+    def test_tabular_inline_object_with_show_change_link(self):
+        from selenium.webdriver.common.by import By
+
+        et = ExtraTerrestrial.objects.create(name="test")
+        Sighting.objects.create(et=et, place="Desert")
+        self.admin_login(username="super", password="secret")
+        url = reverse("admin:admin_inlines_extraterrestrial_change", args=(et.pk,))
+        self.selenium.get(self.live_server_url + url)
+        object_str = self.selenium.find_element(
+            By.CSS_SELECTOR, "fieldset.module tbody tr td.original p"
+        )
+        self.assertTrue(object_str.is_displayed())
+        self.assertIn("Desert", object_str.text)
+        self.take_screenshot("tabular")


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36079

#### Branch description
I fixed the overly small `__str__` size of `TabularInline` objects.
(adjusted size is the same as the `__str__` size used in `StackedInline`)


### Before
<img width="1144" height="96" alt="Screenshot 2025-08-03 at 9 45 12 AM" src="https://github.com/user-attachments/assets/59d393c2-d3f8-4f3b-8623-c3a34836a250" />

### After
<img width="1145" height="101" alt="Screenshot 2025-08-03 at 9 44 06 AM" src="https://github.com/user-attachments/assets/de8176dd-b592-4b24-99be-f82cda530296" />

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
