### PR TITLE
Fixed #36508 -- Interpreted __iexact=None on KeyTransforms as __exact=None.

### DIFF
--- a/django/db/models/fields/json.py
+++ b/django/db/models/fields/json.py
@@ -665,7 +665,19 @@ class KeyTransformExact(JSONExact):
 class KeyTransformIExact(
     CaseInsensitiveMixin, KeyTransformTextLookupMixin, lookups.IExact
 ):
-    pass
+    can_use_none_as_rhs = True
+
+    def as_sql(self, compiler, connection):
+        if self.rhs is None:
+            # Interpret __iexact=None on KeyTextTransform as __exact=None on
+            # KeyTransform.
+            keytransform = KeyTransform(self.lhs.key_name, self.lhs.lhs)
+            exact_lookup = keytransform.get_lookup("exact")(keytransform, self.rhs)
+            # Delegate to the backend vendor method, if it exists.
+            vendor = connection.vendor
+            as_vendor = getattr(exact_lookup, f"as_{vendor}", exact_lookup.as_sql)
+            return as_vendor(compiler, connection)
+        return super().as_sql(compiler, connection)
 
 
 class KeyTransformIContains(

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -400,6 +400,11 @@ Miscellaneous
 
 * The minimum supported version of SQLite is increased from 3.31.0 to 3.37.0.
 
+* The :lookup:`iexact=None <iexact>` lookup on
+  :class:`~django.db.models.JSONField` key transforms now matches JSON
+  ``null``, to match the behavior of :lookup:`exact=None <exact>` on key
+  transforms. Previously, it was interpreted as an :lookup:`isnull` lookup.
+
 .. _deprecated-features-6.1:
 
 Features deprecated in 6.1

--- a/tests/model_fields/test_jsonfield.py
+++ b/tests/model_fields/test_jsonfield.py
@@ -782,6 +782,12 @@ class TestQuerying(TestCase):
             [self.objs[4]],
         )
 
+    def test_key_iexact_none(self):
+        self.assertSequenceEqual(
+            NullableJSONModel.objects.filter(value__j__iexact=None),
+            [self.objs[4]],
+        )
+
     def test_none_key_exclude(self):
         obj = NullableJSONModel.objects.create(value={"j": 1})
         if connection.vendor == "oracle":


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36508

#### Branch description
Matches expectations by reserving the use of `None` in key transform lookups for JSON null.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
