### PR TITLE
Fixed #36573 -- Allowed expressions as valid field defaults in fields.E010 system check.

### DIFF
--- a/django/db/models/fields/mixins.py
+++ b/django/db/models/fields/mixins.py
@@ -42,6 +42,7 @@ class CheckFieldDefaultMixin:
             self.has_default()
             and self.default is not None
             and not callable(self.default)
+            and not hasattr(self.default, "as_sql")
         ):
             return [
                 checks.Warning(

--- a/tests/invalid_models_tests/test_ordinary_fields.py
+++ b/tests/invalid_models_tests/test_ordinary_fields.py
@@ -1069,6 +1069,14 @@ class JSONFieldTests(TestCase):
 
         self.assertEqual(Model._meta.get_field("field").check(), [])
 
+    def test_valid_expression_default(self):
+        class Model(models.Model):
+            field = models.JSONField(
+                default=models.Value({"k": "v"}, models.JSONField())
+            )
+
+        self.assertEqual(Model._meta.get_field("field").check(), [])
+
 
 @isolate_apps("invalid_models_tests")
 class DbCommentTests(TestCase):


### PR DESCRIPTION


#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36573

Should allow `default=JSONNull()` on JSONField once ticket-35381 is fixed and the current `default=Value(None, JSONField())`.

#### Branch description

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
