### PR TITLE
Refs #27222 -- Deduplicated db_returning fields in Model.save().

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1153,7 +1153,8 @@ class Model(AltersData, metaclass=ModelBase):
                     getattr(self, field.attname) if raw else field.pre_save(self, False)
                 )
                 if hasattr(value, "resolve_expression"):
-                    returning_fields.append(field)
+                    if field not in returning_fields:
+                        returning_fields.append(field)
                 elif field.db_returning:
                     returning_fields.remove(field)
             results = self._do_insert(

--- a/tests/queries/test_db_returning.py
+++ b/tests/queries/test_db_returning.py
@@ -42,6 +42,16 @@ class ReturningValuesTests(TestCase):
             ),
             captured_queries[-1]["sql"],
         )
+        self.assertEqual(
+            captured_queries[-1]["sql"]
+            .split("RETURNING ")[1]
+            .count(
+                connection.ops.quote_name(
+                    ReturningModel._meta.get_field("created").column
+                ),
+            ),
+            1,
+        )
         self.assertTrue(obj.pk)
         self.assertIsInstance(obj.created, datetime.datetime)
 


### PR DESCRIPTION
Follow-up to 94680437a45a71c70ca8bd2e68b72aa1e2eff337.

Was seeing duplicate returning fields like:
```
(0.000) INSERT INTO "queries_returningmodel" ("created")
VALUES (STRFTIME('%%Y-%%m-%%d %%H:%%M:%%f', 'NOW')) RETURNING "queries_returningmodel"."id",
                                                              "queries_returningmodel"."created",
                                                              "queries_returningmodel"."created"; args=(); alias=default
```