### PR TITLE
Refs #27222 -- Restored Model.save()'s refreshing of db_returning fields, even if a value is set.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1154,8 +1154,6 @@ class Model(AltersData, metaclass=ModelBase):
                 )
                 if hasattr(value, "resolve_expression"):
                     returning_fields.append(field)
-                elif field.db_returning:
-                    returning_fields.remove(field)
             results = self._do_insert(
                 cls._base_manager, using, fields, returning_fields, raw
             )

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -215,6 +215,15 @@ class ModelInstanceCreationTests(TestCase):
         with self.assertNumQueries(1):
             PrimaryKeyWithFalseyDbDefault().save()
 
+    def test_db_returning_field_with_value_refreshed(self):
+        """
+        A field with db_returning=True must be refreshed by Model.save() even
+        when a value is set because the database may return a value of a
+        different type.
+        """
+        a = Article.objects.create(pk="123456", pub_date=datetime(2025, 9, 16))
+        self.assertEqual(a.pk, 123456)
+
 
 class ModelTest(TestCase):
     def test_objects_attribute_is_only_available_on_the_class_itself(self):


### PR DESCRIPTION
Regression in 94680437a45a71c70ca8bd2e68b72aa1e2eff337.

Discussed at https://github.com/django/django/pull/19285/files#r2076268448.