### PR TITLE
Fixes #36590 - subclasses of BaseCache should use specialized implementation of methods for async version

### DIFF
--- a/django/core/cache/backends/base.py
+++ b/django/core/cache/backends/base.py
@@ -208,6 +208,10 @@ class BaseCache:
 
     async def aget_many(self, keys, version=None):
         """See get_many()."""
+        if self.get_many.__func__ is not BaseCache.get_many:
+            return await sync_to_async(self.get_many, thread_sensitive=True)(
+                keys, version=version
+            )
         d = {}
         for k in keys:
             val = await self.aget(k, self._missing_key, version=version)
@@ -236,6 +240,10 @@ class BaseCache:
 
     async def aget_or_set(self, key, default, timeout=DEFAULT_TIMEOUT, version=None):
         """See get_or_set()."""
+        if self.get_or_set.__func__ is not BaseCache.get_or_set:
+            return await sync_to_async(self.get_or_set, thread_sensitive=True)(
+                key, default, timeout=timeout, version=version
+            )
         val = await self.aget(key, self._missing_key, version=version)
         if val is self._missing_key:
             if callable(default):
@@ -255,6 +263,10 @@ class BaseCache:
         )
 
     async def ahas_key(self, key, version=None):
+        if self.has_key.__func__ is not BaseCache.has_key:
+            return await sync_to_async(self.has_key, thread_sensitive=True)(
+                key, version=version
+            )
         return (
             await self.aget(key, self._missing_key, version=version)
             is not self._missing_key
@@ -274,6 +286,10 @@ class BaseCache:
 
     async def aincr(self, key, delta=1, version=None):
         """See incr()."""
+        if self.incr.__func__ is not BaseCache.incr:
+            return await sync_to_async(self.incr, thread_sensitive=True)(
+                key, delta=delta, version=version
+            )
         value = await self.aget(key, self._missing_key, version=version)
         if value is self._missing_key:
             raise ValueError("Key '%s' not found" % key)
@@ -317,6 +333,10 @@ class BaseCache:
         return []
 
     async def aset_many(self, data, timeout=DEFAULT_TIMEOUT, version=None):
+        if self.set_many.__func__ is not BaseCache.set_many:
+            return await sync_to_async(self.set_many, thread_sensitive=True)(
+                data, timeout=timeout, version=version
+            )
         for key, value in data.items():
             await self.aset(key, value, timeout=timeout, version=version)
         return []
@@ -331,6 +351,10 @@ class BaseCache:
             self.delete(key, version=version)
 
     async def adelete_many(self, keys, version=None):
+        if self.delete_many.__func__ is not BaseCache.delete_many:
+            return await sync_to_async(self.delete_many, thread_sensitive=True)(
+                keys, version=version
+            )
         for key in keys:
             await self.adelete(key, version=version)
 
@@ -361,6 +385,10 @@ class BaseCache:
 
     async def aincr_version(self, key, delta=1, version=None):
         """See incr_version()."""
+        if self.incr_version.__func__ is not BaseCache.incr_version:
+            return await sync_to_async(self.incr_version, thread_sensitive=True)(
+                key, delta=delta, version=version
+            )
         if version is None:
             version = self.version
 
@@ -387,7 +415,7 @@ class BaseCache:
         pass
 
     async def aclose(self, **kwargs):
-        pass
+        return await sync_to_async(self.close, thread_sensitive=True)(**kwargs)
 
 
 memcached_error_chars_re = _lazy_re_compile(r"[\x00-\x20\x7f]")


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36590

#### Branch description
Ensure subclasses of BaseCache that implement get_many, set_many, or delete_many use their specialized implementation for the async version.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
