### PR TITLE
Doc'd that middleware hooks may also be used with function-based middleware

### DIFF
--- a/docs/topics/http/middleware.txt
+++ b/docs/topics/http/middleware.txt
@@ -154,7 +154,8 @@ Other middleware hooks
 ======================
 
 Besides the basic request/response middleware pattern described earlier, you
-can add three other special methods to class-based middleware:
+can add three other special methods to class-based middleware as methods or
+function-based middleware as attributes of the middleware function:
 
 .. _view-middleware:
 


### PR DESCRIPTION
The docs mention these hooks are "class-based middleware hooks" when in fact it's possible to define them on your function-based middleware like so, which is kinda nice because some folks prefer functions over classes:

```python
def simple_middleware(get_response):
    # One-time configuration and initialization.

    def middleware(request):
        # Code to be executed for each request before
        # the view (and later middleware) are called.

        response = get_response(request)

        # Code to be executed for each request/response after
        # the view is called.

        return response

    # hooks here
    def process_view(request, view_func, view_args, view_kwargs):
        # process your view here
        return None  # (or a response to skip it)
 
    # bind hook
    middleware.process_view = process_view

    return middleware
```