### PR TITLE
Fixed #35548 -- Fixed data leakage when setUpTestData() fails without transaction support.

### DIFF
--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -7,7 +7,7 @@ import sys
 import threading
 import unittest
 from collections import Counter
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from copy import copy, deepcopy
 from difflib import get_close_matches
 from functools import wraps
@@ -1153,6 +1153,11 @@ class TransactionTestCase(SimpleTestCase):
         try:
             cls._fixture_setup()
         except Exception:
+            # Attempt to teardown fixtures on exception during setup as
+            # _post_teardown won't be triggered to cleanup state when an
+            # an exception is surfaced to SimpleTestCase._pre_setup.
+            with suppress(Exception):
+                cls("setUp")._fixture_teardown()
             if cls.available_apps is not None:
                 apps.unset_available_apps()
                 setting_changed.send(


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35548

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
