### PR TITLE
Fixed documentation around user_can_authenticate method for django.contrib.auth.backends

### DIFF
--- a/docs/ref/contrib/auth.txt
+++ b/docs/ref/contrib/auth.txt
@@ -653,7 +653,7 @@ The following backends are available in :mod:`django.contrib.auth.backends`:
         Returns whether the ``user_obj`` has any permissions on the app
         ``app_label``.
 
-    .. method:: user_can_authenticate()
+    .. method:: user_can_authenticate(user)
 
         Returns whether the user is allowed to authenticate. To match the
         behavior of :meth:`.AuthenticationForm.confirm_login_allowed`, this
@@ -750,6 +750,12 @@ The following backends are available in :mod:`django.contrib.auth.backends`:
         if it wasn't provided to :func:`~django.contrib.auth.authenticate`
         (which passes it on to the backend).
 
+.. class:: AllowAllUsersRemoteUserBackend
+
+    Same as :class:`RemoteUserBackend` except that it doesn't reject inactive
+    users because :attr:`~AllowAllUsersRemoteUserBackend.user_can_authenticate` always
+    returns ``True``.
+
     .. method:: user_can_authenticate()
 
         Returns whether the user is allowed to authenticate. This method
@@ -757,12 +763,6 @@ The following backends are available in :mod:`django.contrib.auth.backends`:
         <django.contrib.auth.models.User.is_active>`. Custom user models that
         don't have an :attr:`~django.contrib.auth.models.CustomUser.is_active`
         field are allowed.
-
-.. class:: AllowAllUsersRemoteUserBackend
-
-    Same as :class:`RemoteUserBackend` except that it doesn't reject inactive
-    users because :attr:`~RemoteUserBackend.user_can_authenticate` always
-    returns ``True``.
 
 Utility functions
 =================

--- a/docs/ref/contrib/auth.txt
+++ b/docs/ref/contrib/auth.txt
@@ -753,16 +753,8 @@ The following backends are available in :mod:`django.contrib.auth.backends`:
 .. class:: AllowAllUsersRemoteUserBackend
 
     Same as :class:`RemoteUserBackend` except that it doesn't reject inactive
-    users because :attr:`~AllowAllUsersRemoteUserBackend.user_can_authenticate`
-    always returns ``True``.
-
-    .. method:: user_can_authenticate()
-
-        Returns whether the user is allowed to authenticate. This method
-        returns ``False`` for users with :attr:`is_active=False
-        <django.contrib.auth.models.User.is_active>`. Custom user models that
-        don't have an :attr:`~django.contrib.auth.models.CustomUser.is_active`
-        field are allowed.
+    users because :meth:`~AllowAllUsersRemoteUserBackend.user_can_authenticate` always returns
+    ``True``.
 
 Utility functions
 =================

--- a/docs/ref/contrib/auth.txt
+++ b/docs/ref/contrib/auth.txt
@@ -753,8 +753,8 @@ The following backends are available in :mod:`django.contrib.auth.backends`:
 .. class:: AllowAllUsersRemoteUserBackend
 
     Same as :class:`RemoteUserBackend` except that it doesn't reject inactive
-    users because :attr:`~AllowAllUsersRemoteUserBackend.user_can_authenticate` always
-    returns ``True``.
+    users because :attr:`~AllowAllUsersRemoteUserBackend.user_can_authenticate`
+    always returns ``True``.
 
     .. method:: user_can_authenticate()
 


### PR DESCRIPTION
#### Trac ticket number

N/A - minor docs update

#### Branch description
Fixing method signature for `ModelBackend.user_can_authenticate` and moving `user_can_authenticate` to proper location under `AllowAllUsersRemoteUserBackend`.

Thanks in advanced for your consideration of this change! I appreciate the work you do!

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] (N/A) I have checked the "Has patch" ticket flag in the Trac system.
- [x] (N/A) I have added or updated relevant tests.
- [x] (N/A) I have added or updated relevant docs, including release notes if applicable.
- [x] (N/A) I have attached screenshots in both light and dark modes for any UI changes.
