### PR TITLE
Refs #36210 -- Corrected output_field comparison in Subquery.resolve_expression().

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -1804,7 +1804,9 @@ class Subquery(BaseExpression, Combinable):
                 self.output_field
             except AttributeError:
                 return resolved.query
-            if self.output_field and self.output_field != resolved.query.output_field:
+            if self.output_field and type(self.output_field) is not type(
+                resolved.query.output_field
+            ):
                 return ExpressionWrapper(resolved.query, output_field=self.output_field)
             return resolved.query
         return resolved


### PR DESCRIPTION
Follow-up to fd569dd45bf0746378faf7f65172497f21ed27f0.

See [explanation](https://github.com/django/django/pull/19715#issuecomment-3170053702): the `Field` should not be compared by equality.