### PR TITLE
Removed invalid deprecation note in 6.0 release notes.

### DIFF
--- a/docs/releases/6.0.txt
+++ b/docs/releases/6.0.txt
@@ -583,9 +583,6 @@ Miscellaneous
 * The undocumented ``django.core.mail.forbid_multi_line_headers()`` and
   ``django.core.mail.message.sanitize_address()`` functions are deprecated.
 
-* The ``django.utils.crypto.constant_time_compare()`` function is deprecated
-  because it is merely an alias of :func:`hmac.compare_digest`.
-
 Features removed in 6.0
 =======================
 


### PR DESCRIPTION
Mistakenly added in 3c0c54351b58e9386375d2bd7a8c60dadc4bb6e8, maybe that's why it wasn't properly reverted?


