### PR TITLE
Added words to spelling_wordlist.

### DIFF
--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -244,6 +244,8 @@ kwargs
 Kyrgyz
 latin
 lawrence
+lexeme
+lexemes
 Libera
 lifecycle
 lifecycles
@@ -428,6 +430,7 @@ reverter
 roadmap
 Roald
 rss
+runnable
 Sandvik
 savepoint
 savepoints
@@ -529,6 +532,7 @@ unapplied
 unapplying
 uncategorized
 unclaim
+unclosed
 uncopyable
 unencoded
 unencrypted


### PR DESCRIPTION
**Before**
```
cd docs
make spelling
```
```
WARNING: internals/security.txt:50: : Spell check: runnable: Include a runnable proof of concept.
WARNING: ref/contrib/postgres/search.txt:292: : Spell check: lexeme: an untrusted source. The content of each lexeme is escaped so that any.
WARNING: ref/contrib/postgres/search.txt:295: : Spell check: lexemes: You can combine lexemes with other lexemes using the .
WARNING: ref/contrib/postgres/search.txt:295: : Spell check: lexemes: You can combine lexemes with other lexemes using the .
WARNING: ref/contrib/postgres/search.txt:314: : Spell check: Lexeme: Lexeme objects also support term weighting and prefixes:.
WARNING: releases/4.2.21.txt:24: : Spell check: unclosed: exception if it encounters an unusually large number of unclosed opening tags..
WARNING: releases/5.1.9.txt:24: : Spell check: unclosed: exception if it encounters an unusually large number of unclosed opening tags..
WARNING: releases/5.2.1.txt:24: : Spell check: unclosed: exception if it encounters an unusually large number of unclosed opening tags..
WARNING: Found 8 misspelled words
build succeeded, 9 warnings.
```

Looks like the CI check stopped treating warnings as errors in https://github.com/django/django/commit/7a80e29feaa675a27bf525164502ebc8ecbdce1a.