### PR TITLE
Fixed #36549 -- Doc'd use of OpenLayersWidget and OSMWidget with CSP.

### DIFF
--- a/docs/ref/contrib/gis/forms-api.txt
+++ b/docs/ref/contrib/gis/forms-api.txt
@@ -169,11 +169,32 @@ Widget classes
 
         ``3857``
 
-    ``OpenLayersWidget`` and :class:`OSMWidget` use the ``ol.js`` file hosted
-    on the ``cdn.jsdelivr.net`` content-delivery network. You can subclass
-    these widgets in order to specify your own version of the ``ol.js`` file in
-    the ``js`` property of the inner ``Media`` class (see
+    ``OpenLayersWidget`` and :class:`OSMWidget` include the ``ol.js`` and
+    ``ol.css`` files hosted on the ``cdn.jsdelivr.net`` content-delivery
+    network. These files can be overridden by subclassing the widget and
+    setting the ``js`` and ``css`` properties of the inner ``Media`` class (see
     :ref:`assets-as-a-static-definition`).
+
+    .. admonition:: External assets with CSP
+
+        When :class:`~django.middleware.csp.ContentSecurityPolicyMiddleware` is
+        enabled, the default OpenLayers CDN assets (``ol.js`` and ``ol.css``)
+        will be blocked unless explicitly allowed. This can be addressed in one
+        of two ways: **serve assets locally** by subclassing the widget and
+        provide local copies of the JavaScript and CSS files, or
+        **allow the CDN in the CSP policy**.
+
+        For example, to allow the default NASA Worldview base layer (replace
+        ``x.y.z`` with the actual version)::
+
+            from django.utils.csp import CSP
+
+            SECURE_CSP = {
+                "default-src": [CSP.SELF],
+                "script-src": [CSP.SELF, "https://cdn.jsdelivr.net/npm/ol@x.y.z/dist/ol.js"],
+                "style-src": [CSP.SELF, "https://cdn.jsdelivr.net/npm/ol@x.y.z/ol.css"],
+                "img-src": [CSP.SELF, "https://*.earthdata.nasa.gov"],
+            }
 
 ``OSMWidget``
 
@@ -198,9 +219,22 @@ Widget classes
 
         The default map zoom is ``12``.
 
-    The :class:`OpenLayersWidget` note about JavaScript file hosting above also
-    applies here. See also this `FAQ answer`_ about ``https`` access to map
-    tiles.
+    The :class:`OpenLayersWidget` note about using external assets also applies
+    here. See also this `FAQ answer`_ about ``https`` access to map tiles.
+
+    .. admonition:: OpenStreetMap tiles with CSP
+
+        This widget uses OpenStreetMap tiles instead of NASA Worldview. If
+        :ref:`security-csp` enabled, both the OpenLayers CDN resources (as
+        required by :class:`OpenLayersWidget`) and the OpenStreetMap tile
+        servers must be allowed::
+
+            from django.utils.csp import CSP
+
+            SECURE_CSP = {
+                # other directives
+                "img-src": [CSP.SELF, "https://tile.openstreetmap.org"],
+            }
 
     .. _FAQ answer: https://help.openstreetmap.org/questions/10920/how-to-embed-a-map-in-my-https-site
 


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36549

#### Branch description
The discussion on the ticket and related forum [thread](https://forum.djangoproject.com/t/csp-and-geodjango/41879) discussed that addional CSP rules are required for the `OpenLayersWidget` resources to be loaded. Discussion also went on to say that the current version is somewhat outdated. This patch therefore, covers a few things:

- Update OpenLayers to a more recent version.
- Vendored the OpenLayers `.css` and `.js` files. These can then be served by the django admin in the same way as Select2 and so on and means we can avoid neededing to add `"script-src"` and `"style-src"` rules for `https://cdn.jsdelivr.net/...`. I sourced the vendored files from https://github.com/openlayers/openlayers/releases/tag/v10.6.0
- Customised the `.js` file to add a version to that file. Hopefully that will make it clearer in future which version is currently being used. This is similar to the note that's at the top of the `select2.full.min.js` file.
- Even with vendoring OpenLayers access is still required for the map tile server. Therefore a note is added for the two widgets that an `img-src` directive is required. 

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
