### PR TITLE
Refs #35967 -- Removed deprecation note from backwards incompatible changes in 6.0 release notes.

### DIFF
--- a/docs/releases/6.0.txt
+++ b/docs/releases/6.0.txt
@@ -396,9 +396,6 @@ Database backend API
 This section describes changes that may be needed in third-party database
 backends.
 
-* ``BaseDatabaseCreation.create_test_db(serialize)`` is deprecated. Use
-  ``serialize_db_to_string()`` instead.
-
 * :class:`~django.db.backends.base.schema.BaseDatabaseSchemaEditor` and
   PostgreSQL backends no longer use ``CASCADE`` when dropping a column.
 


### PR DESCRIPTION
Ref. https://github.com/django/django/pull/19745#discussion_r2293838460