### PR TITLE
Refs #36528 -- Fixed link underline typo in CSS.

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -130,7 +130,7 @@ a:not(
     #header a,
     #nav-sidebar a,
     #content-main.app-list a,
-    .object-tools a,
+    .object-tools a
 ) {
     text-decoration: underline;
 }


### PR DESCRIPTION
CSS for adding underlines does not work due to the trailing comma inside the `:not()` selector. This seems to have been introduced in this commit. --> 792ca14
