### PR TITLE
Refs #35859 -- Mentioned tasks in the docs index.

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -295,6 +295,7 @@ applications:
   :doc:`API Reference </ref/contrib/auth>`
 * :doc:`Caching </topics/cache>`
 * :doc:`Logging </topics/logging>`
+* :doc:`Tasks framework </topics/tasks>`
 * :doc:`Sending emails </topics/email>`
 * :doc:`Syndication feeds (RSS/Atom) </ref/contrib/syndication>`
 * :doc:`Pagination </topics/pagination>`


### PR DESCRIPTION
I think we should mention Tasks framework in the docs index.