### PR TITLE
Remove unused OneToOneField from DatabaseWrapper.data_types

### DIFF
--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -126,7 +126,6 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         "IPAddressField": "char(15)",
         "GenericIPAddressField": "char(39)",
         "JSONField": "json",
-        "OneToOneField": "integer",
         "PositiveBigIntegerField": "bigint UNSIGNED",
         "PositiveIntegerField": "integer UNSIGNED",
         "PositiveSmallIntegerField": "smallint UNSIGNED",

--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -135,7 +135,6 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         "BigIntegerField": "NUMBER(19)",
         "IPAddressField": "VARCHAR2(15)",
         "GenericIPAddressField": "VARCHAR2(39)",
-        "OneToOneField": "NUMBER(11)",
         "PositiveBigIntegerField": "NUMBER(19)",
         "PositiveIntegerField": "NUMBER(11)",
         "PositiveSmallIntegerField": "NUMBER(11)",

--- a/django/db/backends/postgresql/base.py
+++ b/django/db/backends/postgresql/base.py
@@ -113,7 +113,6 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         "IPAddressField": "inet",
         "GenericIPAddressField": "inet",
         "JSONField": "jsonb",
-        "OneToOneField": "integer",
         "PositiveBigIntegerField": "bigint",
         "PositiveIntegerField": "integer",
         "PositiveSmallIntegerField": "smallint",

--- a/django/db/backends/sqlite3/base.py
+++ b/django/db/backends/sqlite3/base.py
@@ -81,7 +81,6 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         "IPAddressField": "char(15)",
         "GenericIPAddressField": "char(39)",
         "JSONField": "text",
-        "OneToOneField": "integer",
         "PositiveBigIntegerField": "bigint unsigned",
         "PositiveIntegerField": "integer unsigned",
         "PositiveSmallIntegerField": "smallint unsigned",


### PR DESCRIPTION
OneToOneField uses the type of the related field.