### PR TITLE
Refs #36491 -- Skipped ParallelTestSuiteTest.test_buffer_mode_reports_setupclass_failure() without tblib.

### DIFF
--- a/tests/test_runner/test_parallel.py
+++ b/tests/test_runner/test_parallel.py
@@ -283,6 +283,7 @@ class ParallelTestSuiteTest(SimpleTestCase):
         self.assertEqual(len(result.errors), 0)
         self.assertEqual(len(result.failures), 0)
 
+    @unittest.skipUnless(tblib is not None, "requires tblib to be installed")
     def test_buffer_mode_reports_setupclass_failure(self):
         test = SampleErrorTest("dummy_test")
         remote_result = RemoteTestResult()


### PR DESCRIPTION
```
======================================================================
ERROR [0.005s]: test_buffer_mode_reports_setupclass_failure (test_runner.test_parallel.ParallelTestSuiteTest.test_buffer_mode_reports_setupclass_failure)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/workspace/main-no-requirements/database/sqlite3/label/focal/python/python3.13/tests/test_runner/test_parallel.py", line 79, in setUpClass
    raise ValueError("woops")
ValueError: woops

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/jenkins/workspace/main-no-requirements/database/sqlite3/label/focal/python/python3.13/tests/test_runner/test_parallel.py", line 290, in test_buffer_mode_reports_setupclass_failure
    suite.run(remote_result)
    ~~~~~~~~~^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/unittest/suite.py", line 114, in run
    self._handleClassSetUp(test, result)
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/unittest/suite.py", line 176, in _handleClassSetUp
    self._createClassOrModuleLevelException(result, e,
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
                                            'setUpClass',
                                            ^^^^^^^^^^^^^
                                            className)
                                            ^^^^^^^^^^
  File "/usr/lib/python3.13/unittest/suite.py", line 236, in _createClassOrModuleLevelException
    self._addClassOrModuleLevelException(result, exc, errorName, info)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/unittest/suite.py", line 246, in _addClassOrModuleLevelException
    result.addError(error, sys.exc_info())
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jenkins/workspace/main-no-requirements/database/sqlite3/label/focal/python/python3.13/django/test/runner.py", line 315, in addError
    self.check_picklable(test, err)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/home/jenkins/workspace/main-no-requirements/database/sqlite3/label/focal/python/python3.13/django/test/runner.py", line 236, in check_picklable
    self._confirm_picklable(err)
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^
  File "/home/jenkins/workspace/main-no-requirements/database/sqlite3/label/focal/python/python3.13/django/test/runner.py", line 206, in _confirm_picklable
    pickle.loads(pickle.dumps(obj))
                 ~~~~~~~~~~~~^^^^^
TypeError: cannot pickle 'traceback' object
```