### PR TITLE
Enhanced template creation instructions in docs/intro/tutorial03.txt

### DIFF
--- a/docs/intro/tutorial03.txt
+++ b/docs/intro/tutorial03.txt
@@ -180,12 +180,39 @@ backend whose :setting:`APP_DIRS <TEMPLATES-APP_DIRS>` option is set to
 ``True``. By convention ``DjangoTemplates`` looks for a "templates"
 subdirectory in each of the :setting:`INSTALLED_APPS`.
 
-Within the ``templates`` directory you have just created, create another
-directory called ``polls``, and within that create a file called
-``index.html``. In other words, your template should be at
-``polls/templates/polls/index.html``. Because of how the ``app_directories``
-template loader works as described above, you can refer to this template within
-Django as ``polls/index.html``.
+So go to ``mysite/settings.py``, and under `TEMPLATES` add the predefined
+ `BASE_DIR` variable:
+
+.. code-block:: python
+    :caption: ``mysite/settings.py``
+
+    TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [
+            BASE_DIR # Add this
+        ],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
+
+
+    # Leave the rest unchanged
+
+This tells Django where the ``templates`` directory is.
+
+Within templates, create another directory called polls, and within
+that create a file called index.html. In other words, your template should
+be at polls/templates/polls/index.html. Because of how the
+app_directories template loader works as described above, you can refer to
+this template within Django as polls/index.html.
 
 .. admonition:: Template namespacing
 


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

N/A

#### Branch description
On tutorial 03, users are instructed to create their first `templates` folder, and then proceed with creating ``index.html`` and so on.

Unfortunately there is no clear instructions on how to add the `templates` directory to `mysite/settings.py`, where it can be detected by Django. This causes issues further in the tutorial, because the templates are not being rendered.

I propose a simple fix to this, instructing users to add the `templates` directory path to `mysite/settings.py`.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
