### PR TITLE
Fixed #36649 -- Added |= operator support to MultiValueDict and QueryDict.

### DIFF
--- a/django/http/request.py
+++ b/django/http/request.py
@@ -710,6 +710,10 @@ class QueryDict(MultiValueDict):
             )
         return "&".join(output)
 
+    def __ior__(self, other):
+        self._assert_mutable()
+        return super().__ior__(other)
+
 
 class MediaType:
     def __init__(self, media_type_raw_line):

--- a/django/utils/datastructures.py
+++ b/django/utils/datastructures.py
@@ -218,6 +218,10 @@ class MultiValueDict(dict):
         """Return current object as a dict with singular values."""
         return {key: self[key] for key in self}
 
+    def __ior__(self, other):
+        self.update(other)
+        return self
+
 
 class ImmutableList(tuple):
     """

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -550,6 +550,13 @@ The ``QueryDict``\ s at ``request.POST`` and ``request.GET`` will be immutable
 when accessed in a normal request/response cycle. To get a mutable version you
 need to use :meth:`QueryDict.copy`.
 
+.. versionadded:: 6.1
+
+  Mutable ``QueryDict``\s gained support for |the |= update operator|__.
+
+  .. |the |= update operator| replace:: the ``|=`` update operator
+  __ https://docs.python.org/3/library/stdtypes.html#dict:~:text=d%20%7C%3D%20other
+
 Methods
 -------
 

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -186,7 +186,8 @@ Pagination
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 
-* ...
+* Mutable :class:`.QueryDict`\s now support the ``|=`` update operator for
+  updating with the contents of a mapping or key/value iterable.
 
 Security
 ~~~~~~~~

--- a/tests/httpwrappers/tests.py
+++ b/tests/httpwrappers/tests.py
@@ -298,6 +298,37 @@ class QueryDictTests(SimpleTestCase):
         with self.assertRaises(TypeError):
             QueryDict.fromkeys(0)
 
+    def test_update_operator_immutable(self):
+        q = QueryDict("color=red&q=tacos")
+        msg = "This QueryDict instance is immutable"
+        with self.assertRaisesMessage(AttributeError, msg):
+            q |= {"color": "yellow"}
+        self.assertEqual(q, QueryDict("color=red&q=tacos"))
+
+    def test_update_operator_dict(self):
+        q = QueryDict("color=red&q=tacos", mutable=True)
+        q |= {"color": "yellow"}
+        self.assertTrue(q._mutable)
+        self.assertEqual(q, QueryDict("color=red&color=yellow&q=tacos"))
+
+    def test_update_operator_querydict(self):
+        q = QueryDict("color=red&q=tacos", mutable=True)
+        q2 = QueryDict("color=yellow")
+        q |= q2
+        self.assertEqual(q, QueryDict("color=red&color=yellow&q=tacos"))
+
+    def test_update_operator_querydict_list(self):
+        q = QueryDict("color=red&q=tacos", mutable=True)
+        q2 = QueryDict("color=yellow&color=blue")
+        q |= q2
+        self.assertEqual(q, QueryDict("color=red&color=yellow&color=blue&q=tacos"))
+
+    def test_update_operator_nondict(self):
+        q = QueryDict("color=red&q=tacos", mutable=True)
+        msg = "'int' object is not iterable"
+        with self.assertRaisesMessage(TypeError, msg):
+            q |= 42
+
 
 class HttpResponseTests(SimpleTestCase):
     def test_headers_type(self):

--- a/tests/utils_tests/test_datastructures.py
+++ b/tests/utils_tests/test_datastructures.py
@@ -248,6 +248,29 @@ class MultiValueDictTests(SimpleTestCase):
             with self.subTest(value), self.assertRaises(ValueError):
                 MultiValueDict().update(value)
 
+    def test_update_operator_dict(self):
+        d = MultiValueDict({"name": ["Adrian", "Simon"]})
+        d |= {"name": "Holovaty", "position": "Developer"}
+        self.assertEqual(
+            list(d.lists()),
+            [("name", ["Adrian", "Simon", "Holovaty"]), ("position", ["Developer"])],
+        )
+
+    def test_update_operator_multivaluedict(self):
+        d = MultiValueDict({"name": ["Adrian", "Simon"]})
+        d2 = MultiValueDict({"name": ["Holovaty"], "position": ["Developer"]})
+        d |= d2
+        self.assertEqual(
+            list(d.lists()),
+            [("name", ["Adrian", "Simon", "Holovaty"]), ("position", ["Developer"])],
+        )
+
+    def test_update_operator_nondict(self):
+        d = MultiValueDict({"name": ["Adrian", "Simon"]})
+        msg = "'int' object is not iterable"
+        with self.assertRaisesMessage(TypeError, msg):
+            d |= 42
+
 
 class ImmutableListTests(SimpleTestCase):
     def test_sort(self):


### PR DESCRIPTION
#### Trac ticket number

ticket-36649

#### Branch description

Per [forum discussion](https://forum.djangoproject.com/t/add-merge-and-update-operator-support-to-multivaluedict-querydict/43123), add [PEP 584](https://peps.python.org/pep-0584/) `|=` (merge operator) support to these classes.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
