### PR TITLE
Fixed warning in "New contributor" GitHub action.

### DIFF
--- a/.github/workflows/new_contributor_pr.yml
+++ b/.github/workflows/new_contributor_pr.yml
@@ -14,8 +14,8 @@ jobs:
     steps:
       - uses: actions/first-interaction@v3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          pr-message: |
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          pr_message: |
             Hello! Thank you for your contribution 💪
 
             As it's your first contribution be sure to check out the [patch review checklist](https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/submitting-patches/#patch-review-checklist).


### PR DESCRIPTION
Fixes `Unexpected input(s) 'repo-token', 'pr-message', valid inputs are ['issue_message', 'pr_message', 'repo_token']`.

Follow up to b7507bad7730e5f6558cfcce29976f65890083ca.