### PR TITLE
Refs #5815, #31938, #34271 -- Created invalidate_view_cache function …

### DIFF
--- a/django/utils/cache.py
+++ b/django/utils/cache.py
@@ -20,7 +20,7 @@ from collections import defaultdict
 from hashlib import md5
 
 from django.conf import settings
-from django.core.cache import cache, caches
+from django.core.cache import caches
 from django.http import HttpResponse, HttpResponseNotModified
 from django.test import RequestFactory
 from django.utils.http import http_date, parse_etags, parse_http_date_safe, quote_etag
@@ -449,10 +449,7 @@ def _to_tuple(s):
 
 
 def invalidate_view_cache(
-    path=None,
-    request=None,
-    vary_headers=None,
-    key_prefix=None,
+    path=None, request=None, vary_headers=None, key_prefix=None, cache=None
 ):
     """
     This function first creates a fake WSGIRequest to compute the cache key.
@@ -479,7 +476,12 @@ def invalidate_view_cache(
     if vary_headers:
         request.META.update(vary_headers)
 
-    cache_key = get_cache_key(request, key_prefix=key_prefix, ignore_headers=True)
+    if cache is None:
+        cache = caches[settings.CACHE_MIDDLEWARE_ALIAS]
+
+    cache_key = get_cache_key(
+        request, key_prefix=key_prefix, ignore_headers=True, cache=cache
+    )
     if cache_key is None:
         return 0
 

--- a/django/utils/cache.py
+++ b/django/utils/cache.py
@@ -18,11 +18,9 @@ An example: i18n middleware would need to distinguish caches by the
 import time
 from collections import defaultdict
 from hashlib import md5
-from typing import Annotated, Dict, Optional
 
 from django.conf import settings
 from django.core.cache import cache, caches
-from django.core.handlers.wsgi import WSGIRequest
 from django.http import HttpResponse, HttpResponseNotModified
 from django.test import RequestFactory
 from django.utils.http import http_date, parse_etags, parse_http_date_safe, quote_etag
@@ -451,11 +449,11 @@ def _to_tuple(s):
 
 
 def invalidate_view_cache(
-    path: str = None,
-    request: WSGIRequest = None,
-    vary_headers: Optional[Dict[str, str]] = None,
-    key_prefix: Optional[str] = None,
-) -> Annotated[int, "Number of cache keys deleted"]:
+    path=None,
+    request=None,
+    vary_headers=None,
+    key_prefix=None,
+):
     """
     This function first creates a fake WSGIRequest to compute the cache key.
     The key looks like:

--- a/django/views/decorators/cache.py
+++ b/django/views/decorators/cache.py
@@ -85,7 +85,20 @@ def never_cache(view_func):
 
 
 def cache_page_per_item(timeout, key_prefix=None):
-    """Decorator that applies cache_page with a dynamic key_prefix based on item id."""
+    """Decorator that applies cache_page with a dynamic key_prefix
+    based on item id. The item id is expected to be passed as
+    'pk' or 'id' keyword argument to the view. If key_prefix
+    is not provided, the view name will be used as base for the key prefix.
+    Example usage:
+        @cache_page_per_item(60 * 15, key_prefix="prefix")
+        def my_view(request, pk):
+            ...
+
+    This will cache the view for 15 minutes with a key prefix of 'prefix_<pk>'
+    allowing cache keys to be unique per item and identifiable.
+    If key_prefix is not provided it will default to 'my_view_<pk>' where
+    'my_view' is the name of the view function.
+    """
 
     def decorator(view_func):
         @wraps(view_func)

--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -103,6 +103,23 @@ need to distinguish caches by the ``Accept-language`` header.
     cache, this means that we have to build the response once to get at the
     Vary header and so at the list of headers to use for the cache key.
 
+.. function:: invalidate_view_cache(path=None, request=None, key_prefix=None, cache=None):
+
+    Delete a view cache key based on either a relative URL (``path``)
+    or a request object (``request``).
+
+    The cache key is reconstructed in two steps:
+        1. A headers cache key is built using the absolute URL,
+            key prefix, and locale code.
+        2. A response cache key is then built using the absolute URL,
+            key prefix, HTTP method, and recovered headers.
+
+    The ``key_prefix`` must match the value used in the ``cache_page``
+    decorator for the corresponding view.
+
+    Either the ``path`` or ``request`` parameter must be provided.
+    If both are given, ``path`` takes precedence.
+
 ``django.utils.dateparse``
 ==========================
 

--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -103,7 +103,7 @@ need to distinguish caches by the ``Accept-language`` header.
     cache, this means that we have to build the response once to get at the
     Vary header and so at the list of headers to use for the cache key.
 
-.. function:: invalidate_view_cache(request=None, key_prefix=None, cache=None):
+.. function:: invalidate_view_cache(request, key_prefix=None, cache=None):
     Delete a cached page based on either a relative URL (type: ``any``)
     or a request object (type: ``django.http.HttpRequest``).
 

--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -103,10 +103,9 @@ need to distinguish caches by the ``Accept-language`` header.
     cache, this means that we have to build the response once to get at the
     Vary header and so at the list of headers to use for the cache key.
 
-.. function:: invalidate_view_cache(path=None, request=None, key_prefix=None, cache=None):
-
-    Delete a view cache key based on either a relative URL (``path``)
-    or a request object (``request``).
+.. function:: invalidate_view_cache(request=None, key_prefix=None, cache=None):
+    Delete a cached page based on either a relative URL (type: ``any``)
+    or a request object (type: ``django.http.HttpRequest``).
 
     The cache key is reconstructed in two steps:
         1. A headers cache key is built using the absolute URL,
@@ -116,9 +115,6 @@ need to distinguish caches by the ``Accept-language`` header.
 
     The ``key_prefix`` must match the value used in the ``cache_page``
     decorator for the corresponding view.
-
-    Either the ``path`` or ``request`` parameter must be provided.
-    If both are given, ``path`` takes precedence.
 
 ``django.utils.dateparse``
 ==========================


### PR DESCRIPTION
#### Trac ticket number
ticket-5815

#### Branch description
At the moment there is not an 'easy' way to invalidate cached view responses from Django code. This PR introduces an utility function called invalidate_view_cache which allows you to do so using the relative path (request object takes care of putting together the rest of the URL).

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
