### PR TITLE
Refs #36594 -- Improved warning message for UniqueConstraint with nulls_distinct on unsupported backends.

### DIFF
--- a/django/db/models/constraints.py
+++ b/django/db/models/constraints.py
@@ -405,8 +405,13 @@ class UniqueConstraint(BaseConstraint):
         ):
             errors.append(
                 checks.Warning(
-                    f"{connection.display_name} does not support unique constraints "
-                    "with nulls distinct.",
+                    (
+                        f"{connection.display_name} does not support UNIQUE"
+                        "constraints with nulls_distinct=True or False. "
+                        "This option is only supported on PostgreSQL 15+. "
+                        "On other databases (e.g. SQLite, MySQL, MariaDB) "
+                        "the argument is ignored."
+                    ),
                     hint=(
                         "A constraint won't be created. Silence this warning if you "
                         "don't care about it."

--- a/django/db/models/constraints.py
+++ b/django/db/models/constraints.py
@@ -405,13 +405,11 @@ class UniqueConstraint(BaseConstraint):
         ):
             errors.append(
                 checks.Warning(
-                    (
-                        f"{connection.display_name} does not support UNIQUE"
-                        "constraints with nulls_distinct=True or False. "
-                        "This option is only supported on PostgreSQL 15+. "
-                        "On other databases (e.g. SQLite, MySQL, MariaDB) "
-                        "the argument is ignored."
-                    ),
+                    f"{connection.display_name} does not support UNIQUE"
+                    "constraints with nulls_distinct=True or False. "
+                    "This option is only supported on PostgreSQL 15+. "
+                    "On other databases (e.g. SQLite, MySQL, MariaDB) "
+                    "the argument is ignored.",
                     hint=(
                         "A constraint won't be created. Silence this warning if you "
                         "don't care about it."

--- a/tests/invalid_models_tests/test_models.py
+++ b/tests/invalid_models_tests/test_models.py
@@ -2834,8 +2834,7 @@ class ConstraintsTests(TestCase):
                 ]
 
         warn = Warning(
-            f"{connection.display_name} does not support unique constraints with nulls "
-            "distinct.",
+            f"{connection.display_name} does not support UNIQUE constraints with nulls_distinct=True or False. This option is only supported on PostgreSQL 15+. On other databases (e.g. SQLite, MySQL, MariaDB) the argument is ignored.",
             hint=(
                 "A constraint won't be created. Silence this warning if you don't care "
                 "about it."

--- a/tests/invalid_models_tests/test_models.py
+++ b/tests/invalid_models_tests/test_models.py
@@ -2834,7 +2834,11 @@ class ConstraintsTests(TestCase):
                 ]
 
         warn = Warning(
-            f"{connection.display_name} does not support UNIQUE constraints with nulls_distinct=True or False. This option is only supported on PostgreSQL 15+. On other databases (e.g. SQLite, MySQL, MariaDB) the argument is ignored.",
+            f"{connection.display_name} does not support UNIQUE"
+                    "constraints with nulls_distinct=True or False. "
+                    "This option is only supported on PostgreSQL 15+. "
+                    "On other databases (e.g. SQLite, MySQL, MariaDB) "
+                    "the argument is ignored.",
             hint=(
                 "A constraint won't be created. Silence this warning if you don't care "
                 "about it."

--- a/tests/invalid_models_tests/test_models.py
+++ b/tests/invalid_models_tests/test_models.py
@@ -2835,10 +2835,10 @@ class ConstraintsTests(TestCase):
 
         warn = Warning(
             f"{connection.display_name} does not support UNIQUE"
-                    "constraints with nulls_distinct=True or False. "
-                    "This option is only supported on PostgreSQL 15+. "
-                    "On other databases (e.g. SQLite, MySQL, MariaDB) "
-                    "the argument is ignored.",
+            "constraints with nulls_distinct=True or False. "
+            "This option is only supported on PostgreSQL 15+. "
+            "On other databases (e.g. SQLite, MySQL, MariaDB) "
+            "the argument is ignored.",
             hint=(
                 "A constraint won't be created. Silence this warning if you don't care "
                 "about it."


### PR DESCRIPTION
This PR improves the warning raised when using UniqueConstraint(nulls_distinct=...) on unsupported backends.

Updates the check message to explicitly mention that only PostgreSQL 15+ supports this option.

Clarifies that on other databases (e.g. SQLite, MySQL, MariaDB), the argument is ignored.

Keeps the runtime warning consistent with the documentation.

Checklist
[ ] This PR targets the main branch.

[ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.

[ ] I have checked the "Has patch" ticket flag in the Trac system.

[ ] I have added or updated relevant tests.

[ ] I have added or updated relevant docs, including release notes if applicable.

[ ] I have attached screenshots in both light and dark modes for any UI changes.