### PR TITLE
Fixed #36584 -- Fixed RHS subquery cardinality check to allow ForeignObject selection

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1249,12 +1249,11 @@ class Query(BaseExpression):
 
     @property
     def _subquery_fields_len(self):
-        if self.has_select_fields:
-            return sum(
-                len(self.model._meta.pk_fields) if field == "pk" else 1
-                for field in self.selected
-            )
-        return len(self.model._meta.pk_fields)
+        if not self.has_select_fields or not self.select:
+            return len(self.model._meta.pk_fields)
+        return len(self.select) + sum(
+            len(expr.targets) - 1 for expr in self.select if isinstance(expr, ColPairs)
+        )
 
     def resolve_expression(self, query, *args, **kwargs):
         clone = self.clone()

--- a/tests/composite_pk/test_filter.py
+++ b/tests/composite_pk/test_filter.py
@@ -460,6 +460,11 @@ class CompositePKFilterTests(TestCase):
         queryset = User.objects.filter(comments__in=subquery)
         self.assertSequenceEqual(queryset, (self.user_2,))
 
+    def test_filter_comments_by_users_subquery(self):
+        subquery = Comment.objects.filter(id=3).values("user")
+        queryset = Comment.objects.filter(user__in=subquery)
+        self.assertSequenceEqual(queryset, (self.comment_3,))
+
     def test_cannot_cast_pk(self):
         msg = "Cast expression does not support composite primary keys."
         with self.assertRaisesMessage(ValueError, msg):


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36584

#### Branch description
Fix tuple lookup failures in RHS subqueries selecting a multi-column ForeignObject by computing cardinality from physical columns (ColPairs) instead of selected item count.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
