### PR TITLE
Resolves #36639: added CI step to run makemigrations --check against test models

### DIFF
--- a/.github/workflows/check-test-migrations.yml
+++ b/.github/workflows/check-test-migrations.yml
@@ -1,0 +1,29 @@
+name: "Check test migrations"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  check-migrations:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          # Install the checked-out Django package in editable mode so tests
+          # reference the repo source.
+          pip install -e .
+      - name: Run makemigrations --check for test apps
+        working-directory: .
+        run: |
+          python scripts/check_test_migrations.py
+        env:
+          DJANGO_SETTINGS_MODULE: test_sqlite

--- a/.github/workflows/new_contributor_pr.yml
+++ b/.github/workflows/new_contributor_pr.yml
@@ -15,13 +15,7 @@ jobs:
       - uses: actions/first-interaction@v3
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
+          issue-message: To add CI step to run makemigrations --check against test models (ticket_36639)
           pr_message: |
-            Hello! Thank you for your contribution 💪
-
-            As it's your first contribution be sure to check out the [patch review checklist](https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/submitting-patches/#patch-review-checklist).
-
-            If you're fixing a ticket [from Trac](https://code.djangoproject.com/) make sure to set the _"Has patch"_ flag and include a link to this PR in the ticket!
-
-            If you have any design or process questions then you can ask in the [Django forum](https://forum.djangoproject.com/c/internals/5).
-
-            Welcome aboard ⛵️!
+            Done the required changes to add a new CI step to run `makemigrations --check` against test models.
+            Some details or further clarifications in change have been written in comment of PR

--- a/scripts/check_test_migrations.py
+++ b/scripts/check_test_migrations.py
@@ -1,0 +1,55 @@
+"""CI helper: run `makemigrations --check` for test apps.
+
+This script sets DJANGO_SETTINGS_MODULE to the default test settings
+(`test_sqlite`) and runs `django.core.management`'s `call_command` for
+`makemigrations --check`. It exits with a non-zero status if migrations
+are needed.
+
+Designed to be executed in CI from the repository root using the
+checked-out Django package.
+"""
+
+import os
+import sys
+
+from django.core.management import call_command
+
+
+def main():
+    # Use the test settings used by the test runner by default.
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "test_sqlite")
+
+    # Ensure the project's parent directory is on sys.path so `django`
+    # imports resolve to the checked-out tree when running in CI.
+    here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    if here not in sys.path:
+        sys.path.insert(0, here)
+
+    try:
+        # Ensure the test settings module is importable (tests live in the
+        # repository root `tests/` directory and can be imported as
+        # `test_sqlite` when the repo root is on sys.path).
+        try:
+            __import__(os.environ["DJANGO_SETTINGS_MODULE"])
+        except Exception:
+            tests_dir = os.path.join(here, "tests")
+            if tests_dir not in sys.path:
+                sys.path.insert(0, tests_dir)
+        import django
+
+        django.setup()
+
+        # --check exits the process with SystemExit on failure; propagate it
+        # so CI will fail. We silence output on success.
+        call_command("makemigrations", "--check", verbosity=0)
+    except SystemExit:
+        # Rerun with verbosity=1 to show details in CI logs.
+        try:
+            call_command("makemigrations", "--check", verbosity=1)
+        except SystemExit:
+            pass
+        raise
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
#### Trac ticket number
ticket-36639

#### Branch description
Adds check_test_migrations.py a script that runs makemigrations --check using the test settings.
Adds check-test-migrations.yml to run the script in CI on push and pull requests.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.

#### Some more things (if needed will do)
- The workflow runs makemigrations --check without app labels. If INSTALLED_APPS includes third-party or optional apps, makemigrations could report unrelated changes and cause a bit of noise.
- Currently uses test_sqlite. If we want to validate migrations under other DBs, have to add a CI matrix with different DJANGO_SETTINGS_MODULE values and DB services (Postgres/MySQL).
- Needed and asked by maintainer to add integrations test will do.