### PR TITLE
Removed Git attribute merge=union for release notes.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,5 @@
 *js text eol=lf
 tests/staticfiles_tests/apps/test/static/test/*txt text eol=lf
 tests/staticfiles_tests/project/documents/test/*txt text eol=lf
-docs/releases/*.txt merge=union
 # Make GitHub syntax-highlight .html files as Django templates
 *.html linguist-language=django


### PR DESCRIPTION
#### Trac ticket number

N/A

#### Branch description

I added this back in 3222fc79431c0866aa65b2a83fbbffd2c3034d08 to try and avoid merge conflicts from concurrent edits to release notes in different branches. However, in my recent experience, it has caused more problems than it solves.

First, I found that when rebasing a branch that modifies a release note, it can merge sections without an intermediate blank line, leading to broken reST syntax. Example spotted in code review:
https://github.com/django/django/pull/17554#discussion_r2311296513 .

~Second, I think it can lead to inadvertently duplicating content that exists in both branches, when one branch has extra edits. Example fix: https://github.com/django/django/pull/19895~

I think it’s better we remove this configuration and deal with merge conflicts deliberately.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
