### PR TITLE
Fixed #36589 -- Handled full PartialTemplate path in assertTemplateUsed/NotUsed.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -196,6 +196,7 @@ answer newbie questions, and generally made Django that much better:
     btoll@bestweb.net
     C8E
     Caio Ariede <caio.ariede@gmail.com>
+    Caitie Baca <caitlin.baca@yahoo.com>
     Calvin Spealman <ironfroggy@gmail.com>
     Cameron Curry
     Cameron Knight (ckknight)

--- a/tests/test_utils/templates/template_used/partials.html
+++ b/tests/test_utils/templates/template_used/partials.html
@@ -1,0 +1,3 @@
+{% partialdef hello %}
+<p>Hello</p>
+{% endpartialdef %}

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -646,6 +646,53 @@ class AssertTemplateUsedContextManagerTests(SimpleTestCase):
             self.assertTemplateNotUsed(response, "template.html")
 
 
+@override_settings(ROOT_URLCONF="test_utils.urls")
+class AssertTemplateUsedPartialTests(SimpleTestCase):
+    def test_template_used_pass(self):
+        with self.assertTemplateUsed("template_used/partials.html#hello"):
+            render_to_string("template_used/partials.html#hello")
+
+    def test_template_not_used_pass(self):
+        with self.assertTemplateNotUsed("hello"):
+            render_to_string("template_used/partials.html#hello")
+
+    def test_template_used_fail(self):
+        msg = "Template 'hello' was not a template used to render the response."
+        with (
+            self.assertRaisesMessage(AssertionError, msg),
+            self.assertTemplateUsed("hello"),
+        ):
+            render_to_string("template_used/base.html")
+
+    def test_template_not_used_fail(self):
+        msg = (
+            "Template 'template_used/partials.html#hello' was used "
+            "unexpectedly in rendering the response"
+        )
+        with (
+            self.assertRaisesMessage(AssertionError, msg),
+            self.assertTemplateNotUsed("template_used/partials.html#hello"),
+        ):
+            render_to_string("template_used/partials.html#hello")
+
+    def test_template_not_used_pass_non_partial(self):
+        with self.assertTemplateNotUsed(
+            "template_used/base.html#template_used/base.html"
+        ):
+            render_to_string("template_used/base.html")
+
+    def test_template_used_fail_non_partial(self):
+        msg = (
+            "Template 'template_used/base.html#template_used/base.html' was not a "
+            "template used to render the response."
+        )
+        with (
+            self.assertRaisesMessage(AssertionError, msg),
+            self.assertTemplateUsed("template_used/base.html#template_used/base.html"),
+        ):
+            render_to_string("template_used/base.html")
+
+
 class HTMLEqualTests(SimpleTestCase):
     def test_html_parser(self):
         element = parse_html("<div><p>Hello</p></div>")


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36589

#### Branch description
Fixed assertTemplateUsed, as it didn't work with full path for template partials.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
