### PR TITLE
Fixed TypeError when selecting BinaryField in Admin list_filter.

### DIFF
--- a/tests/admin_filters/models.py
+++ b/tests/admin_filters/models.py
@@ -99,3 +99,7 @@ class Bookmark(models.Model):
 
     def __str__(self):
         return self.url
+
+
+class BookBinaryInfo(models.Model):
+    datas = models.BinaryField(max_length=100)


### PR DESCRIPTION
#### Trac ticket number
ticket-N/A

#### Branch description
Fixed TypeError when selecting a BinaryField in Django Admin list_filter.  
Django Admin was passing BinaryField values as repr(bytes) strings instead of actual bytes, causing  
`TypeError: memoryview: a bytes-like object is required, not 'str'`.  
This patch ensures the values are properly converted back to bytes.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
