### PR TITLE
Fixed #2750 — Prevent ManyToManyField default from being used.

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1104,7 +1104,7 @@ class Field(RegisterLookupMixin):
             "label": capfirst(self.verbose_name),
             "help_text": self.help_text,
         }
-        if self.has_default():
+        if self.has_default() and not self.many_to_many:
             if callable(self.default):
                 defaults["initial"] = self.default
                 defaults["show_hidden_initial"] = True

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1104,12 +1104,14 @@ class Field(RegisterLookupMixin):
             "label": capfirst(self.verbose_name),
             "help_text": self.help_text,
         }
-        if self.has_default() and not self.many_to_many:
+        if self.has_default():
             if callable(self.default):
-                defaults["initial"] = self.default
+                if not self.many_to_many:
+                    defaults["initial"] = self.default
                 defaults["show_hidden_initial"] = True
             else:
-                defaults["initial"] = self.get_default()
+                if not self.many_to_many:
+                    defaults["initial"] = self.get_default()
         if self.choices is not None:
             # Fields with choices get special treatment.
             include_blank = self.blank or not (

--- a/tests/forms_tests/tests/tests.py
+++ b/tests/forms_tests/tests/tests.py
@@ -139,7 +139,7 @@ class ModelFormCallableModelDefault(TestCase):
             </select>
             </p>
             """,
-    )
+        )
 
     def test_initial_instance_value(self):
         "Initial instances for model fields may also be instances (refs #7287)"

--- a/tests/forms_tests/tests/tests.py
+++ b/tests/forms_tests/tests/tests.py
@@ -99,7 +99,7 @@ class ModelFormCallableModelDefault(TestCase):
     def test_callable_initial_value(self):
         """
         The initial value for a callable default returning a queryset is the
-        pk.
+        pk for regular fields. ManyToManyField ignores defaults (refs #2750).
         """
         ChoiceOptionModel.objects.create(id=1, name="default")
         ChoiceOptionModel.objects.create(id=2, name="option 2")
@@ -126,24 +126,20 @@ class ModelFormCallableModelDefault(TestCase):
             </p>
             <p><label for="id_multi_choice">Multi choice:</label>
             <select multiple name="multi_choice" id="id_multi_choice" required>
-            <option value="1" selected>ChoiceOption 1</option>
+            <option value="1">ChoiceOption 1</option>
             <option value="2">ChoiceOption 2</option>
             <option value="3">ChoiceOption 3</option>
             </select>
-            <input type="hidden" name="initial-multi_choice" value="1"
-                id="initial-id_multi_choice_0">
             </p>
             <p><label for="id_multi_choice_int">Multi choice int:</label>
             <select multiple name="multi_choice_int" id="id_multi_choice_int" required>
-            <option value="1" selected>ChoiceOption 1</option>
+            <option value="1">ChoiceOption 1</option>
             <option value="2">ChoiceOption 2</option>
             <option value="3">ChoiceOption 3</option>
             </select>
-            <input type="hidden" name="initial-multi_choice_int" value="1"
-                id="initial-id_multi_choice_int_0">
             </p>
             """,
-        )
+    )
 
     def test_initial_instance_value(self):
         "Initial instances for model fields may also be instances (refs #7287)"

--- a/tests/many_to_many/tests.py
+++ b/tests/many_to_many/tests.py
@@ -630,23 +630,6 @@ class ManyToManyTests(TestCase):
             FETCH_PEERS,
         )
         
-    def test_m2m_field_ignores_default(self):
-        """
-        ManyToManyField should not use default in formfield.
-        Regression test for #2750.
-        """
-        m2m_field = Article._meta.get_field('publications')
-        m2m_field.default = lambda: Publication.objects.all()
-        
-        try:
-            form_field = m2m_field.formfield()
-            assert form_field.initial is None
-            
-            article = Article.objects.create(headline='Test')
-            assert article.publications.count() == 0
-        finally:
-            delattr(m2m_field, 'default')
-
 class ManyToManyQueryTests(TestCase):
     """
     SQL is optimized to reference the through table without joining against the

--- a/tests/many_to_many/tests.py
+++ b/tests/many_to_many/tests.py
@@ -629,7 +629,8 @@ class ManyToManyTests(TestCase):
             a._state.fetch_mode,
             FETCH_PEERS,
         )
-        
+
+
 class ManyToManyQueryTests(TestCase):
     """
     SQL is optimized to reference the through table without joining against the

--- a/tests/many_to_many/tests.py
+++ b/tests/many_to_many/tests.py
@@ -629,7 +629,23 @@ class ManyToManyTests(TestCase):
             a._state.fetch_mode,
             FETCH_PEERS,
         )
-
+        
+    def test_m2m_field_ignores_default(self):
+        """
+        ManyToManyField should not use default in formfield.
+        Regression test for #2750.
+        """
+        m2m_field = Article._meta.get_field('publications')
+        m2m_field.default = lambda: Publication.objects.all()
+        
+        try:
+            form_field = m2m_field.formfield()
+            assert form_field.initial is None
+            
+            article = Article.objects.create(headline='Test')
+            assert article.publications.count() == 0
+        finally:
+            delattr(m2m_field, 'default')
 
 class ManyToManyQueryTests(TestCase):
     """


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-2750

#### Branch description
Previously, `ManyToManyField.formfield()` used the field’s `default` when initializing forms. While this caused the admin form to pre-select the default objects, the model never applied the default on save. To avoid this mismatch, default handling for M2M fields has been removed from form initialization.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
