### PR TITLE
Added cleanup of cache clearing to DjangoFilePrefixesTests.setUp().

### DIFF
--- a/tests/deprecation/tests.py
+++ b/tests/deprecation/tests.py
@@ -13,6 +13,7 @@ from django.utils.deprecation import (
 class DjangoFilePrefixesTests(SimpleTestCase):
     def setUp(self):
         django_file_prefixes.cache_clear()
+        self.addCleanup(django_file_prefixes.cache_clear)
 
     def test_no_file(self):
         orig_file = django.__file__


### PR DESCRIPTION
We have the tests in reverse failing in CI: https://djangoci.com/job/main-reverse/348/

Although I cannot replicate this locally, my best guess is that when the tests in `DjangoFilePrefixesTests` are reversed, the cached value of `django_file_prefixes` remains in a polluted state.
