### PR TITLE
Fixed #36729 -- Pre-compiled all regular expressions.

### DIFF
--- a/django/contrib/admindocs/utils.py
+++ b/django/contrib/admindocs/utils.py
@@ -20,6 +20,9 @@ else:
     docutils_is_available = True
 
 
+_docstring_parts_re = _lazy_re_compile(r"\n{2,}")
+
+
 def get_view_name(view_func):
     if hasattr(view_func, "view_class"):
         klass = view_func.view_class
@@ -36,7 +39,7 @@ def parse_docstring(docstring):
     if not docstring:
         return "", "", {}
     docstring = cleandoc(docstring)
-    parts = re.split(r"\n{2,}", docstring)
+    parts = _docstring_parts_re.split(docstring)
     title = parts[0]
     if len(parts) == 1:
         body = ""
@@ -177,12 +180,14 @@ if docutils_is_available:
 named_group_matcher = _lazy_re_compile(r"\(\?P(<\w+>)")
 unnamed_group_matcher = _lazy_re_compile(r"\(")
 non_capturing_group_matcher = _lazy_re_compile(r"\(\?\:")
+unescaped_metacharacters_matcher = _lazy_re_compile(
+    r"((?:^|(?<!\\))(?:\\\\)*)(\\?)([?*+^$]|\\[bBAZ])"
+)
 
 
 def replace_metacharacters(pattern):
     """Remove unescaped metacharacters from the pattern."""
-    return re.sub(
-        r"((?:^|(?<!\\))(?:\\\\)*)(\\?)([?*+^$]|\\[bBAZ])",
+    return unescaped_metacharacters_matcher.sub(
         lambda m: m[1] + m[3] if m[2] else m[1],
         pattern,
     )

--- a/django/contrib/auth/password_validation.py
+++ b/django/contrib/auth/password_validation.py
@@ -1,6 +1,5 @@
 import functools
 import gzip
-import re
 from difflib import SequenceMatcher
 from pathlib import Path
 
@@ -13,6 +12,7 @@ from django.core.exceptions import (
 from django.utils.functional import cached_property, lazy
 from django.utils.html import format_html, format_html_join
 from django.utils.module_loading import import_string
+from django.utils.text import _non_word_re
 from django.utils.translation import gettext as _
 from django.utils.translation import ngettext
 
@@ -190,7 +190,7 @@ class UserAttributeSimilarityValidator:
             if not value or not isinstance(value, str):
                 continue
             value_lower = value.lower()
-            value_parts = [*re.split(r"\W+", value_lower), value_lower]
+            value_parts = [*_non_word_re.split(value_lower), value_lower]
             for value_part in value_parts:
                 if exceeds_maximum_length_ratio(
                     password, self.max_similarity, value_part

--- a/django/contrib/gis/db/backends/base/features.py
+++ b/django/contrib/gis/db/backends/base/features.py
@@ -1,8 +1,9 @@
-import re
-
 from django.contrib.gis.db import models
+from django.utils.regex_helper import _lazy_re_compile
 
 from .operations import BaseSpatialOperations
+
+_has_function_re = _lazy_re_compile(r"has_(\w*)_function$")
 
 
 class BaseSpatialFeatures:
@@ -108,8 +109,7 @@ class BaseSpatialFeatures:
         return models.Union not in self.connection.ops.disallowed_aggregates
 
     def __getattr__(self, name):
-        m = re.match(r"has_(\w*)_function$", name)
-        if m:
+        if m := _has_function_re.match(name):
             func_name = m[1]
             if func_name not in BaseSpatialOperations.unsupported_functions:
                 raise ValueError(

--- a/django/contrib/gis/db/backends/postgis/operations.py
+++ b/django/contrib/gis/db/backends/postgis/operations.py
@@ -23,6 +23,8 @@ from .pgraster import from_pgraster
 # Identifier to mark raster lookups as bilateral.
 BILATERAL = "bilateral"
 
+_postgis_version_re = re.compile(r"(\d+)\.(\d+)\.(\d+)")
+
 
 class PostGISOperator(SpatialOperator):
     def __init__(self, geography=False, raster=False, **kwargs):
@@ -372,10 +374,7 @@ class PostGISOperations(BaseSpatialOperations, DatabaseOperations):
         Return the version of PROJ used by PostGIS as a tuple of the
         major, minor, and subminor release numbers.
         """
-        proj_regex = re.compile(r"(\d+)\.(\d+)\.(\d+)")
-        proj_ver_str = self.postgis_proj_version()
-        m = proj_regex.search(proj_ver_str)
-        if m:
+        if m := _postgis_version_re.search(self.postgis_proj_version()):
             return tuple(map(int, m.groups()))
         else:
             raise Exception("Could not determine PROJ version from PostGIS.")

--- a/django/contrib/gis/gdal/libgdal.py
+++ b/django/contrib/gis/gdal/libgdal.py
@@ -1,13 +1,17 @@
 import logging
 import os
-import re
 from ctypes import CDLL, CFUNCTYPE, c_char_p, c_int
 from ctypes.util import find_library
 
 from django.contrib.gis.gdal.error import GDALException
 from django.core.exceptions import ImproperlyConfigured
+from django.utils.regex_helper import _lazy_re_compile
 
 logger = logging.getLogger("django.contrib.gis")
+
+_gdal_version_re = _lazy_re_compile(
+    rb"^(?P<major>\d+)\.(?P<minor>\d+)(?:\.(?P<subminor>\d+))?"
+)
 
 # Custom library path set?
 try:
@@ -111,7 +115,7 @@ def gdal_full_version():
 
 def gdal_version_info():
     ver = gdal_version()
-    m = re.match(rb"^(?P<major>\d+)\.(?P<minor>\d+)(?:\.(?P<subminor>\d+))?", ver)
+    m = _gdal_version_re.match(ver)
     if not m:
         raise GDALException('Could not parse GDAL version string "%s"' % ver)
     major, minor, subminor = m.groups()

--- a/django/contrib/gis/geos/geometry.py
+++ b/django/contrib/gis/geos/geometry.py
@@ -3,7 +3,6 @@ This module contains the 'base' GEOSGeometry object -- all GEOS Geometries
 inherit from this object.
 """
 
-import re
 from ctypes import addressof, byref, c_double
 
 from django.contrib.gis import gdal
@@ -18,6 +17,9 @@ from django.contrib.gis.geos.prepared import PreparedGeometry
 from django.contrib.gis.geos.prototypes.io import ewkb_w, wkb_r, wkb_w, wkt_r, wkt_w
 from django.utils.deconstruct import deconstructible
 from django.utils.encoding import force_bytes, force_str
+from django.utils.regex_helper import _lazy_re_compile
+
+_srid_re = _lazy_re_compile(rb"SRID=(?P<srid>\-?\d+)")
 
 
 class GEOSGeometryBase(GEOSBase):
@@ -124,7 +126,7 @@ class GEOSGeometryBase(GEOSBase):
         parts = ewkt.split(b";", 1)
         if len(parts) == 2:
             srid_part, wkt = parts
-            match = re.match(rb"SRID=(?P<srid>\-?\d+)", srid_part)
+            match = _srid_re.match(srid_part)
             if not match:
                 raise ValueError("EWKT has invalid SRID part.")
             srid = int(match["srid"])

--- a/django/contrib/humanize/templatetags/humanize.py
+++ b/django/contrib/humanize/templatetags/humanize.py
@@ -17,7 +17,10 @@ from django.utils.translation import (
     round_away_from_one,
 )
 
+_integer_re = re.compile(r"-?\d+")
 register = template.Library()
+_triple_integer_re = re.compile(r"\d{3}")
+_intcomma_leading_comma_re = re.compile(r"^(-?),")
 
 
 @register.filter(is_safe=True)
@@ -82,12 +85,11 @@ def intcomma(value, use_l10n=True):
         else:
             return number_format(value, use_l10n=True, force_grouping=True)
     result = str(value)
-    match = re.match(r"-?\d+", result)
-    if match:
+    if match := _integer_re.match(result):
         prefix = match[0]
-        prefix_with_commas = re.sub(r"\d{3}", r"\g<0>,", prefix[::-1])[::-1]
+        prefix_with_commas = _triple_integer_re.sub(r"\g<0>,", prefix[::-1])[::-1]
         # Remove a leading comma, if needed.
-        prefix_with_commas = re.sub(r"^(-?),", r"\1", prefix_with_commas)
+        prefix_with_commas = _intcomma_leading_comma_re.sub(r"\1", prefix_with_commas)
         result = prefix_with_commas + result[len(prefix) :]
     return result
 

--- a/django/contrib/staticfiles/storage.py
+++ b/django/contrib/staticfiles/storage.py
@@ -11,6 +11,9 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import ContentFile
 from django.core.files.storage import FileSystemStorage, storages
 from django.utils.functional import LazyObject
+from django.utils.regex_helper import _lazy_re_compile
+
+_protocol_prefix_re = _lazy_re_compile(r"^[a-z]+:")
 
 
 class StaticFilesStorage(FileSystemStorage):
@@ -223,7 +226,7 @@ class HashedFilesMixin:
             url = matches["url"]
 
             # Ignore absolute/protocol-relative and data-uri URLs.
-            if re.match(r"^[a-z]+:", url) or url.startswith("//"):
+            if _protocol_prefix_re.match(url) or url.startswith("//"):
                 return matched
 
             # Ignore absolute URLs that don't point to a static file (dynamic

--- a/django/core/cache/backends/memcached.py
+++ b/django/core/cache/backends/memcached.py
@@ -1,6 +1,5 @@
 "Memcached cache backend"
 
-import re
 import time
 
 from django.core.cache.backends.base import (
@@ -9,6 +8,7 @@ from django.core.cache.backends.base import (
     InvalidCacheKey,
     memcache_key_warnings,
 )
+from django.core.cache.utils import server_separator_re
 from django.utils.functional import cached_property
 
 
@@ -16,7 +16,7 @@ class BaseMemcachedCache(BaseCache):
     def __init__(self, server, params, library, value_not_found_exception):
         super().__init__(params)
         if isinstance(server, str):
-            self._servers = re.split("[;,]", server)
+            self._servers = server_separator_re.split(server)
         else:
             self._servers = server
 

--- a/django/core/cache/backends/redis.py
+++ b/django/core/cache/backends/redis.py
@@ -2,9 +2,9 @@
 
 import pickle
 import random
-import re
 
 from django.core.cache.backends.base import DEFAULT_TIMEOUT, BaseCache
+from django.core.cache.utils import server_separator_re
 from django.utils.functional import cached_property
 from django.utils.module_loading import import_string
 
@@ -161,7 +161,7 @@ class RedisCache(BaseCache):
     def __init__(self, server, params):
         super().__init__(params)
         if isinstance(server, str):
-            self._servers = re.split("[;,]", server)
+            self._servers = server_separator_re.split(server)
         else:
             self._servers = server
 

--- a/django/core/cache/utils.py
+++ b/django/core/cache/utils.py
@@ -1,6 +1,10 @@
 from hashlib import md5
 
+from django.utils.regex_helper import _lazy_re_compile
+
 TEMPLATE_FRAGMENT_KEY_TEMPLATE = "template.cache.%s.%s"
+
+server_separator_re = _lazy_re_compile("[;,]")
 
 
 def make_template_fragment_key(fragment_name, vary_on=None):

--- a/django/core/management/commands/inspectdb.py
+++ b/django/core/management/commands/inspectdb.py
@@ -1,10 +1,13 @@
 import keyword
-import re
 
 from django.core.management.base import BaseCommand, CommandError
 from django.db import DEFAULT_DB_ALIAS, connections
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.deletion import DatabaseOnDelete
+from django.utils.regex_helper import _lazy_re_compile
+from django.utils.text import _non_word_re
+
+_non_identifier_re = _lazy_re_compile(r"[^a-zA-Z0-9]")
 
 
 class Command(BaseCommand):
@@ -288,7 +291,7 @@ class Command(BaseCommand):
             else:
                 field_params["db_column"] = col_name
 
-        new_name, num_repl = re.subn(r"\W", "_", new_name)
+        new_name, num_repl = _non_word_re.subn("_", new_name)
         if num_repl > 0:
             field_notes.append("Field renamed to remove unsuitable characters.")
 
@@ -334,7 +337,7 @@ class Command(BaseCommand):
 
     def normalize_table_name(self, table_name):
         """Translate the table name to a Python-compatible model name."""
-        return re.sub(r"[^a-zA-Z0-9]", "", table_name.title())
+        return _non_identifier_re.sub("", table_name.title())
 
     def get_field_type(self, connection, table_name, row):
         """

--- a/django/core/management/commands/runserver.py
+++ b/django/core/management/commands/runserver.py
@@ -88,7 +88,7 @@ class Command(BaseCommand):
             self.addr = ""
             self.port = self.default_port
         else:
-            m = re.match(naiveip_re, options["addrport"])
+            m = naiveip_re.match(options["addrport"])
             if m is None:
                 raise CommandError(
                     '"%s" is not a valid port number '

--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -140,6 +140,7 @@ class URLValidator(RegexValidator):
     tld_re = DomainNameValidator.tld_re
 
     host_re = "(" + hostname_re + domain_re + tld_re + "|localhost)"
+    ipv6_host_re = _lazy_re_compile(r"^\[(.+)\](?::[0-9]{1,5})?$")
 
     regex = _lazy_re_compile(
         r"^(?:[a-z0-9.+-]*)://"  # scheme is validated separately
@@ -177,7 +178,7 @@ class URLValidator(RegexValidator):
             raise ValidationError(self.message, code=self.code, params={"value": value})
         super().__call__(value)
         # Now verify IPv6 in the netloc part
-        host_match = re.search(r"^\[(.+)\](?::[0-9]{1,5})?$", splitted_url.netloc)
+        host_match = self.ipv6_host_re.search(splitted_url.netloc)
         if host_match:
             potential_ip = host_match[1]
             try:

--- a/django/db/backends/oracle/schema.py
+++ b/django/db/backends/oracle/schema.py
@@ -9,6 +9,9 @@ from django.db.backends.base.schema import (
 )
 from django.utils.duration import duration_iso_string
 
+_clob_re = re.compile("^N?CLOB")
+_varchar2_re = re.compile("^N?VARCHAR2")
+
 
 class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
     sql_create_column = "ALTER TABLE %(table)s ADD %(column)s %(definition)s"
@@ -127,10 +130,10 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         # /Data-Type-Comparison-Rules.html#GUID-D0C5A47E-6F93-4C2D-9E49-4F2B86B359DD
         new_value = self.quote_name(old_field.column)
         old_type = old_field.db_type(self.connection)
-        if re.match("^N?CLOB", old_type):
+        if _clob_re.match(old_type):
             new_value = "TO_CHAR(%s)" % new_value
             old_type = "VARCHAR2"
-        if re.match("^N?VARCHAR2", old_type):
+        if _varchar2_re.match(old_type):
             new_internal_type = new_field.get_internal_type()
             if new_internal_type == "DateField":
                 new_value = "TO_DATE(%s, 'YYYY-MM-DD')" % new_value

--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -13,11 +13,13 @@ from django.db.migrations.operations.models import AlterModelOptions
 from django.db.migrations.optimizer import MigrationOptimizer
 from django.db.migrations.questioner import MigrationQuestioner
 from django.db.migrations.utils import (
-    COMPILED_REGEX_TYPE,
     RegexObject,
     resolve_relation,
 )
 from django.utils.functional import cached_property
+
+_squashed_migration_re = re.compile(r".*_squashed_(\d+)")
+_number_prefix_re = re.compile(r"^\d+")
 
 
 class OperationDependency(
@@ -89,7 +91,7 @@ class MigrationAutodetector:
                 self.deep_deconstruct(obj.args),
                 self.deep_deconstruct(obj.keywords),
             )
-        elif isinstance(obj, COMPILED_REGEX_TYPE):
+        elif isinstance(obj, re.Pattern):
             return RegexObject(obj)
         elif isinstance(obj, type):
             # If this is a type that implements 'deconstruct' as an instance
@@ -2055,9 +2057,9 @@ class MigrationAutodetector:
         it. For a squashed migration such as '0001_squashed_0004…', return the
         second number. If no number is found, return None.
         """
-        if squashed_match := re.search(r".*_squashed_(\d+)", name):
+        if squashed_match := _squashed_migration_re.search(name):
             return int(squashed_match[1])
-        match = re.match(r"^\d+", name)
+        match = _number_prefix_re.match(name)
         if match:
             return int(match[0])
         return None

--- a/django/db/migrations/migration.py
+++ b/django/db/migrations/migration.py
@@ -1,7 +1,6 @@
-import re
-
 from django.db.migrations.utils import get_migration_name_timestamp
 from django.db.transaction import atomic
+from django.utils.text import replace_non_word_chars
 
 from .exceptions import IrreversibleError
 
@@ -206,8 +205,11 @@ class Migration:
         if self.initial:
             return "initial"
 
-        raw_fragments = [op.migration_name_fragment for op in self.operations]
-        fragments = [re.sub(r"\W+", "_", name) for name in raw_fragments if name]
+        fragments = [
+            replace_non_word_chars("_", op.migration_name_fragment)
+            for op in self.operations
+            if op.migration_name_fragment
+        ]
 
         if not fragments or len(fragments) != len(self.operations):
             return "auto_%s" % get_migration_name_timestamp()

--- a/django/db/migrations/serializer.py
+++ b/django/db/migrations/serializer.py
@@ -15,7 +15,7 @@ import zoneinfo
 from django.conf import SettingsReference
 from django.db import models
 from django.db.migrations.operations.base import Operation
-from django.db.migrations.utils import COMPILED_REGEX_TYPE, RegexObject
+from django.db.migrations.utils import RegexObject
 from django.db.models.deletion import DatabaseOnDelete
 from django.utils.functional import LazyObject, Promise
 from django.utils.version import get_docs_version
@@ -377,7 +377,7 @@ class Serializer:
         FUNCTION_TYPES: FunctionTypeSerializer,
         types.GenericAlias: GenericAliasSerializer,
         collections.abc.Iterable: IterableSerializer,
-        (COMPILED_REGEX_TYPE, RegexObject): RegexSerializer,
+        (re.Pattern, RegexObject): RegexSerializer,
         uuid.UUID: UUIDSerializer,
         pathlib.PurePath: PathSerializer,
         os.PathLike: PathLikeSerializer,

--- a/django/db/migrations/utils.py
+++ b/django/db/migrations/utils.py
@@ -1,12 +1,9 @@
 import datetime
-import re
 from collections import namedtuple
 
 from django.db.models.fields.related import RECURSIVE_RELATIONSHIP_CONSTANT
 
 FieldReference = namedtuple("FieldReference", "to through")
-
-COMPILED_REGEX_TYPE = type(re.compile(""))
 
 
 class RegexObject:

--- a/django/db/migrations/writer.py
+++ b/django/db/migrations/writer.py
@@ -14,6 +14,8 @@ from django.utils.inspect import get_func_args
 from django.utils.module_loading import module_dir
 from django.utils.timezone import now
 
+_import_re = re.compile(r"^import (.*)\.\d+[^\s]*$")
+
 
 class OperationWriter:
     def __init__(self, operation, indentation=2):
@@ -164,7 +166,7 @@ class MigrationWriter:
         # files for comments
         migration_imports = set()
         for line in list(imports):
-            if re.match(r"^import (.*)\.\d+[^\s]*$", line):
+            if _import_re.match(line):
                 migration_imports.add(line.split("import")[1].strip())
                 imports.remove(line)
                 self.needs_manual_porting = True

--- a/django/forms/boundfield.py
+++ b/django/forms/boundfield.py
@@ -1,13 +1,14 @@
-import re
-
 from django.core.exceptions import ValidationError
 from django.forms.utils import RenderableFieldMixin, pretty_name
 from django.forms.widgets import MultiWidget, Textarea, TextInput
 from django.utils.functional import cached_property
 from django.utils.html import format_html, html_safe
+from django.utils.regex_helper import _lazy_re_compile
 from django.utils.translation import gettext_lazy as _
 
 __all__ = ("BoundField",)
+
+_widget_type_suffix_re = _lazy_re_compile(r"widget$|input$")
 
 
 class BoundField(RenderableFieldMixin):
@@ -317,8 +318,8 @@ class BoundField(RenderableFieldMixin):
 
     @property
     def widget_type(self):
-        return re.sub(
-            r"widget$|input$", "", self.field.widget.__class__.__name__.lower()
+        return _widget_type_suffix_re.sub(
+            "", self.field.widget.__class__.__name__.lower()
         )
 
     @property

--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -29,6 +29,9 @@ from .library import Library
 
 register = Library()
 
+_title_1_re = re.compile("([a-z])'([A-Z])")
+_title_2_re = re.compile(r"\d([A-Z])")
+
 
 #######################
 # STRING DECORATOR    #
@@ -298,8 +301,8 @@ def stringformat(value, arg):
 @stringfilter
 def title(value):
     """Convert a string into titlecase."""
-    t = re.sub("([a-z])'([A-Z])", lambda m: m[0].lower(), value.title())
-    return re.sub(r"\d([A-Z])", lambda m: m[0].lower(), t)
+    t = _title_1_re.sub(lambda m: m[0].lower(), value.title())
+    return _title_2_re.sub(lambda m: m[0].lower(), t)
 
 
 @register.filter(is_safe=True)

--- a/django/template/defaulttags.py
+++ b/django/template/defaulttags.py
@@ -44,6 +44,8 @@ from .smartif import IfParser, Literal
 
 register = Library()
 
+_loopvars_re = re.compile(r" *, *")
+
 
 class AutoEscapeControlNode(Node):
     """Implement the actions of the autoescape tag."""
@@ -883,7 +885,7 @@ def do_for(parser, token):
         )
 
     invalid_chars = frozenset((" ", '"', "'", FILTER_SEPARATOR))
-    loopvars = re.split(r" *, *", " ".join(bits[1:in_index]))
+    loopvars = _loopvars_re.split(" ".join(bits[1:in_index]))
     for var in loopvars:
         if not var or not invalid_chars.isdisjoint(var):
             raise TemplateSyntaxError(

--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -30,6 +30,8 @@ from .converters import get_converters
 from .exceptions import NoReverseMatch, Resolver404
 from .utils import get_callable
 
+_brackets_re = _lazy_re_compile(r"[<>]")
+
 
 class ResolverMatch:
     def __init__(
@@ -365,7 +367,7 @@ class RoutePattern(CheckURLMixin):
     def _check_pattern_unmatched_angle_brackets(self):
         warnings = []
         msg = "Your URL pattern %s has an unmatched '%s' bracket."
-        brackets = re.findall(r"[<>]", str(self._route))
+        brackets = _brackets_re.findall(str(self._route))
         open_bracket_counter = 0
         for bracket in brackets:
             if bracket == "<":

--- a/django/utils/formats.py
+++ b/django/utils/formats.py
@@ -47,6 +47,8 @@ FORMAT_SETTINGS = frozenset(
     ]
 )
 
+_sanitize_strftime_format_re = re.compile(r"((?:^|[^%])(?:%%)*)%([CFGY])")
+
 
 def reset_format_cache():
     """Clear any cached formats.
@@ -266,8 +268,7 @@ def sanitize_strftime_format(fmt):
     if datetime.date(1, 1, 1).strftime("%Y") == "0001":
         return fmt
     mapping = {"C": 2, "F": 10, "G": 4, "Y": 4}
-    return re.sub(
-        r"((?:^|[^%])(?:%%)*)%([CFGY])",
+    return _sanitize_strftime_format_re.sub(
         lambda m: r"%s%%0%s%s" % (m[1], mapping[m[2]], m[2]),
         fmt,
     )

--- a/django/utils/html.py
+++ b/django/utils/html.py
@@ -48,6 +48,8 @@ MAX_STRIP_TAGS_DEPTH = 50
 # HTML tag that opens but has no closing ">" after 1k+ chars.
 long_open_tag_without_closing_re = _lazy_re_compile(r"<[a-zA-Z][^>]{1000,}")
 
+_linebreaks_re = _lazy_re_compile(r"\n{2,}")
+
 
 @keep_lazy(SafeString)
 def escape(text):
@@ -174,8 +176,8 @@ def format_html_join(sep, format_string, args_generator):
 @keep_lazy_text
 def linebreaks(value, autoescape=False):
     """Convert newlines into <p> and <br>s."""
-    value = normalize_newlines(value)
-    paras = re.split("\n{2,}", str(value))
+    value = normalize_newlines(str(value))
+    paras = _linebreaks_re.split(value)
     if autoescape:
         paras = ["<p>%s</p>" % escape(p).replace("\n", "<br>") for p in paras]
     else:
@@ -234,10 +236,13 @@ def strip_tags(value):
     return value
 
 
+_strip_spaces_between_tags_re = re.compile(r">\s+<")
+
+
 @keep_lazy_text
 def strip_spaces_between_tags(value):
     """Return the given HTML with spaces between tags removed."""
-    return re.sub(r">\s+<", "><", str(value))
+    return _strip_spaces_between_tags_re.sub("><", str(value))
 
 
 def smart_urlquote(url):

--- a/django/utils/http.py
+++ b/django/utils/http.py
@@ -41,6 +41,12 @@ RFC3986_SUBDELIMS = "!$&'()*+,;="
 MAX_URL_LENGTH = 2048
 MAX_URL_REDIRECT_LENGTH = 16384
 
+# Quoted strings can contain horizontal tabs, space characters, and
+# characters from 0x21 to 0x7e, except 0x22 (`"`) and 0x5C (`\`) which
+# can still be expressed but must be escaped with their own `\`.
+# https://datatracker.ietf.org/doc/html/rfc9110#name-quoted-strings
+_quotable_chars_re = _lazy_re_compile(r"^[\t \x21-\x7e]*$")
+
 
 def urlencode(query, doseq=False):
     """
@@ -379,12 +385,7 @@ def content_disposition_header(as_attachment, filename):
             is_ascii = True
         except UnicodeEncodeError:
             is_ascii = False
-        # Quoted strings can contain horizontal tabs, space characters, and
-        # characters from 0x21 to 0x7e, except 0x22 (`"`) and 0x5C (`\`) which
-        # can still be expressed but must be escaped with their own `\`.
-        # https://datatracker.ietf.org/doc/html/rfc9110#name-quoted-strings
-        quotable_characters = r"^[\t \x21-\x7e]*$"
-        if is_ascii and re.match(quotable_characters, filename):
+        if is_ascii and _quotable_chars_re.match(filename):
             file_expr = 'filename="{}"'.format(
                 filename.replace("\\", "\\\\").replace('"', r"\"")
             )

--- a/django/utils/xmlutils.py
+++ b/django/utils/xmlutils.py
@@ -2,8 +2,11 @@
 Utilities for XML generation/parsing.
 """
 
-import re
 from xml.sax.saxutils import XMLGenerator
+
+from django.utils.regex_helper import _lazy_re_compile
+
+_xml_control_chars_re = _lazy_re_compile(r"[\x00-\x08\x0B-\x0C\x0E-\x1F]")
 
 
 class UnserializableContentError(ValueError):
@@ -21,13 +24,13 @@ class SimplerXMLGenerator(XMLGenerator):
         self.endElement(name)
 
     def characters(self, content):
-        if content and re.search(r"[\x00-\x08\x0B-\x0C\x0E-\x1F]", content):
+        if content and _xml_control_chars_re.search(content):
             # Fail loudly when content has control chars (unsupported in XML
             # 1.0) See https://www.w3.org/International/questions/qa-controls
             raise UnserializableContentError(
                 "Control characters are not supported in XML 1.0"
             )
-        XMLGenerator.characters(self, content)
+        super().characters(content)
 
     def startElement(self, name, attrs):
         # Sort attrs for a deterministic output.

--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -30,6 +30,10 @@ DEBUG_ENGINE = Engine(
     libraries={"i18n": "django.templatetags.i18n"},
 )
 
+# File coding may be specified. Match pattern from PEP-263
+# (https://www.python.org/dev/peps/pep-0263/)
+_pep_263_encoding_re = _lazy_re_compile(rb"coding[:=]\s*([-\w.]+)")
+
 
 def builtin_template_path(name):
     """
@@ -476,9 +480,7 @@ class ExceptionReporter:
         if isinstance(source[0], bytes):
             encoding = "ascii"
             for line in source[:2]:
-                # File coding may be specified. Match pattern from PEP-263
-                # (https://www.python.org/dev/peps/pep-0263/)
-                match = re.search(rb"coding[:=]\s*([-\w.]+)", line)
+                match = _pep_263_encoding_re.search(line)
                 if match:
                     encoding = match[1].decode("ascii")
                     break

--- a/django/views/i18n.py
+++ b/django/views/i18n.py
@@ -1,6 +1,5 @@
 import json
 import os
-import re
 from pathlib import Path
 
 from django.apps import apps
@@ -10,11 +9,14 @@ from django.template import Context, Engine
 from django.urls import translate_url
 from django.utils.formats import get_format
 from django.utils.http import url_has_allowed_host_and_scheme
+from django.utils.regex_helper import _lazy_re_compile
 from django.utils.translation import check_for_language, get_language
 from django.utils.translation.trans_real import DjangoTranslation
 from django.views.generic import View
 
 LANGUAGE_QUERY_PARAMETER = "language"
+
+_num_plurals_re = _lazy_re_compile(r"nplurals=\s*(\d+)")
 
 
 def builtin_template_path(name):
@@ -146,7 +148,7 @@ class JavaScriptCatalog(View):
         Return the number of plurals for this catalog language, or 2 if no
         plural string is available.
         """
-        match = re.search(r"nplurals=\s*(\d+)", self._plural_string or "")
+        match = _num_plurals_re.search(self._plural_string or "")
         if match:
             return int(match[1])
         return 2

--- a/docs/internals/contributing/writing-code/coding-style.txt
+++ b/docs/internals/contributing/writing-code/coding-style.txt
@@ -126,6 +126,12 @@ Python style
   such as merging mappings (``{**x, **y}``) or sequences (``[*a, *b]``). This
   improves performance, readability, and maintainability while reducing errors.
 
+* Where possible, regular expressions should be defined at the module level and
+  pre-compiled, rather than being compiled at runtime. This means using either
+  :func:`re.compile` when the pattern will be used by the majority of
+  applications, or the internal ``django.utils.regex_helper._lazy_re_compile``
+  to avoid extending startup time at the cost of slightly slower matching.
+
 .. _coding-style-imports:
 
 Imports


### PR DESCRIPTION
#### Trac ticket number

ticket-36729

#### Branch description

This PR moves any remaining regexes loaded at runtime to being pre-compiled, either using `re.compile` or `_lazy_re_compile`.

I've also added a note to the coding style to mention that this should be the default going forwards.

One of the downsides of extracting patterns to the module level is that they now need a name. I've had a go in some places of putting something sensible, but others are named just to extract them, and could do with some other brains :brain: input on some sensible naming. 

I've not run any benchmarks, but I'd expect this to make varying amounts of difference across the codebase. I've intentionally switched between lazy and non-lazy compilation based on _my own thoughts_ as to how frequently and likely a pattern is to be used. Some people may disagree - I'm not especially tied to any of the decisions.

The process for doing this was to find-and-replace each of the top-level `re` functions which operate on patterns, where the pattern isn't built based on input at runtime. I think I caught them all, but can't hurt to check!

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
