### PR TITLE
Bumped latest PostgreSQL to 18 in scheduled tests workflow.

### DIFF
--- a/.github/workflows/schedule_tests.yml
+++ b/.github/workflows/schedule_tests.yml
@@ -141,7 +141,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [16, 17]
+        version: [17, 18]
         server_side_bindings: [0, 1]
     runs-on: ubuntu-latest
     name: PostgreSQL Versions


### PR DESCRIPTION
Follow up to c334c1a8ff4579cdb1dd77cce8da747070ac9fc4.