### PR TITLE
Skipped NOT NULL constraints on PostgreSQL 18+.

### DIFF
--- a/django/db/backends/postgresql/introspection.py
+++ b/django/db/backends/postgresql/introspection.py
@@ -206,7 +206,9 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
                 cl.reloptions
             FROM pg_constraint AS c
             JOIN pg_class AS cl ON c.conrelid = cl.oid
-            WHERE cl.relname = %s AND pg_catalog.pg_table_is_visible(cl.oid)
+            WHERE cl.relname = %s
+                AND pg_catalog.pg_table_is_visible(cl.oid)
+                AND c.contype != 'n'
         """,
             [table_name],
         )


### PR DESCRIPTION
PostgreSQL 18+ stores column "NOT NULL" specifications in `pg_constraint`.

https://www.postgresql.org/docs/release/18.0/

Alternative to #19908.