### PR TITLE
Refs #36520 -- Only passed header value for parsing on multi-part forms

### DIFF
--- a/django/http/multipartparser.py
+++ b/django/http/multipartparser.py
@@ -721,11 +721,10 @@ def parse_boundary_stream(stream, max_header_size):
 
     # Eliminate blank lines
     for line in header.split(b"\r\n"):
-        # This terminology ("main value" and "dictionary of
-        # parameters") is from the Python docs.
         try:
-            main_value_pair, params = parse_header_parameters(line.decode())
-            name, value = main_value_pair.split(":", 1)
+            header_name, value_and_params = line.decode().split(":", 1)
+            name = header_name.lower().rstrip(" ")
+            value, params = parse_header_parameters(value_and_params.lstrip(" "))
             params = {k: v.encode() for k, v in params.items()}
         except ValueError:  # Invalid header.
             continue


### PR DESCRIPTION
#### Trac ticket number

Semi-related to ticket-36520

#### Branch description

Parsing should only be done on the value. The implementation happens to work, but shouldn't depend on that working.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
