### PR TITLE
Fixed #36526 -- Doc'd QuerySet.bulk_update() memory usage when batching.

### DIFF
--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -2506,6 +2506,21 @@ them, but it has a few caveats:
 * If updating a large number of columns in a large number of rows, the SQL
   generated can be very large. Avoid this by specifying a suitable
   ``batch_size``.
+* When updating a large number of objects, be aware that ``bulk_update()``
+  prepares all of the ``WHEN`` clauses for every object across all batches
+  before executing any queries. This can require more memory than expected. To
+  reduce memory usage, you can use an approach like this::
+
+    from itertools import islice
+
+    batch_size = 100
+    ids_iter = range(1000)
+    while ids := list(islice(ids_iter, batch_size)):
+        batch = Entry.objects.filter(ids__in=ids)
+        for entry in batch:
+            entry.headline = f"Updated headline {entry.pk}"
+        Entry.objects.bulk_update(batch, ["headline"], batch_size=batch_size)
+
 * Updating fields defined on multi-table inheritance ancestors will incur an
   extra query per ancestor.
 * When an individual batch contains duplicates, only the first instance in that


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36526

#### Branch description
Tangential follow up to 52aa26e6979ba81b00f1593d5ee8c5c73aaa6391.

#### Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant docs, including release notes if applicable.
