### PR TITLE
Fixed #36468 -- Fixed failure to close popup when adding a related object in the admin.

### DIFF
--- a/django/contrib/admin/static/admin/js/admin/RelatedObjectLookups.js
+++ b/django/contrib/admin/static/admin/js/admin/RelatedObjectLookups.js
@@ -111,7 +111,12 @@
                 option = new Option(newRepr, newId);
                 select.options.add(option);
                 // Update SelectBox cache for related fields.
-                if (window.SelectBox !== undefined && !SelectBox.cache[currentSelect.id]) {
+                if (
+                    window.SelectBox !== undefined
+                    && !SelectBox.cache[currentSelect.id]
+                    // Only if SelectBox is managing that field.
+                    && SelectBox.cache[select.id]
+                ) {
                     SelectBox.add_to_cache(select.id, option);
                     // Sort if there are any groups present
                     if (SelectBox.cache[select.id].some(item => item.group)) {

--- a/tests/admin_views/models.py
+++ b/tests/admin_views/models.py
@@ -1196,3 +1196,7 @@ class CamelCaseModel(models.Model):
 class CamelCaseRelatedModel(models.Model):
     m2m = models.ManyToManyField(CamelCaseModel, related_name="m2m")
     fk = models.ForeignKey(CamelCaseModel, on_delete=models.CASCADE, related_name="fk")
+    # Add another relation that will not participate in filter_horizontal.
+    fk2 = models.ForeignKey(
+        CamelCaseModel, on_delete=models.CASCADE, related_name="fk2"
+    )


### PR DESCRIPTION
…t is managed by SelectBox.js before trying to update the cache

#### Trac ticket number

ticket-36468

#### Branch description

If `filter_horizontal` is used, the `SelectBox.js` is loaded which manages the state of the filter widget. After a popup form is closed, all related selects are updated. It fails for selects that aren't used as a filter widget, because a check is missing, if the `SelectBox` is actually responsible for the select.

#### Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
- [X] I have attached screenshots in both light and dark modes for any UI changes.
