### PR TITLE
Removed reference to flake8 file exclusions.

### DIFF
--- a/docs/internals/contributing/writing-code/coding-style.txt
+++ b/docs/internals/contributing/writing-code/coding-style.txt
@@ -46,11 +46,9 @@ Python style
 * Unless otherwise specified, follow :pep:`8`.
 
   Use :pypi:`flake8` to check for problems in this area. Note that our
-  ``.flake8`` file contains some excluded files (deprecated modules we don't
-  care about cleaning up and some third-party code that Django vendors) as well
-  as some excluded errors that we don't consider as gross violations. Remember
-  that :pep:`8` is only a guide, so respect the style of the surrounding code
-  as a primary goal.
+  ``.flake8`` file excludes some errors that we don't consider as gross
+  violations. Remember that :pep:`8` is only a guide, so respect the style of
+  the surrounding code as a primary goal.
 
   An exception to :pep:`8` is our rules on line lengths. We allow up to 88
   characters in code, as this is the line length used by ``black``.


### PR DESCRIPTION
The flake8 excludes at present look like:
```
exclude = build,.git,.tox,./tests/.env
```
which isn't worth mentioning in this guideline doc.

Obsolete since 41384812efe209c8295a50d78b45e0ffb2992436. (six was removed in 9285926295fbfc86b70e7be8d595d4cfbe7895b8.)