### PR TITLE
Fixed #36533 -- Fix startapp to allow empty directories as valid targets.

### DIFF
--- a/django/core/management/templates.py
+++ b/django/core/management/templates.py
@@ -105,7 +105,20 @@ class TemplateCommand(BaseCommand):
         else:
             top_dir = os.path.abspath(os.path.expanduser(target))
             if app_or_project == "app":
-                self.validate_name(os.path.basename(top_dir), "directory")
+                dir_name = os.path.basename(top_dir)
+
+                # Non empty directory already exists
+                if os.path.exists(top_dir):
+                    if os.listdir(top_dir):
+                        raise CommandError(
+                            f"{top_dir} already exists. Overlaying an app into an "
+                            "existing directory won't replace conflicting files."
+                        )
+                # Does not exist so validate new name
+                else:
+                    self.validate_name(dir_name, "directory")
+
+            # Create directory if it doesn't exist
             if not os.path.exists(top_dir):
                 try:
                     os.makedirs(top_dir)


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36533

#### Branch description
`manage.py startapp <name> <directory>` incorrectly raised a `CommandError` when the target directory already existed, even if it was empty and had a valid name.

This prevented valid workflows such as creating an app inside an intentionally pre-created directory (e.g. `manage.py startapp blog apps/blog`).

Changes:

* Updated `startapp` handling to:

  * Allow creating an app inside an **existing empty directory**, provided the **directory name** itself is valid.
  * Still raise a `CommandError` if the directory is non-empty (to avoid silent overwrites).
  * Always validate the **app name** against existing Python modules (so names like `os` remain disallowed).
  * Validate the **target directory name** only when the directory does not exist yet (so `os` is disallowed as a fresh target, but an empty `destination/` directory is valid).
* Unified behavior of `django-admin startapp` and `manage.py startapp`.

Tests:

* Added tests confirming that empty directories (e.g. `destination`) do not raise false errors.
* Added tests confirming that `os` (a Python module) is always disallowed.
* Added tests confirming that non-empty directories still raise an overlaying error.


Expected Behavior:

* `django-admin startapp example os` -> disallowed
* `manage.py startapp example os` -> disallowed
* `django-admin startapp example destination` -> allowed (even if `destination/` exists and is empty)
* `manage.py startapp example destination` -> allowed (even if `destination/` exists and is empty)
* Overlaying into a non-empty directory -> disallowed

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
