### PR TITLE
Fixed #36434 -- Preserved unbuffered stdio (-u) in autoreloader child.

### DIFF
--- a/django/utils/autoreload.py
+++ b/django/utils/autoreload.py
@@ -268,6 +268,19 @@ def trigger_reload(filename):
 
 def restart_with_reloader():
     new_environ = {**os.environ, DJANGO_AUTORELOAD_ENV: "true"}
+    orig = getattr(sys, "orig_argv", ())
+    if any(
+        (arg == "-u")
+        or (
+            arg.startswith("-")
+            and not arg.startswith(("--", "-X", "-W"))
+            and len(arg) > 2
+            and arg[1:].isalpha()
+            and "u" in arg
+        )
+        for arg in orig[1:]
+    ):
+        new_environ.setdefault("PYTHONUNBUFFERED", "1")
     args = get_child_arguments()
     while True:
         p = subprocess.run(args, env=new_environ, close_fds=False)

--- a/tests/utils_tests/test_autoreload.py
+++ b/tests/utils_tests/test_autoreload.py
@@ -535,6 +535,53 @@ class RestartWithReloaderTests(SimpleTestCase):
                 [self.executable, "-Wall", "-m", "django"] + argv[1:],
             )
 
+    def test_propagates_unbuffered_from_parent(self):
+        for args in ("-u", "-Iuv"):
+            with self.subTest(args=args):
+                with mock.patch.dict(os.environ, {}, clear=True):
+                    with tempfile.TemporaryDirectory() as d:
+                        script = Path(d) / "manage.py"
+                        script.touch()
+                        mock_call = self.patch_autoreload([str(script), "runserver"])
+                        with (
+                            mock.patch("__main__.__spec__", None),
+                            mock.patch.object(
+                                autoreload.sys,
+                                "orig_argv",
+                                [self.executable, args, str(script), "runserver"],
+                            ),
+                        ):
+                            autoreload.restart_with_reloader()
+                    env = mock_call.call_args.kwargs["env"]
+                    self.assertEqual(env.get("PYTHONUNBUFFERED"), "1")
+
+    def test_does_not_propagate_unbuffered_from_parent(self):
+        for args in (
+            "-Xdev",
+            "-Xfaulthandler",
+            "--user",
+            "-Wall",
+            "-Wdefault",
+            "-Wignore::UserWarning",
+        ):
+            with self.subTest(args=args):
+                with mock.patch.dict(os.environ, {}, clear=True):
+                    with tempfile.TemporaryDirectory() as d:
+                        script = Path(d) / "manage.py"
+                        script.touch()
+                        mock_call = self.patch_autoreload([str(script), "runserver"])
+                        with (
+                            mock.patch("__main__.__spec__", None),
+                            mock.patch.object(
+                                autoreload.sys,
+                                "orig_argv",
+                                [self.executable, args, str(script), "runserver"],
+                            ),
+                        ):
+                            autoreload.restart_with_reloader()
+                    env = mock_call.call_args.kwargs["env"]
+                    self.assertIsNone(env.get("PYTHONUNBUFFERED"))
+
 
 class ReloaderTests(SimpleTestCase):
     RELOADER_CLS = None


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36434

#### Branch description
Fixed loss of unbuffered stdio (-u) after autoreload by detecting -u in sys.orig_argv and setting PYTHONUNBUFFERED=1 for the child process.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
