### PR TITLE
changed yesno filter to return string for invalid args

### DIFF
--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -878,7 +878,7 @@ def yesno(value, arg=None):
         arg = gettext("yes,no,maybe")
     bits = arg.split(",")
     if len(bits) < 2:
-        return value  # Invalid arg.
+        bits = "yes,no,maybe".split(",")  # Fallback to default.
     try:
         yes, no, maybe = bits
     except ValueError:

--- a/tests/template_tests/filter_tests/test_yesno.py
+++ b/tests/template_tests/filter_tests/test_yesno.py
@@ -36,6 +36,6 @@ class FunctionTests(SimpleTestCase):
         self.assertEqual(yesno(None, "certainly,get out of town,perhaps"), "perhaps")
 
     def test_invalid_value(self):
-        self.assertIs(yesno(True, "yes"), True)
-        self.assertIs(yesno(False, "yes"), False)
-        self.assertIsNone(yesno(None, "yes"))
+        self.assertEqual(yesno(True, "yes"), "yes")
+        self.assertEqual(yesno(False, "yes"), "no")
+        self.assertEqual(yesno(None, "yes"), "maybe")


### PR DESCRIPTION
#### Trac ticket number

ticket-36579

#### Branch description

As per the ticket: breaking your method signature (in this case: an implied signature) because part of the inputs are malformed is just madness.

It also happens to break when the translation (which contains this `args` input) does not nicely split on `,`, as is currently the case for e.g. simplified Chinese.

This PR is a partial fix for that: at least it patches up the behavior of `yesno`

it does not:

* fix the translations
* ensure that the problem does not re-occur in the future.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
