### PR TITLE
Fixed #27929 -- Added ManifestStaticFilesStorage option to keep/remove original (non-hashed) files after processing

### DIFF
--- a/docs/ref/contrib/staticfiles.txt
+++ b/docs/ref/contrib/staticfiles.txt
@@ -300,9 +300,8 @@ method). The regular expressions used to find those paths
 * The `@import`_ rule and `url()`_ statement of `Cascading Style Sheets`_.
 * `Source map`_ comments in CSS and JavaScript files.
 
-Subclass ``ManifestStaticFilesStorage`` and set the
-``support_js_module_import_aggregation`` attribute to ``True``, if you want to
-use the experimental regular expressions to cover:
+Configure the ``support_js_module_import_aggregation`` to ``True`` via the
+``OPTIONS``, if you want to use the experimental regular expressions to cover:
 
 * The `modules import`_ in JavaScript.
 * The `modules aggregation`_ in JavaScript.
@@ -332,6 +331,27 @@ For example, the ``'css/styles.css'`` file with this content:
     :djadmin:`collectstatic`). At the moment, there is no out-of-the-box
     tooling available for this.
 
+To enable the ``ManifestStaticFilesStorage`` you have to make sure the
+following requirements are met:
+
+* the ``staticfiles`` storage backend in :setting:`STORAGES` setting is set to
+  ``'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'``
+* the :setting:`DEBUG` setting is set to ``False``
+* you've collected all your static files by using the
+  :djadmin:`collectstatic` management command
+
+Since creating the MD5 hash can be a performance burden to your website
+during runtime, ``staticfiles`` will automatically store the mapping with
+hashed names for all processed files in a file called ``staticfiles.json``.
+This happens once when you run the :djadmin:`collectstatic` management
+command.
+
+.. admonition:: References in comments
+
+    ``ManifestStaticFilesStorage`` doesn't ignore paths in statements that are
+    commented out. This :ticket:`may crash on the nonexistent paths <21080>`.
+    You should check and eventually strip comments.
+
 You can change the location of the manifest file by using a custom
 ``ManifestStaticFilesStorage`` subclass that sets the ``manifest_storage``
 argument. For example::
@@ -347,12 +367,6 @@ argument. For example::
         def __init__(self, *args, **kwargs):
             manifest_storage = StaticFilesStorage(location=settings.BASE_DIR)
             super().__init__(*args, manifest_storage=manifest_storage, **kwargs)
-
-.. admonition:: References in comments
-
-    ``ManifestStaticFilesStorage`` doesn't ignore paths in statements that are
-    commented out. This :ticket:`may crash on the nonexistent paths <21080>`.
-    You should check and eventually strip comments.
 
 .. attribute:: storage.ManifestStaticFilesStorage.manifest_hash
 
@@ -372,26 +386,11 @@ passes might be needed. Increase the maximum number of passes by subclassing
 ``ManifestStaticFilesStorage`` and setting the ``max_post_process_passes``
 attribute. It defaults to 5.
 
-To enable the ``ManifestStaticFilesStorage`` you have to make sure the
-following requirements are met:
-
-* the ``staticfiles`` storage backend in :setting:`STORAGES` setting is set to
-  ``'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'``
-* the :setting:`DEBUG` setting is set to ``False``
-* you've collected all your static files by using the
-  :djadmin:`collectstatic` management command
-
-Since creating the MD5 hash can be a performance burden to your website
-during runtime, ``staticfiles`` will automatically store the mapping with
-hashed names for all processed files in a file called ``staticfiles.json``.
-This happens once when you run the :djadmin:`collectstatic` management
-command.
-
 .. attribute:: storage.ManifestStaticFilesStorage.manifest_strict
 
 If a file isn't found in the ``staticfiles.json`` manifest at runtime, a
-``ValueError`` is raised. This behavior can be disabled by subclassing
-``ManifestStaticFilesStorage`` and setting the ``manifest_strict`` attribute to
+``ValueError`` is raised. This behavior can be disabled by providing an
+``OPTIONS`` key with a dict and setting the ``manifest_strict`` attribute to
 ``False`` -- nonexistent paths will remain unchanged.
 
 Due to the requirement of running :djadmin:`collectstatic`, this storage
@@ -399,6 +398,16 @@ typically shouldn't be used when running tests as ``collectstatic`` isn't run
 as part of the normal test setup. During testing, ensure that ``staticfiles``
 storage backend in the :setting:`STORAGES` setting is set to something else
 like ``'django.contrib.staticfiles.storage.StaticFilesStorage'`` (the default).
+
+.. attribute:: storage.ManifestStaticFilesStorage.keep_original_files
+
+.. versionadded:: 6.0
+
+Once the cached copies have been created you can optionally have the
+original files deleted, e.g. ``css/styles.css``, by setting the
+``keep_original_files`` attribute to ``False``. This can be useful in
+deployment scenarios where it is important to reduce the size of the
+build artifact as much as possible.
 
 .. method:: storage.ManifestStaticFilesStorage.file_hash(name, content=None)
 

--- a/docs/releases/6.0.txt
+++ b/docs/releases/6.0.txt
@@ -187,6 +187,15 @@ Minor features
   ensures consistent path ordering in manifest files, making them more
   reproducible and reducing unnecessary diffs.
 
+* :class:`~django.contrib.staticfiles.storage.ManifestStaticFilesStorage` now
+  supports a ``keep_original_files`` attribute which can be set to ``False``
+  if you only want to retain the hashed copies.
+
+* :class:`~django.contrib.staticfiles.storage.ManifestStaticFilesStorage` now
+  supports using the settings' ``OPTIONS`` dict to configure the attributes
+  ``keep_original_files``, ``manifest_name``, ``manifest_strict``.
+  ``support_js_module_import_aggregation``.
+
 :mod:`django.contrib.syndication`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
#### Trac ticket number

ticket-27929

#### Branch description
When collecting static files with ManifestStaticFilesStorage, both hashed and original versions are created by default. This adds a keep_original_files attribute to allow removal of original non-hashed files after processing for production deployments where only hashed versions are needed.

There have already been two PR's on this  https://github.com/django/django/pull/17328 by @theumang100 and https://github.com/django/django/pull/16625 by @valleyofblackpanther
This PR is more inspired by whitenoise's approach of keeping a track of which files to delete during processing and then deleting them at the end, though uses a slightly different approach.

It also makes it more convenient to update the ManifestStaticFilesStorage configuration from the already supported OPTIONS keyword of the [STORAGES](https://docs.djangoproject.com/en/dev/ref/settings/#storages) setting.
eg
```python
{
    "default": {
        "BACKEND": "django.core.files.storage.FileSystemStorage",
    },
    "staticfiles": {
        "BACKEND": "django.contrib.staticfiles.storage.ManifestStaticFilesStorage",
        "OPTIONS":  {
            "keep_original_files": False,
            "manifest_name": "secured_through_obscurity_staticfiles.json",
            "manifest_strict": False,
            "support_js_module_import_aggregation": True,
        },
    },
}
```


#### Checklist
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
