### PR TITLE
Fixed #36629 --  Added missing “Choose all” and “Remove all” buttons in admin m2m filter_vertical widget.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -815,6 +815,7 @@ answer newbie questions, and generally made Django that much better:
     Nicolas Noé <nicolas@niconoe.eu>
     Nikita Marchant <nikita.marchant@gmail.com>
     Nikita Sobolev <mail@sobolevn.me>
+    Nilesh Kumar Pahari <nileshpahari@protonmail.com>
     Nina Menezes <https://github.com/nmenezes0>
     Niran Babalola <niran@niran.org>
     Nis Jørgensen <nis@superlativ.dk>

--- a/django/contrib/admin/static/admin/css/responsive.css
+++ b/django/contrib/admin/static/admin/css/responsive.css
@@ -289,10 +289,6 @@ button {
         flex: 0 1 auto;
     }
 
-    .stacked select {
-        margin-bottom: 0;
-    }
-
     .stacked .selector-available,
     .stacked .selector-chosen {
         width: auto;

--- a/django/contrib/admin/static/admin/css/widgets.css
+++ b/django/contrib/admin/static/admin/css/widgets.css
@@ -252,11 +252,6 @@
     padding: 3px 3px 3px 5px;
 }
 
-.stacked .selector-chooseall,
-.stacked .selector-clearall {
-    display: none;
-}
-
 .stacked .selector-add {
     background: url(../img/selector-icons.svg) 0 -48px no-repeat;
     background-size: 24px auto;

--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -1335,7 +1335,6 @@ class HorizontalVerticalFilterSeleniumTests(AdminWidgetSeleniumTestCase):
 
     def assertButtonsDisabled(
         self,
-        mode,
         field_name,
         choose_btn_disabled=False,
         remove_btn_disabled=False,
@@ -1348,15 +1347,10 @@ class HorizontalVerticalFilterSeleniumTests(AdminWidgetSeleniumTestCase):
         remove_all_button = "#id_%s_remove_all" % field_name
         self.assertEqual(self.is_disabled(choose_button), choose_btn_disabled)
         self.assertEqual(self.is_disabled(remove_button), remove_btn_disabled)
-        if mode == "horizontal":
-            self.assertEqual(
-                self.is_disabled(choose_all_button), choose_all_btn_disabled
-            )
-            self.assertEqual(
-                self.is_disabled(remove_all_button), remove_all_btn_disabled
-            )
+        self.assertEqual(self.is_disabled(choose_all_button), choose_all_btn_disabled)
+        self.assertEqual(self.is_disabled(remove_all_button), remove_all_btn_disabled)
 
-    def execute_basic_operations(self, mode, field_name):
+    def execute_basic_operations(self, field_name):
         from selenium.webdriver.common.by import By
 
         original_url = self.selenium.current_url
@@ -1382,7 +1376,6 @@ class HorizontalVerticalFilterSeleniumTests(AdminWidgetSeleniumTestCase):
         )
         self.assertSelectOptions(to_box, [str(self.lisa.id), str(self.peter.id)])
         self.assertButtonsDisabled(
-            mode,
             field_name,
             choose_btn_disabled=True,
             remove_btn_disabled=True,
@@ -1391,16 +1384,7 @@ class HorizontalVerticalFilterSeleniumTests(AdminWidgetSeleniumTestCase):
         )
 
         # Click 'Choose all' --------------------------------------------------
-        if mode == "horizontal":
-            self.selenium.find_element(By.ID, choose_all_button).click()
-        elif mode == "vertical":
-            # There 's no 'Choose all' button in vertical mode, so individually
-            # select all options and click 'Choose'.
-            for option in self.selenium.find_elements(
-                By.CSS_SELECTOR, from_box + " > option"
-            ):
-                option.click()
-            self.selenium.find_element(By.ID, choose_button).click()
+        self.selenium.find_element(By.ID, choose_all_button).click()
         self.assertSelectOptions(from_box, [])
         self.assertSelectOptions(
             to_box,
@@ -1416,7 +1400,6 @@ class HorizontalVerticalFilterSeleniumTests(AdminWidgetSeleniumTestCase):
             ],
         )
         self.assertButtonsDisabled(
-            mode,
             field_name,
             choose_btn_disabled=True,
             remove_btn_disabled=True,
@@ -1425,16 +1408,7 @@ class HorizontalVerticalFilterSeleniumTests(AdminWidgetSeleniumTestCase):
         )
 
         # Click 'Remove all' --------------------------------------------------
-        if mode == "horizontal":
-            self.selenium.find_element(By.ID, remove_all_button).click()
-        elif mode == "vertical":
-            # There 's no 'Remove all' button in vertical mode, so individually
-            # select all options and click 'Remove'.
-            for option in self.selenium.find_elements(
-                By.CSS_SELECTOR, to_box + " > option"
-            ):
-                option.click()
-            self.selenium.find_element(By.ID, remove_button).click()
+        self.selenium.find_element(By.ID, remove_all_button).click()
         self.assertSelectOptions(
             from_box,
             [
@@ -1450,7 +1424,6 @@ class HorizontalVerticalFilterSeleniumTests(AdminWidgetSeleniumTestCase):
         )
         self.assertSelectOptions(to_box, [])
         self.assertButtonsDisabled(
-            mode,
             field_name,
             choose_btn_disabled=True,
             remove_btn_disabled=True,
@@ -1474,7 +1447,6 @@ class HorizontalVerticalFilterSeleniumTests(AdminWidgetSeleniumTestCase):
         self.select_option(from_box, str(self.bob.id))
         self.select_option(from_box, str(self.john.id))
         self.assertButtonsDisabled(
-            mode,
             field_name,
             choose_btn_disabled=False,
             remove_btn_disabled=True,
@@ -1483,7 +1455,6 @@ class HorizontalVerticalFilterSeleniumTests(AdminWidgetSeleniumTestCase):
         )
         self.selenium.find_element(By.ID, choose_button).click()
         self.assertButtonsDisabled(
-            mode,
             field_name,
             choose_btn_disabled=True,
             remove_btn_disabled=True,
@@ -1523,7 +1494,6 @@ class HorizontalVerticalFilterSeleniumTests(AdminWidgetSeleniumTestCase):
         self.select_option(to_box, str(self.lisa.id))
         self.select_option(to_box, str(self.bob.id))
         self.assertButtonsDisabled(
-            mode,
             field_name,
             choose_btn_disabled=True,
             remove_btn_disabled=False,
@@ -1532,7 +1502,6 @@ class HorizontalVerticalFilterSeleniumTests(AdminWidgetSeleniumTestCase):
         )
         self.selenium.find_element(By.ID, remove_button).click()
         self.assertButtonsDisabled(
-            mode,
             field_name,
             choose_btn_disabled=True,
             remove_btn_disabled=True,
@@ -1623,8 +1592,8 @@ class HorizontalVerticalFilterSeleniumTests(AdminWidgetSeleniumTestCase):
 
             self.wait_page_ready()
             self.trigger_resize()
-            self.execute_basic_operations("vertical", "students")
-            self.execute_basic_operations("horizontal", "alumni")
+            self.execute_basic_operations("students")
+            self.execute_basic_operations("alumni")
 
             # Save, everything should be stored properly stored in the
             # database.


### PR DESCRIPTION
Fix missing “Choose all” and “Remove all” buttons in admin m2m `filter_vertical` widget.
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36629

#### Branch description
The “Choose all” and “Remove all” buttons were not visible in the Django admin ManyToMany `filter_vertical` widget. This was fixed by updating the CSS to ensure the buttons are displayed.

## Screenshots
<img width="1920" height="1078" alt="image" src="https://github.com/user-attachments/assets/8c77ef5c-d81d-4ff3-85b7-7ddb91085b21" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/bad08b6f-cdf9-4632-8f0b-b24da85f41f0" />


#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
