### PR TITLE
Fixed #36189 -- Deprecated use_returning_into option for Oracle backend.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1110,6 +1110,7 @@ answer newbie questions, and generally made Django that much better:
     Yash Jhunjhunwala
     Yasushi Masuda <whosaysni@gmail.com>
     ye7cakf02@sneakemail.com
+    Yeongbae Jeon <ybjeon01@gmail.com>
     ymasuda@ethercube.com
     Yoong Kang Lim <yoongkang.lim@gmail.com>
     Yury V. Zaytsev <yury@shurup.com>

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -64,6 +64,9 @@ details on these changes.
   :class:`~django.db.models.JSONNull` to query for a JSON ``null`` value
   instead.
 
+* The ``use_returning_into`` option for the Oracle database backend will be
+  removed.
+
 .. _deprecation-removed-in-6.1:
 
 6.1

--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -1141,6 +1141,10 @@ alternatively set ``"pool"`` to be a dict::
 INSERT ... RETURNING INTO
 -------------------------
 
+.. deprecated:: 6.1
+
+    The ``use_returning_into`` option is deprecated.
+
 By default, the Oracle backend uses a ``RETURNING INTO`` clause to efficiently
 retrieve the value of an ``AutoField`` when inserting new rows. This behavior
 may result in a ``DatabaseError`` in certain unusual setups, such as when

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -424,6 +424,9 @@ Miscellaneous
   used as the top-level value. :lookup:`Key and index lookups <jsonfield.key>`
   are unaffected by this deprecation.
 
+* The ``use_returning_into`` option for the Oracle database backend is
+  deprecated.
+
 Features removed in 6.1
 =======================
 


### PR DESCRIPTION
The use_returning_into option has known issues with handling explicitly specified primary key values and is no longer maintained. This change adds a deprecation warning when the option is used.

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36189

#### Branch description
The `use_returning_into` option for Oracle backend has known issues when explicitly specified primary key values are used, as documented in ticket #36189. Following the recommendation from the ticket discussion, this PR deprecates the option in Django 6.0 with planned removal in Django 7.0.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
