### PR TITLE
Refs #25706 -- Fixed versionadded admonition.

### DIFF
--- a/docs/ref/contrib/gis/forms-api.txt
+++ b/docs/ref/contrib/gis/forms-api.txt
@@ -157,7 +157,7 @@ Widget classes
 
     .. attribute:: base_layer
 
-       .. versionadded:: 6.0
+        .. versionadded:: 6.0
 
         ``nasaWorldview``
 


### PR DESCRIPTION
Currently, `nasaWorldview` is formatted as part of the admonition, see [docs](https://docs.djangoproject.com/en/dev/ref/contrib/gis/forms-api/#django.contrib.gis.forms.widgets.OpenLayersWidget.base_layer).

I think the fix here is to add space so that `versionadded` has the same indentation as `nasaWorldview`.

This is only visible on the website version of the docs. Viewing the html build locally adding this space means the `<div>` with the `versionadded` class no longer wraps the `<p>` containing `nasaWorldview`.


