### PR TITLE
Fixed #36525 -- Silenced individual deleted file messages in collectstatic --clear's default verbosity.

### DIFF
--- a/docs/releases/6.0.txt
+++ b/docs/releases/6.0.txt
@@ -474,6 +474,10 @@ Miscellaneous
   files due to conflicts when ``--verbosity`` is 1. To see warnings for each
   conflicting destination path, set the ``--verbosity`` flag to 2 or higher.
 
+* The :option:`collectstatic --clear` command now reports only a summary of
+  deleted files when ``--verbosity`` is 1. To see the details for each file
+  deleted, set the ``--verbosity`` flag to 2 or higher.
+
 .. _deprecated-features-6.0:
 
 Features deprecated in 6.0


### PR DESCRIPTION
#### Trac ticket number
ticket-36525

#### Branch description
Show summary of deleted files by default

Changed the collectstatic --clear management command to suppress outputing names of each deleted file at verbosity level 1 and instead show a summary count in the final output (e.g., "42 static files deleted"). Individual files are still shown at verbosity level 2+.

This is based on @matthiask's comment on an older PR https://github.com/django/django/pull/13683#issuecomment-767406813

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
