### PR TITLE
Added backticks to email addresses in docs.

### DIFF
--- a/docs/faq/help.txt
+++ b/docs/faq/help.txt
@@ -56,8 +56,9 @@ I think I've found a security problem! What should I do?
 ========================================================
 
 If you think you've found a security problem with Django, please send a message
-to security@djangoproject.com. This is a private list only open to long-time,
-highly trusted Django developers, and its archives are not publicly readable.
+to ``security@djangoproject.com``. This is a private list only open to
+long-time, highly trusted Django developers, and its archives are not publicly
+readable.
 
 Due to the sensitive nature of security issues, we ask that if you think you
 have found a security problem, *please* don't post a message on the forum, the

--- a/docs/howto/deployment/checklist.txt
+++ b/docs/howto/deployment/checklist.txt
@@ -149,10 +149,10 @@ If you haven't set up backups for your database, do it right now!
 
 If your site sends emails, these values need to be set correctly.
 
-By default, Django sends email from webmaster@localhost and root@localhost.
-However, some mail providers reject email from these addresses. To use
-different sender addresses, modify the :setting:`DEFAULT_FROM_EMAIL` and
-:setting:`SERVER_EMAIL` settings.
+By default, Django sends email from ``webmaster@localhost`` and
+``root@localhost``. However, some mail providers reject email from these
+addresses. To use different sender addresses, modify the
+:setting:`DEFAULT_FROM_EMAIL` and :setting:`SERVER_EMAIL` settings.
 
 :setting:`STATIC_ROOT` and :setting:`STATIC_URL`
 ------------------------------------------------

--- a/docs/howto/error-reporting.txt
+++ b/docs/howto/error-reporting.txt
@@ -37,7 +37,7 @@ caused the error.
    documentation </ref/settings>` for a full list of email-related
    settings.
 
-By default, Django will send email from root@localhost. However, some mail
+By default, Django will send email from ``root@localhost``. However, some mail
 providers reject all email from this address. To use a different sender
 address, modify the :setting:`SERVER_EMAIL` setting.
 

--- a/docs/internals/contributing/bugs-and-features.txt
+++ b/docs/internals/contributing/bugs-and-features.txt
@@ -5,7 +5,7 @@ Reporting bugs and requesting features
 .. Important::
 
     Please report security issues **only** to
-    security@djangoproject.com. This is a private list only open to
+    ``security@djangoproject.com``. This is a private list only open to
     long-time, highly trusted Django developers, and its archives are
     not public. For further details, please see :doc:`our security
     policies </internals/security>`.

--- a/docs/internals/howto-release-django.txt
+++ b/docs/internals/howto-release-django.txt
@@ -650,10 +650,11 @@ Now you're ready to actually put the release out there. To do this:
    Django Forum. This should include a link to the announcement blog post.
 
 #. If this is a security release, send a separate email to
-   oss-security@lists.openwall.com. Provide a descriptive subject, for example,
-   "Django" plus the issue title from the release notes (including CVE ID). The
-   message body should include the vulnerability details, for example, the
-   announcement blog post text. Include a link to the announcement blog post.
+   ``oss-security@lists.openwall.com``. Provide a descriptive subject, for
+   example, "Django" plus the issue title from the release notes (including CVE
+   ID). The message body should include the vulnerability details, for example,
+   the announcement blog post text. Include a link to the announcement blog
+   post.
 
 Post-release
 ============

--- a/docs/internals/mailing-lists.txt
+++ b/docs/internals/mailing-lists.txt
@@ -5,7 +5,7 @@ Mailing lists and Forum
 .. Important::
 
     Please report security issues **only** to
-    security@djangoproject.com. This is a private list only open to
+    ``security@djangoproject.com``. This is a private list only open to
     long-time, highly trusted Django developers, and its archives are
     not public. For further details, please see :doc:`our security
     policies </internals/security>`.

--- a/docs/topics/email.txt
+++ b/docs/topics/email.txt
@@ -226,8 +226,8 @@ both appearing in the "To:"::
         ["john@example.com", "jane@example.com"],
     )
 
-This sends a message to john@example.com and jane@example.com, with them both
-receiving a separate email::
+This sends a message to ``john@example.com`` and ``jane@example.com``, with
+them both receiving a separate email::
 
     datatuple = (
         ("Subject", "Message.", "from@example.com", ["john@example.com"]),
@@ -253,8 +253,8 @@ If a ``message`` contains headers at the start of the string, the headers will
 be printed as the first bit of the email message.
 
 Here's an example view that takes a ``subject``, ``message`` and ``from_email``
-from the request's POST data, sends that to admin@example.com and redirects to
-"/contact/thanks/" when it's done::
+from the request's POST data, sends that to ``admin@example.com`` and redirects
+to "/contact/thanks/" when it's done::
 
     from django.core.mail import send_mail
     from django.http import HttpResponse, HttpResponseRedirect


### PR DESCRIPTION
This prevents them from being wrapped in `mailto`.

Before:

<img width="920" height="277" alt="image" src="https://github.com/user-attachments/assets/2395a34a-710d-45ef-bae7-5b4e765921de" />

Hopefully, this helps slightly reduce the amount of spam we receive at `security@djangoproject.com`.