### PR TITLE
Fixed `#15759` - Excluded formset fields by per-object permissions

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -2022,6 +2022,30 @@ class ModelAdmin(BaseModelAdmin):
             return queryset
         return queryset.filter(pk__in=object_pks)
 
+    def _save_formset(self, request, formset):
+        changecount = 0
+        with transaction.atomic(using=router.db_for_write(self.model)):
+            for form in formset.forms:
+                if form.has_changed():
+                    obj = self.save_form(request, form, change=True)
+                    if obj._state.adding:
+                        raise BadRequest("list_editable does not allow adding.")
+                    self.save_model(request, obj, form, change=True)
+                    self.save_related(request, form, formsets=[], change=True)
+                    change_msg = self.construct_change_message(request, form, None)
+                    self.log_change(request, obj, change_msg)
+                    changecount += 1
+        if changecount:
+            msg = ngettext(
+                "%(count)s %(name)s was changed successfully.",
+                "%(count)s %(name)s were changed successfully.",
+                changecount,
+            ) % {
+                "count": changecount,
+                "name": model_ngettext(self.opts, changecount),
+            }
+            self.message_user(request, msg, messages.SUCCESS)
+
     @csrf_protect_m
     def changelist_view(self, request, extra_context=None):
         """
@@ -2115,30 +2139,7 @@ class ModelAdmin(BaseModelAdmin):
             )
             cl.formset = FormSet(request.POST, request.FILES, queryset=modified_objects)
             if cl.formset.is_valid():
-                changecount = 0
-                with transaction.atomic(using=router.db_for_write(self.model)):
-                    for form in cl.formset.forms:
-                        if form.has_changed():
-                            obj = self.save_form(request, form, change=True)
-                            if obj._state.adding:
-                                raise BadRequest("list_editable does not allow adding.")
-                            self.save_model(request, obj, form, change=True)
-                            self.save_related(request, form, formsets=[], change=True)
-                            change_msg = self.construct_change_message(
-                                request, form, None
-                            )
-                            self.log_change(request, obj, change_msg)
-                            changecount += 1
-                if changecount:
-                    msg = ngettext(
-                        "%(count)s %(name)s was changed successfully.",
-                        "%(count)s %(name)s were changed successfully.",
-                        changecount,
-                    ) % {
-                        "count": changecount,
-                        "name": model_ngettext(self.opts, changecount),
-                    }
-                    self.message_user(request, msg, messages.SUCCESS)
+                self._save_formset(request, cl.formset)
 
                 return HttpResponseRedirect(request.get_full_path())
 

--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -2022,10 +2022,27 @@ class ModelAdmin(BaseModelAdmin):
             return queryset
         return queryset.filter(pk__in=object_pks)
 
+    def _get_formset_with_permissions(self, request, queryset):
+        """
+        Construct a changelist formset, and remove list_editable fields
+        for objects the user cannot change.
+        """
+        FormSet = self.get_changelist_formset(request)
+        formset = FormSet(queryset=queryset)
+
+        for form in formset.forms:
+            if not self.has_change_permission(request, form.instance):
+                for field_name in self.list_editable:
+                    form.fields.pop(field_name, None)
+
+        return formset
+
     def _save_formset(self, request, formset):
         changecount = 0
         with transaction.atomic(using=router.db_for_write(self.model)):
             for form in formset.forms:
+                if not self.has_change_permission(request, form.instance):
+                    continue
                 if form.has_changed():
                     obj = self.save_form(request, form, change=True)
                     if obj._state.adding:
@@ -2145,8 +2162,7 @@ class ModelAdmin(BaseModelAdmin):
 
         # Handle GET -- construct a formset for display.
         elif cl.list_editable and self.has_change_permission(request):
-            FormSet = self.get_changelist_formset(request)
-            cl.formset = FormSet(queryset=cl.result_list)
+            cl.formset = self._get_formset_with_permissions(request, cl.result_list)
 
         # Build the list of media to be used by the formset.
         if cl.formset:

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -377,6 +377,17 @@ class ParentWithUUIDPKNoAddAdmin(admin.ModelAdmin):
         return False
 
 
+class PersonNoChangePermissionsAdmin9(admin.ModelAdmin):
+    list_display = ("name", "gender", "alive")
+    list_editable = ("gender", "alive")
+    ordering = ("id",)
+
+    def has_change_permission(self, request, obj=None):
+        if obj is None:
+            return True
+        return obj.id % 2 == 0
+
+
 class FooAccountAdmin(admin.StackedInline):
     model = FooAccount
     extra = 1
@@ -1491,6 +1502,7 @@ class ActorAdmin9(admin.ModelAdmin):
 site9 = admin.AdminSite(name="admin9")
 site9.register(Article, ArticleAdmin9)
 site9.register(Actor, ActorAdmin9)
+site9.register(Person, PersonNoChangePermissionsAdmin9)
 
 site10 = admin.AdminSite(name="admin10")
 site10.final_catch_all_view = False

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -5045,6 +5045,55 @@ class AdminViewListEditable(TestCase):
             1,
         )
 
+    def test_list_editable_per_object_permissions(self):
+        """
+        List_editable fields are stripped for objects where the user
+        lacks change permissions, and retained for objects where the user has
+        permissions.
+        """
+        self.client.logout()
+        self.client.force_login(self.superuser)
+
+        response = self.client.get(reverse("admin9:admin_views_person_changelist"))
+        # Editable fields present
+        self.assertContains(response, 'name="form-1-gender"')
+        self.assertContains(response, 'name="form-1-alive"')
+        # Non-editable fields should NOT have inputs
+        self.assertNotContains(response, 'name="form-0-gender"')
+        self.assertNotContains(response, 'name="form-0-alive"')
+        self.assertNotContains(response, 'name="form-2-gender"')
+        self.assertNotContains(response, 'name="form-2-alive"')
+
+    def test_list_editable_per_object_permissions_submission(self):
+        """
+        Form submission updates only objects where the user has
+        change permissions, ignoring changes to unauthorized objects.
+        """
+        self.client.logout()
+        self.client.force_login(self.superuser)
+
+        data = {
+            "form-TOTAL_FORMS": "3",
+            "form-INITIAL_FORMS": "3",
+            "form-MAX_NUM_FORMS": "0",
+            "form-0-gender": "2",  # Change per1 (not allowed)
+            "form-0-id": str(self.per1.pk),
+            "form-1-gender": "2",  # Change per2 (allowed)
+            "form-1-id": str(self.per2.pk),
+            "form-2-gender": "2",  # Change per3 (not allowed)
+            "form-2-id": str(self.per3.pk),
+            "_save": "Save",
+        }
+        response = self.client.post(
+            reverse("admin9:admin_views_person_changelist"), data, follow=True
+        )
+        # per2 and per3 were updated, but per1 was not
+        self.assertEqual(Person.objects.get(pk=self.per1.pk).gender, 1)  # Unchanged
+        self.assertEqual(Person.objects.get(pk=self.per2.pk).gender, 2)
+        self.assertEqual(Person.objects.get(pk=self.per3.pk).gender, 1)  # Unchanged
+        # Check for success message
+        self.assertEqual(len(response.context["messages"]), 1)
+
 
 @override_settings(ROOT_URLCONF="admin_views.urls")
 class AdminSearchTest(TestCase):


### PR DESCRIPTION
ticket-15759

Fixed handling of list_editable fields in the Django admin for objects with per-object permissions. Updated changelist formset logic to remove editable fields for objects the user cannot change, ensuring that form submissions only update permitted objects and preventing permission-related crashes.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
