### PR TITLE
Fixed #36593 -- Deprecated QuerySet.select_related() with no arguments.

### DIFF
--- a/django/contrib/admin/checks.py
+++ b/django/contrib/admin/checks.py
@@ -1082,6 +1082,9 @@ class ModelAdminChecks(BaseModelAdminChecks):
 
         if not isinstance(obj.list_select_related, (bool, list, tuple)):
             return must_be(
+                # RemovedInDjango70Warning: when the deprecation ends, replace:
+                # "a tuple, list, or False",
+                # and also update docs/ref/checks.txt.
                 "a boolean, tuple or list",
                 option="list_select_related",
                 obj=obj,

--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -2,6 +2,7 @@ import copy
 import enum
 import json
 import re
+import warnings
 from functools import partial, update_wrapper
 from urllib.parse import parse_qsl
 from urllib.parse import quote as urlquote
@@ -58,6 +59,7 @@ from django.http.response import HttpResponseBase
 from django.template.response import SimpleTemplateResponse, TemplateResponse
 from django.urls import reverse
 from django.utils.decorators import method_decorator
+from django.utils.deprecation import RemovedInDjango70Warning, django_file_prefixes
 from django.utils.html import format_html
 from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
@@ -676,6 +678,18 @@ class ModelAdmin(BaseModelAdmin):
     actions_selection_counter = True
     checks_class = ModelAdminChecks
 
+    def __init_subclass__(cls, **kwargs) -> None:
+        super().__init_subclass__(**kwargs)
+        if cls.__dict__.get("list_select_related") is True:
+            # RemovedInDjango70Warning: when the deprecation ends, raise a
+            # ValueError.
+            warnings.warn(
+                "Setting ModelAdmin.list_select_related to True is deprecated. "
+                "Use False or a list or tuple of fields to fetch instead.",
+                RemovedInDjango70Warning,
+                skip_file_prefixes=django_file_prefixes(),
+            )
+
     def __init__(self, model, admin_site):
         self.model = model
         self.opts = model._meta
@@ -860,6 +874,17 @@ class ModelAdmin(BaseModelAdmin):
             list_display = ["action_checkbox", *list_display]
         sortable_by = self.get_sortable_by(request)
         ChangeList = self.get_changelist(request)
+        list_select_related = self.get_list_select_related(request)
+        if list_select_related is True:
+            # RemovedInDjango70Warning: when the deprecation ends, remove the
+            # below 'if' clause and raise a ValueError here.
+            if self.list_select_related is not True:
+                warnings.warn(
+                    "Returning True from ModelAdmin.get_list_select_related() is "
+                    "deprecated. Return False or a list or tuple of fields to "
+                    "fetch instead.",
+                    RemovedInDjango70Warning,
+                )
         return ChangeList(
             request,
             self.model,
@@ -868,7 +893,7 @@ class ModelAdmin(BaseModelAdmin):
             self.get_list_filter(request),
             self.date_hierarchy,
             self.get_search_fields(request),
-            self.get_list_select_related(request),
+            list_select_related,
             self.list_per_page,
             self.list_max_show_all,
             self.list_editable,

--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -2332,7 +2332,7 @@ class ModelAdmin(BaseModelAdmin):
                 object_id=unquote(object_id),
                 content_type=get_content_type_for_model(model),
             )
-            .select_related()
+            .select_related("user", "content_type")
             .order_by("action_time")
         )
 

--- a/django/contrib/admin/views/main.py
+++ b/django/contrib/admin/views/main.py
@@ -529,25 +529,28 @@ class ChangeList:
             return qs.select_related()
 
         if self.list_select_related is False:
-            if self.has_related_field_in_list_display():
-                return qs.select_related()
+            if fields := self.get_select_related_fields():
+                return qs.select_related(*fields)
 
         if self.list_select_related:
             return qs.select_related(*self.list_select_related)
         return qs
 
-    def has_related_field_in_list_display(self):
+    def get_select_related_fields(self):
+        fields = []
         for field_name in self.list_display:
             try:
                 field = self.lookup_opts.get_field(field_name)
             except FieldDoesNotExist:
                 pass
             else:
-                if isinstance(field.remote_field, ManyToOneRel):
+                if (
+                    isinstance(field.remote_field, ManyToOneRel)
                     # <FK>_id field names don't require a join.
-                    if field_name != field.attname:
-                        return True
-        return False
+                    and field_name != field.attname
+                ):
+                    fields.append(field_name)
+        return fields
 
     def url_for_result(self, result):
         pk = getattr(result, self.pk_attname)

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -37,7 +37,7 @@ from django.db.models.utils import (
     resolve_callables,
 )
 from django.utils import timezone
-from django.utils.deprecation import RemovedInDjango70Warning
+from django.utils.deprecation import RemovedInDjango70Warning, django_file_prefixes
 from django.utils.functional import cached_property
 
 # The maximum number of results to fetch in a get() query.
@@ -1774,6 +1774,14 @@ class QuerySet(AltersData):
         elif fields:
             obj.query.add_select_related(fields)
         else:
+            # RemovedInDjango70Warning: when the deprecation ends, raise a
+            # TypeError instead.
+            warnings.warn(
+                "Calling select_related() with no arguments is deprecated. "
+                "Specify the fields to fetch instead.",
+                category=RemovedInDjango70Warning,
+                skip_file_prefixes=django_file_prefixes(),
+            )
             obj.query.select_related = True
         return obj
 

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -85,6 +85,9 @@ details on these changes.
   ``django.core.signing.base64_hmac()`` will change from ``"sha1"`` to
   ``"sha256"``.
 
+* :meth:`.QuerySet.select_related` will raise :exc:`TypeError` if passed
+  ``True`` rather than :exc:`AttributeError`.
+
 .. _deprecation-removed-in-6.1:
 
 6.1

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -88,6 +88,12 @@ details on these changes.
 * :meth:`.QuerySet.select_related` will raise :exc:`TypeError` if passed
   ``True`` rather than :exc:`AttributeError`.
 
+* :class:`.ModelAdmin` will raise :exc:`ValueError` if subclassed with its
+  :attr:`.list_select_related` attribute set to ``True``.
+
+* :class:`.ModelAdmin` will raise :exc:`ValueError` if its
+  :meth:`.get_list_select_related` method returns ``True``.
+
 .. _deprecation-removed-in-6.1:
 
 6.1

--- a/docs/misc/design-philosophies.txt
+++ b/docs/misc/design-philosophies.txt
@@ -126,9 +126,9 @@ optimize statements internally.
 This is why developers need to call ``save()`` explicitly, rather than the
 framework saving things behind the scenes silently.
 
-This is also why the ``select_related()`` ``QuerySet`` method exists. It's an
-optional performance booster for the common case of selecting "every related
-object."
+This is also why the ``FETCH_PEERS`` :doc:`fetch mode </topics/db/fetch-modes>`
+exists. It's an optional performance booster for the common case of selecting
+related objects for every peer in a ``QuerySet``.
 
 Terse, powerful syntax
 ----------------------

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -961,6 +961,11 @@ subclass::
     If you need to specify a dynamic value based on the request, you can
     implement a :meth:`~ModelAdmin.get_list_select_related` method.
 
+    .. deprecated:: 6.1
+
+        Using ``True`` for ``list_select_related`` is deprecated. Use a list or
+        tuple of field names instead.
+
     .. note::
 
         ``ModelAdmin`` ignores this attribute when
@@ -1629,6 +1634,11 @@ default templates used by the :class:`ModelAdmin` views:
     The ``get_list_select_related`` method is given the ``HttpRequest`` and
     should return a boolean or list as :attr:`ModelAdmin.list_select_related`
     does.
+
+    .. deprecated:: 6.1
+
+        Returning ``True`` is deprecated. Return a list or tuple of field names
+        instead.
 
 .. method:: ModelAdmin.get_search_fields(request)
 

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -1136,13 +1136,6 @@ is defined. Instead of specifying the field name, use the :attr:`related_name
 <django.db.models.ForeignKey.related_name>` for the field on the related
 object.
 
-There may be some situations where you wish to call ``select_related()`` with a
-lot of related objects, or where you don't know all of the relations. In these
-cases it is possible to call ``select_related()`` with no arguments. This will
-follow all non-null foreign keys it can find - nullable foreign keys must be
-specified. This is not recommended in most cases as it is likely to make the
-underlying query more complex, and return more data, than is actually needed.
-
 If you need to clear the list of related fields added by past calls of
 ``select_related`` on a ``QuerySet``, you can pass ``None`` as a parameter:
 
@@ -1153,6 +1146,18 @@ If you need to clear the list of related fields added by past calls of
 Chaining ``select_related`` calls works in a similar way to other methods -
 that is that ``select_related('foo', 'bar')`` is equivalent to
 ``select_related('foo').select_related('bar')``.
+
+There may be some situations where you wish to call ``select_related()`` with a
+lot of related objects, or where you don't know all of the relations. In these
+cases it is possible to call ``select_related()`` with no arguments. This will
+follow all non-null foreign keys it can find - nullable foreign keys must be
+specified. This is not recommended in most cases as it is likely to make the
+underlying query more complex, and return more data, than is actually needed.
+
+.. deprecated:: 6.1
+
+    Calling ``select_related()`` with no arguments is deprecated, and support
+    for it will be removed in Django 7.0. Specify the fields to fetch instead.
 
 ``prefetch_related()``
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/releases/6.0.txt
+++ b/docs/releases/6.0.txt
@@ -565,6 +565,10 @@ Miscellaneous
 * The undocumented ``django.core.mail.forbid_multi_line_headers()`` and
   ``django.core.mail.message.sanitize_address()`` functions are deprecated.
 
+* Setting :attr:`.ModelAdmin.list_select_related` to ``True`` and returning
+  ``True`` from :attr:`.ModelAdmin.get_list_select_related()` are deprecated.
+  Specify the related fields to fetch instead.
+
 Features removed in 6.0
 =======================
 

--- a/docs/releases/6.0.txt
+++ b/docs/releases/6.0.txt
@@ -565,10 +565,6 @@ Miscellaneous
 * The undocumented ``django.core.mail.forbid_multi_line_headers()`` and
   ``django.core.mail.message.sanitize_address()`` functions are deprecated.
 
-* Setting :attr:`.ModelAdmin.list_select_related` to ``True`` and returning
-  ``True`` from :attr:`.ModelAdmin.get_list_select_related()` are deprecated.
-  Specify the related fields to fetch instead.
-
 Features removed in 6.0
 =======================
 

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -600,6 +600,10 @@ Features deprecated in 6.1
 Miscellaneous
 -------------
 
+* Calling :meth:`~django.db.models.query.QuerySet.select_related` with no
+  arguments to select all related fields, is deprecated. Specify the related
+  fields to fetch instead.
+
 * Calling :meth:`.QuerySet.values_list` with ``flat=True`` and no field name
   is deprecated. Pass an explicit field name, like
   ``values_list("pk", flat=True)``.

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -604,6 +604,10 @@ Miscellaneous
   arguments to select all related fields, is deprecated. Specify the related
   fields to fetch instead.
 
+* Setting :attr:`.ModelAdmin.list_select_related` to ``True`` and returning
+  ``True`` from :attr:`.ModelAdmin.get_list_select_related()` are deprecated.
+  Specify the related fields to fetch instead.
+
 * Calling :meth:`.QuerySet.values_list` with ``flat=True`` and no field name
   is deprecated. Pass an explicit field name, like
   ``values_list("pk", flat=True)``.

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -99,6 +99,11 @@ Minor features
   preserve :ref:`named groups <field-choices-named-groups>` (e.g.
   ``choices=[("Group", [("1", "Item")]), ...]``).
 
+* When :attr:`.ModelAdmin.list_select_related` is ``False`` (the default),
+  the change list now selects only the foreign key fields specified in
+  :attr:`.ModelAdmin.list_display`, rather than all foreign key fields. This
+  should improve performance for models with many foreign key fields.
+
 * The :attr:`~django.contrib.admin.ModelAdmin.delete_confirmation_max_display`
   option allows customizing how many objects are displayed on admin delete
   confirmation pages before the remainder is truncated. The default is
@@ -479,6 +484,9 @@ backends.
 
 * The undocumented ``InclusionAdminNode.__init__()`` now takes the template tag
   ``name`` as the first positional argument.
+
+* The undocumented ``ChangeList.has_related_field_in_list_display()`` method
+  has been replaced with ``ChangeList.get_select_related_fields()``.
 
 :mod:`django.contrib.auth`
 --------------------------

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -995,29 +995,29 @@ class AdminViewBasicTest(AdminViewBasicTestCase):
             self.assertContentBefore(response, "The First Item", "The Middle Item")
             self.assertContentBefore(response, "The Middle Item", "The Last Item")
 
-    def test_has_related_field_in_list_display_fk(self):
+    def test_get_select_related_fields_in_list_display_fk(self):
         """Joins shouldn't be performed for <FK>_id fields in list display."""
         state = State.objects.create(name="Karnataka")
         City.objects.create(state=state, name="Bangalore")
         response = self.client.get(reverse("admin:admin_views_city_changelist"), {})
 
         response.context["cl"].list_display = ["id", "name", "state"]
-        self.assertIs(response.context["cl"].has_related_field_in_list_display(), True)
+        self.assertEqual(response.context["cl"].get_select_related_fields(), ["state"])
 
         response.context["cl"].list_display = ["id", "name", "state_id"]
-        self.assertIs(response.context["cl"].has_related_field_in_list_display(), False)
+        self.assertEqual(response.context["cl"].get_select_related_fields(), [])
 
-    def test_has_related_field_in_list_display_o2o(self):
+    def test_get_select_related_fields_in_list_display_o2o(self):
         """Joins shouldn't be performed for <O2O>_id fields in list display."""
         media = Media.objects.create(name="Foo")
         Vodcast.objects.create(media=media)
         response = self.client.get(reverse("admin:admin_views_vodcast_changelist"), {})
 
         response.context["cl"].list_display = ["media"]
-        self.assertIs(response.context["cl"].has_related_field_in_list_display(), True)
+        self.assertEqual(response.context["cl"].get_select_related_fields(), ["media"])
 
         response.context["cl"].list_display = ["media_id"]
-        self.assertIs(response.context["cl"].has_related_field_in_list_display(), False)
+        self.assertEqual(response.context["cl"].get_select_related_fields(), [])
 
     def test_limited_filter(self):
         """

--- a/tests/aggregation_regress/tests.py
+++ b/tests/aggregation_regress/tests.py
@@ -26,7 +26,8 @@ from django.db.models import (
 )
 from django.db.models.functions import Cast, Concat
 from django.test import TestCase, skipUnlessDBFeature
-from django.test.utils import Approximate
+from django.test.utils import Approximate, ignore_warnings
+from django.utils.deprecation import RemovedInDjango70Warning
 
 from .models import (
     Alfa,
@@ -883,12 +884,18 @@ class AggregationTests(TestCase):
 
     def test_annotate_select_related(self):
         # Regression for #10127 - Empty select_related() works with annotate
-        qs = (
-            Book.objects.filter(rating__lt=4.5)
-            .select_related()
-            .annotate(Avg("authors__age"))
-            .order_by("name")
-        )
+        # RemovedInDjango70Warning: when the deprecation ends, the below
+        # queryset and assertion can be removed.
+        with ignore_warnings(
+            category=RemovedInDjango70Warning,
+            message=r"Calling select_related\(\) with no arguments is deprecated\.",
+        ):
+            qs = (
+                Book.objects.filter(rating__lt=4.5)
+                .select_related()
+                .annotate(Avg("authors__age"))
+                .order_by("name")
+            )
         self.assertQuerySetEqual(
             qs,
             [

--- a/tests/defer/tests.py
+++ b/tests/defer/tests.py
@@ -1,6 +1,8 @@
 from django.core.exceptions import FieldDoesNotExist, FieldError, FieldFetchBlocked
 from django.db.models import FETCH_PEERS, RAISE
 from django.test import SimpleTestCase, TestCase
+from django.test.utils import ignore_warnings
+from django.utils.deprecation import RemovedInDjango70Warning
 
 from .models import (
     BigChild,
@@ -142,10 +144,15 @@ class DeferTests(AssertionMixin, TestCase):
         self.assertEqual(obj.related_id, self.s1.pk)
         self.assertEqual(obj.name, "p1")
 
+    # RemovedInDjango70Warning: when the deprecation ends, remove this test.
     def test_defer_foreign_keys_are_deferred_and_not_traversed(self):
         # select_related() overrides defer().
         with self.assertNumQueries(1):
-            obj = Primary.objects.defer("related").select_related()[0]
+            with ignore_warnings(
+                category=RemovedInDjango70Warning,
+                message=r"Calling select_related\(\) with no arguments is deprecated\.",
+            ):
+                obj = Primary.objects.defer("related").select_related()[0]
             self.assert_delayed(obj, 1)
             self.assertEqual(obj.related.id, self.s1.pk)
 
@@ -325,7 +332,11 @@ class TestDefer2(AssertionMixin, TestCase):
         """
         related = Secondary.objects.create(first="x1", second="x2")
         ChildProxy.objects.create(name="p1", value="xx", related=related)
-        children = ChildProxy.objects.select_related().only("id", "name")
+        with ignore_warnings(
+            category=RemovedInDjango70Warning,
+            message=r"Calling select_related\(\) with no arguments is deprecated\.",
+        ):
+            children = ChildProxy.objects.select_related().only("id", "name")
         self.assertEqual(len(children), 1)
         child = children[0]
         self.assert_delayed(child, 2)

--- a/tests/defer/tests.py
+++ b/tests/defer/tests.py
@@ -129,14 +129,14 @@ class DeferTests(AssertionMixin, TestCase):
         self.assert_delayed(qs.only("name").get(pk=self.p1.pk), 2)
 
     def test_defer_with_select_related(self):
-        obj = Primary.objects.select_related().defer(
+        obj = Primary.objects.select_related("related").defer(
             "related__first", "related__second"
         )[0]
         self.assert_delayed(obj.related, 2)
         self.assert_delayed(obj, 0)
 
     def test_only_with_select_related(self):
-        obj = Primary.objects.select_related().only("related__first")[0]
+        obj = Primary.objects.select_related("related").only("related__first")[0]
         self.assert_delayed(obj, 2)
         self.assert_delayed(obj.related, 1)
         self.assertEqual(obj.related_id, self.s1.pk)

--- a/tests/gis_tests/relatedapp/tests.py
+++ b/tests/gis_tests/relatedapp/tests.py
@@ -3,8 +3,9 @@ from django.contrib.gis.db.models.functions import Centroid
 from django.contrib.gis.geos import GEOSGeometry, MultiPoint, Point
 from django.db import NotSupportedError, connection
 from django.test import TestCase, skipUnlessDBFeature
-from django.test.utils import override_settings
+from django.test.utils import ignore_warnings, override_settings
 from django.utils import timezone
+from django.utils.deprecation import RemovedInDjango70Warning
 
 from ..utils import skipUnlessGISLookup
 from .models import Article, Author, Book, City, DirectoryEntry, Event, Location, Parcel
@@ -16,7 +17,13 @@ class RelatedGeoModelTest(TestCase):
     def test02_select_related(self):
         "Testing `select_related` on geographic models (see #7126)."
         qs1 = City.objects.order_by("id")
-        qs2 = City.objects.order_by("id").select_related()
+        # RemovedInDjango70Warning: when the deprecation ends, the below
+        # queryset can be removed.
+        with ignore_warnings(
+            category=RemovedInDjango70Warning,
+            message=r"Calling select_related\(\) with no arguments is deprecated\.",
+        ):
+            qs2 = City.objects.order_by("id").select_related()
         qs3 = City.objects.order_by("id").select_related("location")
 
         # Reference data for what's in the fixtures.

--- a/tests/gis_tests/relatedapp/tests.py
+++ b/tests/gis_tests/relatedapp/tests.py
@@ -116,7 +116,7 @@ class RelatedGeoModelTest(TestCase):
         select_related on a query over a model with an FK to a model subclass.
         """
         # Regression test for #9752.
-        list(DirectoryEntry.objects.select_related())
+        list(DirectoryEntry.objects.select_related("location"))
 
     @skipUnlessGISLookup("within")
     def test06_f_expressions(self):

--- a/tests/m2m_intermediary/tests.py
+++ b/tests/m2m_intermediary/tests.py
@@ -18,7 +18,7 @@ class M2MIntermediaryTests(TestCase):
         w2 = Writer.objects.create(reporter=r2, article=a, position="Contributor")
 
         self.assertQuerySetEqual(
-            a.writer_set.select_related().order_by("-position"),
+            a.writer_set.select_related("reporter", "article").order_by("-position"),
             [
                 ("John Smith", "Main writer"),
                 ("Jane Doe", "Contributor"),

--- a/tests/many_to_one/tests.py
+++ b/tests/many_to_one/tests.py
@@ -467,15 +467,15 @@ class ManyToOneTests(TestCase):
             headline="Second", pub_date=datetime.date(1980, 4, 23), reporter=r2
         )
         self.assertEqual(
-            list(Article.objects.select_related().dates("pub_date", "day")),
+            list(Article.objects.select_related("reporter").dates("pub_date", "day")),
             [datetime.date(1980, 4, 23), datetime.date(2005, 7, 27)],
         )
         self.assertEqual(
-            list(Article.objects.select_related().dates("pub_date", "month")),
+            list(Article.objects.select_related("reporter").dates("pub_date", "month")),
             [datetime.date(1980, 4, 1), datetime.date(2005, 7, 1)],
         )
         self.assertEqual(
-            list(Article.objects.select_related().dates("pub_date", "year")),
+            list(Article.objects.select_related("reporter").dates("pub_date", "year")),
             [datetime.date(1980, 1, 1), datetime.date(2005, 1, 1)],
         )
 

--- a/tests/model_fields/test_booleanfield.py
+++ b/tests/model_fields/test_booleanfield.py
@@ -3,6 +3,8 @@ from django.core.exceptions import ValidationError
 from django.db import IntegrityError, models, transaction
 from django.db.models.utils import get_blank_choice_label
 from django.test import SimpleTestCase, TestCase
+from django.test.utils import ignore_warnings
+from django.utils.deprecation import RemovedInDjango70Warning
 
 from .models import BooleanModel, FksToBooleans, NullBooleanModel
 
@@ -91,8 +93,14 @@ class BooleanFieldTests(TestCase):
         self.assertIs(ma.nbf.nbfield, True)
 
         # select_related()
-        mb = FksToBooleans.objects.select_related().get(pk=m1.id)
-        mc = FksToBooleans.objects.select_related().get(pk=m2.id)
+        # RemovedInDjango70Warning: when the deprecation ends, remove this part
+        # of the test.
+        with ignore_warnings(
+            category=RemovedInDjango70Warning,
+            message=r"Calling select_related\(\) with no arguments is deprecated\.",
+        ):
+            mb = FksToBooleans.objects.select_related().get(pk=m1.id)
+            mc = FksToBooleans.objects.select_related().get(pk=m2.id)
         self.assertIs(mb.bf.bfield, True)
         self.assertIs(mb.nbf.nbfield, True)
         self.assertIs(mc.bf.bfield, False)

--- a/tests/model_inheritance_regress/tests.py
+++ b/tests/model_inheritance_regress/tests.py
@@ -9,6 +9,8 @@ from unittest import expectedFailure
 from django import forms
 from django.db.models import FETCH_PEERS
 from django.test import TestCase
+from django.test.utils import ignore_warnings
+from django.utils.deprecation import RemovedInDjango70Warning
 
 from .models import (
     ArticleWithAuthor,
@@ -252,7 +254,13 @@ class ModelInheritanceTest(TestCase):
         """
         Regression test for #11764
         """
-        wholesalers = list(Wholesaler.objects.select_related())
+        # RemovedInDjango70Warning: when the deprecation ends, this test can
+        # be removed.
+        with ignore_warnings(
+            category=RemovedInDjango70Warning,
+            message=r"Calling select_related\(\) with no arguments is deprecated\.",
+        ):
+            wholesalers = list(Wholesaler.objects.select_related())
         self.assertEqual(wholesalers, [])
 
     def test_issue_7853(self):

--- a/tests/model_inheritance_regress/tests.py
+++ b/tests/model_inheritance_regress/tests.py
@@ -528,7 +528,7 @@ class ModelInheritanceTest(TestCase):
         Supplier.objects.create(name="Jane", restaurant=r2)
 
         self.assertQuerySetEqual(
-            Supplier.objects.order_by("name").select_related(),
+            Supplier.objects.order_by("name").select_related("restaurant"),
             [
                 "Jane",
                 "John",

--- a/tests/modeladmin/test_checks.py
+++ b/tests/modeladmin/test_checks.py
@@ -1233,6 +1233,8 @@ class ListSelectRelatedCheckTests(CheckTestCase):
         self.assertIsInvalid(
             TestModelAdmin,
             ValidationTestModel,
+            # RemovedInDjango70Warning: when the deprecation ends, replace:
+            # ... must be a tuple, list, or False.",
             "The value of 'list_select_related' must be a boolean, tuple or list.",
             "admin.E117",
         )

--- a/tests/modeladmin/tests.py
+++ b/tests/modeladmin/tests.py
@@ -21,7 +21,8 @@ from django.db import models
 from django.db.models.utils import get_blank_choice_label
 from django.forms.widgets import Select
 from django.test import RequestFactory, SimpleTestCase, TestCase
-from django.test.utils import isolate_apps
+from django.test.utils import ignore_warnings, isolate_apps
+from django.utils.deprecation import RemovedInDjango70Warning
 
 from .models import Band, Concert, Song
 
@@ -1026,6 +1027,54 @@ class ModelAdminTests(TestCase):
             repr(ma),
             "<ModelAdmin: model=Band site=AdminSite(name='admin')>",
         )
+
+    def test_list_select_related_true_deprecated(self):
+        msg = (
+            r"Setting ModelAdmin.list_select_related to True is deprecated. "
+            r"Use False or a list or tuple of fields to fetch instead."
+        )
+        # RemovedInDjango70Warning:
+        # with self.assertRaisesMessage(ValueError, msg)
+        with self.assertWarnsMessage(RemovedInDjango70Warning, msg):
+
+            class TestModelAdmin(ModelAdmin):
+                list_select_related = True
+
+    # RemovedInDjango70Warning: when the deprecation ends, remove.
+    def test_list_select_related_true_deprecated_subclass(self):
+        with ignore_warnings(
+            category=RemovedInDjango70Warning,
+            message=r"Setting ModelAdmin.list_select_related to True is deprecated\.",
+        ):
+
+            class BaseTestModelAdmin(ModelAdmin):
+                list_select_related = True
+
+        # Does not warn
+        class TestModelAdmin(BaseTestModelAdmin):
+            pass
+
+    # RemovedInDjango70Warning: when the deprecation ends, rename.
+    def test_get_list_select_related_returns_true_deprecated(self):
+        msg = (
+            "Returning True from ModelAdmin.get_list_select_related() is "
+            "deprecated. Return False or a list or tuple of fields to fetch "
+            "instead."
+        )
+
+        class TestModelAdmin(ModelAdmin):
+            def get_list_select_related(self, request):
+                return True
+
+        request = RequestFactory().get("/")
+        request.user = User.objects.create_superuser(
+            username="bob", email="bob@test.com", password="test"
+        )
+
+        # RemovedInDjango70Warning:
+        # with self.assertRaisesMessage(ValueError, msg)
+        with self.assertWarnsMessage(RemovedInDjango70Warning, msg):
+            TestModelAdmin(Band, self.site).get_changelist_instance(request)
 
 
 class ModelAdminPermissionTests(SimpleTestCase):

--- a/tests/null_fk/tests.py
+++ b/tests/null_fk/tests.py
@@ -17,9 +17,9 @@ class NullFkTests(TestCase):
         # specified set of fields will properly LEFT JOIN multiple levels of
         # NULLs (and the things that come after the NULLs, or else data that
         # should exist won't). Regression test for #7369.
-        c = Comment.objects.select_related().get(id=c1.id)
+        c = Comment.objects.select_related("post").get(id=c1.id)
         self.assertEqual(c.post, p)
-        self.assertIsNone(Comment.objects.select_related().get(id=c2.id).post)
+        self.assertIsNone(Comment.objects.select_related("post").get(id=c2.id).post)
 
         self.assertQuerySetEqual(
             Comment.objects.select_related("post__forum__system_info").all(),

--- a/tests/proxy_models/tests.py
+++ b/tests/proxy_models/tests.py
@@ -320,17 +320,17 @@ class ProxyModelTests(TestCase):
         country = Country.objects.create(name="Australia")
         State.objects.create(name="New South Wales", country=country)
 
-        resp = [s.name for s in State.objects.select_related()]
+        resp = [s.name for s in State.objects.select_related("country")]
         self.assertEqual(resp, ["New South Wales"])
 
-        resp = [s.name for s in StateProxy.objects.select_related()]
+        resp = [s.name for s in StateProxy.objects.select_related("country")]
         self.assertEqual(resp, ["New South Wales"])
 
         self.assertEqual(
             StateProxy.objects.get(name="New South Wales").name, "New South Wales"
         )
 
-        resp = StateProxy.objects.select_related().get(name="New South Wales")
+        resp = StateProxy.objects.select_related("country").get(name="New South Wales")
         self.assertEqual(resp.name, "New South Wales")
 
     def test_filter_proxy_relation_reverse(self):
@@ -369,15 +369,19 @@ class ProxyModelTests(TestCase):
         self.assertEqual(repr(resp), "<ProxyBug: ProxyBug:fix this>")
 
         # Select related + filter on proxy
-        resp = ProxyBug.objects.select_related().get(version__icontains="beta")
+        resp = ProxyBug.objects.select_related("reporter").get(
+            version__icontains="beta"
+        )
         self.assertEqual(repr(resp), "<ProxyBug: ProxyBug:fix this>")
 
         # Proxy of proxy, select_related + filter
-        resp = ProxyProxyBug.objects.select_related().get(version__icontains="beta")
+        resp = ProxyProxyBug.objects.select_related("reporter").get(
+            version__icontains="beta"
+        )
         self.assertEqual(repr(resp), "<ProxyProxyBug: ProxyProxyBug:fix this>")
 
         # Select related + filter on a related proxy field
-        resp = ProxyImprovement.objects.select_related().get(
+        resp = ProxyImprovement.objects.select_related("reporter").get(
             reporter__name__icontains="butor"
         )
         self.assertEqual(
@@ -385,7 +389,7 @@ class ProxyModelTests(TestCase):
         )
 
         # Select related + filter on a related proxy of proxy field
-        resp = ProxyImprovement.objects.select_related().get(
+        resp = ProxyImprovement.objects.select_related("associated_bug").get(
             associated_bug__summary__icontains="fix"
         )
         self.assertEqual(

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -13,7 +13,8 @@ from django.db.models.functions import ExtractYear, Length, LTrim
 from django.db.models.sql.constants import LOUTER
 from django.db.models.sql.where import AND, OR, NothingNode, WhereNode
 from django.test import SimpleTestCase, TestCase, skipUnlessDBFeature
-from django.test.utils import CaptureQueriesContext, register_lookup
+from django.test.utils import CaptureQueriesContext, ignore_warnings, register_lookup
+from django.utils.deprecation import RemovedInDjango70Warning
 
 from .models import (
     FK1,
@@ -2011,7 +2012,13 @@ class SelectRelatedTests(TestCase):
         # infinitely if you forgot to specify "depth". Now we set an arbitrary
         # default upper bound.
         self.assertSequenceEqual(X.objects.all(), [])
-        self.assertSequenceEqual(X.objects.select_related(), [])
+        # RemovedInDjango70Warning: when the deprecation ends, remove this test
+        # case.
+        with ignore_warnings(
+            category=RemovedInDjango70Warning,
+            message=r"Calling select_related\(\) with no arguments is deprecated\.",
+        ):
+            self.assertSequenceEqual(X.objects.select_related(), [])
 
 
 class SubclassFKTests(TestCase):

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -617,7 +617,7 @@ class Queries1Tests(TestCase):
     def test_ticket2496(self):
         self.assertSequenceEqual(
             Item.objects.extra(tables=["queries_author"])
-            .select_related()
+            .select_related("creator")
             .order_by("name")[:1],
             [self.i4],
         )
@@ -668,7 +668,9 @@ class Queries1Tests(TestCase):
         self.assertEqual(len(qs.query.alias_map), 1)
 
     def test_tickets_2874_3002(self):
-        qs = Item.objects.select_related().order_by("note__note", "name")
+        qs = Item.objects.select_related("creator", "note").order_by(
+            "note__note", "name"
+        )
         self.assertQuerySetEqual(qs, [self.i2, self.i4, self.i1, self.i3])
 
         # This is also a good select_related() test because there are multiple
@@ -853,7 +855,7 @@ class Queries1Tests(TestCase):
         # We should also be able to pickle things that use select_related().
         # The only tricky thing here is to ensure that we do the related
         # selections properly after unpickling.
-        qs = Item.objects.select_related()
+        qs = Item.objects.select_related("creator", "note")
         query = qs.query.get_compiler(qs.db).as_sql()[0]
         query2 = pickle.loads(pickle.dumps(qs.query))
         self.assertEqual(query2.get_compiler(qs.db).as_sql()[0], query)

--- a/tests/select_related/tests.py
+++ b/tests/select_related/tests.py
@@ -137,7 +137,7 @@ class SelectRelatedTests(TestCase):
     def test_select_related_with_extra(self):
         s = (
             Species.objects.all()
-            .select_related()
+            .select_related("genus")
             .extra(select={"a": "select_related_species.id + 10"})[0]
         )
         self.assertEqual(s.id + 10, s.a)

--- a/tests/select_related/tests.py
+++ b/tests/select_related/tests.py
@@ -3,7 +3,8 @@ import gc
 from django.core.exceptions import FieldError
 from django.db.models import FETCH_PEERS
 from django.test import SimpleTestCase, TestCase
-from django.test.utils import garbage_collect
+from django.test.utils import garbage_collect, ignore_warnings
+from django.utils.deprecation import RemovedInDjango70Warning
 
 from .models import (
     Bookmark,
@@ -106,10 +107,15 @@ class SelectRelatedTests(TestCase):
                 ],
             )
 
+    # RemovedInDjango70Warning.
     def test_list_with_select_related(self):
         """select_related() applies to entire lists, not just items."""
         with self.assertNumQueries(1):
-            world = Species.objects.select_related()
+            with ignore_warnings(
+                category=RemovedInDjango70Warning,
+                message=r"Calling select_related\(\) with no arguments is deprecated\.",
+            ):
+                world = Species.objects.select_related()
             families = [o.genus.family.name for o in world]
             self.assertEqual(
                 sorted(families),
@@ -120,6 +126,15 @@ class SelectRelatedTests(TestCase):
                     "Hominidae",
                 ],
             )
+
+    # RemovedInDjango70Warning.
+    def test_select_related_no_arguments_deprecated(self):
+        msg = (
+            "Calling select_related() with no arguments is deprecated. "
+            "Specify the fields to fetch instead."
+        )
+        with self.assertWarnsMessage(RemovedInDjango70Warning, msg):
+            Species.objects.select_related()
 
     def test_list_with_depth(self):
         """

--- a/tests/select_related_onetoone/tests.py
+++ b/tests/select_related_onetoone/tests.py
@@ -1,6 +1,8 @@
 from django.core.exceptions import FieldError
 from django.db.models import FilteredRelation
 from django.test import SimpleTestCase, TestCase
+from django.test.utils import ignore_warnings
+from django.utils.deprecation import RemovedInDjango70Warning
 
 from .models import (
     AdvancedUserStat,
@@ -86,7 +88,15 @@ class ReverseSelectRelatedTestCase(TestCase):
             self.assertEqual(u.userstat.user.username, "test")
 
     def test_not_followed_by_default(self):
-        with self.assertNumQueries(2):
+        # RemovedInDjango70Warning: when the deprecation ends, remove this
+        # test.
+        with (
+            self.assertNumQueries(2),
+            ignore_warnings(
+                category=RemovedInDjango70Warning,
+                message=r"Calling select_related\(\) with no arguments is deprecated\.",
+            ),
+        ):
             u = User.objects.select_related().get(username="test")
             self.assertEqual(u.userstat.posts, 150)
 

--- a/tests/select_related_regress/tests.py
+++ b/tests/select_related_regress/tests.py
@@ -62,7 +62,7 @@ class SelectRelatedRegressTests(TestCase):
             Connection.objects.filter(
                 start__device__building=b, end__device__building=b
             )
-            .select_related()
+            .select_related("start__device__building", "end__device__building")
             .order_by("id")
         )
         self.assertEqual(
@@ -93,7 +93,7 @@ class SelectRelatedRegressTests(TestCase):
         c = Class.objects.create(org=o)
         Enrollment.objects.create(std=s, cls=c)
 
-        e_related = Enrollment.objects.select_related()[0]
+        e_related = Enrollment.objects.select_related("std", "cls")[0]
         self.assertEqual(e_related.std.person.user.name, "std")
         self.assertEqual(e_related.cls.org.person.user.name, "org")
 
@@ -112,7 +112,9 @@ class SelectRelatedRegressTests(TestCase):
         client = Client.objects.create(name="client", status=active)
 
         self.assertEqual(client.status, active)
-        self.assertEqual(Client.objects.select_related()[0].status, active)
+        self.assertEqual(
+            Client.objects.select_related("state", "status")[0].status, active
+        )
         self.assertEqual(Client.objects.select_related("state")[0].status, active)
         self.assertEqual(
             Client.objects.select_related("state", "status")[0].status, active
@@ -221,7 +223,7 @@ class SelectRelatedRegressTests(TestCase):
         Chick.objects.create(name="Chick", mother=hen)
 
         self.assertEqual(Chick.objects.all()[0].mother.name, "Hen")
-        self.assertEqual(Chick.objects.select_related()[0].mother.name, "Hen")
+        self.assertEqual(Chick.objects.select_related("mother")[0].mother.name, "Hen")
 
     def test_regression_10733(self):
         a = A.objects.create(name="a", lots_of_text="lots_of_text_a", a_field="a_field")
@@ -237,7 +239,7 @@ class SelectRelatedRegressTests(TestCase):
             "c_b__lots_of_text",
             "c_a__name",
             "c_b__name",
-        ).select_related()
+        ).select_related("c_a", "c_b")
         self.assertSequenceEqual(results, [c])
         with self.assertNumQueries(0):
             qs_c = results[0]


### PR DESCRIPTION
#### Trac ticket number

ticket-36593

#### Branch description

This PR deprecates `QuerySet.select_related()` with no arguments, along with the corresponding admin options for using that method.

There are several commits—read their messages for details! I cherry-picked the first one into a separate PR: #19823.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
