### PR TITLE
Refs #15727 -- Captured failed request log in test_csp.py.

### DIFF
--- a/tests/middleware/test_csp.py
+++ b/tests/middleware/test_csp.py
@@ -100,7 +100,8 @@ class CSPMiddlewareTest(SimpleTestCase):
         """
         Test that the CSP headers are not added to the debug view.
         """
-        response = self.client.get("/csp-500/")
+        with self.assertLogs("django.request", "WARNING"):
+            response = self.client.get("/csp-500/")
         self.assertNotIn(CSP.HEADER_ENFORCE, response)
         self.assertNotIn(CSP.HEADER_REPORT_ONLY, response)
 


### PR DESCRIPTION
***Before***
```
./runtests.py middleware.test_csp
```
```
System check identified no issues (0 silenced).
sInternal Server Error: /csp-500/
........
----------------------------------------------------------------------
Ran 9 tests in 0.320s

OK (skipped=1)
```
***After***
```
System check identified no issues (0 silenced).
s........
----------------------------------------------------------------------
Ran 9 tests in 0.341s

```