### PR TITLE
Refs #36596 -- Skipped SchemaIndexesNotPostgreSQLTests on Postgres.

### DIFF
--- a/django/db/backends/postgresql/features.py
+++ b/django/db/backends/postgresql/features.py
@@ -81,10 +81,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     @cached_property
     def django_test_skips(self):
         skips = {
-            "opclasses are PostgreSQL only.": {
-                "indexes.tests.SchemaIndexesNotPostgreSQLTests."
-                "test_create_index_ignores_opclasses",
-            },
             "PostgreSQL requires casting to text.": {
                 "lookup.tests.LookupTests.test_textfield_exact_null",
             },

--- a/tests/indexes/tests.py
+++ b/tests/indexes/tests.py
@@ -1,5 +1,5 @@
 import datetime
-from unittest import skipUnless
+from unittest import skipIf, skipUnless
 
 from django.conf import settings
 from django.db import connection
@@ -106,6 +106,7 @@ class SchemaIndexesTests(TestCase):
             self.assertIn("charfield_added", str(editor.deferred_sql[0].parts["name"]))
 
 
+@skipIf(connection.vendor == "postgresql", "No PostgreSQL tests")
 class SchemaIndexesNotPostgreSQLTests(TransactionTestCase):
     available_apps = ["indexes"]
 


### PR DESCRIPTION
This change fixes recent CI issues when using parallel > 1 as follows:

```
2025-10-26T03:13:02.4339481Z ====================================================================== 2025-10-26T03:13:02.4340303Z ERROR: test_ops_class (indexes.tests.SchemaIndexesPostgreSQLTests.test_ops_class) 2025-10-26T03:13:02.4341128Z ---------------------------------------------------------------------- 2025-10-26T03:13:02.4341588Z Traceback (most recent call last):
2025-10-26T03:13:02.4342502Z   File "/home/runner/work/django/django/django/db/backends/utils.py", line 103, in _execute
2025-10-26T03:13:02.4343320Z     return self.cursor.execute(sql)
2025-10-26T03:13:02.4343606Z     ^^^^^^^
2025-10-26T03:13:02.4346259Z   File "/opt/hostedtoolcache/Python/3.14.0/x64/lib/python3.14/site-packages/psycopg/cursor.py", line 97, in execute
2025-10-26T03:13:02.4347143Z     raise ex.with_traceback(None)
2025-10-26T03:13:02.4347516Z     ^^^^^^^^^^^
2025-10-26T03:13:02.4348018Z psycopg.errors.DuplicateTable: relation "test_ops_class" already exists
2025-10-26T03:13:02.4348867Z
2025-10-26T03:13:02.4349194Z The above exception was the direct cause of the following exception:
2025-10-26T03:13:02.4349664Z
2025-10-26T03:13:02.4349819Z Traceback (most recent call last):
2025-10-26T03:13:02.4351013Z   File "/opt/hostedtoolcache/Python/3.14.0/x64/lib/python3.14/unittest/case.py", line 58, in testPartExecutor
2025-10-26T03:13:02.4351803Z     yield
2025-10-26T03:13:02.4352590Z   File "/opt/hostedtoolcache/Python/3.14.0/x64/lib/python3.14/unittest/case.py", line 669, in run
2025-10-26T03:13:02.4353481Z     self._callTestMethod(testMethod)
2025-10-26T03:13:02.4353965Z
2025-10-26T03:13:02.4354780Z   File "/opt/hostedtoolcache/Python/3.14.0/x64/lib/python3.14/unittest/case.py", line 615, in _callTestMethod
2025-10-26T03:13:02.4356010Z     result = method()
2025-10-26T03:13:02.4356408Z     ^^^^^^^^^^^^^^^
2025-10-26T03:13:02.4357215Z   File "/home/runner/work/django/django/tests/indexes/tests.py", line 184, in test_ops_class
2025-10-26T03:13:02.4358028Z     editor.add_index(IndexedArticle2, index)
2025-10-26T03:13:02.4358453Z     ^^^^^^^^^^^
2025-10-26T03:13:02.4359276Z   File "/home/runner/work/django/django/django/db/backends/postgresql/schema.py", line 317, in add_index
2025-10-26T03:13:02.4360155Z     self.execute(
2025-10-26T03:13:02.4361078Z   File "/home/runner/work/django/django/django/db/backends/postgresql/schema.py", line 45, in execute
2025-10-26T03:13:02.4361996Z     return super().execute(sql, params)
2025-10-26T03:13:02.4362423Z     ^^^^^^^^^^^
2025-10-26T03:13:02.4363187Z   File "/home/runner/work/django/django/django/db/backends/base/schema.py", line 205, in execute
2025-10-26T03:13:02.4364021Z     cursor.execute(sql, params)
2025-10-26T03:13:02.4364401Z     ^^^^^^^
2025-10-26T03:13:02.4365053Z   File "/home/runner/work/django/django/django/db/backends/utils.py", line 79, in execute
2025-10-26T03:13:02.4366060Z     return self._execute_with_wrappers(
2025-10-26T03:13:02.4366513Z     ^^^^^^^^^^^^^^^
2025-10-26T03:13:02.4367349Z   File "/home/runner/work/django/django/django/db/backends/utils.py", line 92, in _execute_with_wrappers
2025-10-26T03:13:02.4368262Z     return executor(sql, params, many, context)
2025-10-26T03:13:02.4368723Z     ^^^^^^^^^^^^^^^
2025-10-26T03:13:02.4369459Z   File "/home/runner/work/django/django/django/db/backends/utils.py", line 100, in _execute
2025-10-26T03:13:02.4370316Z     with self.db.wrap_database_errors:
2025-10-26T03:13:02.4370730Z     ^^^^^^^^^^^^^^^
2025-10-26T03:13:02.4371377Z   File "/home/runner/work/django/django/django/db/utils.py", line 94, in __exit__
2025-10-26T03:13:02.4372232Z     raise dj_exc_value.with_traceback(traceback) from exc_value
2025-10-26T03:13:02.4376460Z     ^^^^^^^
2025-10-26T03:13:02.4377846Z   File "/home/runner/work/django/django/django/db/backends/utils.py", line 103, in _execute
2025-10-26T03:13:02.4378971Z     return self.cursor.execute(sql)
2025-10-26T03:13:02.4379398Z     ^^^^^^^
2025-10-26T03:13:02.4380458Z   File "/opt/hostedtoolcache/Python/3.14.0/x64/lib/python3.14/site-packages/psycopg/cursor.py", line 97, in execute
2025-10-26T03:13:02.4381662Z     raise ex.with_traceback(None)
2025-10-26T03:13:02.4382073Z     ^^^^^^^^^^^
2025-10-26T03:13:02.4382650Z django.db.utils.ProgrammingError: relation "test_ops_class" already exists
```

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36596

#### Branch description
Since the recent upgrade of GHA to 3.14, scheduled tests for Postgres have been failing with the traceback shown above. The traceback is caused by a collision between `indexes.tests.SchemaIndexesNotPostgreSQLTests.test_create_index_ignores_opclasses` and `indexes.tests.SchemaIndexesPostgreSQLTests.test_ops_class`. The former should be skipped for Postgresql.

#### Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
