### PR TITLE
Fixed #36580 -- Fixed constraint validation crash when condition uses a `ForeignObject`.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1310,7 +1310,7 @@ class Model(AltersData, metaclass=ModelBase):
         meta = meta or self._meta
         field_map = {}
         generated_fields = []
-        for field in meta.local_concrete_fields:
+        for field in meta.local_fields:
             if field.name in exclude:
                 continue
             if field.generated:

--- a/tests/composite_pk/models/tenant.py
+++ b/tests/composite_pk/models/tenant.py
@@ -48,6 +48,14 @@ class Comment(models.Model):
     text = models.TextField(default="", blank=True)
     integer = models.IntegerField(default=0)
 
+    class Meta:
+        constraints = [
+            models.CheckConstraint(
+                condition=models.Q(user__isnull=False),
+                name="user_not_null",
+            ),
+        ]
+
 
 class Post(models.Model):
     pk = models.CompositePrimaryKey("tenant_id", "id")

--- a/tests/composite_pk/test_models.py
+++ b/tests/composite_pk/test_models.py
@@ -119,7 +119,7 @@ class CompositePKModelsTests(TestCase):
                 self.assertSequenceEqual(ctx.exception.messages, messages)
 
     def test_full_clean_update(self):
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(4):
             self.comment_1.full_clean()
 
     def test_field_conflicts(self):

--- a/tests/composite_pk/tests.py
+++ b/tests/composite_pk/tests.py
@@ -205,12 +205,17 @@ class CompositePKTests(TestCase):
             self.assertEqual(user.email, self.user.email)
 
     def test_select_related(self):
-        Comment.objects.create(tenant=self.tenant, id=2)
+        user2 = User.objects.create(
+            tenant=self.tenant,
+            id=2,
+            email="user0002@example.com",
+        )
+        Comment.objects.create(tenant=self.tenant, id=2, user=user2)
         with self.assertNumQueries(1):
             comments = list(Comment.objects.select_related("user").order_by("pk"))
             self.assertEqual(len(comments), 2)
             self.assertEqual(comments[0].user, self.user)
-            self.assertIsNone(comments[1].user)
+            self.assertEqual(comments[1].user, user2)
 
     def test_model_forms(self):
         fields = ["tenant", "id", "user_id", "text", "integer"]


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36580

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
