### PR TITLE
Fixed #36582 -- Added required attribute to mandatory fields in admin inline forms.

### DIFF
--- a/django/contrib/admin/helpers.py
+++ b/django/contrib/admin/helpers.py
@@ -174,6 +174,9 @@ class AdminField:
         self.is_checkbox = isinstance(self.field.field.widget, forms.CheckboxInput)
         self.is_readonly = False
         self.is_fieldset = self.field.field.widget.use_fieldset
+        bound_field = self.field.field
+        if bound_field.required:
+            bound_field.widget.attrs["required"] = True
 
     def label_tag(self):
         classes = []

--- a/tests/admin_inlines/models.py
+++ b/tests/admin_inlines/models.py
@@ -243,6 +243,7 @@ class NovelReadonlyChapter(Novel):
 
 class Chapter(models.Model):
     name = models.CharField(max_length=40)
+    page = models.IntegerField(blank=True, null=True)
     novel = models.ForeignKey(Novel, models.CASCADE)
 
 

--- a/tests/admin_inlines/tests.py
+++ b/tests/admin_inlines/tests.py
@@ -127,7 +127,7 @@ class TestInline(TestDataMixin, TestCase):
         self.assertContains(
             response,
             f'<input type="hidden" name="uuidchild_set-0-id" value="{child.id}" '
-            'id="id_uuidchild_set-0-id">',
+            'required id="id_uuidchild_set-0-id">',
             html=True,
         )
 
@@ -339,7 +339,7 @@ class TestInline(TestDataMixin, TestCase):
         self.assertNotContains(response, '<td class="field-position">')
         self.assertInHTML(
             '<input id="id_somechildmodel_set-1-position" '
-            'name="somechildmodel_set-1-position" type="hidden" value="1">',
+            'name="somechildmodel_set-1-position" type="hidden" required value="1">',
             response.rendered_content,
         )
 
@@ -498,7 +498,7 @@ class TestInline(TestDataMixin, TestCase):
         self.assertContains(
             response,
             '<input id="id_-1-0-name" type="text" class="vTextField" name="-1-0-name" '
-            'maxlength="100" aria-describedby="id_-1-0-name_helptext">',
+            'maxlength="100" required aria-describedby="id_-1-0-name_helptext">',
             html=True,
         )
         self.assertContains(
@@ -513,7 +513,7 @@ class TestInline(TestDataMixin, TestCase):
         self.assertContains(
             response,
             '<input id="id_-2-0-name" type="text" class="vTextField" name="-2-0-name" '
-            'maxlength="100">',
+            'required maxlength="100">',
             html=True,
         )
 
@@ -696,14 +696,14 @@ class TestInline(TestDataMixin, TestCase):
         self.assertContains(
             response,
             '<input class="vIntegerField" id="id_editablepkbook_set-0-manual_pk" '
-            'name="editablepkbook_set-0-manual_pk" type="number">',
+            'name="editablepkbook_set-0-manual_pk" required type="number">',
             html=True,
             count=1,
         )
         self.assertContains(
             response,
             '<input class="vIntegerField" id="id_editablepkbook_set-2-0-manual_pk" '
-            'name="editablepkbook_set-2-0-manual_pk" type="number">',
+            'name="editablepkbook_set-2-0-manual_pk" required type="number">',
             html=True,
             count=1,
         )
@@ -777,7 +777,7 @@ class TestInline(TestDataMixin, TestCase):
         self.assertContains(
             response,
             '<input type="text" name="chapter_set-0-name" '
-            'class="vTextField" maxlength="40" id="id_chapter_set-0-name">',
+            'class="vTextField" maxlength="40" required id="id_chapter_set-0-name">',
             html=True,
         )
 
@@ -827,6 +827,21 @@ class TestInline(TestDataMixin, TestCase):
         self.assertEqual(response.status_code, 302)
         parent.refresh_from_db()
         self.assertIs(parent.show_inlines, True)
+
+    def test_inline_fields_required_attribute(self):
+        response = self.client.get(reverse("admin:admin_inlines_novel_add"))
+        self.assertContains(
+            response,
+            '<input type="number" name="chapter_set-1-page" class="vIntegerField" '
+            'id="id_chapter_set-1-page">',
+            html=True,
+        )
+        self.assertContains(
+            response,
+            '<input type="text" name="chapter_set-1-name" class="vTextField" '
+            'maxlength="40" required id="id_chapter_set-1-name">',
+            html=True,
+        )
 
 
 @override_settings(ROOT_URLCONF="admin_inlines.urls")
@@ -1199,7 +1214,8 @@ class TestInlinePermissions(TestCase):
         self.assertContains(
             response,
             '<input type="hidden" id="id_Author_books-0-id" value="%i" '
-            'name="Author_books-0-id">' % self.author_book_auto_m2m_intermediate_id,
+            'required name="Author_books-0-id">'
+            % self.author_book_auto_m2m_intermediate_id,
             html=True,
         )
         self.assertContains(response, 'id="id_Author_books-0-DELETE"')
@@ -1259,7 +1275,7 @@ class TestInlinePermissions(TestCase):
         self.assertContains(
             response,
             '<input type="hidden" id="id_inner2_set-0-id" value="%i" '
-            'name="inner2_set-0-id">' % self.inner2.id,
+            'required name="inner2_set-0-id">' % self.inner2.id,
             html=True,
         )
         # max-num 0 means we can't add new ones
@@ -1276,7 +1292,8 @@ class TestInlinePermissions(TestCase):
         self.assertContains(
             response,
             '<input type="number" name="inner2_set-2-0-dummy" value="%s" '
-            'class="vIntegerField" id="id_inner2_set-2-0-dummy">' % self.inner2.dummy,
+            'class="vIntegerField" required id="id_inner2_set-2-0-dummy">'
+            % self.inner2.dummy,
             html=True,
         )
 
@@ -1306,7 +1323,7 @@ class TestInlinePermissions(TestCase):
         self.assertContains(
             response,
             '<input type="hidden" id="id_inner2_set-0-id" value="%i" '
-            'name="inner2_set-0-id">' % self.inner2.id,
+            'required name="inner2_set-0-id">' % self.inner2.id,
             html=True,
         )
 
@@ -1336,7 +1353,7 @@ class TestInlinePermissions(TestCase):
         self.assertContains(
             response,
             '<input type="hidden" id="id_inner2_set-0-id" value="%i" '
-            'name="inner2_set-0-id">' % self.inner2.id,
+            'required name="inner2_set-0-id">' % self.inner2.id,
             html=True,
         )
         self.assertContains(response, 'id="id_inner2_set-0-DELETE"')
@@ -1376,7 +1393,7 @@ class TestInlinePermissions(TestCase):
         self.assertContains(
             response,
             '<input type="hidden" id="id_inner2_set-0-id" value="%i" '
-            'name="inner2_set-0-id">' % self.inner2.id,
+            'required name="inner2_set-0-id">' % self.inner2.id,
             html=True,
         )
         self.assertContains(response, 'id="id_inner2_set-0-DELETE"')
@@ -1387,7 +1404,8 @@ class TestInlinePermissions(TestCase):
         self.assertContains(
             response,
             '<input type="number" name="inner2_set-2-0-dummy" value="%s" '
-            'class="vIntegerField" id="id_inner2_set-2-0-dummy">' % self.inner2.dummy,
+            'class="vIntegerField" required id="id_inner2_set-2-0-dummy">'
+            % self.inner2.dummy,
             html=True,
         )
 


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36582

#### Branch description
Add `required` attribute to mandatory fields inside admin inline forms to improve accessibility.

<img width="974" height="289" alt="Screenshot 2025-10-17 at 11 35 36 AM" src="https://github.com/user-attachments/assets/afa6fb0b-1531-4bc5-90a8-b9a0ace03b4a" />

Visual users could identify required fields through label styling, but screen reader users were unable to distinguish them.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
