### PR TITLE
feat: add color for argparse

### DIFF
--- a/django/core/management/__init__.py
+++ b/django/core/management/__init__.py
@@ -24,6 +24,7 @@ from django.core.management.base import (
 )
 from django.core.management.color import color_style
 from django.utils import autoreload
+from django.utils.version import PY314
 
 
 def find_commands(management_dir):
@@ -364,11 +365,16 @@ class ManagementUtility:
         # Preprocess options to extract --settings and --pythonpath.
         # These options could affect the commands that are available, so they
         # must be processed early.
+        if PY314:
+            color_kwargs = {"color": os.environ.get("DJANGO_COLORS") != "nocolor"}
+        else:
+            color_kwargs = {}
         parser = CommandParser(
             prog=self.prog_name,
             usage="%(prog)s subcommand [options] [args]",
             add_help=False,
             allow_abbrev=False,
+            **color_kwargs,
         )
         parser.add_argument("--settings")
         parser.add_argument("--pythonpath")

--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -15,6 +15,7 @@ from django.core import checks
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management.color import color_style, no_style
 from django.db import DEFAULT_DB_ALIAS, connections
+from django.utils.version import PY314
 
 ALL_CHECKS = "__all__"
 
@@ -301,11 +302,18 @@ class BaseCommand:
         parse the arguments to this command.
         """
         kwargs.setdefault("formatter_class", DjangoHelpFormatter)
+        # argparse's color defaults to True on Python 3.14+.
+        # Respect DJANGO_COLORS=nocolor by explicitly passing color=False.
+        if PY314:
+            color_kwargs = {"color": os.environ.get("DJANGO_COLORS") != "nocolor"}
+        else:
+            color_kwargs = {}
         parser = CommandParser(
             prog="%s %s" % (os.path.basename(prog_name), subcommand),
             description=self.help or None,
             missing_args_message=getattr(self, "missing_args_message", None),
             called_from_command_line=getattr(self, "_called_from_command_line", None),
+            **color_kwargs,
             **kwargs,
         )
         self.add_base_argument(


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36376

#### Branch description

•  Enabled colorized help for management command parsers on Python 3.14+ by setting the argparse color parameter when creating the command parser, unless DJANGO_COLORS=nocolor is set.
•  Kept compatibility with older Python versions by guarding the new parameter behind a Python 3.14+ check.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
