### PR TITLE
Refs #27222 -- Restored Model.save()'s refreshing of db_returning fields even if a value is set.

### DIFF
--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -215,6 +215,14 @@ class ModelInstanceCreationTests(TestCase):
         with self.assertNumQueries(1):
             PrimaryKeyWithFalseyDbDefault().save()
 
+    def test_auto_field_with_value_refreshed(self):
+        """
+        An auto field must be refreshed by Model.save() even when a value is
+        set because the database may return a value of a different type.
+        """
+        a = Article.objects.create(pk="123456", pub_date=datetime(2025, 9, 16))
+        self.assertEqual(a.pk, 123456)
+
 
 class ModelTest(TestCase):
     def test_objects_attribute_is_only_available_on_the_class_itself(self):

--- a/tests/queries/test_db_returning.py
+++ b/tests/queries/test_db_returning.py
@@ -26,6 +26,11 @@ class ReturningValuesTests(TestCase):
         self.assertTrue(obj.created)
         self.assertIsInstance(obj.created, datetime.datetime)
 
+    def test_insert_returning_non_integer_from_literal_value(self):
+        obj = NonIntegerPKReturningModel.objects.create(pk="2025-01-01")
+        self.assertTrue(obj.created)
+        self.assertIsInstance(obj.created, datetime.datetime)
+
     def test_insert_returning_multiple(self):
         with CaptureQueriesContext(connection) as captured_queries:
             obj = ReturningModel.objects.create()


### PR DESCRIPTION
Regression in https://github.com/django/django/commit/94680437a45a71c70ca8bd2e68b72aa1e2eff337.

Discussed at https://github.com/django/django/pull/19285/files#r2076268448.

I can't push changes to #19868 to I created this other PR @timgraham, @jacobtylerwalls. Please adjust authorship to whatever feels best.