### PR TITLE
Fixed Construction of a cookie using user-supplied input

### DIFF
--- a/django/views/i18n.py
+++ b/django/views/i18n.py
@@ -2,7 +2,7 @@ import json
 import os
 import re
 from pathlib import Path
-
+from urllib.parse import quote
 from django.apps import apps
 from django.conf import settings
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
@@ -63,7 +63,7 @@ def set_language(request):
                     response = HttpResponseRedirect(next_trans)
             response.set_cookie(
                 settings.LANGUAGE_COOKIE_NAME,
-                lang_code,
+                quote(lang_code),
                 max_age=settings.LANGUAGE_COOKIE_AGE,
                 path=settings.LANGUAGE_COOKIE_PATH,
                 domain=settings.LANGUAGE_COOKIE_DOMAIN,


### PR DESCRIPTION


fix the problem, we should ensure that the value set in the cookie is safe and cannot be used to inject malicious content. The best way to do this is to encode the value before setting it as a cookie. In Django, the `django.utils.http.urlquote` (or, in modern Django, `urllib.parse.quote`) can be used to percent-encode the value, making it safe for use in cookies. This should be done in the `set_language` view, just before calling `set_cookie`, to ensure only safe values are set. No changes are needed in the generic `set_cookie` method, as it is a general-purpose method and should not enforce encoding on all values.

**Required changes:**
- In `django/views/i18n.py`, encode `lang_code` before passing it to `set_cookie`.
- Add the necessary import for the encoding function (`from urllib.parse import quote`).



#### Branch description
Provide a concise overview of the issue or rationale behind the proposed changes.

#### Checklist
- [ ] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
