### PR TITLE
Fixed #26886 -- Provided URLResolver namespace in technical 404 template.

### DIFF
--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -5,13 +5,14 @@ import re
 import sys
 import types
 import warnings
+from collections import namedtuple
 from pathlib import Path
 
 from django.conf import settings
 from django.http import Http404, HttpResponse, HttpResponseNotFound
 from django.template import Context, Engine, TemplateDoesNotExist
 from django.template.defaultfilters import pprint
-from django.urls import resolve
+from django.urls import URLResolver, resolve
 from django.utils import timezone
 from django.utils.datastructures import MultiValueDict
 from django.utils.encoding import force_str
@@ -635,6 +636,16 @@ def technical_404_response(request, exception):
         ):
             return default_urlconf(request)
 
+    for inner_tried in itertools.chain(*tried or []):
+        if isinstance(inner_tried, URLResolver):
+            inner_tried.debug_key_val = TriedPatternDebugInfo(
+                key="namespace", val=inner_tried.namespace
+            )
+        else:
+            inner_tried.debug_key_val = TriedPatternDebugInfo(
+                key="name", val=inner_tried.name
+            )
+
     urlconf = getattr(request, "urlconf", settings.ROOT_URLCONF)
     if isinstance(urlconf, types.ModuleType):
         urlconf = urlconf.__name__
@@ -669,3 +680,6 @@ def default_urlconf(request):
     )
 
     return HttpResponse(t.render(c))
+
+
+TriedPatternDebugInfo = namedtuple("TriedPatternDebugInfo", ["key", "val"])

--- a/django/views/templates/technical_404.html
+++ b/django/views/templates/technical_404.html
@@ -57,7 +57,7 @@
             {% for pat in pattern %}
               <code>
                 {{ pat.pattern }}
-                {% if forloop.last and pat.name %}[name='{{ pat.name }}']{% endif %}
+                {% if forloop.last and pat.debug_key_val.val %}[{{ pat.debug_key_val.key }}='{{ pat.debug_key_val.val }}']{% endif %}
               </code>
             {% endfor %}
           </li>

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -423,6 +423,11 @@ class DebugViewTests(SimpleTestCase):
             response, "<h1>The install worked successfully! Congratulations!</h1>"
         )
 
+    @override_settings(ROOT_URLCONF="view_tests.default_urls")
+    def test_default_urlconf_template_404(self):
+        response = self.client.get("/favicon.ico")
+        self.assertContains(response, "[namespace='admin']", status_code=404)
+
     @override_settings(ROOT_URLCONF="view_tests.regression_21530_urls")
     def test_regression_21530(self):
         """


### PR DESCRIPTION
#### Trac ticket number

ticket-26686

#### Branch description
Before, the technical 404 view was written in a way that interrogates a possibly missing `.name` on a url pattern or resolver. `.name` only exists on `URLPattern`.

Now, we log something else helpful for `URLResolver`, namely `.namespace`. This takes care of the huge traceback cited in the issue.

A custom template tag might have been a nicer implementation that what I ended up with, but the technical 500 template is not inside an app, so we can't register a custom tag AFIACT.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
