### PR TITLE
Fixed #36775 -- Raised ImproperlyConfigured if 'link' attribute is missing in Feed subclasses.

### DIFF
--- a/django/contrib/syndication/views.py
+++ b/django/contrib/syndication/views.py
@@ -140,6 +140,9 @@ class Feed:
         current_site = get_current_site(request)
 
         link = self._get_dynamic_attr("link", obj)
+        if link is None:
+            raise ImproperlyConfigured("Feed class must define a 'link' attribute.")
+
         link = add_domain(current_site.domain, link, request.is_secure())
 
         feed = self.feed_type(


### PR DESCRIPTION
Refs https://code.djangoproject.com/ticket/36775

Unlike `item_link()`, which raises `ImproperlyConfigured` when missing, the `link` attribute has no safeguard. This produces a confusing runtime error.
## Changes Made
- Added a check in `Feed.get_feed()` before calling `add_domain()`:
```python
link = self._get_dynamic_attr("link", obj)
if link is None:
    raise ImproperlyConfigured("Feed class must define a 'link' attribute.")
link = add_domain(current_site.domain, link, request.is_secure())