### PR TITLE
Fixed #36436 -- Made CookieStorage.signer attribute private.

### DIFF
--- a/django/contrib/messages/storage/cookie.py
+++ b/django/contrib/messages/storage/cookie.py
@@ -89,7 +89,7 @@ class CookieStorage(BaseStorage):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.signer = signing.get_cookie_signer(salt=self.key_salt)
+        self._signer = signing.get_cookie_signer(salt=self.key_salt)
 
     def _get(self, *args, **kwargs):
         """
@@ -181,7 +181,7 @@ class CookieStorage(BaseStorage):
         also contains a hash to ensure that the data was not tampered with.
         """
         if messages or encode_empty:
-            return self.signer.sign_object(
+            return self._signer.sign_object(
                 messages, serializer=MessagePartGatherSerializer, compress=True
             )
 
@@ -205,7 +205,7 @@ class CookieStorage(BaseStorage):
         if not data:
             return None
         try:
-            return self.signer.unsign_object(data, serializer=MessageSerializer)
+            return self._signer.unsign_object(data, serializer=MessageSerializer)
         except (signing.BadSignature, binascii.Error, json.JSONDecodeError):
             pass
         # Mark the data as used (so it gets removed) since something was wrong


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36436

#### Branch description
Rename: self.signer → self._signer (As its forbidden to access attributes with trailing " _ " , making the signer attribute non accessable and private in templates.)

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
