### PR TITLE
Fixed #35951 -- Updated timezone diff note on time inputs in admin panel.

### DIFF
--- a/django/contrib/admin/static/admin/js/admin/DateTimeShortcuts.js
+++ b/django/contrib/admin/static/admin/js/admin/DateTimeShortcuts.js
@@ -82,22 +82,32 @@
                 return;
             }
 
+            const serverTimezone =
+                document.body.dataset.adminServerTimezone || gettext("server");
             let message;
             if (timezoneOffset > 0) {
                 message = ngettext(
-                    "Note: You are %s hour ahead of server time.",
-                    "Note: You are %s hours ahead of server time.",
+                    "Note: Enter times in the %(timezone)s timezone. " +
+                        "(You are %(offset)s hour ahead.)",
+                    "Note: Enter times in the %(timezone)s timezone. " +
+                        "(You are %(offset)s hours ahead.)",
                     timezoneOffset,
                 );
             } else {
                 timezoneOffset *= -1;
                 message = ngettext(
-                    "Note: You are %s hour behind server time.",
-                    "Note: You are %s hours behind server time.",
+                    "Note: Enter times in the %(timezone)s timezone. " +
+                        "(You are %(offset)s hour behind.)",
+                    "Note: Enter times in the %(timezone)s timezone. " +
+                        "(You are %(offset)s hours behind.)",
                     timezoneOffset,
                 );
             }
-            message = interpolate(message, [timezoneOffset]);
+            message = interpolate(
+                message,
+                { timezone: serverTimezone, offset: timezoneOffset },
+                true,
+            );
 
             const warning = document.createElement("div");
             const id = inp.id;

--- a/django/contrib/admin/templates/admin/base.html
+++ b/django/contrib/admin/templates/admin/base.html
@@ -1,4 +1,4 @@
-{% load i18n static %}<!DOCTYPE html>
+{% load i18n static tz %}<!DOCTYPE html>
 {% get_current_language as LANGUAGE_CODE %}{% get_current_language_bidi as LANGUAGE_BIDI %}
 <html lang="{{ LANGUAGE_CODE|default:"en-us" }}" dir="{{ LANGUAGE_BIDI|yesno:'rtl,ltr,auto' }}">
 <head>
@@ -25,7 +25,8 @@
 </head>
 
 <body class="{% if is_popup %}popup {% endif %}{% block bodyclass %}{% endblock %}"
-  data-admin-utc-offset="{% now "Z" %}">
+  data-admin-utc-offset="{% now "Z" %}"
+  data-admin-server-timezone="{% get_current_timezone as time_zone %}{{ time_zone }}">
 <a href="#content-start" class="skip-to-content-link">{% translate 'Skip to main content' %}</a>
 <!-- Container -->
 <div id="container">

--- a/js_tests/admin/DateTimeShortcuts.test.js
+++ b/js_tests/admin/DateTimeShortcuts.test.js
@@ -1,7 +1,15 @@
 /* global QUnit, DateTimeShortcuts */
 "use strict";
 
-QUnit.module("admin.DateTimeShortcuts");
+QUnit.module("admin.DateTimeShortcuts", {
+    afterEach: function () {
+        const $ = django.jQuery;
+        $("body")
+            .removeAttr("data-admin-server-timezone")
+            .removeAttr("data-admin-utc-offset");
+        $(".timezonewarning").remove();
+    },
+});
 
 QUnit.test("init", function (assert) {
     const $ = django.jQuery;
@@ -46,11 +54,13 @@ QUnit.test("time zone offset warning - single field", function (assert) {
         "data-admin-utc-offset",
         new Date().getTimezoneOffset() * -60 + 3600,
     );
+    $("body").attr("data-admin-server-timezone", "America/Chicago");
     DateTimeShortcuts.init();
     $("body").attr("data-admin-utc-offset", savedOffset);
     assert.equal(
         $(".timezonewarning").text(),
-        "Note: You are 1 hour behind server time.",
+        "Note: Enter times in the America/Chicago timezone. " +
+            "(You are 1 hour behind.)",
     );
     assert.equal(
         $(".timezonewarning").attr("id"),
@@ -74,6 +84,10 @@ QUnit.test("time zone offset warning - date and time field", function (assert) {
     );
     DateTimeShortcuts.init();
     $("body").attr("data-admin-utc-offset", savedOffset);
+    assert.equal(
+        $(".timezonewarning").text(),
+        "Note: Enter times in the server timezone. (You are 1 hour behind.)",
+    );
     assert.equal(
         $(".timezonewarning").attr("id"),
         "id_updated_at_timezone_warning_helptext",


### PR DESCRIPTION
#### Trac ticket number
[ticket-35951](https://code.djangoproject.com/ticket/35951)

#### Branch description
The existing note that is shown to the users when entering a time value from a different timezone than the server's timezone was not descriptive enough and led to confusion. This commit updates the note to explicitly state that the user should enter times in the server's timezone.

New note:
| Light mode  | Dark mode |
| ------------- | ------------- |
| <img width="470" height="496" alt="Screenshot from 2026-04-29 09-03-17" src="https://github.com/user-attachments/assets/2bc433e0-fcdf-4f88-ae54-757a387e887a" /> | <img width="470" height="496" alt="Screenshot from 2026-04-29 09-03-22" src="https://github.com/user-attachments/assets/199fc0cb-505a-491a-a676-1157d0a2cb15" />  |

~Since this change changes a user-facing string, I ran the `python scripts/manage_translations.py update_catalogs` script that generated a bunch of changed in unrelated file. Not sure if those change should stay in the commit or if there is a way to avoid them with that script.~
Got told in the official Discord that these are not necessary

#### AI Use
I've used Claude Code to review the changes locally. I did not write the code.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.

