### PR TITLE
Fixed #30149 -- Correctly handled boolean values in RelatedFieldListFilter

### DIFF
--- a/django/contrib/admin/filters.py
+++ b/django/contrib/admin/filters.py
@@ -225,9 +225,14 @@ class RelatedFieldListFilter(FieldListFilter):
         self.lookup_kwarg = "%s__%s__exact" % (field_path, field.target_field.name)
         self.lookup_kwarg_isnull = "%s__isnull" % field_path
         self.lookup_val = params.get(self.lookup_kwarg)
-        self.lookup_val_isnull = get_last_value_from_parameters(
-            params, self.lookup_kwarg_isnull
-        )
+        isnull_value = get_last_value_from_parameters(params, self.lookup_kwarg_isnull)
+        if isnull_value is not None:
+            if isnull_value.lower() in ("false", "0"):
+                self.lookup_val_isnull = False
+            else:
+                self.lookup_val_isnull = True
+        else:
+            self.lookup_val_isnull = None
         super().__init__(field, request, params, model, model_admin, field_path)
         self.lookup_choices = self.field_choices(field, request, model_admin)
         if hasattr(field, "verbose_name"):

--- a/tests/admin_filters/tests.py
+++ b/tests/admin_filters/tests.py
@@ -2048,6 +2048,20 @@ class ListFiltersTests(TestCase):
         queryset = changelist.get_queryset(request)
         self.assertEqual(list(queryset), [jane])
 
+    def test_relatedfieldlistfilter_isnull_false(self):
+        modeladmin = BookAdmin(Book, site)
+        request = self.request_factory.get("/", {"author__isnull": "False"})
+        request.user = self.alfred
+        changelist = modeladmin.get_changelist_instance(request)
+        queryset = changelist.get_queryset(request)
+        self.assertCountEqual(
+            list(queryset), [self.django_book, self.bio_book, self.djangonaut_book]
+        )
+        filters = changelist.get_filters(request)[0]
+        author_filter = filters[1]
+        choices = list(author_filter.choices(changelist))
+        self.assertIs(choices[-1]["selected"], False)
+
 
 class FacetsMixinTests(SimpleTestCase):
     def test_get_facet_counts(self):


### PR DESCRIPTION
#### Trac ticket number

ticket-30149

#### Branch description
The `RelatedFieldListFilter` previously interpreted the string `'False'` as a boolean `True`, making it impossible to filter for non-null values using query parameters (e.g., `?field__isnull=False`).

This PR updates the `__init__` method to explicitly check for false-y string values ('0', 'false'). A regression test has been added to `tests/admin_filters/tests.py`.

#### Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
