### PR TITLE
Refs #36282 -- Fixed PrefetchRelatedMTICacheTests test ordering expectations.

### DIFF
--- a/tests/prefetch_related/tests.py
+++ b/tests/prefetch_related/tests.py
@@ -2176,20 +2176,20 @@ class PrefetchRelatedMTICacheTests(TestCase):
             .prefetch_related("favorite_authors")
             .get(pk=self.m2m_child.pk)
         )
-        self.assertQuerySetEqual(
+        self.assertCountEqual(
             gp.favorite_authors.all(),
             {self.related1, self.related2, self.related3},
         )
-        self.assertQuerySetEqual(
+        self.assertCountEqual(
             gp.authorwithage.favorite_authors.all(),
             {self.related1, self.related2, self.related3},
         )
         gp.authorwithage.favorite_authors.add(self.related4)
-        self.assertQuerySetEqual(
+        self.assertCountEqual(
             gp.favorite_authors.all(),
             {self.related1, self.related2, self.related3, self.related4},
         )
-        self.assertQuerySetEqual(
+        self.assertCountEqual(
             gp.authorwithage.favorite_authors.all(),
             {self.related1, self.related2, self.related3, self.related4},
         )
@@ -2202,28 +2202,28 @@ class PrefetchRelatedMTICacheTests(TestCase):
             .prefetch_related("favorite_authors")
             .get(pk=self.m2m_child.pk)
         )
-        self.assertQuerySetEqual(
+        self.assertCountEqual(
             gp.favorite_authors.all(),
             [self.related1, self.related2, self.related3],
         )
-        self.assertQuerySetEqual(
+        self.assertCountEqual(
             gp.authorwithage.favorite_authors.all(),
             [self.related1, self.related2, self.related3],
         )
-        self.assertQuerySetEqual(
+        self.assertCountEqual(
             gp.authorwithage.authorwithagechild.favorite_authors.all(),
             [self.related1, self.related2, self.related3],
         )
         gp.authorwithage.authorwithagechild.favorite_authors.add(self.related4)
-        self.assertQuerySetEqual(
+        self.assertCountEqual(
             gp.favorite_authors.all(),
             [self.related1, self.related2, self.related3, self.related4],
         )
-        self.assertQuerySetEqual(
+        self.assertCountEqual(
             gp.authorwithage.favorite_authors.all(),
             [self.related1, self.related2, self.related3, self.related4],
         )
-        self.assertQuerySetEqual(
+        self.assertCountEqual(
             gp.authorwithage.authorwithagechild.favorite_authors.all(),
             [self.related1, self.related2, self.related3, self.related4],
         )
@@ -2234,17 +2234,17 @@ class PrefetchRelatedMTICacheTests(TestCase):
             .prefetch_related("favorite_authors")
             .get(pk=self.m2m_child.pk)
         )
-        self.assertQuerySetEqual(
+        self.assertCountEqual(
             gp.favorite_authors.all(),
             [self.related1, self.related2, self.related3],
         )
-        self.assertQuerySetEqual(
+        self.assertCountEqual(
             gp.authorwithage.favorite_authors.all(),
             [self.related1, self.related2, self.related3],
         )
         gp.authorwithage.favorite_authors.clear()
-        self.assertQuerySetEqual(gp.favorite_authors.all(), [])
-        self.assertQuerySetEqual(gp.authorwithage.favorite_authors.all(), [])
+        self.assertSequenceEqual(gp.favorite_authors.all(), [])
+        self.assertSequenceEqual(gp.authorwithage.favorite_authors.all(), [])
 
     def test_remove_clears_prefetched_objects_in_grandparent(self):
         gp = (
@@ -2254,21 +2254,21 @@ class PrefetchRelatedMTICacheTests(TestCase):
             .prefetch_related("favorite_authors")
             .get(pk=self.m2m_child.pk)
         )
-        self.assertQuerySetEqual(
+        self.assertCountEqual(
             gp.favorite_authors.all(),
             [self.related1, self.related2, self.related3],
         )
-        self.assertQuerySetEqual(
+        self.assertCountEqual(
             gp.authorwithage.favorite_authors.all(),
             [self.related1, self.related2, self.related3],
         )
-        self.assertQuerySetEqual(
+        self.assertCountEqual(
             gp.authorwithage.authorwithagechild.favorite_authors.all(),
             [self.related1, self.related2, self.related3],
         )
         gp.authorwithage.favorite_authors.clear()
-        self.assertQuerySetEqual(gp.favorite_authors.all(), [])
-        self.assertQuerySetEqual(gp.authorwithage.favorite_authors.all(), [])
-        self.assertQuerySetEqual(
+        self.assertSequenceEqual(gp.favorite_authors.all(), [])
+        self.assertSequenceEqual(gp.authorwithage.favorite_authors.all(), [])
+        self.assertSequenceEqual(
             gp.authorwithage.authorwithagechild.favorite_authors.all(), []
         )


### PR DESCRIPTION
[Logs](https://djangoci.com/job/main-random/database=mysql,label=focal,python=python3.13/lastCompletedBuild/testReport/prefetch_related.tests/PrefetchRelatedMTICacheTests/test_add_clears_prefetched_objects_in_parent/):

For example:

```
Traceback (most recent call last):
  File "/home/jenkins/workspace/main-random/database/mysql/label/focal/python/python3.13/tests/prefetch_related/tests.py", line 2188, in test_add_clears_prefetched_objects_in_parent
    self.assertQuerySetEqual(
    ~~~~~~~~~~~~~~~~~~~~~~~~^
        gp.favorite_authors.all(),
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
        {self.related1, self.related2, self.related3, self.related4},
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
AssertionError: Lists differ: [<Author: related1>, <Author: related2>, <Author: related3>, <Author: related4>] != [<Author: related4>, <Author: related1>, <Author: related2>, <Author: related3>]

First differing element 0:
<Author: related1>
<Author: related4>

- [<Author: related1>, <Author: related2>, <Author: related3>, <Author: related4>]
?                                                            --------------------

+ [<Author: related4>, <Author: related1>, <Author: related2>, <Author: related3>]
?          ++++++++++++++++++++
```
