### PR TITLE
Fixed #36554 -- Fixed TabularInline to prevent link truncation with long title.

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -130,7 +130,8 @@ a:not(
     #header a,
     #nav-sidebar a,
     #content-main.app-list a,
-    .object-tools a
+    .object-tools a,
+    a.viewsitelink
 ) {
     text-decoration: underline;
 }
@@ -824,11 +825,11 @@ a.deletelink:focus, a.deletelink:hover {
     margin-left: 15px;
 }
 
-.object-tools a {
+.object-tools a, a.viewsitelink {
     border-radius: 15px;
 }
 
-.object-tools a:link, .object-tools a:visited {
+.object-tools a:link, .object-tools a:visited, a.viewsitelink {
     display: block;
     float: left;
     padding: 3px 12px;
@@ -840,7 +841,10 @@ a.deletelink:focus, a.deletelink:hover {
     letter-spacing: 0.5px;
 }
 
-.object-tools a:focus, .object-tools a:hover {
+.object-tools a:focus,
+.object-tools a:hover,
+a.viewsitelink:focus,
+a.viewsitelink:hover {
     background-color: var(--object-tools-hover-bg);
 }
 
@@ -848,13 +852,15 @@ a.deletelink:focus, a.deletelink:hover {
     text-decoration: none;
 }
 
-.object-tools a.viewsitelink, .object-tools a.addlink {
+.object-tools a.viewsitelink,
+.object-tools a.addlink,
+a.viewsitelink {
     background-repeat: no-repeat;
     background-position: right 7px center;
     padding-right: 26px;
 }
 
-.object-tools a.viewsitelink {
+.object-tools a.viewsitelink, a.viewsitelink {
     background-image: url(../img/tooltag-arrowright.svg);
 }
 

--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -449,8 +449,21 @@ body.popup .submit-row {
 }
 
 .inline-group .tabular tr td.original {
-    padding: 2px 0 0 0;
-    width: 0;
+    position: absolute;
+    display: flex;
+    align-items: center;
+    left: 0;
+    height: 2em;
+    padding: 2px 9px;
+    overflow: hidden;
+    font-size: 0.875rem;
+    font-weight: bold;
+    color: var(--body-quiet-color);
+    border-bottom: 0;
+}
+
+.inline-group .tabular tr td.original:has(p) {
+    width: 100%;
 }
 
 .inline-group .tabular th.original {
@@ -463,14 +476,13 @@ body.popup .submit-row {
 }
 
 .inline-group .tabular td.original p {
-    position: absolute;
-    left: 0;
-    height: 1.2em;
-    padding: 2px 9px;
+    display: inline-block;
+    max-width: 80%;
+    white-space: nowrap;
     overflow: hidden;
+    text-overflow: ellipsis;
     font-size: 0.875rem;
     font-weight: bold;
-    color: var(--body-quiet-color);
 }
 
 .inline-group div.add-row,
@@ -489,6 +501,17 @@ body.popup .submit-row {
 .inline-group div.add-row a,
 .inline-group .tabular tr.add-row td a {
     font-size: 0.75rem;
+}
+
+.inline-group a.viewsitelink {
+    display: inline-block;
+    float: none;
+    line-height: 1rem;
+    white-space: nowrap;
+}
+
+.inline-group:has(a.inlinechangelink) a.viewsitelink {
+    margin: 0 0.75rem;
 }
 
 .empty-form {

--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -412,6 +412,14 @@ body.popup .submit-row {
     border-right-color: var(--darkened-bg);
 }
 
+.inline-related:not(.tabular) h3 > div {
+    width: 100%;
+}
+
+.inline-related:not(.tabular) h3 div.inline-links {
+    margin: 0.4rem 0;
+}
+
 .inline-related h3 span.delete {
     float: right;
 }

--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -452,31 +452,15 @@ body.popup .submit-row {
     border: none;
 }
 
-.inline-group .tabular tr.has_original td {
-    padding-top: 2em;
-}
-
 .inline-group .tabular tr td.original {
-    position: absolute;
-    display: flex;
-    align-items: center;
-    left: 0;
-    height: 2em;
-    padding: 2px 9px;
-    overflow: hidden;
     font-size: 0.875rem;
     font-weight: bold;
     color: var(--body-quiet-color);
     border-bottom: 0;
 }
 
-.inline-group .tabular tr td.original:has(p) {
-    width: 100%;
-}
-
 .inline-group .tabular th.original {
-    width: 0px;
-    padding: 0;
+    display: contents;
 }
 
 .inline-group .tabular td {
@@ -484,13 +468,10 @@ body.popup .submit-row {
 }
 
 .inline-group .tabular td.original p {
-    display: inline-block;
-    max-width: 80%;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
     font-size: 0.875rem;
     font-weight: bold;
+    padding: 0;
+    margin-bottom: 4px;
 }
 
 .inline-group div.add-row,

--- a/django/contrib/admin/static/admin/css/responsive.css
+++ b/django/contrib/admin/static/admin/css/responsive.css
@@ -658,9 +658,6 @@ input[type="submit"], button {
         padding: 10px;
         border-top-width: 0;
         border-bottom-width: 2px;
-        display: flex;
-        flex-wrap: wrap;
-        align-items: center;
     }
 
     .inline-group[data-inline-type="stacked"] .inline-related h3 .inline_label {

--- a/django/contrib/admin/static/admin/css/rtl.css
+++ b/django/contrib/admin/static/admin/css/rtl.css
@@ -285,6 +285,10 @@ form .form-row p.datetime {
     right: 0;
 }
 
+.inline-group .tabular tr.has_original td p {
+    padding-left: 10px;
+}
+
 .selector .selector-chooser {
     margin: 0;
 }

--- a/django/contrib/admin/static/admin/js/inlines.js
+++ b/django/contrib/admin/static/admin/js/inlines.js
@@ -112,7 +112,7 @@
             } else {
                 // Otherwise, just insert the remove button as the
                 // last child element of the form's container:
-                row.children(":first").append('<span><a role="button" class="' + options.deleteCssClass + '" href="#">' + options.deleteText + "</a></span>");
+                row.find('h3 > div').append('<span><a role="button" class="' + options.deleteCssClass + '" href="#">' + options.deleteText + "</a></span>");
             }
             // Add delete handler for each row.
             row.find("a." + options.deleteCssClass).on('click', inlineDeleteHandler.bind(this));

--- a/django/contrib/admin/static/admin/js/inlines.js
+++ b/django/contrib/admin/static/admin/js/inlines.js
@@ -112,7 +112,7 @@
             } else {
                 // Otherwise, just insert the remove button as the
                 // last child element of the form's container:
-                row.find('h3 > div').append('<span><a role="button" class="' + options.deleteCssClass + '" href="#">' + options.deleteText + "</a></span>");
+                row.find('h3').append('<span><a role="button" class="' + options.deleteCssClass + '" href="#">' + options.deleteText + "</a></span>");
             }
             // Add delete handler for each row.
             row.find("a." + options.deleteCssClass).on('click', inlineDeleteHandler.bind(this));

--- a/django/contrib/admin/templates/admin/edit_inline/stacked.html
+++ b/django/contrib/admin/templates/admin/edit_inline/stacked.html
@@ -17,7 +17,8 @@
 {{ inline_admin_formset.formset.non_form_errors }}
 
 {% for inline_admin_form in inline_admin_formset %}<div class="inline-related{% if inline_admin_form.original or inline_admin_form.show_url %} has_original{% endif %}{% if forloop.last and inline_admin_formset.has_add_permission %} empty-form last-related{% endif %}" id="{{ inline_admin_formset.formset.prefix }}-{% if forloop.last and inline_admin_formset.has_add_permission %}empty{% else %}{{ forloop.counter0 }}{% endif %}">
-  <h3><div><b>{{ inline_admin_formset.opts.verbose_name|capfirst }}:</b> <span class="inline_label">{% if inline_admin_form.original %}{{ inline_admin_form.original }}{% else %}#{{ forloop.counter }}{% endif %}</span></div>
+  <h3>
+    <span class="inline_label">{% if inline_admin_form.original %}{{ inline_admin_form.original }}{% else %}#{{ forloop.counter }}{% endif %}</span>
     {% if inline_admin_form.original %}
     <div class="inline-links">
     {% if inline_admin_form.model_admin.show_change_link and inline_admin_form.model_admin.has_registered_model %} <a href="{% url inline_admin_form.model_admin.opts|admin_urlname:'change' inline_admin_form.original.pk|admin_urlquote %}" class="{{ inline_admin_formset.has_change_permission|yesno:'inlinechangelink,inlineviewlink' }}">{% if inline_admin_formset.has_change_permission %}{% translate "Change" %}{% else %}{% translate "View" %}{% endif %}</a>{% endif %}

--- a/django/contrib/admin/templates/admin/edit_inline/stacked.html
+++ b/django/contrib/admin/templates/admin/edit_inline/stacked.html
@@ -17,9 +17,13 @@
 {{ inline_admin_formset.formset.non_form_errors }}
 
 {% for inline_admin_form in inline_admin_formset %}<div class="inline-related{% if inline_admin_form.original or inline_admin_form.show_url %} has_original{% endif %}{% if forloop.last and inline_admin_formset.has_add_permission %} empty-form last-related{% endif %}" id="{{ inline_admin_formset.formset.prefix }}-{% if forloop.last and inline_admin_formset.has_add_permission %}empty{% else %}{{ forloop.counter0 }}{% endif %}">
-  <h3><b>{{ inline_admin_formset.opts.verbose_name|capfirst }}:</b> <span class="inline_label">{% if inline_admin_form.original %}{{ inline_admin_form.original }}{% if inline_admin_form.model_admin.show_change_link and inline_admin_form.model_admin.has_registered_model %} <a href="{% url inline_admin_form.model_admin.opts|admin_urlname:'change' inline_admin_form.original.pk|admin_urlquote %}" class="{{ inline_admin_formset.has_change_permission|yesno:'inlinechangelink,inlineviewlink' }}">{% if inline_admin_formset.has_change_permission %}{% translate "Change" %}{% else %}{% translate "View" %}{% endif %}</a>{% endif %}
-{% else %}#{{ forloop.counter }}{% endif %}</span>
-      {% if inline_admin_form.show_url %}<a href="{{ inline_admin_form.absolute_url }}">{% translate "View on site" %}</a>{% endif %}
+  <h3><div><b>{{ inline_admin_formset.opts.verbose_name|capfirst }}:</b> <span class="inline_label">{% if inline_admin_form.original %}{{ inline_admin_form.original }}{% else %}#{{ forloop.counter }}{% endif %}</span></div>
+    {% if inline_admin_form.original %}
+    <div class="inline-links">
+    {% if inline_admin_form.model_admin.show_change_link and inline_admin_form.model_admin.has_registered_model %} <a href="{% url inline_admin_form.model_admin.opts|admin_urlname:'change' inline_admin_form.original.pk|admin_urlquote %}" class="{{ inline_admin_formset.has_change_permission|yesno:'inlinechangelink,inlineviewlink' }}">{% if inline_admin_formset.has_change_permission %}{% translate "Change" %}{% else %}{% translate "View" %}{% endif %}</a>{% endif %}
+    {% if inline_admin_form.show_url %}<a href="{{ inline_admin_form.absolute_url }}" class="viewsitelink">{% translate "View on site" %}</a>{% endif %}
+    </div>
+    {% endif %}
     {% if inline_admin_formset.formset.can_delete and inline_admin_formset.has_delete_permission and inline_admin_form.original %}<span class="delete">{{ inline_admin_form.deletion_field.field }} {{ inline_admin_form.deletion_field.label_tag }}</span>{% endif %}
   </h3>
   {% if inline_admin_form.form.non_field_errors %}{{ inline_admin_form.form.non_field_errors }}{% endif %}

--- a/django/contrib/admin/templates/admin/edit_inline/tabular.html
+++ b/django/contrib/admin/templates/admin/edit_inline/tabular.html
@@ -38,10 +38,10 @@
           {% if inline_admin_form.original or inline_admin_form.show_url %}<p>
           {% if inline_admin_form.original %}
           {{ inline_admin_form.original }}
+          </p>
           {% if inline_admin_form.model_admin.show_change_link and inline_admin_form.model_admin.has_registered_model %}<a href="{% url inline_admin_form.model_admin.opts|admin_urlname:'change' inline_admin_form.original.pk|admin_urlquote %}" class="{{ inline_admin_formset.has_change_permission|yesno:'inlinechangelink,inlineviewlink' }}">{% if inline_admin_formset.has_change_permission %}{% translate "Change" %}{% else %}{% translate "View" %}{% endif %}</a>{% endif %}
           {% endif %}
-          {% if inline_admin_form.show_url %}<a href="{{ inline_admin_form.absolute_url }}">{% translate "View on site" %}</a>{% endif %}
-            </p>{% endif %}
+          {% if inline_admin_form.show_url %}<a href="{{ inline_admin_form.absolute_url }}" class="viewsitelink">{% translate "View on site" %}</a>{% endif %}{% endif %}
           {% if inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
           {% if inline_admin_form.fk_field %}{{ inline_admin_form.fk_field.field }}{% endif %}
         </td>

--- a/django/contrib/admin/templates/admin/edit_inline/tabular.html
+++ b/django/contrib/admin/templates/admin/edit_inline/tabular.html
@@ -32,19 +32,21 @@
         {% if inline_admin_form.form.non_field_errors %}
         <tr class="row-form-errors"><td colspan="{{ inline_admin_form|cell_count }}">{{ inline_admin_form.form.non_field_errors }}</td></tr>
         {% endif %}
+        {% if inline_admin_form.original or inline_admin_form.show_url %}
+        <tr>
+          <td class="original" colspan="{{ inline_admin_form|cell_count }}"><p>{% if inline_admin_form.original %} {{ inline_admin_form.original }}</p>
+            <div>
+            {% if inline_admin_form.model_admin.show_change_link and inline_admin_form.model_admin.has_registered_model %}<a href="{% url inline_admin_form.model_admin.opts|admin_urlname:'change' inline_admin_form.original.pk|admin_urlquote %}" class="{{ inline_admin_formset.has_change_permission|yesno:'inlinechangelink,inlineviewlink' }}">{% if inline_admin_formset.has_change_permission %}{% translate "Change" %}{% else %}{% translate "View" %}{% endif %}</a>{% endif %}
+            {% endif %}
+            {% if inline_admin_form.show_url %}<a href="{{ inline_admin_form.absolute_url }}" class="viewsitelink">{% translate "View on site" %}</a>{% endif %}
+            </div>
+          </td>
+        </tr>
+        {% endif %}
         <tr class="form-row {% if inline_admin_form.original or inline_admin_form.show_url %}has_original{% endif %}{% if forloop.last and inline_admin_formset.has_add_permission %} empty-form{% endif %}"
              id="{{ inline_admin_formset.formset.prefix }}-{% if forloop.last and inline_admin_formset.has_add_permission %}empty{% else %}{{ forloop.counter0 }}{% endif %}">
-        <td class="original">
-          {% if inline_admin_form.original or inline_admin_form.show_url %}<p>
-          {% if inline_admin_form.original %}
-          {{ inline_admin_form.original }}
-          </p>
-          {% if inline_admin_form.model_admin.show_change_link and inline_admin_form.model_admin.has_registered_model %}<a href="{% url inline_admin_form.model_admin.opts|admin_urlname:'change' inline_admin_form.original.pk|admin_urlquote %}" class="{{ inline_admin_formset.has_change_permission|yesno:'inlinechangelink,inlineviewlink' }}">{% if inline_admin_formset.has_change_permission %}{% translate "Change" %}{% else %}{% translate "View" %}{% endif %}</a>{% endif %}
-          {% endif %}
-          {% if inline_admin_form.show_url %}<a href="{{ inline_admin_form.absolute_url }}" class="viewsitelink">{% translate "View on site" %}</a>{% endif %}{% endif %}
-          {% if inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
-          {% if inline_admin_form.fk_field %}{{ inline_admin_form.fk_field.field }}{% endif %}
-        </td>
+        {% if inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
+        {% if inline_admin_form.fk_field %}{{ inline_admin_form.fk_field.field }}{% endif %}
         {% for fieldset in inline_admin_form %}
           {% for line in fieldset %}
             {% for field in line %}

--- a/tests/admin_inlines/admin.py
+++ b/tests/admin_inlines/admin.py
@@ -397,6 +397,7 @@ class TeacherAdmin(admin.ModelAdmin):
 
 class AuthorTabularInline(admin.TabularInline):
     model = Author
+    show_change_link = True
 
 
 class FashonistaStackedInline(admin.StackedInline):

--- a/tests/admin_inlines/admin.py
+++ b/tests/admin_inlines/admin.py
@@ -400,6 +400,11 @@ class AuthorTabularInline(admin.TabularInline):
     show_change_link = True
 
 
+class AuthorStackedInline(admin.StackedInline):
+    model = Author
+    show_change_link = True
+
+
 class FashonistaStackedInline(admin.StackedInline):
     model = Fashionista
 
@@ -538,3 +543,6 @@ site3 = admin.AdminSite(name="stacked_inline_hidden_field_in_group_admin")
 site3.register(SomeParentModel, inlines=[ChildHiddenFieldInFieldsGroupStackedInline])
 site4 = admin.AdminSite(name="stacked_inline_hidden_field_on_single_line_admin")
 site4.register(SomeParentModel, inlines=[ChildHiddenFieldOnSingleLineStackedInline])
+site5 = admin.AdminSite(name="admin5")
+site5.register(Person, inlines=[AuthorStackedInline])
+site5.register(Author, AuthorAdmin)

--- a/tests/admin_inlines/models.py
+++ b/tests/admin_inlines/models.py
@@ -45,9 +45,15 @@ class Book(models.Model):
 
 
 class Author(models.Model):
-    name = models.CharField(max_length=50)
+    name = models.CharField(max_length=1000)
     books = models.ManyToManyField(Book)
     person = models.OneToOneField("Person", models.CASCADE, null=True)
+
+    def __str__(self):
+        return self.name
+
+    def get_absolute_url(self):
+        return "/author/"
 
 
 class NonAutoPKBook(models.Model):

--- a/tests/admin_inlines/tests.py
+++ b/tests/admin_inlines/tests.py
@@ -1846,8 +1846,7 @@ class TestInlineWithFieldsets(TestDataMixin, TestCase):
             for y, inline_admin_form in enumerate(inline_admin_formset):
                 y_plus_one = y + 1
                 form_heading = (
-                    f'<h3><div><b>Photo:</b> <span class="inline_label">#{y_plus_one}'
-                    "</span></div></h3>"
+                    f'<h3><span class="inline_label">#{y_plus_one}</span></h3>'
                 )
                 self.assertContains(response, form_heading, html=True)
 
@@ -2596,7 +2595,7 @@ class SeleniumTests(AdminSeleniumTestCase):
         self.selenium.get(self.live_server_url + url)
 
         object_str = self.selenium.find_element(
-            By.CSS_SELECTOR, "fieldset.module div.inline-related h3 div"
+            By.CSS_SELECTOR, "fieldset.module div.inline-related h3 span"
         )
         links = self.selenium.find_elements(
             By.CSS_SELECTOR, "fieldset.module div.inline-related div.inline-links a"

--- a/tests/admin_inlines/tests.py
+++ b/tests/admin_inlines/tests.py
@@ -2572,7 +2572,7 @@ class SeleniumTests(AdminSeleniumTestCase):
         self.take_screenshot("tabular")
 
     @screenshot_cases(["desktop_size", "mobile_size", "rtl", "dark", "high_contrast"])
-    def test_long_title_with_tabular_inline_layout(self):
+    def test_long_title_with_inlines_layout(self):
         from selenium.webdriver.common.by import By
 
         person = Person.objects.create(firstname="Lee")
@@ -2591,3 +2591,17 @@ class SeleniumTests(AdminSeleniumTestCase):
         self.assertGreater(len(object_str.text), 100)
         self.assertEqual(len(links), 2)
         self.take_screenshot("tabular")
+
+        url = reverse("admin5:admin_inlines_person_change", args=(person.pk,))
+        self.selenium.get(self.live_server_url + url)
+
+        object_str = self.selenium.find_element(
+            By.CSS_SELECTOR, "fieldset.module div.inline-related h3 div"
+        )
+        links = self.selenium.find_elements(
+            By.CSS_SELECTOR, "fieldset.module div.inline-related div.inline-links a"
+        )
+        self.assertTrue(object_str.is_displayed())
+        self.assertGreater(len(object_str.text), 100)
+        self.assertEqual(len(links), 2)
+        self.take_screenshot("stacked")

--- a/tests/admin_inlines/tests.py
+++ b/tests/admin_inlines/tests.py
@@ -2570,3 +2570,24 @@ class SeleniumTests(AdminSeleniumTestCase):
         m2m_widget = self.selenium.find_element(By.CSS_SELECTOR, "div.selector")
         self.assertTrue(m2m_widget.is_displayed())
         self.take_screenshot("tabular")
+
+    @screenshot_cases(["desktop_size", "mobile_size", "rtl", "dark", "high_contrast"])
+    def test_long_title_with_tabular_inline_layout(self):
+        from selenium.webdriver.common.by import By
+
+        person = Person.objects.create(firstname="Lee")
+        Author.objects.create(name="very " + "long " * 30 + "title", person=person)
+        self.admin_login(username="super", password="secret")
+        url = reverse("admin:admin_inlines_person_change", args=(person.pk,))
+        self.selenium.get(self.live_server_url + url)
+
+        object_str = self.selenium.find_element(
+            By.CSS_SELECTOR, "fieldset.module tbody tr td.original p"
+        )
+        links = self.selenium.find_elements(
+            By.CSS_SELECTOR, "fieldset.module tbody tr td.original a"
+        )
+        self.assertTrue(object_str.is_displayed())
+        self.assertGreater(len(object_str.text), 100)
+        self.assertEqual(len(links), 2)
+        self.take_screenshot("tabular")

--- a/tests/admin_inlines/tests.py
+++ b/tests/admin_inlines/tests.py
@@ -1846,8 +1846,8 @@ class TestInlineWithFieldsets(TestDataMixin, TestCase):
             for y, inline_admin_form in enumerate(inline_admin_formset):
                 y_plus_one = y + 1
                 form_heading = (
-                    f'<h3><b>Photo:</b> <span class="inline_label">#{y_plus_one}</span>'
-                    "</h3>"
+                    f'<h3><div><b>Photo:</b> <span class="inline_label">#{y_plus_one}'
+                    "</span></div></h3>"
                 )
                 self.assertContains(response, form_heading, html=True)
 

--- a/tests/admin_inlines/urls.py
+++ b/tests/admin_inlines/urls.py
@@ -7,4 +7,5 @@ urlpatterns = [
     path("admin2/", admin.site2.urls),
     path("admin3/", admin.site3.urls),
     path("admin4/", admin.site4.urls),
+    path("admin5/", admin.site5.urls),
 ]


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36554

#### Branch description
I fixed TabularInline to prevent link truncation when the title is long.

### Before

<img width="1388" height="206" alt="Screenshot 2025-08-17 at 2 53 23 PM" src="https://github.com/user-attachments/assets/6fa4b902-ded4-4718-a1cf-61d7a15265ff" />

### After

<img width="951" height="351" alt="Screenshot 2025-08-30 at 7 41 00 PM" src="https://github.com/user-attachments/assets/b2fe1e2a-c108-41dc-b3c5-492070edb128" />

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
