### PR TITLE
Fixed assertIndexExists() crash when non-index constraint exists on the same columns.

### DIFF
--- a/tests/migrations/test_base.py
+++ b/tests/migrations/test_base.py
@@ -108,6 +108,7 @@ class MigrationTestBase(TransactionTestCase):
                     .values()
                     if (
                         c["columns"] == list(columns)
+                        and c["index"] is True
                         and (index_type is None or c["type"] == index_type)
                         and not c["unique"]
                     )


### PR DESCRIPTION
For example, the following tests crash on PostgreSQL 18+ because it returns `NOT NULL` constraints on the same columns:

```
======================================================================
ERROR: test_add_other_index_type (postgres_tests.test_operations.AddIndexConcurrentlyTests.test_add_other_index_type)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/usr/local/lib/python3.12/unittest/case.py", line 634, in run
    self._callTestMethod(testMethod)
    ^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/unittest/case.py", line 589, in _callTestMethod
    if method() is not None:
    ^^^^^^^^^^^^^^^^^
  File "/django/source/tests/postgres_tests/test_operations.py", line 105, in test_add_other_index_type
    self.assertIndexExists(table_name, ["pink"], index_type="brin")
    ^^^^^^^^^^^^^^^^^
  File "/django/source/tests/migrations/test_base.py", line 104, in assertIndexExists
    any(
  File "/django/source/tests/migrations/test_base.py", line 111, in <genexpr>
    and (index_type is None or c["type"] == index_type)
    ^^^^^^^^^^^^^^^^^
KeyError: 'type'

======================================================================
ERROR: test_add_with_options (postgres_tests.test_operations.AddIndexConcurrentlyTests.test_add_with_options)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/usr/local/lib/python3.12/unittest/case.py", line 634, in run
    self._callTestMethod(testMethod)
    ^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/unittest/case.py", line 589, in _callTestMethod
    if method() is not None:
    ^^^^^^^^^^^^^^^^^
  File "/django/source/tests/postgres_tests/test_operations.py", line 125, in test_add_with_options
    self.assertIndexExists(table_name, ["pink"], index_type="btree")
    ^^^^^^^^^^^^^^^^^
  File "/django/source/tests/migrations/test_base.py", line 104, in assertIndexExists
    any(
  File "/django/source/tests/migrations/test_base.py", line 111, in <genexpr>
    and (index_type is None or c["type"] == index_type)
    ^^^^^^^^^^^^^^^^^
KeyError: 'type'

----------------------------------------------------------------------

```