### PR TITLE
Fixed #36264 -- Excluded proxy neighbors of parents from deletion collection when keep_parents=True.

### DIFF
--- a/django/db/models/deletion.py
+++ b/django/db/models/deletion.py
@@ -309,7 +309,10 @@ class Collector:
         protected_objects = defaultdict(list)
         for related in get_candidate_relations_to_delete(model._meta):
             # Preserve parent reverse relationships if keep_parents=True.
-            if keep_parents and related.model in model._meta.all_parents:
+            if (
+                keep_parents
+                and related.model._meta.concrete_model in model._meta.all_parents
+            ):
                 continue
             field = related.field
             on_delete = field.remote_field.on_delete

--- a/tests/delete/models.py
+++ b/tests/delete/models.py
@@ -241,3 +241,20 @@ class GenericDeleteBottomParent(models.Model):
     generic_delete_bottom = models.ForeignKey(
         GenericDeleteBottom, on_delete=models.CASCADE
     )
+
+
+class Foo(models.Model):
+    pass
+
+
+class Bar(Foo):
+    pass
+
+
+class Baz(Foo):
+    class Meta:
+        proxy = True
+
+
+class BazItem(models.Model):
+    baz = models.ForeignKey("Baz", on_delete=models.CASCADE)

--- a/tests/delete/tests.py
+++ b/tests/delete/tests.py
@@ -14,7 +14,10 @@ from .models import (
     A,
     Avatar,
     B,
+    Bar,
     Base,
+    Baz,
+    BazItem,
     Child,
     DeleteBottom,
     DeleteTop,
@@ -674,6 +677,15 @@ class DeletionTests(TestCase):
                     ctx.captured_queries[0]["sql"],
                 )
                 signal.disconnect(receiver, sender=Referrer)
+
+    def test_keep_parents_does_not_delete_proxy_related(self):
+        bar = Bar.objects.create()
+        baz = Baz.objects.get(pk=bar.pk)
+        BazItem.objects.create(baz=baz)
+
+        self.assertEqual(BazItem.objects.count(), 1)
+        bar.delete(keep_parents=True)
+        self.assertEqual(BazItem.objects.count(), 1)
 
 
 class FastDeleteTests(TestCase):


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36264

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
