### PR TITLE
docs: Updated 5.0 release notes about MariaDB UUIDField migration (#33507).

### DIFF
--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -529,9 +529,10 @@ Should become::
         uuid = Char32UUIDField(primary_key=True, default=uuid.uuid4)
 
 Running the :djadmin:`makemigrations` command will generate a migration
-containing a no-op ``AlterField`` operation. Since any new ``UUIDField``
-would use a ``UUID`` column, the ``Char32UUIDField`` should be used
-instead, when mixing column types is not desired.
+containing a no-op ``AlterField`` operation. By default, new
+``UUIDField`` instances will use the ``UUID`` column type: To ensure
+consistency with existing fields, use ``Char32UUIDField`` instead for
+new fields that should have the same column type.
 
 ----
 
@@ -551,8 +552,8 @@ a data migration::
           )
       ]
 
-This would avoid potentially mixing the old and new column types and
-needs no additional consideration on new fields, once migrated.
+Once migrated, this would need no additional consideration when adding
+new ``UUIDField`` instances.
 
 Please note that for larger tables or when ``UUIDFields`` are used as
 primary keys or in constraints, this operation could either require a

--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -530,9 +530,9 @@ Should become::
 
 Running the :djadmin:`makemigrations` command will generate a migration
 containing a no-op ``AlterField`` operation. By default, new
-``UUIDField`` instances will use the ``UUID`` column type: To ensure
-consistency with existing fields, use ``Char32UUIDField`` instead for
-new fields that should have the same column type.
+``UUIDField`` instances will use the ``UUID`` column type. If a
+``CHAR(32)`` column is needed, for example if you want to ensure
+consistency with existing columns, use a ``Char32UUIDField``.
 
 ----
 

--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -547,6 +547,7 @@ a data migration::
               ALTER TABLE my_app_model1 MODIFY my_uuid_field1 UUID NOT NULL;
               ALTER TABLE my_app_model2 MODIFY my_uuid_field2 UUID NOT NULL;
               """,
+              elidable=True,
           )
       ]
 

--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -529,7 +529,34 @@ Should become::
         uuid = Char32UUIDField(primary_key=True, default=uuid.uuid4)
 
 Running the :djadmin:`makemigrations` command will generate a migration
-containing a no-op ``AlterField`` operation.
+containing a no-op ``AlterField`` operation. Since any new ``UUIDField``
+would use a ``UUID`` column, the ``Char32UUIDField`` should be used
+instead, when mixing column types is not desired.
+
+----
+
+Alternatively, existing ``UUIDField`` columns could be altered in the
+database to use a ``UUID`` column, by running a ``RunSQL`` operation in
+a data migration::
+
+  class Migration(migrations.Migration):
+      ...
+      operations = [
+          migrations.RunSQL(
+              sql="""
+              ALTER TABLE my_app_model1 MODIFY my_uuid_field1 UUID NOT NULL;
+              ALTER TABLE my_app_model2 MODIFY my_uuid_field2 UUID NOT NULL;
+              """,
+          )
+      ]
+
+This would avoid potentially mixing the old and new column types and
+needs no additional consideration on new fields, once migrated.
+
+Please note that for larger tables or when ``UUIDFields`` are used as
+primary keys or in constraints, this operation could either require a
+lengthy table rebuild, or even end up failing to migrate the constraints
+without additional steps (see :ticket:`33507` for details).
 
 Miscellaneous
 -------------


### PR DESCRIPTION
#### Trac ticket number
No ticket of its own, relevant ticket-33507, see comment: https://code.djangoproject.com/ticket/33507#comment:24

#### Branch description

This extends the release notes to **mention an alternative migration path for `UUIDFields` when using MariaDB 10.7+**, which backs `UUIDField` using a `UUID` column as opposed to the previous `CHAR(32)` column. We also link to the original ticket for additional insight.

Rationale: I would have liked to see this mentioned in the docs while upgrading from Django 3.2 to 5.x (using MariaDB 10.11).

---

The [recommended way to migrate](https://docs.djangoproject.com/en/5.2/releases/5.0/#migrating-existing-uuidfield-on-mariadb-10-7) existing `UUIDFields` is to define a custom field class (`Char32UUIDField`) that ensures that `CHAR(32)` is still used. 
- Benefit: This requires no change to the database itself.
- Downside: Developers have to remember using the new field class from then on (easy to forget), or handle mixed columns for old VS new `UUIDFields`.

While [#33507](https://code.djangoproject.com/ticket/33507) illustrates why this is the preferred migration path for more complex scenarios, there is an alternative way to handle this for simpler scenarios (when `UUIDFields` are neither primary keys nor part of constraints), and that is to just convert existing `CHAR(32)` columns to `UUID` columns. 
- Benefit: Does not need any additional thought once successfully migrated, since all existing and new `UUIDFields` will use `UUID`, so no mixed types.
- Downside: The migration may not be easy/possible for more complex schemas.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
