### PR TITLE
Refs #35667 -- Updated contributing guide to use django file prefixes on deprecations.

### DIFF
--- a/docs/internals/contributing/writing-code/submitting-patches.txt
+++ b/docs/internals/contributing/writing-code/submitting-patches.txt
@@ -282,7 +282,7 @@ previous behavior, or standalone items that are unnecessary or unused when the
 deprecation ends. For example::
 
     import warnings
-    from django.utils.deprecation import RemovedInDjangoXXWarning
+    from django.utils.deprecation import RemovedInDjangoXXWarning, django_file_prefixes
 
 
     # RemovedInDjangoXXWarning.
@@ -295,7 +295,7 @@ deprecation ends. For example::
         warnings.warn(
             "foo() is deprecated.",
             category=RemovedInDjangoXXWarning,
-            stacklevel=2,
+            stacklevel=django_file_prefixes(),
         )
         old_private_helper()
         ...


### PR DESCRIPTION
Follow up of 7b26b64a63b5fc15134426a6ee0534dca2a1a855.

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35667

#### Branch description
PR #19823 added a helper to calculate the django file prefixes and we should use it in the deprecating docs.