### PR TITLE
Fixed #36594 -- Improved UniqueConstraint's nulls_distinct system check warning

### DIFF
--- a/django/db/models/constraints.py
+++ b/django/db/models/constraints.py
@@ -406,7 +406,8 @@ class UniqueConstraint(BaseConstraint):
             errors.append(
                 checks.Warning(
                     f"{connection.display_name} does not support unique constraints "
-                    "with nulls distinct.",
+                    "with nulls distinct. They are ignored for databases besides "
+                    "PostgreSQL 15+.",
                     hint=(
                         "A constraint won't be created. Silence this warning if you "
                         "don't care about it."

--- a/docs/ref/models/constraints.txt
+++ b/docs/ref/models/constraints.txt
@@ -272,8 +272,10 @@ For example::
 creates a unique constraint that only allows one row to store a ``NULL`` value
 in the ``ordering`` column.
 
-Unique constraints with ``nulls_distinct`` are ignored for databases besides
-PostgreSQL 15+.
+.. warning::
+
+    Unique constraints with ``nulls_distinct`` are ignored for databases
+    besides PostgreSQL 15+.
 
 ``violation_error_code``
 ------------------------

--- a/tests/invalid_models_tests/test_models.py
+++ b/tests/invalid_models_tests/test_models.py
@@ -2835,7 +2835,7 @@ class ConstraintsTests(TestCase):
 
         warn = Warning(
             f"{connection.display_name} does not support unique constraints with nulls "
-            "distinct.",
+            "distinct. They are ignored for databases besides PostgreSQL 15+.",
             hint=(
                 "A constraint won't be created. Silence this warning if you don't care "
                 "about it."


### PR DESCRIPTION
Clarified unique constraints with nulls distinct are ignored for databases besides PostgreSQL 15+. Added warning in unique constraint docs.

Thanks Russell Owen for the report.

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36594

#### Branch description
Expanded error message for `UniqueConstraint`'s `nulls_distinct` check to clarify that `nulls_distinct` are ignored for databases besides PostgreSQL 15+. Additionally, converted relevant docs note to warning to make it more obvious.
 
#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
