### PR TITLE
Removed advice to only upload wheels for pre-releases.

### DIFF
--- a/docs/internals/howto-release-django.txt
+++ b/docs/internals/howto-release-django.txt
@@ -606,8 +606,7 @@ Now you're ready to actually put the release out there. To do this:
 
    __ https://djangoci.com/job/confirm-release/
 
-#. Upload the release packages to PyPI (for pre-releases, only upload the wheel
-   file):
+#. Upload the release packages to PyPI:
 
    .. code-block:: shell
 


### PR DESCRIPTION
The practice since 2.2a1 (2019) has been to upload source distributions as well.

https://pypi.org/project/Django/2.2a1/#files
https://pypi.org/project/Django/2.1rc1/#files