### PR TITLE
Fixed #36636 -- Removed session-based storage reference from set_language() docs and docstring.

### DIFF
--- a/django/views/i18n.py
+++ b/django/views/i18n.py
@@ -29,9 +29,9 @@ def builtin_template_path(name):
 
 def set_language(request):
     """
-    Redirect to a given URL while setting the chosen language in the session
-    (if enabled) and in a cookie. The URL and the language code need to be
-    specified in the request parameters.
+    Redirect to a given URL while setting the chosen language in the language
+    cookie. The URL and the language code need to be specified in the request
+    parameters.
 
     Since this view changes how the user will see the rest of the site, it must
     only be accessed as a POST request. If called as a GET request, it will

--- a/docs/topics/i18n/translation.txt
+++ b/docs/topics/i18n/translation.txt
@@ -1884,10 +1884,9 @@ Activate this view by adding the following line to your URLconf::
     language-independent itself to work correctly.
 
 The view expects to be called via the ``POST`` method, with a ``language``
-parameter set in request. If session support is enabled, the view saves the
-language choice in the user's session. It also saves the language choice in a
-cookie that is named ``django_language`` by default. (The name can be changed
-through the :setting:`LANGUAGE_COOKIE_NAME` setting.)
+parameter set in request. The view saves the language choice in a cookie that
+is named ``django_language`` by default. (The name can be changed through the
+:setting:`LANGUAGE_COOKIE_NAME` setting.)
 
 After setting the language choice, Django looks for a ``next`` parameter in the
 ``POST`` or ``GET`` data. If that is found and Django considers it to be a safe


### PR DESCRIPTION
This PR fixes outdated references in the documentation and docstring of django.views.i18n.set_language().
Since Django 4.0, the view no longer stores the chosen language in the session. It only uses the cookie defined by the LANGUAGE_COOKIE_NAME setting.
The docstring and docs have been updated accordingly to avoid confusion.

Thanks to Samriddha Kumar Tripathi and kid_alan_ on Discord for the report

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36636

#### Branch description
Remove outdated references to session-based language storage in the set_language() view docstring and in the i18n documentation.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
