### PR TITLE
Fixed #35877, Refs #36128 -- Documented unique constraint when migrating a m2m field to use a through model.

### DIFF
--- a/docs/howto/writing-migrations.txt
+++ b/docs/howto/writing-migrations.txt
@@ -336,7 +336,7 @@ model, the default migration will delete the existing table and create a new
 one, losing the existing relations. To avoid this, you can use
 :class:`.SeparateDatabaseAndState` to rename the existing table to the new
 table name while telling the migration autodetector that the new model has
-been created. You can check the existing table name through
+been created. You can check the existing table name and constraint name through
 :djadmin:`sqlmigrate` or :djadmin:`dbshell`. You can check the new table name
 with the through model's ``_meta.db_table`` property. Your new ``through``
 model should use the same names for the ``ForeignKey``\s as Django did. Also if
@@ -394,6 +394,14 @@ For example, if we had a ``Book`` model with a ``ManyToManyField`` linking to
                                 ),
                             ),
                         ],
+                        options={
+                            "constraints": [
+                                models.UniqueConstraint(
+                                    fields=["author", "book"],
+                                    name="unique_author_book",
+                                )
+                            ],
+                        },
                     ),
                     migrations.AlterField(
                         model_name="book",


### PR DESCRIPTION
Trac ticket number
ticket-35877

Branch description
This PR updates the migration documentation to clarify behavior when switching from an implicit ManyToManyField to a custom through model. Django does not automatically preserve the unique index on foreign keys in this transition, which can lead to subtle bugs across database backends. To maintain consistent behavior, a UniqueConstraint should be added manually. This note aims to prevent confusion and improve migration reliability for contributors and users.

Checklist
[ ] This PR targets the main branch.

[ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.

[ ] I have checked the "Has patch" ticket flag in the Trac system.

[ ] I have added or updated relevant tests.

[ ] I have added or updated relevant docs, including release notes if applicable.

[ ] I have attached screenshots in both light and dark modes for any UI changes.