### PR TITLE
Fixed #36480 -- Made values() resolving error mention unselected aliases.

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1824,7 +1824,7 @@ class Query(BaseExpression):
                     available = sorted(
                         [
                             *get_field_names_from_opts(opts),
-                            *self.annotation_select,
+                            *self.annotations,
                             *self._filtered_relations,
                         ]
                     )

--- a/tests/annotations/tests.py
+++ b/tests/annotations/tests.py
@@ -1539,3 +1539,13 @@ class AliasTests(TestCase):
         )
         with self.assertRaisesMessage(ValueError, msg):
             Book.objects.alias(**{crafted_alias: FilteredRelation("authors")})
+
+    def test_values_wrong_alias(self):
+        expected_message = (
+            "Cannot resolve keyword 'alias_typo' into field. Choices are: %s"
+        )
+        alias_fields = ", ".join(
+            sorted(["my_alias"] + list(get_field_names_from_opts(Book._meta)))
+        )
+        with self.assertRaisesMessage(FieldError, expected_message % alias_fields):
+            Book.objects.alias(my_alias=F("pk")).order_by("alias_typo")


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36480

#### Branch description
Currently if we try to access an non-existent `alias` the `FieldError` message doesn't include the alias you created while it works fine for non-existent annotations. This PR fixes it by ensuring that we provide the created `alias` in the`FieldError` message and try to be consistent with `alias` and `annotation`.

#### Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
