### PR TITLE
Fixed #33113 -- Documented usage and caveats of HTML5 date input in DateInput widget

### DIFF
--- a/docs/ref/forms/widgets.txt
+++ b/docs/ref/forms/widgets.txt
@@ -646,6 +646,29 @@ These widgets make use of the HTML elements ``input`` and ``textarea``.
     :doc:`/topics/i18n/formatting`. ``%U``, ``%W``, and ``%j`` formats are not
     supported by this widget.
 
+    .. admonition:: Using the HTML5 "date" input type
+
+        If you are targeting browsers that support the
+        `HTML5 "date" input type`_, you can override the ``input_type``
+        attribute to enable the browser’s native date picker::
+
+            class MyDateInput(forms.DateInput):
+                input_type = "date"
+                format = "%Y-%m-%d"
+
+        Alternatively::
+
+            DateInput(attrs={"type": "date"}, format="%Y-%m-%d")
+
+        HTML5 date inputs expect values in the ISO format ``YYYY-MM-DD``. If a
+        different format is provided, the field may appear empty even when a
+        value exists. Setting the ``format`` attribute controls how Django
+        provides the value, but the browser controls how it is displayed.
+        Hence, the ``format`` attribute and the :setting:`DATE_INPUT_FORMATS`
+        setting will have no effect on the displayed value.
+
+        .. _HTML5 "date" input type: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date
+
 ``DateTimeInput``
 ~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Fixed #33113 — Documented usage and caveats of HTML5 date input in DateInput widget.

Trac ticket number
ticket-33113

Branch description
This PR revives ticket #33113 and merges the intent of PRs #14905 and #17327, as suggested by @nessita. It adds a usage example for overriding DateInput to use input_type='date', enabling native browser date pickers. It also includes a warning explaining why Django defaults to type="text"—due to localization inconsistencies across browsers.

The warning references tickets #16630 and #34853, which document real-world formatting issues. This aims to prevent confusion and redundant PRs in the future.

Thanks to @dennisvang and @blue-hexagon for their original contributions, and to @nessita for guiding the consolidation.

Checklist
[ ] This PR targets the main branch.

[ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.

[ ] I have checked the "Has patch" ticket flag in the Trac system.

[ ] I have added or updated relevant tests.

[ ] I have added or updated relevant docs, including release notes if applicable.

[ ] I have attached screenshots in both light and dark modes for any UI changes.