### PR TITLE
Improved docs.yml GitHub Action covering docs quality checks.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   docs:
     runs-on: ubuntu-24.04
-    name: docs
+    name: spelling
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
       - name: Build docs
         run: |
           cd docs
-          sphinx-build -b spelling -n -q -W --keep-going -d _build/doctrees -D language=en_US -j auto . _build/spelling
+          sphinx-build -b spelling -n -q -W -d _build/doctrees -D language=en_US -j auto . _build/spelling
 
   blacken-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR is to continue the discussion on https://github.com/django/django/pull/19605#pullrequestreview-3085741513

@nessita  asked:

> Should we consider switching the GitHub Action to use this new combined rule?
I noticed that the current docs.yml separates spelling and blacken-docs checks,
and that the spelling step uses slightly different parameters (-q -W --keep-going).
It seems beneficial to run the same commands in CI as locally, so contributors get
consistent, reliable results and avoid surprises from mismatched CI runs.

Taking these in turn.

>Should we consider switching the GitHub Action to use this new combined rule?

I think they should be kept separate in separate steps as it helps the community to more easily see what the error is. See this action run here for example: https://github.com/django/django/actions/runs/16800290117?pr=18804 While you still have to look at the logs to see what's gone wrong I think it's helpful to have this higher level summary available. 

> I noticed that the current docs.yml separates spelling and blacken-docs checks,

I noticed that you called it the `spelling` check, and I'd call it that too. That's not what it's called in the action, so the first commit addresses this. I think there's value in seeing that 'spelling' has failed rather than 'docs'. 

> spelling step uses slightly different parameters (-q -W --keep-going)

[`--keep-going`](https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-keep-going) is no longer required since Sphinx 8.1 and is removed in the second commit.

[`-q`](https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-q) I tried locally to see what the difference in output is. It results in some messages being hidden, for example this message is currently hidden:

```
checking consistency... /mnt/c/Users/smith/PycharmProjects/django/docs/intro/contributing.txt: document is referenced in multiple toctrees: ['internals/contributing/writing-code/index', 'intro/index'], selecting: intro/index <- intro/contributing
/mnt/c/Users/smith/PycharmProjects/django/docs/topics/testing/overview.txt: document is referenced in multiple toctrees: ['internals/contributing/writing-code/index', 'topics/testing/index'], selecting: topics/testing/index <- topics/testing/overview
done
```

I'm not sure about enabling `-q` locally. I could foresee a time when we're trying to debug some Sphinx build issue and having `-q` enabled when running locally may hide some messages that would be useful. Sure, we'd figure it out but it may take a cycle to realise that we're hiding some messages. I think it's ok in CI though as we just want to see the errors for that specific check.

[`-W`](https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-W) I don't really have an opinion on this one. I'm not sure on the benefit of exiting with a different status code when running the check locally. 