### PR TITLE
Clarify EmailValidator validates an email **address**

### DIFF
--- a/docs/ref/validators.txt
+++ b/docs/ref/validators.txt
@@ -133,8 +133,8 @@ to, or in lieu of custom ``field.clean()`` methods.
     :param code: If not ``None``, overrides :attr:`code`.
     :param allowlist: If not ``None``, overrides :attr:`allowlist`.
 
-    An :class:`EmailValidator` ensures that a value looks like an email, and
-    raises a :exc:`~django.core.exceptions.ValidationError` with
+    An :class:`EmailValidator` ensures that a value looks like an email address,
+    and raises a :exc:`~django.core.exceptions.ValidationError` with
     :attr:`message` and :attr:`code` if it doesn't. Values longer than 320
     characters are always considered invalid.
 


### PR DESCRIPTION
This confused me a bit at first, because it is also possible to validate an email body (`X-Mailer:...\nSubject: ...`). Add the word `address`.

#### Checklist
- [ ] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
