### PR TITLE
Fixed #36539 -- Admin uses related field verbose_name attribute if available

### DIFF
--- a/django/contrib/admin/utils.py
+++ b/django/contrib/admin/utils.py
@@ -405,6 +405,8 @@ def label_for_field(name, model, model_admin=None, return_attr=False, form=None)
                     label = "--"
                 else:
                     label = pretty_name(attr.__name__)
+            elif hasattr(attr, "verbose_name"):
+                label = attr.verbose_name
             else:
                 label = pretty_name(name)
     except FieldIsAForeignKeyColumnName:

--- a/tests/admin_utils/models.py
+++ b/tests/admin_utils/models.py
@@ -5,6 +5,7 @@ from django.utils.translation import gettext_lazy as _
 
 class Site(models.Model):
     domain = models.CharField(max_length=100)
+    owner = models.CharField(verbose_name=_("Site owner"))
 
     def __str__(self):
         return self.domain

--- a/tests/admin_utils/models.py
+++ b/tests/admin_utils/models.py
@@ -5,7 +5,7 @@ from django.utils.translation import gettext_lazy as _
 
 class Site(models.Model):
     domain = models.CharField(max_length=100)
-    owner = models.CharField(verbose_name=_("Site owner"))
+    owner = models.CharField(verbose_name=_("Site owner"), blank=True, null=True)
 
     def __str__(self):
         return self.domain

--- a/tests/admin_utils/test_logentry.py
+++ b/tests/admin_utils/test_logentry.py
@@ -21,7 +21,7 @@ class LogEntryTests(TestCase):
         cls.user = User.objects.create_superuser(
             username="super", password="secret", email="super@example.com"
         )
-        cls.site = Site.objects.create(domain="example.org", owner="Tom")
+        cls.site = Site.objects.create(domain="example.org")
         cls.a1 = Article.objects.create(
             site=cls.site,
             title="Title",
@@ -148,7 +148,6 @@ class LogEntryTests(TestCase):
         )
         post_data = {
             "domain": "example.com",  # domain changed
-            "owner": "Tom",
             "admin_articles-TOTAL_FORMS": "5",
             "admin_articles-INITIAL_FORMS": "2",
             "admin_articles-MIN_NUM_FORMS": "0",

--- a/tests/admin_utils/test_logentry.py
+++ b/tests/admin_utils/test_logentry.py
@@ -21,7 +21,7 @@ class LogEntryTests(TestCase):
         cls.user = User.objects.create_superuser(
             username="super", password="secret", email="super@example.com"
         )
-        cls.site = Site.objects.create(domain="example.org")
+        cls.site = Site.objects.create(domain="example.org", owner="Tom")
         cls.a1 = Article.objects.create(
             site=cls.site,
             title="Title",
@@ -148,6 +148,7 @@ class LogEntryTests(TestCase):
         )
         post_data = {
             "domain": "example.com",  # domain changed
+            "owner": "Tom",
             "admin_articles-TOTAL_FORMS": "5",
             "admin_articles-INITIAL_FORMS": "2",
             "admin_articles-MIN_NUM_FORMS": "0",

--- a/tests/admin_utils/tests.py
+++ b/tests/admin_utils/tests.py
@@ -329,12 +329,12 @@ class UtilsTests(SimpleTestCase):
 
         self.assertEqual(label_for_field(lambda x: "nothing", Article), "--")
         self.assertEqual(label_for_field("site_id", Article), "Site id")
-        # The correct name and attr are returned when `__` is in the field
+        # The verbose_name and attr are returned when `__` is in the field
         # name.
-        self.assertEqual(label_for_field("site__domain", Article), "Site  domain")
+        self.assertEqual(label_for_field("site__domain", Article), "domain")
         self.assertEqual(
             label_for_field("site__domain", Article, return_attr=True),
-            ("Site  domain", Site._meta.get_field("domain")),
+            ("domain", Site._meta.get_field("domain")),
         )
 
     def test_label_for_field_failed_lookup(self):

--- a/tests/admin_utils/tests.py
+++ b/tests/admin_utils/tests.py
@@ -330,27 +330,10 @@ class UtilsTests(SimpleTestCase):
         self.assertEqual(label_for_field(lambda x: "nothing", Article), "--")
         self.assertEqual(label_for_field("site_id", Article), "Site id")
 
-        # Related lookup, field doesn't have a explicit verbose_name defined
-        domain_field_attr_name = "domain"
-        domain_field = Site._meta.get_field(domain_field_attr_name)
-        self.assertIsNone(domain_field._verbose_name)
-        self.assertEqual(
-            label_for_field("site__domain", Article), domain_field_attr_name
-        )
-        self.assertEqual(
-            label_for_field("site__domain", Article, return_attr=True),
-            ("domain", domain_field),
-        )
-
-        # Related lookup, field does have a explicit verbose_name defined
-        owner_verbose_name = "Site owner"
-        owner_field = Site._meta.get_field("owner")
-        self.assertEqual(owner_field.verbose_name, owner_verbose_name)
-        self.assertEqual(label_for_field("site__owner", Article), owner_verbose_name)
-        self.assertEqual(
-            label_for_field("site__owner", Article, return_attr=True),
-            (owner_verbose_name, owner_field),
-        )
+        # Related lookup, field doesn't have an explicit verbose_name defined.
+        self.assertEqual(label_for_field("site__domain", Article), "Domain")
+        # Related lookup, field has an explicit verbose_name defined.
+        self.assertEqual(label_for_field("site__owner", Article), "Site owner")
 
     def test_label_for_field_failed_lookup(self):
         msg = "Unable to lookup 'site__unknown' on Article"

--- a/tests/admin_utils/tests.py
+++ b/tests/admin_utils/tests.py
@@ -329,12 +329,27 @@ class UtilsTests(SimpleTestCase):
 
         self.assertEqual(label_for_field(lambda x: "nothing", Article), "--")
         self.assertEqual(label_for_field("site_id", Article), "Site id")
-        # The verbose_name and attr are returned when `__` is in the field
-        # name.
-        self.assertEqual(label_for_field("site__domain", Article), "domain")
+
+        # Related lookup, field doesn't have a explicit verbose_name defined
+        domain_field_attr_name = "domain"
+        domain_field = Site._meta.get_field(domain_field_attr_name)
+        self.assertIsNone(domain_field._verbose_name)
+        self.assertEqual(
+            label_for_field("site__domain", Article), domain_field_attr_name
+        )
         self.assertEqual(
             label_for_field("site__domain", Article, return_attr=True),
-            ("domain", Site._meta.get_field("domain")),
+            ("domain", domain_field),
+        )
+
+        # Related lookup, field does have a explicit verbose_name defined
+        owner_verbose_name = "Site owner"
+        owner_field = Site._meta.get_field("owner")
+        self.assertEqual(owner_field.verbose_name, owner_verbose_name)
+        self.assertEqual(label_for_field("site__owner", Article), owner_verbose_name)
+        self.assertEqual(
+            label_for_field("site__domain", Article, return_attr=True),
+            (owner_verbose_name, domain_field),
         )
 
     def test_label_for_field_failed_lookup(self):

--- a/tests/admin_utils/tests.py
+++ b/tests/admin_utils/tests.py
@@ -348,8 +348,8 @@ class UtilsTests(SimpleTestCase):
         self.assertEqual(owner_field.verbose_name, owner_verbose_name)
         self.assertEqual(label_for_field("site__owner", Article), owner_verbose_name)
         self.assertEqual(
-            label_for_field("site__domain", Article, return_attr=True),
-            (owner_verbose_name, domain_field),
+            label_for_field("site__owner", Article, return_attr=True),
+            (owner_verbose_name, owner_field),
         )
 
     def test_label_for_field_failed_lookup(self):


### PR DESCRIPTION
### Trac ticket number
ticket-36539 

#### Branch description
Related name supported was added on 5.1 but related field verbose names weren't taken into consideration.
This PR added support for using the verbose_name attribute of the related field.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.