### PR TITLE
Fixed #36561 -- Used request.auser() in contrib.auth.aupdate_session_a…

### DIFF
--- a/django/contrib/auth/__init__.py
+++ b/django/contrib/auth/__init__.py
@@ -408,5 +408,5 @@ def update_session_auth_hash(request, user):
 async def aupdate_session_auth_hash(request, user):
     """See update_session_auth_hash()."""
     await request.session.acycle_key()
-    if hasattr(user, "get_session_auth_hash") and request.user == user:
+    if hasattr(user, "get_session_auth_hash") and await request.auser() == user:
         await request.session.aset(HASH_SESSION_KEY, user.get_session_auth_hash())

--- a/tests/async/test_async_auth.py
+++ b/tests/async/test_async_auth.py
@@ -143,7 +143,11 @@ class AsyncAuthTest(TestCase):
         await self.client.alogin(username="testuser", password="testpw")
         request = HttpRequest()
         request.session = await self.client.asession()
-        request.user = self.test_user
+
+        async def auser():
+            return self.test_user
+
+        request.auser = auser
         await aupdate_session_auth_hash(request, self.test_user)
         user = await aget_user(request)
         self.assertIsInstance(user, User)


### PR DESCRIPTION
…uth_hash().

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36561

#### Branch description

In async context `contrib.auth.aupdate_session_auth_hash()` should use `request.auser()`.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
