### PR TITLE
Fixed #26619 - BaseCache incr method will reset the timeout

### DIFF
--- a/django/core/cache/backends/db.py
+++ b/django/core/cache/backends/db.py
@@ -117,8 +117,8 @@ class DatabaseCache(BaseDatabaseCache):
         key = self.make_and_validate_key(key, version=version)
         return self._base_set("touch", key, None, timeout)
 
-    def _base_set(self, mode, key, value, timeout='no_timeout'):
-        no_timeout = timeout == 'no_timeout'
+    def _base_set(self, mode, key, value, timeout="no_timeout"):
+        no_timeout = timeout == "no_timeout"
         if no_timeout:
             timeout = DEFAULT_TIMEOUT
 

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -1297,7 +1297,8 @@ class DBCacheTests(BaseCacheTests, TransactionTestCase):
 
     def test_incr_decr_without_timeout(self):
         """
-        Increment/decrement a key without timeout shouldn’t set one; if it exists, keep its timeout.
+        Increment/decrement a key without timeout
+        shouldn’t set one; if it exists, keep its timeout.
         """
         current_time = int(time.time())
         timeout = 86400  # 1 day

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -1297,8 +1297,7 @@ class DBCacheTests(BaseCacheTests, TransactionTestCase):
 
     def test_incr_decr_without_timeout(self):
         """
-        Incrementing or decrementing a key that doesn't have a timeout
-        shouldn't set one if the key is not found otherwise use the existing expiring.
+        Increment/decrement a key without timeout shouldn’t set one; if it exists, keep its timeout.
         """
         current_time = int(time.time())
         timeout = 86400  # 1 day


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-26619

#### Branch description
Problem description

When using DatabaseCache with the incr() and decr() methods, if a key already has a custom timeout set, its expiration date is reset to the default value instead of keeping the existing one.

This leads to loss of the correct expiry value, causing keys with custom timeouts to be invalidated earlier or later than expected.

Steps to reproduce

Configure a DatabaseCache.
Save a key with an explicit timeout:
cache.set("key", 1, timeout=86400) # 1 day

Check the expiration in the DB (correct: ~current_time + 86400).
Increment the value with:
cache.incr("key")

Check the expiration again: it is reset to the default instead of remaining unchanged.
Expected behavior

The incr() and decr() operations should not modify the expiration date of an existing key. They should preserve the previously defined timeout.

Proposed changes

Introduced a get_many_rows() method to isolate and directly test expiry handling.
Added a no_timeout flag in _base_set to distinguish cases where no new timeout should be set.
Updated the UPDATE logic so that incr/decr does not overwrite the expires field.
Added tests to ensure incr() and decr() maintain the original expiry
Affected files

django/core/cache/backends/db.py
#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
