### PR TITLE
Fixed #36642 -- Fixed capitalization of locale suggestions in makemessages.

### DIFF
--- a/tests/i18n/test_extraction.py
+++ b/tests/i18n/test_extraction.py
@@ -1069,3 +1069,37 @@ class UnchangedPoExtractionTests(ExtractorTests):
             "This is a hitherto undiscovered translatable string.",
             po_contents,
         )
+
+class InvalidLocaleExtractionTests(ExtractorTests):
+
+    def setUp(self):
+        super().setUp()
+        # Ensure locale directory exists
+        Path("locale").mkdir(exist_ok=True)
+
+    def test_invalid_locale_script_code(self):
+        """
+        Test that script codes (like Hans in zh_Hans) are correctly capitalized
+        in locale suggestions. Regression test for #36642.
+        """
+        out = StringIO()
+        management.call_command(
+            "makemessages", locale=["zh-hans"], stdout=out, verbosity=1
+        )
+        self.assertIn("invalid locale zh-hans, did you mean zh_Hans?", out.getvalue())
+        self.assertNotIn("processing locale zh-hans", out.getvalue())
+        self.assertIs(Path("locale/zh-hans/LC_MESSAGES/django.po").exists(), False)
+
+    def test_invalid_locale_script_code_latn(self):
+        """
+        Test script code suggestion for shi_Latn_MA with hyphens.
+        """
+        out = StringIO()
+        management.call_command(
+            "makemessages", locale=["shi-latn-ma"], stdout=out, verbosity=1
+        )
+        self.assertIn(
+            "invalid locale shi-latn-ma, did you mean shi_Latn_MA?", out.getvalue()
+        )
+        self.assertNotIn("processing locale shi-latn-ma", out.getvalue())
+        self.assertIs(Path("locale/shi-latn-ma/LC_MESSAGES/django.po").exists(), False)


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36642

#### Branch description
This fixes the issue where makemessages provided invalid locale suggestions when attempting to format locale strings.

**Problem**: When an invalid locale like `zh-hans` was provided, makemessages would suggest `zh_HAns` (also invalid) instead of the correct `zh_Hans`.

**Root Cause**: The old regex-based logic assumed all non-language components were 2-letter country codes and capitalized the first 2 characters, breaking script codes.

**Solution**:
- Use case-insensitive lookup in Django's LANG_INFO dictionary
- Apply proper locale capitalization rules:
  - Language codes: lowercase
  - Script codes (4 letters): Title case  
  - Country codes (2 letters): UPPERCASE
- Handle private subtags (e.g., `-x-informal`)

#### Checklist

- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in the past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
