### PR TITLE
Corrected release notes of calling format_html() without arguments.

### DIFF
--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -628,8 +628,8 @@ Miscellaneous
 
 * ``FORMS_URLFIELD_ASSUME_HTTPS`` transitional setting is deprecated.
 
-* Support for calling ``format_html()`` without passing args or kwargs will be
-  removed.
+* Support for calling ``format_html()`` without passing args or kwargs is
+  deprecated.
 
 * Support for ``cx_Oracle`` is deprecated in favor of `oracledb`_ 1.3.2+ Python
   driver.


### PR DESCRIPTION
It was deprecated, not removed in Django 5.0.