### PR TITLE
Fixed #36767 -- Allowed max redirect URL length to be set on HttpResponseRedirect.

### DIFF
--- a/django/http/response.py
+++ b/django/http/response.py
@@ -632,13 +632,20 @@ class FileResponse(StreamingHttpResponse):
 class HttpResponseRedirectBase(HttpResponse):
     allowed_schemes = ["http", "https", "ftp"]
 
-    def __init__(self, redirect_to, preserve_request=False, *args, **kwargs):
+    def __init__(
+        self,
+        redirect_to,
+        preserve_request=False,
+        *args,
+        max_length=MAX_URL_REDIRECT_LENGTH,
+        **kwargs,
+    ):
         super().__init__(*args, **kwargs)
         self["Location"] = iri_to_uri(redirect_to)
         redirect_to_str = str(redirect_to)
-        if len(redirect_to_str) > MAX_URL_REDIRECT_LENGTH:
+        if max_length is not None and len(redirect_to_str) > max_length:
             raise DisallowedRedirect(
-                f"Unsafe redirect exceeding {MAX_URL_REDIRECT_LENGTH} characters"
+                f"Unsafe redirect exceeding {max_length} characters"
             )
         parsed = urlsplit(redirect_to_str)
         if preserve_request:

--- a/django/shortcuts.py
+++ b/django/shortcuts.py
@@ -13,6 +13,7 @@ from django.http import (
 from django.template import loader
 from django.urls import NoReverseMatch, reverse
 from django.utils.functional import Promise
+from django.utils.http import MAX_URL_REDIRECT_LENGTH
 from django.utils.translation import gettext as _
 
 
@@ -27,7 +28,14 @@ def render(
     return HttpResponse(content, content_type, status)
 
 
-def redirect(to, *args, permanent=False, preserve_request=False, **kwargs):
+def redirect(
+    to,
+    *args,
+    permanent=False,
+    preserve_request=False,
+    max_length=MAX_URL_REDIRECT_LENGTH,
+    **kwargs,
+):
     """
     Return an HttpResponseRedirect to the appropriate URL for the arguments
     passed.
@@ -51,6 +59,7 @@ def redirect(to, *args, permanent=False, preserve_request=False, **kwargs):
     return redirect_class(
         resolve_url(to, *args, **kwargs),
         preserve_request=preserve_request,
+        max_length=max_length,
     )
 
 

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -1142,7 +1142,15 @@ types of HTTP responses. Like ``HttpResponse``, these subclasses live in
     that defaults to ``False``, producing a response with a 302 status code. If
     ``preserve_request`` is ``True``, the status code will be 307 instead.
 
+    The constructor accepts an optional ``max_length`` keyword argument to
+    override the maximum allowed length for the redirect URL. You can set it
+    to ``None`` to disable the length check.
+
     See :class:`HttpResponse` for other optional constructor arguments.
+
+    .. versionchanged:: 6.1
+
+       ``max_length`` was added.
 
     .. attribute:: HttpResponseRedirect.url
 

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -349,6 +349,10 @@ Requests and Responses
 * :attr:`HttpRequest.multipart_parser_class <django.http.HttpRequest.multipart_parser_class>`
   can now be customized to use a different multipart parser class.
 
+* :class:`~django.http.HttpResponseRedirect` (and its subclasses), as well as
+  the :func:`~django.shortcuts.redirect` shortcut, now accept a ``max_length``
+  parameter to override the default maximum URL length limit.
+
 Security
 ~~~~~~~~
 

--- a/docs/topics/http/shortcuts.txt
+++ b/docs/topics/http/shortcuts.txt
@@ -91,7 +91,7 @@ This example is equivalent to::
 ``redirect()``
 ==============
 
-.. function:: redirect(to, *args, permanent=False, preserve_request=False, **kwargs)
+.. function:: redirect(to, *args, permanent=False, preserve_request=False, max_length=MAX_URL_REDIRECT_LENGTH, **kwargs)
 
    Returns an :class:`~django.http.HttpResponseRedirect` to the appropriate URL
    for the arguments passed.
@@ -124,6 +124,14 @@ This example is equivalent to::
    ``False``  ``True``         307
    ``True``   ``True``         308
    =========  ================ ================
+
+   An optional ``max_length`` keyword argument can be provided to override
+   the maximum allowed length for the redirect URL. Set it to ``None`` to
+   disable the length check.
+
+    .. versionchanged:: 6.1
+
+       ``max_length`` was added.
 
 Examples
 --------

--- a/tests/httpwrappers/tests.py
+++ b/tests/httpwrappers/tests.py
@@ -1,4 +1,5 @@
 import copy
+import itertools
 import json
 import os
 import pickle
@@ -488,15 +489,24 @@ class HttpResponseTests(SimpleTestCase):
 
     def test_redirect_url_max_length(self):
         base_url = "https://example.com/"
-        for length in (
-            MAX_URL_REDIRECT_LENGTH - 1,
-            MAX_URL_REDIRECT_LENGTH,
+        for length, response_class in itertools.product(
+            (MAX_URL_REDIRECT_LENGTH - 1, MAX_URL_REDIRECT_LENGTH),
+            (HttpResponseRedirect, HttpResponsePermanentRedirect),
         ):
             long_url = base_url + "x" * (length - len(base_url))
-            with self.subTest(length=length):
-                response = HttpResponseRedirect(long_url)
+            with self.subTest(length=length, response_class=response_class):
+                response = response_class(long_url)
                 self.assertEqual(response.url, long_url)
-                response = HttpResponsePermanentRedirect(long_url)
+
+    def test_redirect_url_max_length_override_via_param(self):
+        base_url = "https://example.com/"
+        for (max_length, length), response_class in itertools.product(
+            ((None, MAX_URL_REDIRECT_LENGTH + 1), (100, 99), (100, 100)),
+            (HttpResponseRedirect, HttpResponsePermanentRedirect),
+        ):
+            long_url = base_url + "x" * (length - len(base_url))
+            with self.subTest(length=length, response_class=response_class):
+                response = response_class(long_url, max_length=max_length)
                 self.assertEqual(response.url, long_url)
 
     def test_unsafe_redirect(self):
@@ -506,11 +516,23 @@ class HttpResponseTests(SimpleTestCase):
             "file:///etc/passwd",
             "é" * (MAX_URL_REDIRECT_LENGTH + 1),
         ]
-        for url in bad_urls:
-            with self.assertRaises(DisallowedRedirect):
-                HttpResponseRedirect(url)
-            with self.assertRaises(DisallowedRedirect):
-                HttpResponsePermanentRedirect(url)
+        for url, response_class in itertools.product(
+            bad_urls, (HttpResponseRedirect, HttpResponsePermanentRedirect)
+        ):
+            with (
+                self.subTest(url=url, response_class=response_class),
+                self.assertRaises(DisallowedRedirect),
+            ):
+                response_class(url)
+
+    def test_unsafe_redirect_via_max_length(self):
+        url = "https://example.com/"
+        for response_class in (HttpResponseRedirect, HttpResponsePermanentRedirect):
+            with (
+                self.subTest(response_class=response_class),
+                self.assertRaises(DisallowedRedirect),
+            ):
+                response_class(url, max_length=len(url) - 1)
 
     def test_header_deletion(self):
         r = HttpResponse("hello")

--- a/tests/shortcuts/tests.py
+++ b/tests/shortcuts/tests.py
@@ -1,7 +1,9 @@
+from django.core.exceptions import DisallowedRedirect
 from django.http.response import HttpResponseRedirectBase
 from django.shortcuts import redirect
 from django.test import SimpleTestCase, override_settings
 from django.test.utils import require_jinja2
+from django.utils.http import MAX_URL_REDIRECT_LENGTH
 
 
 @override_settings(ROOT_URLCONF="shortcuts.urls")
@@ -56,3 +58,19 @@ class RedirectTests(SimpleTestCase):
                 )
                 self.assertIsInstance(response, HttpResponseRedirectBase)
                 self.assertEqual(response.status_code, expected_status_code)
+
+    def test_redirect_max_length_default_raises(self):
+        long_url = "https://example.com/" + "x" * MAX_URL_REDIRECT_LENGTH
+        msg = f"Unsafe redirect exceeding {MAX_URL_REDIRECT_LENGTH} characters"
+        with self.assertRaisesMessage(DisallowedRedirect, msg):
+            redirect(long_url)
+
+    def test_redirect_max_length_override_passes(self):
+        long_url = "https://example.com/" + "x" * MAX_URL_REDIRECT_LENGTH
+        response = redirect(long_url, max_length=None)
+        self.assertEqual(response.url, long_url)
+
+    def test_redirect_custom_strict_limit_raises(self):
+        msg = "Unsafe redirect exceeding 5 characters"
+        with self.assertRaisesMessage(DisallowedRedirect, msg):
+            redirect("https://example.com/", max_length=5)


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36767 

#### Branch description

Currently, Django blocks very long redirect URLs due to a hardcoded length limit.

This PR adds an optional max_length parameter to HttpResponseRedirect and the redirect() shortcut to override or disable the limit.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have added or updated relevant tests.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
