### PR TITLE
Corrected usage of skip_file_prefixes in contributing docs.

### DIFF
--- a/docs/internals/contributing/writing-code/submitting-patches.txt
+++ b/docs/internals/contributing/writing-code/submitting-patches.txt
@@ -295,7 +295,7 @@ deprecation ends. For example::
         warnings.warn(
             "foo() is deprecated.",
             category=RemovedInDjangoXXWarning,
-            stacklevel=django_file_prefixes(),
+            skip_file_prefixes=django_file_prefixes(),
         )
         old_private_helper()
         ...


### PR DESCRIPTION
Typo in 8956ee3ce393f143696fa6c50a1153c0623003ad.
