### PR TITLE
Clarified description of Version attribute in Trac.

### DIFF
--- a/docs/internals/contributing/triaging-tickets.txt
+++ b/docs/internals/contributing/triaging-tickets.txt
@@ -234,8 +234,12 @@ majority of tickets have a severity of "Normal".
 Version
 -------
 
-It is possible to use the *version* attribute to indicate in which
-version the reported bug was identified.
+The *version* attribute indicates the version in which the bug was reproduced.
+During triage, it is helpful to update this field to the earliest supported
+version that reproduces the issue, but there is no need to make further updates
+when that version goes out of support. Avoid resetting the version to "dev"
+merely to indicate the issue still exists. Instead, reference the commit hash
+you tested in a comment.
 
 UI/UX
 -----


### PR DESCRIPTION
When triaging, I've never been sure how to use the version field in Trac. I believe I've seen issues affecting main and 4.2 be be bumped from 4.2 -> dev or from dev -> 4.2 by triagers. It would be nice to settle on a practice and doc it.

I polled the current fellows today, and it seems the highest value from this field is being able to filter on release blockers for a version, e.g. 5.2, and so for that purpose, it helps for the version to be set to the earliest supported version.

Clarified this below.
Left a couple notes to discourage:
- noisy updates from 4.2 -> 5.2 after 4.2 goes out of support
- unnecessary updates to "dev"