### PR TITLE
Fixed #35667 -- Improved deprecation warning handling by replacing stacklevel with skip_file_prefixes

### DIFF
--- a/django/apps/registry.py
+++ b/django/apps/registry.py
@@ -6,6 +6,7 @@ from collections import Counter, defaultdict
 from functools import partial
 
 from django.core.exceptions import AppRegistryNotReady, ImproperlyConfigured
+from django.utils.deprecation import django_file_prefixes
 
 from .config import AppConfig
 
@@ -228,7 +229,7 @@ class Apps:
                     "advised as it can lead to inconsistencies, most notably with "
                     "related models." % (app_label, model_name),
                     RuntimeWarning,
-                    stacklevel=2,
+                    skip_file_prefixes=django_file_prefixes(),
                 )
             else:
                 raise RuntimeError(

--- a/django/conf/__init__.py
+++ b/django/conf/__init__.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import django
 from django.conf import global_settings
 from django.core.exceptions import ImproperlyConfigured
+from django.utils.deprecation import django_file_prefixes
 from django.utils.functional import LazyObject, empty
 
 ENVIRONMENT_VARIABLE = "DJANGO_SETTINGS_MODULE"
@@ -145,7 +146,7 @@ class LazySettings(LazyObject):
         # LazyObject __getattribute__(), -4 the caller.
         filename, _, _, _ = stack[-4]
         if not filename.startswith(os.path.dirname(django.__file__)):
-            warnings.warn(message, category, stacklevel=2)
+            warnings.warn(message, category, skip_file_prefixes=django_file_prefixes())
 
 
 class Settings:

--- a/django/contrib/postgres/aggregates/general.py
+++ b/django/contrib/postgres/aggregates/general.py
@@ -4,7 +4,7 @@ from django.contrib.postgres.fields import ArrayField
 from django.db.models import Aggregate, BooleanField, JSONField
 from django.db.models import StringAgg as _StringAgg
 from django.db.models import Value
-from django.utils.deprecation import RemovedInDjango70Warning
+from django.utils.deprecation import RemovedInDjango70Warning, django_file_prefixes
 
 __all__ = [
     "ArrayAgg",
@@ -67,7 +67,7 @@ class StringAgg(_StringAgg):
                 "of a string literal on Django 7.0. Pass "
                 f"`delimiter=Value({delimiter!r})` to preserve the previous behavior.",
                 category=RemovedInDjango70Warning,
-                stacklevel=2,
+                skip_file_prefixes=django_file_prefixes(),
             )
 
             delimiter = Value(delimiter)
@@ -76,7 +76,7 @@ class StringAgg(_StringAgg):
             "The PostgreSQL specific StringAgg function is deprecated. Use "
             "django.db.models.aggregate.StringAgg instead.",
             category=RemovedInDjango70Warning,
-            stacklevel=2,
+            skip_file_prefixes=django_file_prefixes(),
         )
 
         super().__init__(expression, delimiter, **extra)

--- a/django/contrib/postgres/aggregates/mixins.py
+++ b/django/contrib/postgres/aggregates/mixins.py
@@ -1,7 +1,7 @@
 # RemovedInDjango70Warning: When the deprecation ends, remove completely.
 import warnings
 
-from django.utils.deprecation import RemovedInDjango70Warning
+from django.utils.deprecation import RemovedInDjango70Warning, django_file_prefixes
 
 
 # RemovedInDjango70Warning.
@@ -13,6 +13,6 @@ class OrderableAggMixin:
             "OrderableAggMixin is deprecated. Use Aggregate and allow_order_by "
             "instead.",
             category=RemovedInDjango70Warning,
-            stacklevel=1,
+            skip_file_prefixes=django_file_prefixes(),
         )
         super().__init_subclass__(*args, **kwargs)

--- a/django/core/mail/__init__.py
+++ b/django/core/mail/__init__.py
@@ -21,7 +21,11 @@ from django.core.mail.message import (
     make_msgid,
 )
 from django.core.mail.utils import DNS_NAME, CachedDnsName
-from django.utils.deprecation import RemovedInDjango70Warning, deprecate_posargs
+from django.utils.deprecation import (
+    RemovedInDjango70Warning,
+    deprecate_posargs,
+    django_file_prefixes,
+)
 from django.utils.functional import Promise
 from django.utils.module_loading import import_string
 
@@ -168,7 +172,7 @@ def _send_server_message(
             f"Using (name, address) pairs in the {setting_name} setting is deprecated."
             " Replace with a list of email address strings.",
             RemovedInDjango70Warning,
-            stacklevel=2,
+            skip_file_prefixes=django_file_prefixes(),
         )
         recipients = [a[1] for a in recipients]
 

--- a/django/core/paginator.py
+++ b/django/core/paginator.py
@@ -5,7 +5,7 @@ from math import ceil
 
 from asgiref.sync import iscoroutinefunction, sync_to_async
 
-from django.utils.deprecation import RemovedInDjango70Warning
+from django.utils.deprecation import RemovedInDjango70Warning, django_file_prefixes
 from django.utils.functional import cached_property
 from django.utils.inspect import method_has_no_args
 from django.utils.translation import gettext_lazy as _
@@ -67,7 +67,11 @@ class BasePaginator:
                 "per_page argument is deprecated. This will raise a ValueError in "
                 "Django 7.0."
             )
-            warnings.warn(msg, category=RemovedInDjango70Warning, stacklevel=2)
+            warnings.warn(
+                msg,
+                category=RemovedInDjango70Warning,
+                skip_file_prefixes=django_file_prefixes(),
+            )
 
     def _check_object_list_is_ordered(self):
         """
@@ -86,7 +90,7 @@ class BasePaginator:
                 "Pagination may yield inconsistent results with an unordered "
                 "object_list: {}.".format(obj_list_repr),
                 UnorderedObjectListWarning,
-                stacklevel=3,
+                skip_file_prefixes=django_file_prefixes(),
             )
 
     def _get_elided_page_range(

--- a/django/db/backends/base/base.py
+++ b/django/db/backends/base/base.py
@@ -19,6 +19,7 @@ from django.db.backends.utils import debug_transaction
 from django.db.transaction import TransactionManagementError
 from django.db.utils import DatabaseErrorWrapper, ProgrammingError
 from django.utils.asyncio import async_unsafe
+from django.utils.deprecation import django_file_prefixes
 from django.utils.functional import cached_property
 
 NO_DB_ALIAS = "__no_db__"
@@ -176,7 +177,7 @@ class BaseDatabaseWrapper:
             warnings.warn(
                 "Limit for query logging exceeded, only the last {} queries "
                 "will be returned.".format(self.queries_log.maxlen),
-                stacklevel=2,
+                skip_file_prefixes=django_file_prefixes(),
             )
         return list(self.queries_log)
 

--- a/django/db/backends/base/creation.py
+++ b/django/db/backends/base/creation.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.core import serializers
 from django.db import router
 from django.db.transaction import atomic
-from django.utils.deprecation import RemovedInDjango70Warning
+from django.utils.deprecation import RemovedInDjango70Warning, django_file_prefixes
 from django.utils.module_loading import import_string
 
 # The prefix to put on the default database name when creating
@@ -103,7 +103,7 @@ class BaseDatabaseCreation:
                 "DatabaseCreation.create_test_db(serialize) is deprecated. Call "
                 "DatabaseCreation.serialize_test_db() once all test databases are set "
                 "up instead if you need fixtures persistence between tests.",
-                stacklevel=2,
+                skip_file_prefixes=django_file_prefixes(),
                 category=RemovedInDjango70Warning,
             )
             if serialize:

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -51,6 +51,7 @@ from django.db.models.signals import (
     pre_save,
 )
 from django.db.models.utils import AltersData, make_model_tuple
+from django.utils.deprecation import django_file_prefixes
 from django.utils.encoding import force_str
 from django.utils.hashable import make_hashable
 from django.utils.text import capfirst, get_text_list
@@ -660,13 +661,13 @@ class Model(AltersData, metaclass=ModelBase):
                     "match the current version %s."
                     % (pickled_version, django.__version__),
                     RuntimeWarning,
-                    stacklevel=2,
+                    skip_file_prefixes=django_file_prefixes(),
                 )
         else:
             warnings.warn(
                 "Pickled model instance's Django version is not specified.",
                 RuntimeWarning,
-                stacklevel=2,
+                skip_file_prefixes=django_file_prefixes(),
             )
         if "_memoryview_attrs" in state:
             for attr, value in state.pop("_memoryview_attrs"):

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -35,7 +35,7 @@ from django.db.models.utils import (
     resolve_callables,
 )
 from django.utils import timezone
-from django.utils.deprecation import RemovedInDjango70Warning
+from django.utils.deprecation import RemovedInDjango70Warning, django_file_prefixes
 from django.utils.functional import cached_property
 
 # The maximum number of results to fetch in a get() query.
@@ -350,13 +350,13 @@ class QuerySet(AltersData):
                     "match the current version %s."
                     % (pickled_version, django.__version__),
                     RuntimeWarning,
-                    stacklevel=2,
+                    skip_file_prefixes=django_file_prefixes(),
                 )
         else:
             warnings.warn(
                 "Pickled queryset instance's Django version is not specified.",
                 RuntimeWarning,
-                stacklevel=2,
+                skip_file_prefixes=django_file_prefixes(),
             )
         self.__dict__.update(state)
 

--- a/django/http/response.py
+++ b/django/http/response.py
@@ -20,6 +20,7 @@ from django.core.serializers.json import DjangoJSONEncoder
 from django.http.cookie import SimpleCookie
 from django.utils import timezone
 from django.utils.datastructures import CaseInsensitiveMapping
+from django.utils.deprecation import django_file_prefixes
 from django.utils.encoding import iri_to_uri
 from django.utils.functional import cached_property
 from django.utils.http import content_disposition_header, http_date
@@ -511,7 +512,7 @@ class StreamingHttpResponse(HttpResponseBase):
                 "StreamingHttpResponse must consume asynchronous iterators in order to "
                 "serve them synchronously. Use a synchronous iterator instead.",
                 Warning,
-                stacklevel=2,
+                skip_file_prefixes=django_file_prefixes(),
             )
 
             # async iterator. Consume in async_to_sync and map back.
@@ -532,7 +533,7 @@ class StreamingHttpResponse(HttpResponseBase):
                 "StreamingHttpResponse must consume synchronous iterators in order to "
                 "serve them asynchronously. Use an asynchronous iterator instead.",
                 Warning,
-                stacklevel=2,
+                skip_file_prefixes=django_file_prefixes(),
             )
             # sync iterator. Consume via sync_to_async and yield via async
             # generator.

--- a/django/test/signals.py
+++ b/django/test/signals.py
@@ -11,6 +11,7 @@ from django.db import connections, router
 from django.db.utils import ConnectionRouter
 from django.dispatch import Signal, receiver
 from django.utils import timezone
+from django.utils.deprecation import django_file_prefixes
 from django.utils.formats import FORMAT_SETTINGS, reset_format_cache
 from django.utils.functional import empty
 
@@ -167,7 +168,7 @@ def complex_setting_changed(*, enter, setting, **kwargs):
         # this stacklevel shows the line containing the override_settings call.
         warnings.warn(
             f"Overriding setting {setting} can lead to unexpected behavior.",
-            stacklevel=5,
+            skip_file_prefixes=django_file_prefixes(),
         )
 
 

--- a/django/utils/html.py
+++ b/django/utils/html.py
@@ -11,7 +11,7 @@ from urllib.parse import parse_qsl, quote, unquote, urlencode, urlsplit, urlunsp
 from django.conf import settings
 from django.core.exceptions import SuspiciousOperation, ValidationError
 from django.core.validators import DomainNameValidator, EmailValidator
-from django.utils.deprecation import RemovedInDjango70Warning
+from django.utils.deprecation import RemovedInDjango70Warning, django_file_prefixes
 from django.utils.functional import Promise, cached_property, keep_lazy, keep_lazy_text
 from django.utils.http import MAX_URL_LENGTH, RFC3986_GENDELIMS, RFC3986_SUBDELIMS
 from django.utils.regex_helper import _lazy_re_compile
@@ -369,7 +369,7 @@ class Urlizer:
                         "transitional setting to True to opt into using HTTPS as the "
                         "new default protocol.",
                         RemovedInDjango70Warning,
-                        stacklevel=2,
+                        skip_file_prefixes=django_file_prefixes(),
                     )
                 url = smart_urlquote(f"{protocol}://{unescaped_middle}")
             elif ":" not in middle and self.is_email_simple(middle):

--- a/tests/pagination/tests.py
+++ b/tests/pagination/tests.py
@@ -1,13 +1,10 @@
 import collections.abc
-import inspect
-import pathlib
 import unittest.mock
 import warnings
 from datetime import datetime
 
 from django.core.paginator import (
     AsyncPaginator,
-    BasePaginator,
     EmptyPage,
     InvalidPage,
     PageNotAnInteger,
@@ -900,14 +897,9 @@ class ModelPaginationTests(TestCase):
         )
         with self.assertWarnsMessage(UnorderedObjectListWarning, msg) as cm:
             AsyncPaginator(Article.objects.all(), 5)
-        # The warning points at the BasePaginator caller.
-        # The reason is that the UnorderedObjectListWarning occurs in
-        # BasePaginator.
-        base_paginator_path = pathlib.Path(inspect.getfile(BasePaginator))
-        self.assertIn(
-            cm.filename,
-            [str(base_paginator_path), str(base_paginator_path.with_suffix(".py"))],
-        )
+        # The warning points at the AsyncPaginator caller (i.e. the stacklevel
+        # is appropriate), same as the synchronous version.
+        self.assertEqual(cm.filename, __file__)
 
     def test_paginating_empty_queryset_does_not_warn(self):
         with warnings.catch_warnings(record=True) as recorded:


### PR DESCRIPTION
#### Trac ticket number
[ticket-35667](https://code.djangoproject.com/ticket/35667)

#### Branch description
Improved deprecation warning handling across Django by replacing stacklevel with skip_file_prefixes. This change ensures that deprecation warnings accurately point to the actual user code call sites by skipping Django's internal files, providing clearer and more actionable warning messages. The update leverages the django.utils.deprecation.django_file_prefixes() function to identify Django's internal files and implements consistent warning handling across the codebase including StreamingHttpResponse and AsyncPaginator.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
