### PR TITLE
Fixed spelling of "logged-in" when used as an adjective in docs.

### DIFF
--- a/docs/ref/clickjacking.txt
+++ b/docs/ref/clickjacking.txt
@@ -15,7 +15,7 @@ have loaded in a hidden frame or iframe.
 An example of clickjacking
 ==========================
 
-Suppose an online store has a page where a logged in user can click "Buy Now" to
+Suppose an online store has a page where a logged-in user can click "Buy Now" to
 purchase an item. A user has chosen to stay logged into the store all the time
 for convenience. An attacker site might create an "I Like Ponies" button on one
 of their own pages, and load the store's page in a transparent iframe such that

--- a/docs/topics/cache.txt
+++ b/docs/topics/cache.txt
@@ -783,7 +783,7 @@ uniquely identify the cache fragment:
 
     {% load cache %}
     {% cache 500 sidebar request.user.username %}
-        .. sidebar for logged in user ..
+        .. sidebar for logged-in user ..
     {% endcache %}
 
 If :setting:`USE_I18N` is set to ``True`` the per-site middleware cache will

--- a/docs/topics/security.txt
+++ b/docs/topics/security.txt
@@ -75,7 +75,7 @@ control.
 
 :ref:`CSRF protection works <how-csrf-works>` by checking for a secret in each
 POST request. This ensures that a malicious user cannot "replay" a form POST to
-your website and have another logged in user unwittingly submit that form. The
+your website and have another logged-in user unwittingly submit that form. The
 malicious user would have to know the secret, which is user specific (using a
 cookie).
 


### PR DESCRIPTION
#### Trac ticket number
N/A

#### Branch description
Improve the security.txt grammar by converting ‘logged in’ to ‘logged-in’.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, ~~mentions the ticket number~~, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
