### PR TITLE
Fixed #36556 -- Fixed TabularInline width overflowing the page.

### DIFF
--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -432,9 +432,12 @@ body.popup .submit-row {
     border: none;
 }
 
+.inline-related.tabular div.wrapper {
+    overflow-x: auto;
+}
+
 .inline-related.tabular fieldset.module table {
     width: 100%;
-    overflow-x: scroll;
 }
 
 .last-related fieldset {

--- a/django/contrib/admin/templates/admin/edit_inline/tabular.html
+++ b/django/contrib/admin/templates/admin/edit_inline/tabular.html
@@ -15,7 +15,8 @@
   </h2>
   {% if inline_admin_formset.is_collapsible %}</summary>{% endif %}
    {{ inline_admin_formset.formset.non_form_errors }}
-   <table>
+  <div class="wrapper">
+    <table>
      <thead><tr>
        <th class="original"></th>
      {% for field in inline_admin_formset.fields %}
@@ -62,7 +63,8 @@
         </tr>
      {% endfor %}
      </tbody>
-   </table>
+    </table>
+  </div>
   {% if inline_admin_formset.is_collapsible %}</details>{% endif %}
 </fieldset>
   </div>

--- a/tests/admin_inlines/tests.py
+++ b/tests/admin_inlines/tests.py
@@ -2501,6 +2501,16 @@ class SeleniumTests(AdminSeleniumTestCase):
             tabular_inline.find_elements(By.CSS_SELECTOR, ".collapse"),
             [],
         )
+        # The table does not overflow the content section.
+        content = self.selenium.find_element(By.ID, "content-main")
+        tabular_wrapper = self.selenium.find_element(
+            By.CSS_SELECTOR, "div.tabular.inline-related div.wrapper"
+        )
+        self.assertGreater(
+            tabular_wrapper.find_element(By.TAG_NAME, "table").size["width"],
+            tabular_wrapper.size["width"],
+        )
+        self.assertLessEqual(tabular_wrapper.size["width"], content.size["width"])
 
     @screenshot_cases(["desktop_size", "mobile_size", "rtl", "dark", "high_contrast"])
     def test_tabular_inline_delete_layout(self):


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36556

#### Branch description
Fixed TabularInline table width from overflowing the page when its model has multiple fields.

### Before

<img width="1375" height="635" alt="Screenshot 2025-08-16 at 10 25 30 AM" src="https://github.com/user-attachments/assets/0faf4912-31e3-4978-83cc-2becc3eb2308" />

### After

<img width="1187" height="557" alt="Screenshot 2025-08-16 at 10 25 52 AM" src="https://github.com/user-attachments/assets/f374521b-86e9-4bf4-877d-15f33d496639" />

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
