### PR TITLE
Fixed #36559 -- Ignored partials embedded in verbatim or comment blocks in PartialTemplate.source.

### DIFF
--- a/django/template/base.py
+++ b/django/template/base.py
@@ -89,11 +89,6 @@ UNKNOWN_SOURCE = "<unknown source>"
 # than instantiating SimpleLazyObject with _lazy_re_compile().
 tag_re = re.compile(r"({%.*?%}|{{.*?}}|{#.*?#})")
 
-combined_partial_re = re.compile(
-    r"{%\s*partialdef\s+(?P<name>[\w-]+)(?:\s+inline)?\s*%}"
-    r"|{%\s*endpartialdef(?:\s+[\w-]+)?\s*%}"
-)
-
 logger = logging.getLogger("django.template")
 
 
@@ -301,29 +296,26 @@ class PartialTemplate:
     Wraps nodelist as a partial, in order to be able to bind context.
     """
 
-    def __init__(self, nodelist, origin, name):
+    def __init__(self, nodelist, origin, name, source_start=None, source_end=None):
         self.nodelist = nodelist
         self.origin = origin
         self.name = name
+        # If available (debug mode), the absolute character offsets in the
+        # template.source correspond to the full partial region.
+        self._source_start = source_start
+        self._source_end = source_end
 
     def get_exception_info(self, exception, token):
         template = self.origin.loader.get_template(self.origin.template_name)
         return template.get_exception_info(exception, token)
 
-    def find_partial_source(self, full_source, partial_name):
-        start_match = None
-        nesting = 0
-
-        for match in combined_partial_re.finditer(full_source):
-            if name := match["name"]:  # Opening tag.
-                if start_match is None and name == partial_name:
-                    start_match = match
-                if start_match is not None:
-                    nesting += 1
-            elif start_match is not None:
-                nesting -= 1
-                if nesting == 0:
-                    return full_source[start_match.start() : match.end()]
+    def find_partial_source(self, full_source):
+        if (
+            self._source_start is not None
+            and self._source_end is not None
+            and 0 <= self._source_start <= self._source_end <= len(full_source)
+        ):
+            return full_source[self._source_start : self._source_end]
 
         return ""
 
@@ -337,7 +329,7 @@ class PartialTemplate:
                 RuntimeWarning,
                 stacklevel=2,
             )
-        return self.find_partial_source(template.source, self.name)
+        return self.find_partial_source(template.source)
 
     def _render(self, context):
         return self.nodelist.render(context)

--- a/django/template/base.py
+++ b/django/template/base.py
@@ -53,6 +53,7 @@ times with multiple contexts)
 import inspect
 import logging
 import re
+import warnings
 from enum import Enum
 
 from django.template.context import BaseContext
@@ -329,6 +330,13 @@ class PartialTemplate:
     @property
     def source(self):
         template = self.origin.loader.get_template(self.origin.template_name)
+        if not template.engine.debug:
+            warnings.warn(
+                "PartialTemplate.source is only available when template "
+                "debugging is enabled.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
         return self.find_partial_source(template.source, self.name)
 
     def _render(self, context):

--- a/django/template/defaulttags.py
+++ b/django/template/defaulttags.py
@@ -1235,10 +1235,17 @@ def partialdef_func(parser, token):
 
     # Parse the content until the end tag.
     valid_endpartials = ("endpartialdef", f"endpartialdef {partial_name}")
+
+    pos_open = getattr(token, "position", None)
+    source_start = pos_open[0] if isinstance(pos_open, tuple) else None
+
     nodelist = parser.parse(valid_endpartials)
     endpartial = parser.next_token()
     if endpartial.contents not in valid_endpartials:
         parser.invalid_block_tag(endpartial, "endpartialdef", valid_endpartials)
+
+    pos_close = getattr(endpartial, "position", None)
+    source_end = pos_close[1] if isinstance(pos_close, tuple) else None
 
     # Store the partial nodelist in the parser.extra_data attribute.
     partials = parser.extra_data.setdefault("partials", {})
@@ -1247,7 +1254,13 @@ def partialdef_func(parser, token):
             f"Partial '{partial_name}' is already defined in the "
             f"'{parser.origin.name}' template."
         )
-    partials[partial_name] = PartialTemplate(nodelist, parser.origin, partial_name)
+    partials[partial_name] = PartialTemplate(
+        nodelist,
+        parser.origin,
+        partial_name,
+        source_start=source_start,
+        source_end=source_end,
+    )
 
     return PartialDefNode(partial_name, inline, nodelist)
 

--- a/tests/template_tests/utils.py
+++ b/tests/template_tests/utils.py
@@ -9,7 +9,7 @@ ROOT = os.path.dirname(os.path.abspath(__file__))
 TEMPLATE_DIR = os.path.join(ROOT, "templates")
 
 
-def setup(templates, *args, test_once=False):
+def setup(templates, *args, test_once=False, debug_only=False):
     """
     Runs test method multiple times in the following order:
 
@@ -54,11 +54,14 @@ def setup(templates, *args, test_once=False):
             self.engine = Engine(
                 libraries=libraries,
                 loaders=loaders,
+                debug=debug_only,
             )
             func(self)
             if test_once:
                 return
             func(self)
+            if debug_only:
+                return
 
             self.engine = Engine(
                 libraries=libraries,


### PR DESCRIPTION
Enhanced partial template handling in Django's template system. Introduced source offset tracking for partials in debug mode, allowing for more accurate error reporting and debugging. Updated `PartialTemplate` to accept source start and end positions, and modified the `find_partial_source` method to utilize these offsets when available. Added comprehensive tests to verify behavior in both debug and non-debug modes, ensuring correct functionality when partials are embedded in various template constructs.

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36559

#### Branch description
Provide a concise overview of the issue or rationale behind the proposed changes.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
