### PR TITLE
Refs #36152, #35667 -- Used skip_file_prefixes in deprecation warning for aliases with "%".

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -10,7 +10,6 @@ all about the internals of models in order to get the information it needs.
 import copy
 import difflib
 import functools
-import inspect
 import sys
 import warnings
 from collections import Counter, namedtuple
@@ -44,7 +43,7 @@ from django.db.models.query_utils import (
 from django.db.models.sql.constants import INNER, LOUTER, ORDER_DIR, SINGLE
 from django.db.models.sql.datastructures import BaseTable, Empty, Join, MultiJoin
 from django.db.models.sql.where import AND, OR, ExtraWhere, NothingNode, WhereNode
-from django.utils.deprecation import RemovedInDjango70Warning
+from django.utils.deprecation import RemovedInDjango70Warning, django_file_prefixes
 from django.utils.functional import cached_property
 from django.utils.regex_helper import _lazy_re_compile
 from django.utils.tree import Node
@@ -1216,15 +1215,10 @@ class Query(BaseExpression):
     def check_alias(self, alias):
         # RemovedInDjango70Warning: When the deprecation ends, remove.
         if "%" in alias:
-            if "aggregate" in {frame.function for frame in inspect.stack()}:
-                stacklevel = 5
-            else:
-                # annotate(), alias(), and values().
-                stacklevel = 6
             warnings.warn(
                 "Using percent signs in a column alias is deprecated.",
-                stacklevel=stacklevel,
                 category=RemovedInDjango70Warning,
+                skip_file_prefixes=django_file_prefixes(),
             )
         if FORBIDDEN_ALIAS_PATTERN.search(alias):
             raise ValueError(


### PR DESCRIPTION
Follow-up to 8ede411a81b40ca53362e6788601193c7e56a0cf.

This was still missing yet another variant via `.extra(select=...`, so just easier to rip 'n replace with the newer pattern.