### PR TITLE
Fixed #36504 -- Clarified docs for using  with FileField storage.

### DIFF
--- a/docs/topics/files.txt
+++ b/docs/topics/files.txt
@@ -298,7 +298,7 @@ make this work, connect to the
 :data:`~django.test.signals.setting_changed` signal and reset storages when
 ``STORAGES`` is overridden::
 
-    from django.core.files.storage import storages
+    from django.core.files.storage import default_storage, staticfiles_storage
     from django.core.signals import setting_changed
     from django.dispatch import receiver
 
@@ -306,13 +306,14 @@ make this work, connect to the
     @receiver(setting_changed)
     def update_filefield_storage(setting, **kwargs):
         if setting == "STORAGES":
-            storages._storages.clear()
+            default_storage._wrapped = empty
+            staticfiles_storage._wrapped = empty
 
 And in your tests::
 
     @override_settings(
         STORAGES={
-            "mystorage": {
+            "default": {
                 "BACKEND": "django.core.files.storage.InMemoryStorage",
             }
         }

--- a/docs/topics/files.txt
+++ b/docs/topics/files.txt
@@ -292,8 +292,23 @@ need to override the :setting:`STORAGES` setting in tests, you should use a
     class MyModel(models.Model):
         upload = models.FileField(storage=my_storage)
 
-The ``LazyObject`` delays the evaluation of the storage until it's actually
-needed, allowing :func:`~django.test.override_settings` to take effect::
+The ``LazyObject`` delays evaluation of the storage until it's actually
+needed, allowing :func:`~django.test.override_settings` to take effect. To
+make this work, connect to the
+:data:`~django.test.signals.setting_changed` signal and reset storages when
+``STORAGES`` is overridden::
+
+    from django.core.files.storage import storages
+    from django.core.signals import setting_changed
+    from django.dispatch import receiver
+
+
+    @receiver(setting_changed)
+    def update_filefield_storage(setting, **kwargs):
+        if setting == "STORAGES":
+            storages._storages.clear()
+
+And in your tests::
 
     @override_settings(
         STORAGES={


### PR DESCRIPTION
#### Trac ticket number
Fixed #36504

#### Branch description
This PR clarifies the Django documentation regarding the usage of `override_settings` with `FileField` storage.  
It explains why using a simple callable for the `storage` argument may not behave as expected in tests due to early evaluation at import time.  
It adds a note recommending the use of a `LazyObject` subclass pattern to delay storage evaluation, ensuring `override_settings` works properly in test scenarios.

#### Checklist
- [x] This PR targets the `main` branch. 
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
