### PR TITLE
Fixed incorrect IDs in test_in_bulk_preserve_ordering.

### DIFF
--- a/tests/lookup/tests.py
+++ b/tests/lookup/tests.py
@@ -250,8 +250,8 @@ class LookupTests(TestCase):
 
     def test_in_bulk_preserve_ordering(self):
         self.assertEqual(
-            list(Article.objects.in_bulk([self.au2.id, self.au1.id])),
-            [self.au2.id, self.au1.id],
+            list(Article.objects.in_bulk([self.a2.id, self.a1.id])),
+            [self.a2.id, self.a1.id],
         )
 
     def test_in_bulk_preserve_ordering_with_batch_size(self):


### PR DESCRIPTION
`au` objects are authors, not articles. Failure observed on MongoDB after d3cf24e9b415b41f570c9f426b2cd113b5fdb4de which removed the skipping of this test.