### PR TITLE
Fixed typo in django/contrib/gis/geos/geometry.py.

### DIFF
--- a/django/contrib/gis/geos/geometry.py
+++ b/django/contrib/gis/geos/geometry.py
@@ -215,7 +215,7 @@ class GEOSGeometryBase(GEOSBase):
 
     @property
     def num_points(self):
-        "Return the number points, or coordinates, in the Geometry."
+        "Return the number of points, or coordinates, in the Geometry."
         return self.num_coords
 
     @property


### PR DESCRIPTION
#### Branch description
Fixed typo in GEOSGeometryBase.num_points docstring: added the missing “of” to the property’s description.

#### Trac ticket number

N/A

#### Checklist
- [x] This PR targets the `main` branch.
- [X ] The commit message is written in past tense and ends with a period.
