### PR TITLE
Refs #36595 -- Ran GitHub tests against PostGIS 3.6.

### DIFF
--- a/.github/workflows/postgis.yml
+++ b/.github/workflows/postgis.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        postgis-version: [latest, "17-3.5-alpine", "17-master"]
+        postgis-version: ["latest", "18-3.6-alpine", "17-master"]
     name: PostGIS ${{ matrix.postgis-version }}
     services:
       postgres:


### PR DESCRIPTION
#### Trac ticket number

ticket-36595

#### Branch description

This change updates the GitHub tests to run against the latest Postgres 17/PostGIS 3.6 docker image at: https://hub.docker.com/r/postgis/postgis/tags?page=1&name=17-3.6-alpine

I have run the tests locally using PostGIS 3.6 without errors. However, I haven't used this specific image yet, as I am on an Apple chip machine and the postgis docker images don't support it.

This version support is already documented in changes from https://code.djangoproject.com/ticket/36623.

#### Checklist
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
