### PR TITLE
Fixed #36251 -- Avoided mutating form Meta.fields in BaseInlineFormSet.

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -1131,8 +1131,7 @@ class BaseInlineFormSet(BaseModelFormSet):
         # Add the generated field to form._meta.fields if it's defined to make
         # sure validation isn't skipped on that field.
         if self.form._meta.fields and self.fk.name not in self.form._meta.fields:
-            if isinstance(self.form._meta.fields, tuple):
-                self.form._meta.fields = list(self.form._meta.fields)
+            self.form._meta.fields = list(self.form._meta.fields)
             self.form._meta.fields.append(self.fk.name)
 
     def initial_form_count(self):

--- a/tests/model_formsets/tests.py
+++ b/tests/model_formsets/tests.py
@@ -1685,9 +1685,10 @@ class ModelFormsetTest(TestCase):
 
             class Meta:
                 model = Book
-                fields = ("title",)
+                fields = ["title"]
 
         BookFormSet = inlineformset_factory(Author, Book, form=BookForm)
+        self.assertEqual(BookForm.Meta.fields, ["title"])
         data = {
             "book_set-TOTAL_FORMS": "3",
             "book_set-INITIAL_FORMS": "0",
@@ -1698,6 +1699,7 @@ class ModelFormsetTest(TestCase):
         }
         author = Author.objects.create(name="test")
         formset = BookFormSet(data, instance=author)
+        self.assertEqual(BookForm.Meta.fields, ["title"])
         self.assertEqual(
             formset.errors,
             [{}, {"__all__": ["Please correct the duplicate values below."]}, {}],


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36251

#### Branch description
BaseInlineFormSet was mutating a passed form class’s Meta.fields when it was a list, causing the FK field to leak into other usages. This change always copies Meta.fields before appending the FK, preserving the original form definition.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
