### PR TITLE
Ticket 36550 bulk create composite auto now add

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -109,10 +109,6 @@ body {
     background: var(--body-bg);
 }
 
-label {
-    font-size: 1rem;
-}
-
 /* LINKS */
 
 a:link, a:visited {

--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -109,6 +109,10 @@ body {
     background: var(--body-bg);
 }
 
+label {
+    font-size: 1rem;
+}
+
 /* LINKS */
 
 a:link, a:visited {

--- a/tests/composite_pk/test_create.py
+++ b/tests/composite_pk/test_create.py
@@ -1,7 +1,7 @@
 from django.db import IntegrityError
 from django.test import TestCase, skipUnlessDBFeature
 
-from .models import Post, Tenant, User
+from .models import Post, Tenant, User, TimeStamped
 
 
 class CompositePKCreateTests(TestCase):
@@ -77,6 +77,16 @@ class CompositePKCreateTests(TestCase):
         self.assertEqual(obj_3.id, 8214)
         self.assertEqual(obj_3.pk, (obj_3.tenant_id, obj_3.id))
         self.assertEqual(obj_3.email, "user8214@example.com")
+
+    def test_bulk_create_auto_now_add_primary_key(self):
+        objs = [TimeStamped(id=1), TimeStamped(id=2), TimeStamped(id=3)]
+        created = TimeStamped.objects.bulk_create(objs)
+        self.assertEqual(len(created), 3)
+        self.assertEqual(TimeStamped.objects.count(), 3)
+        for db_obj in TimeStamped.objects.all():
+            self.assertIsNotNone(db_obj.pk)
+        for obj in created:
+            self.assertIsNotNone(obj.pk)
 
     @skipUnlessDBFeature(
         "supports_update_conflicts",

--- a/tests/composite_pk/test_create.py
+++ b/tests/composite_pk/test_create.py
@@ -1,7 +1,7 @@
 from django.db import IntegrityError
 from django.test import TestCase, skipUnlessDBFeature
 
-from .models import Post, Tenant, User, TimeStamped
+from .models import Post, Tenant, TimeStamped, User
 
 
 class CompositePKCreateTests(TestCase):


### PR DESCRIPTION
#### Trac ticket number
ticket-36550

#### Branch description
This patch updates QuerySet._prepare_for_bulk_create() to properly handle models with composite primary keys and auto_now_add fields.  Instead of relying solely on _is_pk_set(), it now verifies that all PK fields are populated before treating an object as having a primary key.

Additionally, a new test case was added to ensure that bulk_create() correctly sets composite primary keys with auto_now_add fields, both in memory and in the database.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
