### PR TITLE
Refs #36438 -- Simplified retrieval of GeneratedField base fields in migrations autodetector.

### DIFF
--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -1682,7 +1682,10 @@ class MigrationAutodetector:
 
     def _get_dependencies_for_generated_field(self, field):
         dependencies = []
-        referenced_base_fields = models.Q(field.expression).referenced_base_fields
+        referenced_base_fields = [
+            name
+            for name, *lookups in models.Model._get_expr_references(field.expression)
+        ]
         newly_added_fields = sorted(self.new_field_keys - self.old_field_keys)
         for app_label, model_name, added_field_name in newly_added_fields:
             added_field = self.to_state.models[app_label, model_name].get_field(


### PR DESCRIPTION
Stops abusing Q objects by creating an unusable Q object solely to call referenced_base_fields on it.

Based on https://github.com/django/django/pull/19620#discussion_r2188747941
> passing field.expression: Expression to a Q object (which is meant to be used for conditional expressions) so we can then call referenced_base_fields which then defers to query.get_children_from_q seems plain wrong given the created Q object is likely unusable (unless field.expression resolves to a boolean).

I'd hoped we could use the new `GeneratedField.referenced_fields` but it is unusable outside of query contexts 🤔.