### PR TITLE
Fixed #35706 -- Improved accessibility of admin errornote and updated new feature.

### DIFF
--- a/django/contrib/admin/helpers.py
+++ b/django/contrib/admin/helpers.py
@@ -74,6 +74,12 @@ class AdminForm:
             )
 
     @property
+    def has_field_error(self):
+        return any(
+            field.errors() for fieldset in self for line in fieldset for field in line
+        )
+
+    @property
     def errors(self):
         return self.form.errors
 
@@ -378,6 +384,10 @@ class InlineAdminFormSet:
                 model_admin=self.opts,
             )
 
+    @property
+    def has_error(self):
+        return any(form.has_error for form in self) or self.non_form_errors()
+
     def fields(self):
         fk = getattr(self.formset, "fk", None)
         empty_form = self.formset.empty_form
@@ -500,6 +510,16 @@ class InlineAdminForm(AdminForm):
                 model_admin=self.model_admin,
                 **options,
             )
+
+    @property
+    def has_field_error(self):
+        return any(
+            field.errors() for fieldset in self for line in fieldset for field in line
+        )
+
+    @property
+    def has_error(self):
+        return self.has_field_error or self.form.non_field_errors()
 
     def needs_explicit_pk_field(self):
         return (

--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -33,6 +33,14 @@ html[data-theme="light"],
     --border-color: #ccc;
 
     --error-fg: #ba2121;
+    --error-note-section-bg: #fee1e1;
+    --error-note-section-border-color: #f26868;
+    --error-note-info-bg: #fff7eb;
+    --error-note-info-border-color: #f2a950;
+    --error-note-inline-border-color: #ed8936;
+    --error-note-link-border-color: #f56565;
+    --error-note-link-hover-bg: #fafdff;
+    --error-note-link-hover-border-color: #c8d1db;
 
     --message-debug-bg: #efefef;
     --message-debug-icon: url(../img/icon-debug.svg);
@@ -690,13 +698,100 @@ ul.messagelist li.error {
     font-weight: 700;
     display: block;
     padding: 10px 12px;
-    margin: 0 0 10px 0;
+    margin: 2rem 0;
     color: var(--error-fg);
-    border: 1px solid var(--error-fg);
+    border: 2px solid var(--error-fg);
+    border-left: 6px solid var(--error-fg);
     border-radius: 4px;
     background-color: var(--body-bg);
     background-position: 5px 12px;
     overflow-wrap: break-word;
+}
+
+.errornote h2 {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin: 0 0 16px 0;
+}
+
+.errornote .group {
+    margin: 20px 0 12px 0;
+    padding: 8px 12px;
+    background: var(--error-note-section-bg);
+    border-radius: 4px;
+    border-left: 4px solid var(--error-note-section-border-color);
+}
+
+.errornote .group h3 {
+    font-size: 1.1rem;
+    font-weight: 500;
+    color: var(--error-fg);
+}
+
+.errornote ul.errorlist {
+    padding: 12px;
+    margin: 8px 0;
+    background: transparent;
+}
+
+.errornote h3 > ul.errorlist.nonfield,
+.errornote h3 > ul.errorlist.nonform,
+.errornote div.inline h4 > ul.errorlist.nonfield {
+    background-color: var(--error-note-info-bg);
+    border: 1px solid var(--error-note-info-border-color);
+    border-radius: 4px;
+    font-weight: 500;
+}
+
+.errornote .group div.inline {
+    margin: 15px 0 9px 0;
+    padding: 8px 12px;
+    border: 1px solid var(--error-note-inline-border-color);
+    border-left: 4px solid var(--error-note-inline-border-color);
+    border-radius: 4px;
+    background-color: var(--body-bg);
+}
+
+.errornote .group div.inline h4 {
+    font-size: 0.9rem;
+    color: var(--error-fg);
+    margin-bottom: 0;
+}
+
+.errornote ul.errorlist li a {
+    display: inline-block;
+    position: relative;
+    box-sizing: border-box;
+    width: 100%;
+    padding: 8px 12px;
+    border: 1px solid var(--error-note-link-border-color);
+    border-left: 4px solid var(--error-note-link-border-color);
+    border-radius: 4px;
+    transition: all 0.2s ease;
+    background: var(--body-bg);
+}
+
+.errornote ul.errorlist li + li {
+    margin-top: 8px;
+}
+
+.errornote ul.errorlist li a:hover {
+    background-color: var(--error-note-link-hover-bg);
+    border-color: var(--error-note-link-hover-border-color);
+    transform: translateX(2px);
+}
+
+.errornote ul.errorlist li a::after {
+    content: '→';
+    position: absolute;
+    right: 8px;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+}
+
+.errornote ul.errorlist a:hover::after,
+.errornote ul.errorlist a:focus::after {
+    opacity: 1;
 }
 
 ul.errorlist {

--- a/django/contrib/admin/static/admin/css/dark_mode.css
+++ b/django/contrib/admin/static/admin/css/dark_mode.css
@@ -20,6 +20,14 @@
       --border-color: #353535;
   
       --error-fg: #e35f5f;
+      --error-note-section-bg: #400202;
+      --error-note-section-border-color: #f28080;
+      --error-note-info-bg: #2e1c00;
+      --error-note-info-border-color: #f2b56b;
+      --error-note-inline-border-color: #f5a15d;
+      --error-note-link-border-color: #eb7878;
+      --error-note-link-hover-bg: #000000;
+      --error-note-link-hover-border-color: #4a4a4a;
 
       --message-debug-bg: #4e4e4e;
       --message-debug-icon: url(../img/icon-debug-dark.svg);
@@ -65,6 +73,14 @@ html[data-theme="dark"] {
     --border-color: #353535;
 
     --error-fg: #e35f5f;
+    --error-note-section-bg: #2b0303;
+    --error-note-section-border-color: #f28080;
+    --error-note-info-bg: #2e1c00;
+    --error-note-info-border-color: #f2b56b;
+    --error-note-inline-border-color: #f5a15d;
+    --error-note-link-border-color: #eb7878;
+    --error-note-link-hover-bg: #000000;
+    --error-note-link-hover-border-color: #4a4a4a;
 
     --message-debug-bg: #4e4e4e;
     --message-debug-icon: url(../img/icon-debug-dark.svg);

--- a/django/contrib/admin/templates/admin/auth/user/change_password.html
+++ b/django/contrib/admin/templates/admin/auth/user/change_password.html
@@ -20,16 +20,16 @@
 </div>
 {% endblock %}
 {% endif %}
+
+{% block pretitle %}
+{% include 'admin/errornote.html' with errors=form.errors form=form %}
+{% endblock %}
+
 {% block content %}<div id="content-main">
 <form{% if form_url %} action="{{ form_url }}"{% endif %} method="post" id="{{ opts.model_name }}_form">{% csrf_token %}{% block form_top %}{% endblock %}
 <input type="text" name="username" value="{{ original.get_username }}" class="hidden">
 <div>
 {% if is_popup %}<input type="hidden" name="{{ is_popup_var }}" value="1">{% endif %}
-{% if form.errors %}
-    <p class="errornote">
-    {% blocktranslate count counter=form.errors.items|length %}Please correct the error below.{% plural %}Please correct the errors below.{% endblocktranslate %}
-    </p>
-{% endif %}
 
 <p>{% blocktranslate with username=original %}Enter a new password for the user <strong>{{ username }}</strong>.{% endblocktranslate %}</p>
 {% if not form.user.has_usable_password %}

--- a/django/contrib/admin/templates/admin/change_form.html
+++ b/django/contrib/admin/templates/admin/change_form.html
@@ -24,6 +24,79 @@
 {% endblock %}
 {% endif %}
 
+{% block pretitle %}
+  {% block errornote %}
+  {% if errors %}
+    {% translate 'The following fields have errors:' as field_error_title %}
+    <div class="errornote" role="alert" aria-labelledby="error-summary-title" tabindex="-1">
+      <h2 id="error-summary-title">
+        {% translate 'There is a problem' %}
+      </h2>
+      {% if adminform.has_field_error or adminform.non_field_errors %}
+      <div class="group">
+        <h3>
+          <span>{{ opts.verbose_name|capfirst }}</span>
+          {{ adminform.form.non_field_errors }}
+        </h3>
+        {% if adminform.has_field_error %}
+        <p>{{ field_error_title }}</p>
+        <ul class="errorlist">
+          {% for fieldset in adminform %}
+            {% for line in fieldset %}
+              {% for field in line %}
+                {% if field.errors %}
+                  <li>
+                    <a href="#{{ field.field.id_for_label }}">{{ field.field.label }}</a>
+                  </li>
+                {% endif %}
+              {% endfor %}
+            {% endfor %}
+          {% endfor %}
+        </ul>
+        {% endif %}
+      </div>
+      {% endif %}
+      {% for inline_admin_formset in inline_admin_formsets %}
+        {% if inline_admin_formset.has_error %}
+        <div class="group">
+        <h3>
+          <span>{% if inline_admin_formset.formset.max_num == 1 %}{{ inline_admin_formset.opts.verbose_name|capfirst }}{% else %}{{ inline_admin_formset.opts.verbose_name_plural|capfirst }}{% endif %}</span>
+          {{ inline_admin_formset.formset.non_form_errors }}
+        </h3>
+        {% endif %}
+        {% for inline_admin_form in inline_admin_formset %}
+        {% if not forloop.last %}
+          {% if inline_admin_form.has_error %}
+          <div class="inline">
+            <h4>
+              <span>{% if inline_admin_form.original %}{{ inline_admin_form.original }}{% else %}{{ inline_admin_formset.opts.verbose_name|capfirst }}: #{{ forloop.counter }}{% endif %}</span>
+              {{ inline_admin_form.form.non_field_errors }}
+            </h4>
+            {% if inline_admin_form.has_field_error %}
+            <p>{{ field_error_title }}</p>
+            <ul class="errorlist">
+            {% for fieldset in inline_admin_form %}
+              {% for line in fieldset %}
+                {% for field in line %}
+                  {% if field.errors %}
+                    <li><a href="#{{ field.field.id_for_label }}">{{ field.field.label }}</a></li>
+                  {% endif %}
+                {% endfor %}
+              {% endfor %}
+            {% endfor %}
+            </ul>
+            {% endif %}
+          </div>
+          {% endif %}
+        {% endif %}
+        {% endfor %}
+        </div>
+      {% endfor %}
+    </div>
+  {% endif %}
+  {% endblock %}
+{% endblock %}
+
 {% block content %}<div id="content-main">
 {% block object-tools %}
 {% if change and not is_popup %}
@@ -38,13 +111,8 @@
 <div>
 {% if is_popup %}<input type="hidden" name="{{ is_popup_var }}" value="1">{% endif %}
 {% if to_field %}<input type="hidden" name="{{ to_field_var }}" value="{{ to_field }}">{% endif %}
+{{ adminform.form.non_field_errors }}
 {% if save_on_top %}{% block submit_buttons_top %}{% submit_row %}{% endblock %}{% endif %}
-{% if errors %}
-    <p class="errornote">
-    {% blocktranslate count counter=errors|length %}Please correct the error below.{% plural %}Please correct the errors below.{% endblocktranslate %}
-    </p>
-    {{ adminform.form.non_field_errors }}
-{% endif %}
 
 {% block field_sets %}
 {% for fieldset in adminform %}

--- a/django/contrib/admin/templates/admin/change_list.html
+++ b/django/contrib/admin/templates/admin/change_list.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n admin_urls static admin_list %}
+{% load i18n admin_urls static admin_list admin_form %}
 
 {% block title %}{% if cl.formset and cl.formset.errors %}{% translate "Error:" %} {% endif %}{{ block.super }}{% endblock %}
 {% block extrastyle %}
@@ -37,6 +37,43 @@
 {% endblock %}
 {% endif %}
 
+{% block pretitle %}
+{% if cl.formset and cl.formset.errors %}
+{% translate 'The following fields have errors:' as field_error_title %}
+<div class="errornote" role="alert" aria-labelledby="error-summary-title" tabindex="-1">
+  <h2 id="error-summary-title">
+    {% translate 'There is a problem' %}
+  </h2>
+  <div class="group">
+    <h3>
+      <span>{% if cl.formset.max_num == 1 %}{{ cl.opts.verbose_name|capfirst }}{% else %}{{ cl.opts.verbose_name_plural|capfirst }}{% endif %}</span>
+      {{ inline_admin_formset.formset.non_form_errors }}
+    </h3>
+    {% for form in cl.formset %}
+      {% if form.errors %}
+      <div class="inline">
+        <h4>
+          <span>{{ cl.opts.verbose_name|capfirst }}: #{{ forloop.counter }}</span>
+          {{ form.non_field_errors }}
+        </h4>
+        {% if form|has_field_errors %}
+        <p>{{ field_error_title }}</p>
+        <ul class="errorlist">
+          {% for field in form %}
+            {% if field.errors %}
+              <li><a href="#{{ field.id_for_label }}">{{ field.label }}</a></li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+        {% endif %}
+      </div>
+      {% endif %}
+    {% endfor %}
+  </div>
+</div>
+{% endif %}
+{% endblock %}
+
 {% block coltype %}{% endblock %}
 
 {% block content %}
@@ -48,12 +85,6 @@
           {% endblock %}
         </ul>
     {% endblock %}
-    {% if cl.formset and cl.formset.errors %}
-        <p class="errornote">
-        {% blocktranslate count counter=cl.formset.total_error_count %}Please correct the error below.{% plural %}Please correct the errors below.{% endblocktranslate %}
-        </p>
-        {{ cl.formset.non_form_errors }}
-    {% endif %}
     <div class="module{% if cl.has_filters %} filtered{% endif %}" id="changelist">
       <div class="changelist-form-container">
         {% block filters %}

--- a/django/contrib/admin/templates/admin/errornote.html
+++ b/django/contrib/admin/templates/admin/errornote.html
@@ -1,0 +1,28 @@
+{% load i18n admin_form %}
+
+{% if errors %}
+  {% translate 'The following fields have errors:' as field_error_title %}
+  <div class="errornote" role="alert" aria-labelledby="error-summary-title" tabindex="-1">
+    <h2 id="error-summary-title">
+      {% translate 'There is a problem' %}
+    </h2>
+    {% if form.errors %}
+    <div class="group">
+      <h3>
+        <span>{{ opts.verbose_name|capfirst }}</span>
+        {{ form.non_field_errors }}
+      </h3>
+      {% if form|has_field_errors %}
+      <p>{{ field_error_title }}</p>
+      <ul class="errorlist">
+        {% for field in form %}
+          {% if field.errors %}
+          <li><a href="#{{ field.id_for_label }}">{{ field.label }}</a></li>
+          {% endif %}
+        {% endfor %}
+      </ul>
+      {% endif %}
+    </div>
+    {% endif %}
+  </div>
+{% endif %}

--- a/django/contrib/admin/templates/registration/password_change_form.html
+++ b/django/contrib/admin/templates/registration/password_change_form.html
@@ -18,16 +18,14 @@
 </div>
 {% endblock %}
 
+{% block pretitle %}
+{% include 'admin/errornote.html' with errors=form.errors form=form %}
+{% endblock %}
+
 {% block content %}<div id="content-main">
 
 <form method="post">{% csrf_token %}
 <div>
-{% if form.errors %}
-    <p class="errornote">
-    {% blocktranslate count counter=form.errors.items|length %}Please correct the error below.{% plural %}Please correct the errors below.{% endblocktranslate %}
-    </p>
-{% endif %}
-
 
 <p>{% translate 'Please enter your old password, for security’s sake, and then enter your new password twice so we can verify you typed it in correctly.' %}</p>
 

--- a/django/contrib/admin/templates/registration/password_reset_confirm.html
+++ b/django/contrib/admin/templates/registration/password_reset_confirm.html
@@ -10,6 +10,10 @@
 </div>
 {% endblock %}
 
+{% block pretitle %}
+{% include 'admin/errornote.html' with errors=form.errors form=form %}
+{% endblock %}
+
 {% block content %}
 
 {% if validlink %}

--- a/django/contrib/admin/templates/registration/password_reset_form.html
+++ b/django/contrib/admin/templates/registration/password_reset_form.html
@@ -10,6 +10,10 @@
 </div>
 {% endblock %}
 
+{% block pretitle %}
+{% include 'admin/errornote.html' with errors=form.errors form=form %}
+{% endblock %}
+
 {% block content %}
 
 <p>{% translate 'Forgotten your password? Enter your email address below, and we’ll email instructions for setting a new one.' %}</p>

--- a/django/contrib/admin/templatetags/admin_form.py
+++ b/django/contrib/admin/templatetags/admin_form.py
@@ -1,0 +1,8 @@
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def has_field_errors(form):
+    return any(field.errors for field in form)


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35706

#### Branch description

Continue [PR](https://github.com/django/django/pull/18537)... 
Thanks to the previous work @sanjeevholla26 , and special thanks to @sarahboyce for suggesting this improvement.

I improved the accessibility of the errornote and updated a new feature.
(It is more detailed than before and provides a significant improvement in terms of UX.)

## After

### Change Form

#### Light

<img width="1377" height="279" alt="Screenshot 2025-09-02 at 4 28 44 PM" src="https://github.com/user-attachments/assets/589cbb3b-3874-4513-870b-36433b8c3de3" />

#### Dark

<img width="1388" height="289" alt="Screenshot 2025-09-02 at 4 32 58 PM" src="https://github.com/user-attachments/assets/64e32cc1-1b3b-4f87-9560-d30c58f8a9f4" />

### Inline Form

#### Light

<img width="1360" height="703" alt="Screenshot 2025-09-02 at 4 31 41 PM" src="https://github.com/user-attachments/assets/8654af85-396b-4e32-80a8-9763b9108daa" />

#### Dark

<img width="1381" height="707" alt="Screenshot 2025-09-02 at 4 33 20 PM" src="https://github.com/user-attachments/assets/a2be2d8f-4c25-4050-b965-4842b9541e30" />


#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
