### PR TITLE
Fixed #36431 -- Returned tuples for multi-column `ForeignObject` in `values()`/`values_list()`.

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -2269,8 +2269,21 @@ class Query(BaseExpression):
                     join_info.joins,
                     join_info.path,
                 )
-                for target in targets:
-                    cols.append(join_info.transform_function(target, final_alias))
+                if len(targets) > 1:
+                    transformed_targets = [
+                        join_info.transform_function(target, final_alias)
+                        for target in targets
+                    ]
+                    cols.append(
+                        ColPairs(
+                            final_alias if self.alias_cols else None,
+                            [col.target for col in transformed_targets],
+                            [col.output_field for col in transformed_targets],
+                            join_info.final_field,
+                        )
+                    )
+                else:
+                    cols.append(join_info.transform_function(targets[0], final_alias))
             if cols:
                 self.set_select(cols)
         except MultiJoin:

--- a/docs/releases/5.2.6.txt
+++ b/docs/releases/5.2.6.txt
@@ -10,4 +10,6 @@ Django 5.2.6 fixes a security issue with severity "high" and several bugs in
 Bugfixes
 ========
 
-* ...
+* Fixed a bug where using ``QuerySet.values()`` or ``values_list()`` with a
+  ``ForeignObject`` composed of multiple fields returned incorrect results
+  instead of tuples of the referenced fields (:ticket:`36431`).

--- a/tests/composite_pk/test_values.py
+++ b/tests/composite_pk/test_values.py
@@ -3,7 +3,7 @@ from uuid import UUID
 
 from django.test import TestCase
 
-from .models import Post, Tenant, User
+from .models import Comment, Post, Tenant, User
 
 
 class CompositePKValuesTests(TestCase):
@@ -210,3 +210,17 @@ class CompositePKValuesTests(TestCase):
                     {"pk": self.user_3.pk, "id": self.user_3.id},
                 ),
             )
+
+    def test_foreign_object_values(self):
+        Comment.objects.create(id=1, user=self.user_1, integer=42)
+        testcases = {
+            "all": Comment.objects.all(),
+            "exclude_user_email": Comment.objects.exclude(user__email__endswith="net"),
+        }
+        for name, queryset in testcases.items():
+            with self.subTest(name=name):
+                values = list(queryset.values("user", "integer"))
+                self.assertEqual(
+                    values[0]["user"], (self.user_1.tenant_id, self.user_1.id)
+                )
+                self.assertEqual(values[0]["integer"], 42)


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36431

#### Branch description
Thanks to @jacobtylerwalls and @charettes  for the tests.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
