### PR TITLE
Fixed #36488 -- Fixed merging of query strings in RedirectView.

### DIFF
--- a/django/views/generic/base.py
+++ b/django/views/generic/base.py
@@ -1,4 +1,5 @@
 import logging
+from urllib.parse import urlparse
 
 from asgiref.sync import iscoroutinefunction, markcoroutinefunction
 
@@ -252,7 +253,10 @@ class RedirectView(View):
 
         args = self.request.META.get("QUERY_STRING", "")
         if args and self.query_string:
-            url = "%s?%s" % (url, args)
+            if urlparse(url).query:
+                url = f"{url}&{args}"
+            else:
+                url = f"{url}?{args}"
         return url
 
     def get(self, request, *args, **kwargs):

--- a/tests/generic_views/test_base.py
+++ b/tests/generic_views/test_base.py
@@ -587,6 +587,31 @@ class RedirectViewTest(LoggingAssertionMixin, SimpleTestCase):
                     handler, f"Gone: {escaped}", logging.WARNING, 410, request
                 )
 
+    def test_redirect_with_querry_string_in_destination(self):
+        response = RedirectView.as_view(url="/bar/?pork=spam", query_string=True)(
+            self.rf.get("/foo")
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.headers["Location"], "/bar/?pork=spam")
+
+    def test_redirect_with_query_string_in_destination_and_request(self):
+        response = RedirectView.as_view(url="/bar/?pork=spam", query_string=True)(
+            self.rf.get("/foo/?utm_source=social")
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.headers["Location"], "/bar/?pork=spam&utm_source=social"
+        )
+
+    def test_redirect_with_same_query_string_param_will_append_not_replace(self):
+        response = RedirectView.as_view(url="/bar/?pork=spam", query_string=True)(
+            self.rf.get("/foo/?utm_source=social&pork=ham")
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.headers["Location"], "/bar/?pork=spam&utm_source=social&pork=ham"
+        )
+
 
 class GetContextDataTest(SimpleTestCase):
     def test_get_context_data_super(self):


### PR DESCRIPTION
### PR Description

Previously, `RedirectView` always appended `"?"` before query parameters, causing issues when the target URL already contained query strings.  

Updated logic to check existing query params using `urllib.parse.urlparse` and correctly append `"&"` or `"?"` as needed.  

Added tests in `generic_views/test_base.py` to cover this case.  

**Acknowledgment:** Thanks to @nessita for suggesting the use of `urllib.parse.urlparse` during the review discussion — it made the solution cleaner and more robust. 🙏  

---

#### Trac ticket number
ticket-36488  

#### Branch description
This branch fixes incorrect query parameter concatenation in `RedirectView` by using `urllib.parse.urlparse` to detect existing query strings before appending new ones. This ensures proper URL construction when redirects already contain query parameters.  

---

#### Checklist
- [ ] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.