### PR TITLE
Removed unused import in docs/ref/models/expressions.txt example.

### DIFF
--- a/docs/ref/models/expressions.txt
+++ b/docs/ref/models/expressions.txt
@@ -1220,7 +1220,6 @@ values. It will return the first column or value that isn't ``NULL``.
 We'll start by defining the template to be used for SQL generation and
 an ``__init__()`` method to set some attributes::
 
-  import copy
   from django.db.models import Expression
 
 


### PR DESCRIPTION
copying is done by `self.copy()`