### PR TITLE
Fixed #36601 -- Fixed a color contrast issue in admin FilteredSelectMultiple widget chosen label.

### DIFF
--- a/django/contrib/admin/static/admin/css/widgets.css
+++ b/django/contrib/admin/static/admin/css/widgets.css
@@ -49,7 +49,7 @@
     padding: 8px;
 }
 
-.aligned .selector-chosen-title label {
+.selector-chosen-title label {
     color: var(--header-link-color);
     width: 100%;
 }
@@ -60,7 +60,7 @@
     padding: 8px;
 }
 
-.aligned .selector-available-title label {
+.selector-available-title label {
     width: 100%;
 }
 

--- a/docs/releases/5.2.7.txt
+++ b/docs/releases/5.2.7.txt
@@ -9,4 +9,6 @@ Django 5.2.7 fixes several bugs in 5.2.6.
 Bugfixes
 ========
 
-* ...
+* Fixed a regression in Django 5.2 that reduced the color contrast of
+  the chosen label of ``filter_horizontal`` and ``filter_vertical`` widgets
+  within a ``TabularInline`` (:ticket:`36601`).

--- a/tests/admin_inlines/tests.py
+++ b/tests/admin_inlines/tests.py
@@ -2558,3 +2558,15 @@ class SeleniumTests(AdminSeleniumTestCase):
         self.assertTrue(object_str.is_displayed())
         self.assertIn("Desert", object_str.text)
         self.take_screenshot("tabular")
+
+    @screenshot_cases(["desktop_size", "mobile_size", "rtl", "dark", "high_contrast"])
+    def test_tabular_inline_with_filter_horizontal(self):
+        from selenium.webdriver.common.by import By
+
+        self.admin_login(username="super", password="secret")
+        self.selenium.get(
+            self.live_server_url + reverse("admin:admin_inlines_courseproxy2_add")
+        )
+        m2m_widget = self.selenium.find_element(By.CSS_SELECTOR, "div.selector")
+        self.assertTrue(m2m_widget.is_displayed())
+        self.take_screenshot("tabular")


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36601

#### Branch description

<img width="1249" height="654" alt="Screenshot 2025-09-10 at 11 29 47 AM" src="https://github.com/user-attachments/assets/50f24d28-0560-4af9-948a-e3ec9f93cde1" />

### Color Contrast

- bg(`#417690`)
- fg(`#ffffff`)

<img width="871" height="133" alt="Screenshot 2025-09-10 at 11 30 13 AM" src="https://github.com/user-attachments/assets/be9eb488-869b-4d32-8361-634e0d54c3f1" />



#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
