### PR TITLE
Update request.py

### DIFF
--- a/django/http/request.py
+++ b/django/http/request.py
@@ -202,7 +202,7 @@ class HttpRequest:
                 msg += (
                     " The domain name provided is not valid according to RFC 1034/1035."
                 )
-            raise DisallowedHost(msg)
+            raise BadRequest(msg)
 
     def get_port(self):
         """Return the port number for the request as a string."""


### PR DESCRIPTION
Now days, there are spiders scanning many kinds of host names. 

*.yourdomain.com will cause lots of DisallowedHost errors which will send out thousands of emails to admin.

Use BadRequest will keep silent.

For example:
http://1.2.178.27_www.a.yourdomain.com:8004/sitemap.xml



 
