### PR TITLE
[WIP] Switched SimpleTestCase to TestCase in OGRInspectTest.

### DIFF
--- a/tests/gis_tests/inspectapp/tests.py
+++ b/tests/gis_tests/inspectapp/tests.py
@@ -6,7 +6,7 @@ from django.contrib.gis.gdal import GDAL_VERSION, Driver, GDALException
 from django.contrib.gis.utils.ogrinspect import ogrinspect
 from django.core.management import call_command
 from django.db import connection, connections
-from django.test import SimpleTestCase, TestCase, skipUnlessDBFeature
+from django.test import TestCase, skipUnlessDBFeature
 from django.test.utils import modify_settings
 
 from ..test_data import TEST_DATA
@@ -61,7 +61,7 @@ class InspectDbTests(TestCase):
 @modify_settings(
     INSTALLED_APPS={"append": "django.contrib.gis"},
 )
-class OGRInspectTest(SimpleTestCase):
+class OGRInspectTest(TestCase):
     maxDiff = 1024
 
     def test_poly(self):


### PR DESCRIPTION
**experiment** to see if this resolves the GDAL error on recent Jenkins runs that migrated to Focal nodes.
***
test_time_field() uses a layer_key corresponding to a table.

Follow-up to 7056a4dd8e10dd16eb30fb9ed997f75bd54c00bb.