### PR TITLE
Fixed #36489 -- Fixed stale reverse OneToOne cache in get_or_create

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -991,23 +991,33 @@ class QuerySet(AltersData):
 
     abulk_update.alters_data = True
 
-    def _clear_stale_reverse_one_to_one_caches(self, params):
-        # When a related object is passed as a lookup, a failed create() (or
-        # a caller-built unsaved instance) can leave an unsaved object in that
-        # related object's reverse one-to-one cache. Once an existing row has
-        # been found, drop the cache if it still holds an unsaved value so the
-        # reverse accessor resolves to the real row instead of the stale
-        # instance.
-        get_field = self.model._meta.get_field
+    def _resolve_stale_reverse_one_to_one_caches(self, params, obj=None):
+        # When a related object is passed as a lookup or default, a failed
+        # create() (or a caller-built unsaved instance) can leave an unsaved
+        # object in that related object's reverse one-to-one cache, and a
+        # select_related() to the reverse relation run before the row existed
+        # leaves None there. Both are stale once get_or_create() has resolved
+        # an existing row. When obj is given (the row about to be returned,
+        # which the caller guarantees matches every value in params), replace
+        # stale entries with it so the reverse accessor resolves without a
+        # query. When obj is None, drop them. Valid entries are never
+        # touched. This also runs on calls where no race happened, which is
+        # acceptable because it is a loop over the passed params with no
+        # queries.
         for field_name, value in params.items():
+            # Keys that are not field names (a lookup spanning a relation, an
+            # attname, a pk alias, or a property passed via defaults) have no
+            # reverse cache to resolve.
             try:
-                field = get_field(field_name)
+                field = self.model._meta.get_field(field_name)
             except exceptions.FieldDoesNotExist:
                 continue
             # Only concrete forward OneToOneFields hold a reverse one-to-one
             # cache on the related object. Reverse accessors (OneToOneRel) also
             # report one_to_one=True, but they're not concrete and their cache
             # is legitimate in-flight forward state that must not be cleared.
+            # The value is only a related object to look at when it's an
+            # instance; a one-to-one lookup may also be given a bare pk.
             # Compare against the concrete model so a field targeting a proxy
             # model still matches a concrete instance passed as the lookup.
             if (
@@ -1020,8 +1030,14 @@ class QuerySet(AltersData):
             if not remote_field.is_cached(value):
                 continue
             cached = remote_field.get_cached_value(value)
+            # A select_related() to the reverse relation caches None when no
+            # related row exists, so a cached None is stale here for the same
+            # reason an unsaved instance is.
             if cached is None or cached._state.adding:
-                remote_field.delete_cached_value(value)
+                if obj is None:
+                    remote_field.delete_cached_value(value)
+                else:
+                    remote_field.set_cached_value(value, obj)
 
     def get_or_create(self, defaults=None, **kwargs):
         """
@@ -1034,7 +1050,7 @@ class QuerySet(AltersData):
         self._for_write = True
         try:
             obj = self.get(**kwargs)
-            self._clear_stale_reverse_one_to_one_caches(kwargs)
+            self._resolve_stale_reverse_one_to_one_caches(kwargs, obj)
             return obj, False
         except self.model.DoesNotExist:
             params = self._extract_model_params(defaults, **kwargs)
@@ -1044,17 +1060,25 @@ class QuerySet(AltersData):
                     params = dict(resolve_callables(params))
                     return self.create(**params), True
             except IntegrityError:
-                # The create() that lost the race already populated the
-                # reverse one-to-one cache with its unsaved instance; clear
-                # it before the retry so a successful get() (or a re-raise)
-                # can't leave it behind. Use params (defaults plus kwargs)
-                # since create() may have been passed a related object via
-                # defaults, not just the lookup kwargs.
-                self._clear_stale_reverse_one_to_one_caches(params)
                 try:
-                    return self.get(**kwargs), False
+                    obj = self.get(**kwargs)
                 except self.model.DoesNotExist:
                     pass
+                else:
+                    # Point the lookup values' reverse one-to-one caches at
+                    # the row that won the race. The create() that lost it
+                    # left its unsaved instance there.
+                    self._resolve_stale_reverse_one_to_one_caches(kwargs, obj)
+                    return obj, False
+                finally:
+                    # Whether the retry succeeded or not, drop any stale
+                    # entries the failed create() left behind. Use params
+                    # (defaults plus kwargs) since create() may have been
+                    # passed a related object via defaults, and such a value
+                    # is not filtered on by the get() above, so obj cannot be
+                    # assumed to match it. Entries just repointed at obj are
+                    # no longer stale and are left alone.
+                    self._resolve_stale_reverse_one_to_one_caches(params)
                 raise
 
     get_or_create.alters_data = True

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -991,6 +991,38 @@ class QuerySet(AltersData):
 
     abulk_update.alters_data = True
 
+    def _clear_stale_reverse_one_to_one_caches(self, params):
+        # When a related object is passed as a lookup, a failed create() (or
+        # a caller-built unsaved instance) can leave an unsaved object in that
+        # related object's reverse one-to-one cache. Once an existing row has
+        # been found, drop the cache if it still holds an unsaved value so the
+        # reverse accessor resolves to the real row instead of the stale
+        # instance.
+        get_field = self.model._meta.get_field
+        for field_name, value in params.items():
+            try:
+                field = get_field(field_name)
+            except exceptions.FieldDoesNotExist:
+                continue
+            # Only concrete forward OneToOneFields hold a reverse one-to-one
+            # cache on the related object. Reverse accessors (OneToOneRel) also
+            # report one_to_one=True, but they're not concrete and their cache
+            # is legitimate in-flight forward state that must not be cleared.
+            # Compare against the concrete model so a field targeting a proxy
+            # model still matches a concrete instance passed as the lookup.
+            if (
+                not field.concrete
+                or not field.one_to_one
+                or not isinstance(value, field.related_model._meta.concrete_model)
+            ):
+                continue
+            remote_field = field.remote_field
+            if not remote_field.is_cached(value):
+                continue
+            cached = remote_field.get_cached_value(value)
+            if cached is None or cached._state.adding:
+                remote_field.delete_cached_value(value)
+
     def get_or_create(self, defaults=None, **kwargs):
         """
         Look up an object with the given kwargs, creating one if necessary.
@@ -1001,7 +1033,9 @@ class QuerySet(AltersData):
         # to avoid potential transaction consistency problems.
         self._for_write = True
         try:
-            return self.get(**kwargs), False
+            obj = self.get(**kwargs)
+            self._clear_stale_reverse_one_to_one_caches(kwargs)
+            return obj, False
         except self.model.DoesNotExist:
             params = self._extract_model_params(defaults, **kwargs)
             # Try to create an object using passed params.
@@ -1010,6 +1044,13 @@ class QuerySet(AltersData):
                     params = dict(resolve_callables(params))
                     return self.create(**params), True
             except IntegrityError:
+                # The create() that lost the race already populated the
+                # reverse one-to-one cache with its unsaved instance; clear
+                # it before the retry so a successful get() (or a re-raise)
+                # can't leave it behind. Use params (defaults plus kwargs)
+                # since create() may have been passed a related object via
+                # defaults, not just the lookup kwargs.
+                self._clear_stale_reverse_one_to_one_caches(params)
                 try:
                     return self.get(**kwargs), False
                 except self.model.DoesNotExist:

--- a/tests/one_to_one/models.py
+++ b/tests/one_to_one/models.py
@@ -31,6 +31,21 @@ class Bar(models.Model):
     serves_cocktails = models.BooleanField(default=True)
 
 
+class Branch(models.Model):
+    pk = models.CompositePrimaryKey("place", "number")
+    place = models.OneToOneField(Place, models.CASCADE)
+    number = models.SmallIntegerField(default=1)
+
+
+class ProxyPlace(Place):
+    class Meta:
+        proxy = True
+
+
+class PlaceProxyPointer(models.Model):
+    place = models.OneToOneField(ProxyPlace, models.CASCADE)
+
+
 class UndergroundBar(models.Model):
     place = models.OneToOneField(Place, models.SET_NULL, null=True)
     serves_cocktails = models.BooleanField(default=True)

--- a/tests/one_to_one/tests.py
+++ b/tests/one_to_one/tests.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from unittest.mock import patch
 
 from django.core.exceptions import FieldFetchBlocked
@@ -701,10 +702,36 @@ class OneToOneTests(TestCase):
             FETCH_PEERS,
         )
 
+    @contextmanager
+    def simulate_lost_insert_race(self, insert_winning_row):
+        """
+        Run the enclosed block with a concurrent writer injected into
+        get_or_create().
+
+        insert_winning_row() is called from the first
+        _extract_model_params() call, which get_or_create() only makes once
+        its initial get() has found nothing, so the row it inserts makes the
+        create() that follows lose the race.
+
+        Yield a dict whose "done" key records whether the injection fired, so
+        a test can tell a real race from a patch that stopped intercepting.
+        """
+        original = QuerySet._extract_model_params
+        triggered = {"done": False}
+
+        def side_effect(queryset, defaults=None, **kwargs):
+            if not triggered["done"]:
+                triggered["done"] = True
+                insert_winning_row()
+            return original(queryset, defaults, **kwargs)
+
+        with patch(
+            "django.db.models.query.QuerySet._extract_model_params", side_effect
+        ):
+            yield triggered
+
     def test_get_or_create_race_keeps_reverse_o2o_cache_consistent(self):
         """
-        Regression test for #36489.
-
         Simulate two concurrent Bar.get_or_create(place=...) calls
         racing on the same OneToOneField. The loser of the insert must not
         leave an unsaved instance cached on the reverse side (place.bar
@@ -717,25 +744,16 @@ class OneToOneTests(TestCase):
         """
         place = Place.objects.create(name="Race Diner", address="Somewhere")
 
-        # We'll inject a concurrent get_or_create inside the first one by
-        # patching QuerySet._extract_model_params
-        original = QuerySet._extract_model_params
-        triggered = {"done": False}
+        def insert_winning_row():
+            # Use a fresh instance of place to emulate a separate thread.
+            Bar.objects.get_or_create(place=Place.objects.get(pk=place.pk))
 
-        def side_effect(self, defaults=None, **kwargs):
-            # Only re-enter once, and only for the same place kwarg.
-            if not triggered["done"] and kwargs.get("place") == place:
-                triggered["done"] = True
-                # Use a *fresh* instance of place to emulate a separate thread.
-                Bar.objects.get_or_create(place=Place.objects.get(pk=place.pk))
-            return original(self, defaults, **kwargs)
-
-        with patch(
-            "django.db.models.query.QuerySet._extract_model_params",
-            side_effect,
-        ):
+        with self.simulate_lost_insert_race(insert_winning_row) as triggered:
             bar, created = Bar.objects.get_or_create(place=place)
-            self.assertFalse(created)
+        self.assertFalse(created)
+        # Guard against the patch no longer intercepting the call, which
+        # would make this test pass without simulating any race.
+        self.assertTrue(triggered["done"])
 
         # The reverse cache must not contain an unsaved Bar.
         # Accessing place.bar should yield a saved row with a pk,
@@ -749,22 +767,142 @@ class OneToOneTests(TestCase):
         place = Place.objects.create(name="Silver Square", address="Somewhere")
         Bar.objects.create(place=place)
 
-        # Prime a valid forward cache via select_related()
-        # (we don't clear this path).
-        fetched = Bar.objects.select_related("place").get(place=place)
-
-        # Run a no-op get_or_create (no IntegrityError path taken).
-        _, created = Bar.objects.get_or_create(place=place)
+        # Run a no-op get_or_create (no IntegrityError path taken) that
+        # primes a valid forward cache via select_related().
+        fetched, created = Bar.objects.select_related("place").get_or_create(
+            place=place
+        )
         self.assertFalse(created)
 
         # Using the forward cache should not cause a query.
         with self.assertNumQueries(0):
             _ = fetched.place.id
 
+    def test_get_or_create_race_lost_insert_preserves_forward_select_related(self):
+        """
+        When the insert race is lost, the fallback get() runs on the same
+        queryset, so a select_related() on the losing call still populates
+        the forward cache of the returned object.
+        """
+        place = Place.objects.create(name="Fallback Diner", address="Somewhere")
+
+        def insert_winning_row():
+            Bar.objects.get_or_create(place=Place.objects.get(pk=place.pk))
+
+        with self.simulate_lost_insert_race(insert_winning_row) as triggered:
+            bar, created = Bar.objects.select_related("place").get_or_create(
+                place=place
+            )
+        self.assertFalse(created)
+        # Guard against the patch no longer intercepting the call, which
+        # would make this test pass without simulating any race.
+        self.assertTrue(triggered["done"])
+
+        with self.assertNumQueries(0):
+            self.assertEqual(bar.place.pk, place.pk)
+
+    def test_get_or_create_race_lost_insert_restores_reverse_o2o_cache(self):
+        """
+        A reverse one-to-one cache primed by select_related() must survive
+        losing the insert race. The cache on place mutates in this order:
+
+        1. select_related("bar") caches None on place, since no row exists.
+        2. The losing get_or_create() runs its initial get(), which raises
+           DoesNotExist. Meanwhile the concurrent winner inserts the row.
+        3. The losing create() builds Bar(place=place). The forward
+           descriptor's __set__ overwrites the cached None with that unsaved
+           Bar.
+        4. The insert raises IntegrityError.
+        5. The fallback get() fetches the winning row, and get_or_create()
+           replaces the unsaved instance in the cache with that row before
+           returning it.
+
+        Afterwards place.bar must resolve to the returned row with no query.
+        """
+        place = Place.objects.create(name="Restored Cache Diner", address="Somewhere")
+        # No bar exists yet, so select_related() caches None on the reverse
+        # relation: place.bar raises without querying.
+        place = Place.objects.select_related("bar").get(pk=place.pk)
+        with self.assertNumQueries(0):
+            with self.assertRaises(Bar.DoesNotExist):
+                place.bar
+
+        def insert_winning_row():
+            Bar.objects.get_or_create(place=Place.objects.get(pk=place.pk))
+
+        with self.simulate_lost_insert_race(insert_winning_row) as triggered:
+            bar, created = Bar.objects.get_or_create(place=place)
+        self.assertFalse(created)
+        # Guard against the patch no longer intercepting the call, which
+        # would make this test pass without simulating any race.
+        self.assertTrue(triggered["done"])
+
+        # The cache now holds the row that won the race, so the reverse
+        # accessor resolves without a query.
+        with self.assertNumQueries(0):
+            self.assertEqual(place.bar.pk, bar.pk)
+
+    def test_get_or_create_race_reraise_drops_stale_reverse_o2o_cache(self):
+        """
+        When the fallback get() after an IntegrityError also fails, the
+        IntegrityError is re-raised. The unsaved instance that the failed
+        create() left in the reverse one-to-one cache must still be dropped,
+        so the reverse accessor afterwards fetches the real row instead of
+        returning the unsaved instance.
+        """
+        place = Place.objects.create(name="Reraise Diner", address="Somewhere")
+
+        def insert_winning_row():
+            # The winner inserts a row that does not match the loser's full
+            # lookup, so the loser's fallback get() fails too.
+            Bar.objects.create(
+                place=Place.objects.get(pk=place.pk), serves_cocktails=False
+            )
+
+        with self.simulate_lost_insert_race(insert_winning_row) as triggered:
+            with self.assertRaises(IntegrityError):
+                Bar.objects.get_or_create(place=place, serves_cocktails=True)
+        # Guard against the patch no longer intercepting the call, which
+        # would make this test pass without simulating any race.
+        self.assertTrue(triggered["done"])
+
+        # The stale entry was dropped, so the reverse accessor pays a query
+        # and yields the winning row instead of the unsaved instance.
+        winner = Bar.objects.get(place=place)
+        with self.assertNumQueries(1):
+            self.assertEqual(place.bar.pk, winner.pk)
+        self.assertFalse(place.bar.serves_cocktails)
+
+    def test_get_or_create_race_drops_stale_cache_from_defaults_related_object(self):
+        """
+        A related object passed via defaults is seeded into the reverse
+        one-to-one cache by the failed create(), but it is not part of the
+        lookup, so the fallback get() proves nothing about which row it
+        relates to. Its stale entry must be dropped rather than repointed at
+        the returned row.
+        """
+        place = Place.objects.create(name="Defaults Object Diner", address="Anywhere")
+
+        def insert_winning_row():
+            Bar.objects.create(place=Place.objects.get(pk=place.pk))
+
+        with self.simulate_lost_insert_race(insert_winning_row) as triggered:
+            bar, created = Bar.objects.get_or_create(
+                serves_cocktails=True, defaults={"place": place}
+            )
+        # Guard against the patch no longer intercepting the call, which
+        # would make this test pass without simulating any race.
+        self.assertTrue(triggered["done"])
+        self.assertFalse(created)
+        self.assertEqual(bar.place_id, place.pk)
+
+        # The stale entry was dropped rather than repointed at the returned
+        # row, so the reverse accessor re-fetches before yielding it.
+        with self.assertNumQueries(1):
+            self.assertEqual(place.bar.pk, bar.pk)
+
     def test_update_or_create_race_keeps_reverse_o2o_cache_consistent(self):
         """
-        Regression test for #36489 (update_or_create path).
-
         Simulate two concurrent Bar.update_or_create(place=...) calls
         racing on the same OneToOneField. The loser of the insert must not
         leave an unsaved instance cached on the reverse side (place.bar
@@ -773,26 +911,19 @@ class OneToOneTests(TestCase):
         """
         place = Place.objects.create(name="Update Race Diner", address="Somewhere")
 
-        # Inject a concurrent get_or_create inside the first one by
-        # patching QuerySet._extract_model_params.
-        original = QuerySet._extract_model_params
-        triggered = {"done": False}
+        def insert_winning_row():
+            # Use a fresh instance of place to emulate a separate thread.
+            Bar.objects.get_or_create(place=Place.objects.get(pk=place.pk))
 
-        def side_effect(self, defaults=None, **kwargs):
-            if not triggered["done"] and kwargs.get("place") == place:
-                triggered["done"] = True
-                # Use a fresh instance of place to emulate a separate thread.
-                Bar.objects.get_or_create(place=Place.objects.get(pk=place.pk))
-            return original(self, defaults, **kwargs)
-
-        with patch(
-            "django.db.models.query.QuerySet._extract_model_params", side_effect
-        ):
+        with self.simulate_lost_insert_race(insert_winning_row) as triggered:
             bar, created = Bar.objects.update_or_create(
                 place=place,
                 defaults={"serves_cocktails": False},
             )
-            self.assertFalse(created)
+        self.assertFalse(created)
+        # Guard against the patch no longer intercepting the call, which
+        # would make this test pass without simulating any race.
+        self.assertTrue(triggered["done"])
 
         # The reverse cache must not contain an unsaved Bar.
         # Accessing place.bar should yield a saved row with a pk,
@@ -804,8 +935,6 @@ class OneToOneTests(TestCase):
 
     def test_update_or_create_race_with_defaults_reverse_o2o_cache_consistent(self):
         """
-        Regression test for #36489 (defaults/create_defaults path).
-
         Simulate two concurrent Bar.update_or_create(place=...) calls
         with non-trivial defaults. The loser of the insert must not leave an
         unsaved instance cached on the reverse side (place.bar with pk=None).
@@ -817,27 +946,21 @@ class OneToOneTests(TestCase):
         default_context = {"serves_cocktails": True}
         alt_context = {"serves_cocktails": False}
 
-        # Inject a concurrent get_or_create inside the first one.
-        original = QuerySet._extract_model_params
-        triggered = {"done": False}
+        def insert_winning_row():
+            Bar.objects.update_or_create(
+                place=Place.objects.get(pk=place.pk),
+                defaults=alt_context,
+            )
 
-        def side_effect(self, defaults=None, **kwargs):
-            if not triggered["done"] and kwargs.get("place") == place:
-                triggered["done"] = True
-                Bar.objects.update_or_create(
-                    place=Place.objects.get(pk=place.pk),
-                    defaults=alt_context,
-                )
-            return original(self, defaults, **kwargs)
-
-        with patch(
-            "django.db.models.query.QuerySet._extract_model_params", side_effect
-        ):
+        with self.simulate_lost_insert_race(insert_winning_row) as triggered:
             bar, created = Bar.objects.update_or_create(
                 place=place,
                 defaults=default_context,
             )
-            self.assertFalse(created)
+        self.assertFalse(created)
+        # Guard against the patch no longer intercepting the call, which
+        # would make this test pass without simulating any race.
+        self.assertTrue(triggered["done"])
 
         # The reverse cache must not contain an unsaved Bar.
         self.assertIsNotNone(bar.pk)
@@ -852,8 +975,6 @@ class OneToOneTests(TestCase):
 
     def test_get_or_create_initial_get_does_not_leave_stale_reverse_o2o_cache(self):
         """
-        Regression test for #36489 (initial get() path, created=False).
-
         get_or_create() must behave consistently on every path where it
         returns an existing object. The IntegrityError fallback is one such
         path; the initial get() is the other. Whether a caller hits one or
@@ -871,9 +992,10 @@ class OneToOneTests(TestCase):
         # pk=None>. The live `place` reference keeps it alive.
         Bar(place=place)
 
-        # Precondition: the reverse cache is stale (unsaved instance).
-        stale = Bar.place.field.remote_field.get_cached_value(place)
-        self.assertIsNone(stale.pk)
+        # Precondition: place.bar resolves to that unsaved instance without
+        # querying.
+        with self.assertNumQueries(0):
+            self.assertIsNone(place.bar.pk)
 
         # Create the real row through a separate Place instance so the cache
         # on the original `place` object is not updated (emulates a
@@ -893,9 +1015,78 @@ class OneToOneTests(TestCase):
         self.assertIsNotNone(place.bar.pk)
         self.assertEqual(place.bar.pk, bar.pk)
 
+    def test_get_or_create_resolves_stale_none_reverse_o2o_cache(self):
+        """
+        select_related() to a reverse one-to-one relation caches None when no
+        related row exists. If the row is then created concurrently, that
+        None is just as stale as an unsaved instance. Without handling it,
+        place.bar raises RelatedObjectDoesNotExist even though
+        get_or_create() just returned the existing row.
+
+        This exercises the initial get() path only. The cache cleanup runs
+        right after the first get() succeeds, on every get_or_create() call
+        that finds a row there, whether or not a race happened. The
+        IntegrityError fallback path is never reached here.
+        """
+        place = Place.objects.create(name="None Cache Diner", address="Somewhere")
+        # No bar exists yet, so select_related() caches None on the reverse
+        # relation: place.bar raises without querying.
+        place = Place.objects.select_related("bar").get(pk=place.pk)
+        with self.assertNumQueries(0):
+            with self.assertRaises(Bar.DoesNotExist):
+                place.bar
+
+        # A concurrent writer creates the row through a separate Place
+        # instance, so the cache on place is not refreshed.
+        real_bar = Bar.objects.create(place=Place.objects.get(pk=place.pk))
+
+        # Exactly one query (the successful get) proves the initial-get path
+        # is taken.
+        with self.assertNumQueries(1):
+            bar, created = Bar.objects.get_or_create(place=place)
+
+        self.assertFalse(created)
+        self.assertEqual(bar.pk, real_bar.pk)
+
+        # The stale None must have been replaced by the returned row, so the
+        # reverse accessor resolves without a query instead of raising
+        # RelatedObjectDoesNotExist.
+        with self.assertNumQueries(0):
+            self.assertEqual(place.bar.pk, bar.pk)
+
+    def test_get_or_create_lookup_spanning_relation(self):
+        """
+        A lookup may span the one-to-one relation ("place__name"), which is
+        not a field name of the model being queried. Such a key names no
+        reverse cache, so _resolve_stale_reverse_one_to_one_caches() must
+        skip it rather than fail to resolve it as a field.
+        """
+        place = Place.objects.create(name="Spanning Diner", address="Somewhere")
+        real_bar = Bar.objects.create(place=place)
+
+        bar, created = Bar.objects.get_or_create(place__name=place.name)
+
+        self.assertFalse(created)
+        self.assertEqual(bar.pk, real_bar.pk)
+
+    def test_get_or_create_one_to_one_lookup_by_pk_value(self):
+        """
+        A one-to-one lookup may be given the related object's primary key
+        instead of the instance. There is then no related object to hold a
+        reverse cache, so _resolve_stale_reverse_one_to_one_caches() must
+        skip the value rather than treat it as a model instance.
+        """
+        place = Place.objects.create(name="Pk Lookup Diner", address="Somewhere")
+        real_bar = Bar.objects.create(place=place)
+
+        bar, created = Bar.objects.get_or_create(place=place.pk)
+
+        self.assertFalse(created)
+        self.assertEqual(bar.pk, real_bar.pk)
+
     def test_get_or_create_reverse_o2o_lookup_preserves_forward_cache(self):
         """
-        _clear_stale_reverse_one_to_one_caches() must only act on concrete
+        _resolve_stale_reverse_one_to_one_caches() must only act on concrete
         forward OneToOneFields named in the lookup.
 
         When a reverse accessor is used as a lookup
@@ -934,7 +1125,7 @@ class OneToOneTests(TestCase):
         """
         The OneToOneField may target a proxy model while the caller passes a
         concrete instance as the lookup value. Comparing the value against the
-        concrete model lets the helper still recognize it and clear a stale
+        concrete model lets the helper still recognize it and resolve a stale
         reverse one-to-one cache.
         """
         place = Place.objects.create(name="Proxy Diner", address="Somewhere")
@@ -943,7 +1134,7 @@ class OneToOneTests(TestCase):
         # Seed the reverse cache on the concrete place with an unsaved pointer.
         stale = PlaceProxyPointer(place=ProxyPlace.objects.get(pk=place.pk))
         field.remote_field.set_cached_value(place, stale)
-        self.assertTrue(stale._state.adding)
+        self.assertIsNone(stale.pk)
 
         # Create the real row through a separate instance (emulating a
         # concurrent writer) so the cache on place is not refreshed.
@@ -956,23 +1147,25 @@ class OneToOneTests(TestCase):
         self.assertFalse(created)
         self.assertEqual(pointer.pk, real.pk)
 
-        # The stale unsaved pointer must have been cleared from the cache.
-        self.assertFalse(field.remote_field.is_cached(place))
+        # The stale unsaved pointer must have been replaced by the returned
+        # row, so the reverse accessor resolves without a query.
+        with self.assertNumQueries(0):
+            self.assertEqual(place.placeproxypointer.pk, real.pk)
 
     def test_get_or_create_clears_stale_composite_pk_reverse_o2o_cache(self):
         """
-        Regression test for #36489 (composite primary key variant).
-
-        _clear_stale_reverse_one_to_one_caches() detects unsaved instances via
-        _state.adding, so it works regardless of the primary key shape. With a
-        CompositePrimaryKey an unsaved instance has pk = (None, <value>) — a
-        tuple, not None — which a scalar `pk is None` check would mishandle.
+        _resolve_stale_reverse_one_to_one_caches() detects unsaved instances
+        via _state.adding, so it works regardless of the primary key shape.
+        With a CompositePrimaryKey an unsaved instance has
+        pk = (None, <value>), a tuple rather than None, which a scalar
+        `pk is None` check would mishandle.
         """
         place = Place.objects.create(name="Composite Race Diner", address="Somewhere")
         Branch.objects.create(place=place, number=1)
 
         # Seed the reverse cache with an unsaved Branch instance. place_id is
-        # None (not yet assigned), so pk == (None, 2) — a tuple, not None.
+        # None (not yet assigned), so pk == (None, 2), a tuple rather than
+        # None.
         stale = Branch(number=2)
         place_field = Branch._meta.get_field("place")
         place_field.remote_field.set_cached_value(place, stale)

--- a/tests/one_to_one/tests.py
+++ b/tests/one_to_one/tests.py
@@ -1,17 +1,22 @@
+from unittest.mock import patch
+
 from django.core.exceptions import FieldFetchBlocked
 from django.db import IntegrityError, connection, transaction
-from django.db.models import FETCH_PEERS, RAISE
+from django.db.models import FETCH_PEERS, RAISE, QuerySet
 from django.test import TestCase
 
 from .models import (
     Bar,
+    Branch,
     Director,
     Favorites,
     HiddenPointer,
     ManualPrimaryKey,
     MultiModel,
     Place,
+    PlaceProxyPointer,
     Pointer,
+    ProxyPlace,
     RelatedModel,
     Restaurant,
     School,
@@ -695,3 +700,290 @@ class OneToOneTests(TestCase):
             p1.restaurant._state.fetch_mode,
             FETCH_PEERS,
         )
+
+    def test_get_or_create_race_keeps_reverse_o2o_cache_consistent(self):
+        """
+        Regression test for #36489.
+
+        Simulate two concurrent Bar.get_or_create(place=...) calls
+        racing on the same OneToOneField. The loser of the insert must not
+        leave an unsaved instance cached on the reverse side (place.bar
+        with pk=None). After get_or_create(), place.bar must resolve to
+        the saved row.
+
+        Bar is used (not Restaurant) because Bar.place is not the primary
+        key, so bar.pk is genuinely None before save() and the stale-cache
+        bug can be observed.
+        """
+        place = Place.objects.create(name="Race Diner", address="Somewhere")
+
+        # We'll inject a concurrent get_or_create inside the first one by
+        # patching QuerySet._extract_model_params
+        original = QuerySet._extract_model_params
+        triggered = {"done": False}
+
+        def side_effect(self, defaults=None, **kwargs):
+            # Only re-enter once, and only for the same place kwarg.
+            if not triggered["done"] and kwargs.get("place") == place:
+                triggered["done"] = True
+                # Use a *fresh* instance of place to emulate a separate thread.
+                Bar.objects.get_or_create(place=Place.objects.get(pk=place.pk))
+            return original(self, defaults, **kwargs)
+
+        with patch(
+            "django.db.models.query.QuerySet._extract_model_params",
+            side_effect,
+        ):
+            bar, created = Bar.objects.get_or_create(place=place)
+            self.assertFalse(created)
+
+        # The reverse cache must not contain an unsaved Bar.
+        # Accessing place.bar should yield a saved row with a pk,
+        # and it should be the same row returned above.
+        self.assertIsNotNone(bar.pk)
+        self.assertIsNotNone(place.bar.pk)
+        self.assertEqual(place.bar.pk, bar.pk)
+        self.assertEqual(bar.place_id, place.pk)
+
+    def test_get_or_create_race_does_not_clear_valid_select_related_cache(self):
+        place = Place.objects.create(name="Silver Square", address="Somewhere")
+        Bar.objects.create(place=place)
+
+        # Prime a valid forward cache via select_related()
+        # (we don't clear this path).
+        fetched = Bar.objects.select_related("place").get(place=place)
+
+        # Run a no-op get_or_create (no IntegrityError path taken).
+        _, created = Bar.objects.get_or_create(place=place)
+        self.assertFalse(created)
+
+        # Using the forward cache should not cause a query.
+        with self.assertNumQueries(0):
+            _ = fetched.place.id
+
+    def test_update_or_create_race_keeps_reverse_o2o_cache_consistent(self):
+        """
+        Regression test for #36489 (update_or_create path).
+
+        Simulate two concurrent Bar.update_or_create(place=...) calls
+        racing on the same OneToOneField. The loser of the insert must not
+        leave an unsaved instance cached on the reverse side (place.bar
+        with pk=None). After update_or_create(), place.bar must resolve
+        to the saved row.
+        """
+        place = Place.objects.create(name="Update Race Diner", address="Somewhere")
+
+        # Inject a concurrent get_or_create inside the first one by
+        # patching QuerySet._extract_model_params.
+        original = QuerySet._extract_model_params
+        triggered = {"done": False}
+
+        def side_effect(self, defaults=None, **kwargs):
+            if not triggered["done"] and kwargs.get("place") == place:
+                triggered["done"] = True
+                # Use a fresh instance of place to emulate a separate thread.
+                Bar.objects.get_or_create(place=Place.objects.get(pk=place.pk))
+            return original(self, defaults, **kwargs)
+
+        with patch(
+            "django.db.models.query.QuerySet._extract_model_params", side_effect
+        ):
+            bar, created = Bar.objects.update_or_create(
+                place=place,
+                defaults={"serves_cocktails": False},
+            )
+            self.assertFalse(created)
+
+        # The reverse cache must not contain an unsaved Bar.
+        # Accessing place.bar should yield a saved row with a pk,
+        # and it should be the same row returned above.
+        self.assertIsNotNone(bar.pk)
+        self.assertIsNotNone(place.bar.pk)
+        self.assertEqual(place.bar.pk, bar.pk)
+        self.assertEqual(bar.place_id, place.pk)
+
+    def test_update_or_create_race_with_defaults_reverse_o2o_cache_consistent(self):
+        """
+        Regression test for #36489 (defaults/create_defaults path).
+
+        Simulate two concurrent Bar.update_or_create(place=...) calls
+        with non-trivial defaults. The loser of the insert must not leave an
+        unsaved instance cached on the reverse side (place.bar with pk=None).
+        After update_or_create(), place.bar must resolve to the saved row,
+        and the defaults must be consistent with the actual saved object.
+        """
+        place = Place.objects.create(name="Defaults Diner", address="Anywhere")
+
+        default_context = {"serves_cocktails": True}
+        alt_context = {"serves_cocktails": False}
+
+        # Inject a concurrent get_or_create inside the first one.
+        original = QuerySet._extract_model_params
+        triggered = {"done": False}
+
+        def side_effect(self, defaults=None, **kwargs):
+            if not triggered["done"] and kwargs.get("place") == place:
+                triggered["done"] = True
+                Bar.objects.update_or_create(
+                    place=Place.objects.get(pk=place.pk),
+                    defaults=alt_context,
+                )
+            return original(self, defaults, **kwargs)
+
+        with patch(
+            "django.db.models.query.QuerySet._extract_model_params", side_effect
+        ):
+            bar, created = Bar.objects.update_or_create(
+                place=place,
+                defaults=default_context,
+            )
+            self.assertFalse(created)
+
+        # The reverse cache must not contain an unsaved Bar.
+        self.assertIsNotNone(bar.pk)
+        self.assertIsNotNone(place.bar.pk)
+        self.assertEqual(place.bar.pk, bar.pk)
+        self.assertEqual(bar.place_id, place.pk)
+
+        # Ensure the actual persisted defaults match the winning insert,
+        # not some stale in-memory values.
+        db_bar = Bar.objects.get(pk=bar.pk)
+        self.assertEqual(db_bar.serves_cocktails, place.bar.serves_cocktails)
+
+    def test_get_or_create_initial_get_does_not_leave_stale_reverse_o2o_cache(self):
+        """
+        Regression test for #36489 (initial get() path, created=False).
+
+        get_or_create() must behave consistently on every path where it
+        returns an existing object. The IntegrityError fallback is one such
+        path; the initial get() is the other. Whether a caller hits one or
+        the other is decided by a non-deterministic race, so the observable
+        state of the returned relation must not differ between them. After
+        get_or_create() returns created=False, the reverse OneToOne relation
+        must reflect the returned object, not a stale unsaved instance left
+        in the cache.
+        """
+        place = Place.objects.create(name="Stale Cache Diner", address="Somewhere")
+
+        # Instantiating Bar(place=place) triggers
+        # ForwardManyToOneDescriptor.__set__, which (the relation being
+        # one-to-one) seeds the reverse cache: place.bar -> <unsaved Bar,
+        # pk=None>. The live `place` reference keeps it alive.
+        Bar(place=place)
+
+        # Precondition: the reverse cache is stale (unsaved instance).
+        stale = Bar.place.field.remote_field.get_cached_value(place)
+        self.assertIsNone(stale.pk)
+
+        # Create the real row through a separate Place instance so the cache
+        # on the original `place` object is not updated (emulates a
+        # concurrent writer).
+        real_bar = Bar.objects.create(place=Place.objects.get(pk=place.pk))
+
+        # Exactly one query (the successful get) proves the initial-get path
+        # is taken and the create / IntegrityError fallback is never reached.
+        with self.assertNumQueries(1):
+            bar, created = Bar.objects.get_or_create(place=place)
+
+        self.assertFalse(created)
+        self.assertEqual(bar.pk, real_bar.pk)
+
+        # The reverse relation must now resolve to the real row, not the stale
+        # unsaved instance. Without the fix, place.bar.pk is None.
+        self.assertIsNotNone(place.bar.pk)
+        self.assertEqual(place.bar.pk, bar.pk)
+
+    def test_get_or_create_reverse_o2o_lookup_preserves_forward_cache(self):
+        """
+        _clear_stale_reverse_one_to_one_caches() must only act on concrete
+        forward OneToOneFields named in the lookup.
+
+        When a reverse accessor is used as a lookup
+        (Place.objects.get_or_create(bar=...)), _meta.get_field() resolves it
+        to a OneToOneRel, whose one_to_one flag is also True and whose
+        remote_field points back at the forward field. The rel is not
+        concrete, so the helper must skip it and leave the forward cache on
+        the Bar instance untouched. That cache holds legitimate in-flight
+        state (the caller is midway through bar.place = Place(...)), unlike a
+        stale reverse cache, and must survive a lookup-only get_or_create().
+        """
+        old_place = Place.objects.create(name="Old Diner", address="Somewhere")
+        bar = Bar.objects.create(place=old_place)
+
+        # Begin reassigning bar to a brand-new Place. The forward descriptor
+        # sets bar.place_id = None and caches the unsaved instance.
+        pending = Place(name="New Diner", address="Elsewhere")
+        bar.place = pending
+        self.assertIsNone(bar.place_id)
+        self.assertFalse(pending._is_pk_set())
+
+        # bar itself is saved, so the lookup joins on bar.pk; the database row
+        # still points at old_place, so the initial get() succeeds and the
+        # helper runs.
+        with self.assertNumQueries(1):
+            found, created = Place.objects.get_or_create(bar=bar)
+
+        self.assertFalse(created)
+        self.assertEqual(found, old_place)
+
+        # The in-flight forward assignment must survive the lookup.
+        self.assertIs(bar.place, pending)
+        self.assertIsNone(bar.place_id)
+
+    def test_get_or_create_clears_stale_reverse_o2o_cache_for_proxy_target(self):
+        """
+        The OneToOneField may target a proxy model while the caller passes a
+        concrete instance as the lookup value. Comparing the value against the
+        concrete model lets the helper still recognize it and clear a stale
+        reverse one-to-one cache.
+        """
+        place = Place.objects.create(name="Proxy Diner", address="Somewhere")
+        field = PlaceProxyPointer._meta.get_field("place")
+
+        # Seed the reverse cache on the concrete place with an unsaved pointer.
+        stale = PlaceProxyPointer(place=ProxyPlace.objects.get(pk=place.pk))
+        field.remote_field.set_cached_value(place, stale)
+        self.assertTrue(stale._state.adding)
+
+        # Create the real row through a separate instance (emulating a
+        # concurrent writer) so the cache on place is not refreshed.
+        real = PlaceProxyPointer.objects.create(
+            place=ProxyPlace.objects.get(pk=place.pk)
+        )
+
+        # Pass the concrete Place instance as the lookup value.
+        pointer, created = PlaceProxyPointer.objects.get_or_create(place=place)
+        self.assertFalse(created)
+        self.assertEqual(pointer.pk, real.pk)
+
+        # The stale unsaved pointer must have been cleared from the cache.
+        self.assertFalse(field.remote_field.is_cached(place))
+
+    def test_get_or_create_clears_stale_composite_pk_reverse_o2o_cache(self):
+        """
+        Regression test for #36489 (composite primary key variant).
+
+        _clear_stale_reverse_one_to_one_caches() detects unsaved instances via
+        _state.adding, so it works regardless of the primary key shape. With a
+        CompositePrimaryKey an unsaved instance has pk = (None, <value>) — a
+        tuple, not None — which a scalar `pk is None` check would mishandle.
+        """
+        place = Place.objects.create(name="Composite Race Diner", address="Somewhere")
+        Branch.objects.create(place=place, number=1)
+
+        # Seed the reverse cache with an unsaved Branch instance. place_id is
+        # None (not yet assigned), so pk == (None, 2) — a tuple, not None.
+        stale = Branch(number=2)
+        place_field = Branch._meta.get_field("place")
+        place_field.remote_field.set_cached_value(place, stale)
+
+        # Precondition: pk is a tuple (not None) but the instance is unsaved.
+        self.assertIsNotNone(stale.pk)
+        self.assertTrue(stale._state.adding)
+
+        branch, created = Branch.objects.get_or_create(place=place, number=1)
+        self.assertFalse(created)
+
+        # The reverse cache must hold the saved branch, not the stale instance.
+        self.assertTrue(place.branch._is_pk_set())
+        self.assertEqual(place.branch.pk, branch.pk)


### PR DESCRIPTION
When concurrent `get_or_create()`/`update_or_create()` calls raced on a
`OneToOneField`, the loser of the insert could leave an unsaved object cached
on the reverse relation (e.g. `parent.child` with `pk=None`). This has been
fixed by conditionally clearing the reverse cache.

#### Trac ticket number
ticket-36489

#### Branch description
Fixes a bug where concurrent `get_or_create()`/`update_or_create()` calls on a
`OneToOneField` could leave an unsaved instance cached on the reverse relation.
This patch adds conditional cache clearing to prevent stale objects, regression
tests for both `get_or_create()` and `update_or_create()`, and a release note.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.

