### PR TITLE
Fixed #36597 -- Corrected directives for functions from email module in docs.

### DIFF
--- a/docs/ref/contrib/auth.txt
+++ b/docs/ref/contrib/auth.txt
@@ -294,7 +294,7 @@ Methods
 
         Sends an email to the user. If ``from_email`` is ``None``, Django uses
         the :setting:`DEFAULT_FROM_EMAIL`. Any ``**kwargs`` are passed to the
-        underlying :meth:`~django.core.mail.send_mail` call.
+        underlying :func:`~django.core.mail.send_mail` call.
 
 Manager methods
 ---------------

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1052,12 +1052,12 @@ together:
 .. django-admin-option:: --managers
 
 Mails the email addresses specified in :setting:`MANAGERS` using
-:meth:`~django.core.mail.mail_managers`.
+:func:`~django.core.mail.mail_managers`.
 
 .. django-admin-option:: --admins
 
 Mails the email addresses specified in :setting:`ADMINS` using
-:meth:`~django.core.mail.mail_admins`.
+:func:`~django.core.mail.mail_admins`.
 
 ``shell``
 ---------

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -2656,7 +2656,7 @@ protocol.
 .. admonition:: Why are my emails sent from a different address?
 
     This address is used only for error messages. It is *not* the address that
-    regular email messages sent with :meth:`~django.core.mail.send_mail`
+    regular email messages sent with :func:`~django.core.mail.send_mail`
     come from; for that, see :setting:`DEFAULT_FROM_EMAIL`.
 
 .. setting:: SHORT_DATE_FORMAT

--- a/docs/releases/1.2.txt
+++ b/docs/releases/1.2.txt
@@ -878,7 +878,7 @@ of an SMTPConnection::
     messages = get_notification_email()
     connection.send_messages(messages)
 
-...should now call :meth:`~django.core.mail.get_connection` to
+...should now call :func:`~django.core.mail.get_connection` to
 instantiate a generic email connection::
 
     from django.core.mail import get_connection
@@ -900,7 +900,7 @@ SMTP connection::
 
 If your call to construct an instance of ``SMTPConnection`` required
 additional arguments, those arguments can be passed to the
-:meth:`~django.core.mail.get_connection` call::
+:func:`~django.core.mail.get_connection` call::
 
     connection = get_connection(
         "django.core.mail.backends.smtp.EmailBackend", hostname="localhost", port=1234

--- a/docs/releases/1.3.txt
+++ b/docs/releases/1.3.txt
@@ -292,8 +292,8 @@ requests. These include:
 
 * Support for HttpOnly_ cookies.
 
-* :meth:`~django.core.mail.mail_admins` and
-  :meth:`~django.core.mail.mail_managers` now support easily attaching
+* :func:`~django.core.mail.mail_admins` and
+  :func:`~django.core.mail.mail_managers` now support easily attaching
   HTML content to messages.
 
 * :class:`~django.core.mail.EmailMessage` now supports CC's.

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -422,7 +422,7 @@ Minor features
 
 * Any ``**kwargs`` passed to
   :meth:`~django.contrib.auth.models.User.email_user` are passed to the
-  underlying :meth:`~django.core.mail.send_mail` call.
+  underlying :func:`~django.core.mail.send_mail` call.
 
 * The :func:`~django.contrib.auth.decorators.permission_required` decorator can
   take a list of permissions as well as a single permission.

--- a/docs/topics/email.txt
+++ b/docs/topics/email.txt
@@ -133,11 +133,11 @@ can be ``0`` or ``1`` since it can only send one message).
     (subject, message, from_email, recipient_list)
 
 ``fail_silently``, ``auth_user``, ``auth_password`` and ``connection`` have the
-same functions as in :meth:`~django.core.mail.send_mail`. They must be given
+same functions as in :func:`~django.core.mail.send_mail`. They must be given
 as keyword arguments if used.
 
 Each separate element of ``datatuple`` results in a separate email message.
-As in :meth:`~django.core.mail.send_mail`, recipients in the same
+As in :func:`~django.core.mail.send_mail`, recipients in the same
 ``recipient_list`` will all see the other addresses in the email messages'
 "To:" field.
 
@@ -169,12 +169,12 @@ The return value will be the number of successfully delivered messages.
 ``send_mass_mail()`` vs. ``send_mail()``
 ----------------------------------------
 
-The main difference between :meth:`~django.core.mail.send_mass_mail` and
-:meth:`~django.core.mail.send_mail` is that
-:meth:`~django.core.mail.send_mail` opens a connection to the mail server
-each time it's executed, while :meth:`~django.core.mail.send_mass_mail` uses
+The main difference between :func:`~django.core.mail.send_mass_mail` and
+:func:`~django.core.mail.send_mail` is that
+:func:`~django.core.mail.send_mail` opens a connection to the mail server
+each time it's executed, while :func:`~django.core.mail.send_mass_mail` uses
 a single connection for all of its messages. This makes
-:meth:`~django.core.mail.send_mass_mail` slightly more efficient.
+:func:`~django.core.mail.send_mass_mail` slightly more efficient.
 
 ``mail_admins()``
 =================
@@ -248,7 +248,7 @@ scripts generate.
 The Django email functions outlined above all protect against header injection
 by forbidding newlines in header values. If any ``subject``, ``from_email`` or
 ``recipient_list`` contains a newline (in either Unix, Windows or Mac style),
-the email function (e.g. :meth:`~django.core.mail.send_mail`) will raise
+the email function (e.g. :func:`~django.core.mail.send_mail`) will raise
 :exc:`ValueError` and, hence, will not send the email. It's your responsibility
 to validate all data before passing it to the email functions.
 
@@ -291,18 +291,18 @@ from the request's POST data, sends that to admin@example.com and redirects to
 The ``EmailMessage`` class
 ==========================
 
-Django's :meth:`~django.core.mail.send_mail` and
-:meth:`~django.core.mail.send_mass_mail` functions are actually thin
+Django's :func:`~django.core.mail.send_mail` and
+:func:`~django.core.mail.send_mass_mail` functions are actually thin
 wrappers that make use of the :class:`~django.core.mail.EmailMessage` class.
 
 Not all features of the :class:`~django.core.mail.EmailMessage` class are
-available through the :meth:`~django.core.mail.send_mail` and related
+available through the :func:`~django.core.mail.send_mail` and related
 wrapper functions. If you wish to use advanced features, such as BCC'ed
 recipients, file attachments, or multi-part email, you'll need to create
 :class:`~django.core.mail.EmailMessage` instances directly.
 
 .. note::
-    This is a design feature. :meth:`~django.core.mail.send_mail` and
+    This is a design feature. :func:`~django.core.mail.send_mail` and
     related functions were originally the only interface Django provided.
     However, the list of parameters they accepted was slowly growing over
     time. It made sense to move to a more object-oriented design for email
@@ -675,7 +675,7 @@ It can also be used as a context manager, which will automatically call
 Obtaining an instance of an email backend
 -----------------------------------------
 
-The :meth:`get_connection` function in ``django.core.mail`` returns an
+The :func:`get_connection` function in ``django.core.mail`` returns an
 instance of the email backend that you can use.
 
 .. function:: get_connection(backend=None, *, fail_silently=False, **kwargs)
@@ -756,7 +756,7 @@ The file backend writes emails to a file. A new file is created for each new
 session that is opened on this backend. The directory to which the files are
 written is either taken from the :setting:`EMAIL_FILE_PATH` setting or from
 the ``file_path`` keyword when creating a connection with
-:meth:`~django.core.mail.get_connection`.
+:func:`~django.core.mail.get_connection`.
 
 To specify this backend, put the following in your settings::
 


### PR DESCRIPTION
Replaced incorrect uses of :meth: with :func:

Thanks Mike Edmunds for the report.

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36597

#### Branch description
Replaced uses of `:meth:` with `:func:` as needed in email docs.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
