### PR TITLE
Fixed #36612 -- Fixed a KeyTextTransform crash on MySQL against annotations.

### DIFF
--- a/django/db/models/fields/json.py
+++ b/django/db/models/fields/json.py
@@ -424,8 +424,12 @@ class KeyTextTransform(KeyTransform):
     output_field = TextField()
 
     def as_mysql(self, compiler, connection):
-        if connection.mysql_is_mariadb:
-            # MariaDB doesn't support -> and ->> operators (see MDEV-13594).
+        # The ->> operator is not supported on MariaDB (see MDEV-13594) and
+        # only supported against columns on MySQL.
+        if (
+            connection.mysql_is_mariadb
+            or getattr(self.lhs.output_field, "model", None) is None
+        ):
             sql, params = super().as_mysql(compiler, connection)
             return "JSON_UNQUOTE(%s)" % sql, params
         else:

--- a/tests/model_fields/test_jsonfield.py
+++ b/tests/model_fields/test_jsonfield.py
@@ -1160,6 +1160,12 @@ class TestQuerying(TestCase):
                     True,
                 )
 
+    def test_cast_with_key_text_transform(self):
+        obj = NullableJSONModel.objects.annotate(
+            json_data=Cast(Value({"foo": "bar"}, JSONField()), JSONField())
+        ).get(pk=self.objs[0].pk, json_data__foo__icontains="bar")
+        self.assertEqual(obj, self.objs[0])
+
     @skipUnlessDBFeature("supports_json_field_contains")
     def test_contains_contained_by_with_key_transform(self):
         tests = [


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36612

#### Branch description

MySQL only supports the `->>` when used directly against columns, this can be inferred by the presence of `lhs.output_field.model` as model bounds fields are directly tied to columns.

Purposely don't systematically switch to using `JSON_QUOTE(JSON_EXTRACT(...))` as there might be functional indices out there that rely on the SQL remaining stable between versions.

Thanks @jacobtavenerhulla for the report.
