### PR TITLE
Refs #36485 -- Corrected docs linter to detect too-long lines at file end.

### DIFF
--- a/docs/lint.py
+++ b/docs/lint.py
@@ -96,7 +96,7 @@ def check_line_too_long_django(file, lines, options=None):
                     continue
             except IndexError:
                 # End of file
-                continue
+                pass
             if len(set(line.strip())) == 1 and len(line) == len(lines[lno - 1]):
                 continue  # Ignore heading underline
             if lno in table_rows:

--- a/docs/releases/1.8.11.txt
+++ b/docs/releases/1.8.11.txt
@@ -5,4 +5,5 @@ Django 1.8.11 release notes
 *March 5, 2016*
 
 Django 1.8.11 fixes a regression on Python 2 in the 1.8.10 security release
-where ``utils.http.is_safe_url()`` crashes on bytestring URLs (:ticket:`26308`).
+where ``utils.http.is_safe_url()`` crashes on bytestring URLs
+(:ticket:`26308`).

--- a/docs/releases/1.9.4.txt
+++ b/docs/releases/1.9.4.txt
@@ -5,4 +5,5 @@ Django 1.9.4 release notes
 *March 5, 2016*
 
 Django 1.9.4 fixes a regression on Python 2 in the 1.9.3 security release
-where ``utils.http.is_safe_url()`` crashes on bytestring URLs (:ticket:`26308`).
+where ``utils.http.is_safe_url()`` crashes on bytestring URLs
+(:ticket:`26308`).


### PR DESCRIPTION
Noticed that the terrific linter from #19549 was not catching too-long lines if it was the last line of the file.

See passing CI run for [long line](https://github.com/django/django/blob/076cf8137615630cd600971415c22dc9cdc13d2e/docs/releases/5.2.6.txt) in #19771.