### PR TITLE
Fixed #36546 -- Deprecated `django.utils.crypto.constant_time_compare()` in favor of `hmac.compare_digest()`.

### DIFF
--- a/django/contrib/auth/hashers.py
+++ b/django/contrib/auth/hashers.py
@@ -2,6 +2,7 @@ import base64
 import binascii
 import functools
 import hashlib
+import hmac
 import importlib
 import math
 import warnings
@@ -12,12 +13,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.signals import setting_changed
 from django.dispatch import receiver
-from django.utils.crypto import (
-    RANDOM_STRING_CHARS,
-    constant_time_compare,
-    get_random_string,
-    pbkdf2,
-)
+from django.utils.crypto import RANDOM_STRING_CHARS, get_random_string, pbkdf2
 from django.utils.encoding import force_bytes, force_str
 from django.utils.module_loading import import_string
 from django.utils.translation import gettext_noop as _
@@ -349,7 +345,7 @@ class PBKDF2PasswordHasher(BasePasswordHasher):
     def verify(self, password, encoded):
         decoded = self.decode(encoded)
         encoded_2 = self.encode(password, decoded["salt"], decoded["iterations"])
-        return constant_time_compare(encoded, encoded_2)
+        return hmac.compare_digest(encoded, encoded_2)
 
     def safe_summary(self, encoded):
         decoded = self.decode(encoded)
@@ -533,7 +529,7 @@ class BCryptSHA256PasswordHasher(BasePasswordHasher):
         algorithm, data = encoded.split("$", 1)
         assert algorithm == self.algorithm
         encoded_2 = self.encode(password, data.encode("ascii"))
-        return constant_time_compare(encoded, encoded_2)
+        return hmac.compare_digest(encoded, encoded_2)
 
     def safe_summary(self, encoded):
         decoded = self.decode(encoded)
@@ -628,7 +624,7 @@ class ScryptPasswordHasher(BasePasswordHasher):
             decoded["block_size"],
             decoded["parallelism"],
         )
-        return constant_time_compare(encoded, encoded_2)
+        return hmac.compare_digest(encoded, encoded_2)
 
     def safe_summary(self, encoded):
         decoded = self.decode(encoded)
@@ -681,7 +677,7 @@ class MD5PasswordHasher(BasePasswordHasher):
     def verify(self, password, encoded):
         decoded = self.decode(encoded)
         encoded_2 = self.encode(password, decoded["salt"])
-        return constant_time_compare(encoded, encoded_2)
+        return hmac.compare_digest(encoded, encoded_2)
 
     def safe_summary(self, encoded):
         decoded = self.decode(encoded)

--- a/django/contrib/auth/tokens.py
+++ b/django/contrib/auth/tokens.py
@@ -1,7 +1,8 @@
+import hmac
 from datetime import datetime
 
 from django.conf import settings
-from django.utils.crypto import constant_time_compare, salted_hmac
+from django.utils.crypto import salted_hmac
 from django.utils.http import base36_to_int, int_to_base36
 
 
@@ -67,7 +68,7 @@ class PasswordResetTokenGenerator:
 
         # Check that the timestamp/uid has not been tampered with
         for secret in [self.secret, *self.secret_fallbacks]:
-            if constant_time_compare(
+            if hmac.compare_digest(
                 self._make_token_with_timestamp(user, ts, secret),
                 token,
             ):

--- a/django/core/signing.py
+++ b/django/core/signing.py
@@ -36,12 +36,13 @@ These functions make use of all of them.
 
 import base64
 import datetime
+import hmac
 import json
 import time
 import zlib
 
 from django.conf import settings
-from django.utils.crypto import constant_time_compare, salted_hmac
+from django.utils.crypto import salted_hmac
 from django.utils.encoding import force_bytes
 from django.utils.module_loading import import_string
 from django.utils.regex_helper import _lazy_re_compile
@@ -209,7 +210,7 @@ class Signer:
             raise BadSignature('No "%s" found in value' % self.sep)
         value, sig = signed_value.rsplit(self.sep, 1)
         for key in [self.key, *self.fallback_keys]:
-            if constant_time_compare(sig, self.signature(value, key)):
+            if hmac.compare_digest(sig, self.signature(value, key)):
                 return value
         raise BadSignature('Signature "%s" does not match' % sig)
 

--- a/django/middleware/csrf.py
+++ b/django/middleware/csrf.py
@@ -5,6 +5,7 @@ This module provides a middleware that implements protection
 against request forgeries from other sites.
 """
 
+import hmac
 import logging
 import string
 from collections import defaultdict
@@ -15,7 +16,7 @@ from django.core.exceptions import DisallowedHost, ImproperlyConfigured
 from django.http import HttpHeaders, UnreadablePostError
 from django.urls import get_callable
 from django.utils.cache import patch_vary_headers
-from django.utils.crypto import constant_time_compare, get_random_string
+from django.utils.crypto import get_random_string
 from django.utils.deprecation import MiddlewareMixin
 from django.utils.functional import cached_property
 from django.utils.http import is_same_domain
@@ -154,7 +155,7 @@ def _does_token_match(request_csrf_token, csrf_secret):
     if len(request_csrf_token) == CSRF_TOKEN_LENGTH:
         request_csrf_token = _unmask_cipher_token(request_csrf_token)
     assert len(request_csrf_token) == CSRF_SECRET_LENGTH
-    return constant_time_compare(request_csrf_token, csrf_secret)
+    return hmac.compare_digest(request_csrf_token, csrf_secret)
 
 
 class RejectRequest(Exception):

--- a/django/utils/crypto.py
+++ b/django/utils/crypto.py
@@ -5,8 +5,10 @@ Django's standard crypto functions and utilities.
 import hashlib
 import hmac
 import secrets
+import warnings
 
 from django.conf import settings
+from django.utils.deprecation import RemovedInDjango70Warning
 from django.utils.encoding import force_bytes
 
 
@@ -64,7 +66,12 @@ def get_random_string(length, allowed_chars=RANDOM_STRING_CHARS):
 
 def constant_time_compare(val1, val2):
     """Return True if the two strings are equal, False otherwise."""
-    return secrets.compare_digest(force_bytes(val1), force_bytes(val2))
+    warnings.warn(
+        "constant_time_compare() is deprecated. Use hmac.compare_digest() instead.",
+        RemovedInDjango70Warning,
+        stacklevel=2,
+    )
+    return hmac.compare_digest(val1, val2)
 
 
 def pbkdf2(password, salt, iterations, dklen=0, digest=None):

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -53,6 +53,8 @@ details on these changes.
 * The ``django.core.mail.forbid_multi_line_headers()`` and
   ``django.core.mail.message.sanitize_address()`` functions will be removed.
 
+* The ``django.utils.crypto.constant_time_compare()`` function will be removed.
+
 .. _deprecation-removed-in-6.1:
 
 6.1

--- a/docs/releases/6.0.txt
+++ b/docs/releases/6.0.txt
@@ -570,6 +570,9 @@ Miscellaneous
 * The undocumented ``django.core.mail.forbid_multi_line_headers()`` and
   ``django.core.mail.message.sanitize_address()`` functions are deprecated.
 
+* The ``django.utils.crypto.constant_time_compare()`` function is deprecated
+  because it is merely an alias of :py:func:`hmac.compare_digest`.
+
 Features removed in 6.0
 =======================
 

--- a/tests/utils_tests/test_crypto.py
+++ b/tests/utils_tests/test_crypto.py
@@ -2,21 +2,34 @@ import hashlib
 import unittest
 
 from django.test import SimpleTestCase
+from django.test.utils import ignore_warnings
 from django.utils.crypto import (
     InvalidAlgorithm,
     constant_time_compare,
     pbkdf2,
     salted_hmac,
 )
+from django.utils.deprecation import RemovedInDjango70Warning
 
 
 class TestUtilsCryptoMisc(SimpleTestCase):
+    # RemovedInDjango70Warning.
+    @ignore_warnings(category=RemovedInDjango70Warning)
     def test_constant_time_compare(self):
         # It's hard to test for constant time, just test the result.
         self.assertTrue(constant_time_compare(b"spam", b"spam"))
         self.assertFalse(constant_time_compare(b"spam", b"eggs"))
         self.assertTrue(constant_time_compare("spam", "spam"))
         self.assertFalse(constant_time_compare("spam", "eggs"))
+
+    def test_constant_time_compare_deprecated(self):
+        msg = (
+            "constant_time_compare() is deprecated. "
+            "Use hmac.compare_digest() instead."
+        )
+        with self.assertWarnsMessage(RemovedInDjango70Warning, msg) as ctx:
+            constant_time_compare(b"spam", b"spam")
+        self.assertEqual(ctx.filename, __file__)
 
     def test_salted_hmac(self):
         tests = [


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36546

#### Branch description
django.utils.crypto.constant_time_compare() is now just a duplicate wrapper around the standard library’s hmac.compare_digest(), so it is being deprecated in favor of using the standard function directly.


#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
