### PR TITLE
Updated the minor stylistic changes for cleaner code

### DIFF
--- a/django/template/backends/base.py
+++ b/django/template/backends/base.py
@@ -39,8 +39,7 @@ class BaseEngine:
 
         This method is optional.
         """
-        raise NotImplementedError(
-            "subclasses of BaseEngine should provide a from_string() method"
+        raise NotImplementedError("get_template() must be implemented by subclasses")
         )
 
     def get_template(self, template_name):
@@ -49,8 +48,7 @@ class BaseEngine:
 
         Raise TemplateDoesNotExist if no such template exists.
         """
-        raise NotImplementedError(
-            "subclasses of BaseEngine must provide a get_template() method"
+        raise NotImplementedError("get_template() must be implemented by subclasses")
         )
 
     # Utility methods: they are provided to minimize code duplication and


### PR DESCRIPTION
Changes on django/template/backends/base.py for tracking purpose
raise NotImplementedError(
    "subclasses of BaseEngine must provide a get_template() method"
    
 Changes on:
For a minor stylistic changes for cleaner code
# proposed changes:

raise NotImplementedError("get_template() must be implemented by subclasses")
