### PR TITLE
Fixed missing model import in tutorial_02

### DIFF
--- a/docs/intro/tutorial02.txt
+++ b/docs/intro/tutorial02.txt
@@ -353,7 +353,8 @@ your :setting:`INSTALLED_APPS`.
 Once you're in the shell, explore the :doc:`database API </topics/db/queries>`:
 
 .. code-block:: pycon
-
+    # Import the models so we can interact with the database.
+    >>> from polls.models import Question
     # No questions are in the system yet.
     >>> Question.objects.all()
     <QuerySet []>


### PR DESCRIPTION
#### Trac ticket number
N/A

#### Branch description
The tutorial in `docs/intro/tutorial02.txt` uses `Question.objects.all()` without first showing the required import `from polls.models import Question, Choice`. While experienced users may expect this, it can confuse beginners who are following the tutorial step by step.
This change adds the missing import statement with a clarifying comment to improve clarity and make the example self-contained:

```python
# Import the models so we can interact with the database.
from polls.models import Question
```

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.