### PR TITLE
Fixed #26329 -- Support leading slashes and backslashes on static URLs

### DIFF
--- a/django/contrib/staticfiles/storage.py
+++ b/django/contrib/staticfiles/storage.py
@@ -178,7 +178,7 @@ class HashedFilesMixin:
             if urlsplit(clean_name).path.endswith("/"):  # don't hash paths
                 hashed_name = name
             else:
-                args = (clean_name,)
+                args = (self.clean_name(clean_name).lstrip("/"),)
                 if hashed_files is not None:
                     args += (hashed_files,)
                 hashed_name = hashed_name_func(*args)

--- a/tests/staticfiles_tests/test_storage.py
+++ b/tests/staticfiles_tests/test_storage.py
@@ -368,6 +368,22 @@ class TestHashedFiles:
         self.assertEqual("Post-processing 'nonutf8.css' failed!\n\n", err.getvalue())
         self.assertPostCondition()
 
+    def test_leading_slash(self):
+        self.assertStaticRenders("/test/file.txt", "/static/test/file.dad0999e4f8f.txt")
+        self.assertStaticRenders(
+            "/test/file.txt", "/static/test/file.dad0999e4f8f.txt", asvar=True
+        )
+        self.assertStaticRenders(
+            "/cached/styles.css", "/static/cached/styles.5e0040571e1a.css"
+        )
+        self.assertStaticRenders("/path/", "/static/path/")
+        self.assertStaticRenders("/path/?query", "/static/path/?query")
+        self.assertPostCondition()
+
+    def test_backslash_separator(self):
+        self.assertStaticRenders(r"test\file.txt", "/static/test/file.dad0999e4f8f.txt")
+        self.assertPostCondition()
+
 
 @override_settings(
     STORAGES={


### PR DESCRIPTION
#### Trac ticket number
ticket-26329

#### Branch description
This picks up from #19309. It matchs the behaviour of the `{% static %}` tag when used with `StaticFilesStorage`/`FileSystemStorage` and with a leading forwardslash or a backslash in the path. These classes strip the leading forwardslash and replace the backslashes for forwardslashes. Leading to correct static paths for `/test/file.txt` and `test\file.txt`.

It is safer to only change the `_url` function to match the same replacements in `FileSystemStorage.url`. (Which are a little hidden between the body of the `url` function and the `filepath_to_uri` funciton.)

I'm not confident changing the functions hashed_name, stored_name and clean_name. They are used by the collectstatic post_process step in creating the staticfiles.json file and updating references in css files. I think best to leave them unchanged.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
