### PR TITLE
Fixed #36507 -- Documented prefetch_related behavior in union.

### DIFF
--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -994,6 +994,48 @@ on the resulting ``QuerySet``. Further, databases place restrictions on
 what operations are allowed in the combined queries. For example, most
 databases don't allow ``LIMIT`` or ``OFFSET`` in the combined queries.
 
+If a ``union()`` of ``QuerySet``\s with custom ``Prefetch`` filters is
+created, then only the filters of the first ``Prefetch`` will be used in
+the prefetched results.
+
+.. code-block:: pycon
+
+    >>> qs1 = Restaurant.objects.filter(pk=1).prefetch_related(
+    ...     Prefetch("pizzas", queryset=Pizza.objects.filter(name="Deluxe"))
+    ... )
+    >>> qs2 = Restaurant.objects.filter(pk=2).prefetch_related(
+    ...     Prefetch("pizzas", queryset=Pizza.objects.filter(name="Hawaiian"))
+    ... )
+    >>> qs = qs1.union(qs2)
+    >>> qs[0].pizzas.all()
+    QuerySet [<Pizza: Deluxe>]
+    >>> qs[1].pizzas.all()
+    QuerySet []
+
+``qs[1].pizzas.all()`` will never include pizzas with the name ``Hawaiian``
+because the prefetch SQL query will include the filter
+``app_pizza.name = 'Deluxe'`` but not ``app_pizza.name = 'Hawaiian'``.
+
+If this filtering is required, consider combining the ``Prefetch`` filters
+into the first ``prefetch_related`` using ``Q`` objects instead.
+
+.. code-block:: pycon
+
+    >>> qs1 = Restaurant.objects.filter(pk=1).prefetch_related(
+    ...     Prefetch(
+    ...         "pizzas",
+    ...         queryset=Pizza.objects.filter(
+    ...             Q(retaurant__pk=1, name="Deluxe") | Q(restaurant__pk=2, name="Hawaiian")
+    ...         ),
+    ...     )
+    ... )
+    >>> qs2 = Restaurant.objects.filter(pk=2)
+    >>> qs = qs1.union(qs2)
+    >>> qs[0].pizzas.all()
+    QuerySet [<Pizza: Deluxe>]
+    >>> qs[1].pizzas.all()
+    QuerySet [<Pizza: Hawaiian>]
+
 ``intersection()``
 ~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
#### Trac ticket number

ticket-36507

#### Branch description

Documentation is added regarding the unique behaviors of `Prefetch` filters within `union` querysets, noting that only the filters from the first `Prefetch` are applied in the final SQL query.

This is an attempt at documenting conversations in a [forum conversation](https://forum.djangoproject.com/t/using-union-with-querysets-that-have-a-custom-prefetch-object/41638/9) .

<img width="676" height="615" alt="Screenshot 2025-10-07 at 9 44 04 PM" src="https://github.com/user-attachments/assets/9fb93dda-ffd1-496d-a2fa-de848909df0c" />

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
