### PR TITLE
Fixed #31908 -- Added parallel testing support to Oracle backend.

### DIFF
--- a/django/db/backends/oracle/creation.py
+++ b/django/db/backends/oracle/creation.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 from django.conf import settings
@@ -11,6 +12,9 @@ TEST_DATABASE_PREFIX = "test_"
 
 class DatabaseCreation(BaseDatabaseCreation):
     destroy_test_db_connection_close_method = "close"
+    # Suffix of the clone being torn down, set by destroy_test_db() and read by
+    # _destroy_test_db(). None means the main (non-parallel) test database.
+    _suffix = None
 
     @cached_property
     def _maindb_connection(self):
@@ -203,21 +207,155 @@ class DatabaseCreation(BaseDatabaseCreation):
             self.log("Tests cancelled -- test database cannot be recreated.")
             sys.exit(1)
 
-    def _destroy_test_db(self, test_database_name, verbosity=1):
+    def _clone_test_db(self, suffix, verbosity, keepdb=False):
+        """
+        Create a cloned test database (tablespace + user) for parallel testing.
+        """
+        parameters = self._get_test_db_params(suffix)
+
+        with self._maindb_connection.cursor() as cursor:
+            if self._test_database_create():
+                try:
+                    self._execute_test_db_creation(
+                        cursor, parameters, verbosity, keepdb
+                    )
+                except Exception as e:
+                    if "ORA-01543" not in str(e):
+                        # Errors except "tablespace exists" cancel tests
+                        self.log(
+                            "Got an error creating the cloned test database: %s" % e
+                        )
+                        sys.exit(2)
+                    # The tablespace is left over from an earlier interrupted
+                    # run. Drop any remnants and recreate it from scratch,
+                    # unless we're keeping the database.
+                    if not keepdb:
+                        self._destroy_clone_remnants(cursor, parameters, verbosity)
+                        self._execute_test_db_creation(
+                            cursor, parameters, verbosity, keepdb
+                        )
+
+            if self._test_user_create():
+                try:
+                    self._create_test_user(cursor, parameters, verbosity, keepdb)
+                except Exception as e:
+                    if "ORA-01920" not in str(e):
+                        # All errors except "user already exists" cancel tests
+                        self.log("Got an error creating the cloned test user: %s" % e)
+                        sys.exit(2)
+                    if not keepdb:
+                        self._destroy_test_user(cursor, parameters, verbosity)
+                        self._create_test_user(cursor, parameters, verbosity, keepdb)
+
+        if not keepdb:
+            self._run_migrations_on_clone(suffix, verbosity)
+
+    def _run_migrations_on_clone(self, suffix, verbosity):
+        """
+        Build the clone's schema by running migrations against it, avoiding a
+        dependency on external Oracle tools (exp/imp, expdp/impdp).
+        """
+        from django.apps import apps
+        from django.core.management import call_command
+        from django.db import connections
+
+        # Migrate the clone through a dedicated connection on a temporary
+        # alias. self.connection.settings_dict is settings.DATABASES[alias],
+        # which the parallel runner snapshots by reference, so mutating it here
+        # would leak clone credentials into the workers and the teardown
+        # connection and break them under the spawn/forkserver start methods.
+        clone_settings = self.get_test_db_clone_settings(suffix)
+        clone_alias = "%s__clone_%s" % (self.connection.alias, suffix)
+
+        disable_migrations = clone_settings["TEST"].get("MIGRATE", True) is False
+        if disable_migrations:
+            old_migration_modules = settings.MIGRATION_MODULES
+            settings.MIGRATION_MODULES = {
+                app.label: None for app in apps.get_app_configs()
+            }
+
+        connections.databases[clone_alias] = clone_settings
+        try:
+            call_command(
+                "migrate",
+                verbosity=max(verbosity - 1, 0),
+                interactive=False,
+                database=clone_alias,
+                run_syncdb=True,
+            )
+            call_command("createcachetable", database=clone_alias)
+        finally:
+            if disable_migrations:
+                settings.MIGRATION_MODULES = old_migration_modules
+            connections[clone_alias].close()
+            del connections.databases[clone_alias]
+
+    def _destroy_clone_remnants(self, cursor, parameters, verbosity):
+        """
+        Drop a leftover clone user and tablespaces from an earlier interrupted
+        run. Only some of the objects may have been created before the
+        interruption, so each drop is allowed to fail with the matching "does
+        not exist" error (ORA-01918 for the user, ORA-00959 for a tablespace).
+        """
+        drops = [
+            ("DROP USER %(user)s CASCADE", "ORA-01918"),
+            (
+                "DROP TABLESPACE %(tblspace)s "
+                "INCLUDING CONTENTS AND DATAFILES CASCADE CONSTRAINTS",
+                "ORA-00959",
+            ),
+            (
+                "DROP TABLESPACE %(tblspace_temp)s "
+                "INCLUDING CONTENTS AND DATAFILES CASCADE CONSTRAINTS",
+                "ORA-00959",
+            ),
+        ]
+        for statement, acceptable_ora_err in drops:
+            self._execute_allow_fail_statements(
+                cursor, [statement], parameters, verbosity, acceptable_ora_err
+            )
+
+    def get_test_db_clone_settings(self, suffix):
+        """
+        Return a modified connection settings dict for the n-th clone of a DB.
+        """
+        orig = self.connection.settings_dict
+        user = self._test_database_user(suffix)
+        return {
+            **orig,
+            "USER": user,
+        }
+
+    def destroy_test_db(
+        self, old_database_name=None, verbosity=1, keepdb=False, suffix=None
+    ):
         """
         Destroy a test database, prompting the user for confirmation if the
-        database already exists. Return the name of the test database created.
+        database already exists.
         """
-        if not self.connection.is_pool:
-            self.connection.settings_dict["USER"] = self.connection.settings_dict[
-                "SAVED_USER"
-            ]
-            self.connection.settings_dict["PASSWORD"] = self.connection.settings_dict[
-                "SAVED_PASSWORD"
-            ]
-        self.connection.close()
+        # Restore main user credentials for cleanup, but only for the main
+        # test database -- clones are dropped while connected as the main user.
+        if suffix is None and not self.connection.is_pool:
+            saved_user = self.connection.settings_dict.get("SAVED_USER")
+            saved_password = self.connection.settings_dict.get("SAVED_PASSWORD")
+            if saved_user:
+                self.connection.settings_dict["USER"] = saved_user
+            if saved_password:
+                self.connection.settings_dict["PASSWORD"] = saved_password
+        # _destroy_test_db() can't take a suffix without breaking its
+        # documented signature, so pass it via an attribute instead.
+        self._suffix = suffix
+        super().destroy_test_db(old_database_name, verbosity, keepdb, suffix)
+
+    def _destroy_test_db(self, test_database_name, verbosity=1):
+        """
+        Drop the test user and tablespace. self._suffix (set by
+        destroy_test_db) selects which clone to drop, or the main test
+        database when None.
+        """
         self.connection.close_pool()
-        parameters = self._get_test_db_params()
+        parameters = self._get_test_db_params(self._suffix)
+
         with self._maindb_connection.cursor() as cursor:
             if self._test_user_create():
                 if verbosity >= 1:
@@ -366,15 +504,19 @@ class DatabaseCreation(BaseDatabaseCreation):
                 raise
             return False
 
-    def _get_test_db_params(self):
+    def _get_test_db_params(self, suffix=None):
         return {
             "dbname": self._test_database_name(),
-            "user": self._test_database_user(),
-            "password": self._test_database_passwd(),
-            "tblspace": self._test_database_tblspace(),
-            "tblspace_temp": self._test_database_tblspace_tmp(),
-            "datafile": self._test_database_tblspace_datafile(),
-            "datafile_tmp": self._test_database_tblspace_tmp_datafile(),
+            "user": self._test_database_user(suffix),
+            "password": (
+                self.connection.settings_dict["PASSWORD"]
+                if suffix
+                else self._test_database_passwd()
+            ),
+            "tblspace": self._test_database_tblspace(suffix),
+            "tblspace_temp": self._test_database_tblspace_tmp(suffix),
+            "datafile": self._test_database_tblspace_datafile(suffix),
+            "datafile_tmp": self._test_database_tblspace_tmp_datafile(suffix),
             "maxsize": self._test_database_tblspace_maxsize(),
             "maxsize_tmp": self._test_database_tblspace_tmp_maxsize(),
             "size": self._test_database_tblspace_size(),
@@ -403,8 +545,11 @@ class DatabaseCreation(BaseDatabaseCreation):
     def _test_user_create(self):
         return self._test_settings_get("CREATE_USER", default=True)
 
-    def _test_database_user(self):
-        return self._test_settings_get("USER", prefixed="USER")
+    def _test_database_user(self, suffix=None):
+        user = self._test_settings_get("USER", prefixed="USER")
+        if suffix:
+            user = f"{user}_{suffix}"
+        return user
 
     def _test_database_passwd(self):
         password = self._test_settings_get("PASSWORD")
@@ -414,22 +559,41 @@ class DatabaseCreation(BaseDatabaseCreation):
             password = get_random_string(30)
         return password
 
-    def _test_database_tblspace(self):
-        return self._test_settings_get("TBLSPACE", prefixed="USER")
+    def _test_database_tblspace(self, suffix=None):
+        tblspace = self._test_settings_get("TBLSPACE", prefixed="USER")
+        if suffix:
+            tblspace = f"{tblspace}_{suffix}"
+        return tblspace
 
-    def _test_database_tblspace_tmp(self):
+    def _test_database_tblspace_tmp(self, suffix=None):
         settings_dict = self.connection.settings_dict
-        return settings_dict["TEST"].get(
+        tblspace_tmp = settings_dict["TEST"].get(
             "TBLSPACE_TMP", TEST_DATABASE_PREFIX + settings_dict["USER"] + "_temp"
         )
+        if suffix:
+            tblspace_tmp = f"{tblspace_tmp}_{suffix}"
+        return tblspace_tmp
 
-    def _test_database_tblspace_datafile(self):
-        tblspace = "%s.dbf" % self._test_database_tblspace()
-        return self._test_settings_get("DATAFILE", default=tblspace)
+    def _test_database_tblspace_datafile(self, suffix=None):
+        default = "%s.dbf" % self._test_database_tblspace(suffix)
+        datafile = self._test_settings_get("DATAFILE", default=default)
+        if suffix and datafile != default:
+            datafile = self._insert_datafile_suffix(datafile, suffix)
+        return datafile
 
-    def _test_database_tblspace_tmp_datafile(self):
-        tblspace = "%s.dbf" % self._test_database_tblspace_tmp()
-        return self._test_settings_get("DATAFILE_TMP", default=tblspace)
+    def _test_database_tblspace_tmp_datafile(self, suffix=None):
+        default = "%s.dbf" % self._test_database_tblspace_tmp(suffix)
+        datafile = self._test_settings_get("DATAFILE_TMP", default=default)
+        if suffix and datafile != default:
+            datafile = self._insert_datafile_suffix(datafile, suffix)
+        return datafile
+
+    @staticmethod
+    def _insert_datafile_suffix(datafile, suffix):
+        # Insert the worker suffix before the extension so parallel clones get
+        # distinct datafiles. splitext() handles paths with no extension.
+        root, ext = os.path.splitext(datafile)
+        return f"{root}_{suffix}{ext}"
 
     def _test_database_tblspace_maxsize(self):
         return self._test_settings_get("DATAFILE_MAXSIZE", default="500M")

--- a/django/db/backends/oracle/creation.py
+++ b/django/db/backends/oracle/creation.py
@@ -1,4 +1,6 @@
+import os
 import sys
+import time
 
 from django.conf import settings
 from django.db import DatabaseError
@@ -11,6 +13,9 @@ TEST_DATABASE_PREFIX = "test_"
 
 class DatabaseCreation(BaseDatabaseCreation):
     destroy_test_db_connection_close_method = "close"
+    # Suffix of the clone being torn down, set by destroy_test_db() and read by
+    # _destroy_test_db(). None means the main (non-parallel) test database.
+    _suffix = None
 
     @cached_property
     def _maindb_connection(self):
@@ -203,21 +208,161 @@ class DatabaseCreation(BaseDatabaseCreation):
             self.log("Tests cancelled -- test database cannot be recreated.")
             sys.exit(1)
 
-    def _destroy_test_db(self, test_database_name, verbosity=1):
+    def _clone_test_db(self, suffix, verbosity, keepdb=False):
+        """
+        Create a cloned test database (tablespace + user) for parallel testing.
+        """
+        parameters = self._get_test_db_params(suffix)
+
+        with self._maindb_connection.cursor() as cursor:
+            if self._test_database_create():
+                try:
+                    self._execute_test_db_creation(
+                        cursor, parameters, verbosity, keepdb
+                    )
+                except Exception as e:
+                    if "ORA-01543" not in str(e):
+                        # Errors except "tablespace exists" cancel tests
+                        self.log(
+                            "Got an error creating the cloned test database: %s" % e
+                        )
+                        sys.exit(2)
+                    # The tablespace is left over from an earlier interrupted
+                    # run. Drop any remnants and recreate it from scratch,
+                    # unless we're keeping the database.
+                    if not keepdb:
+                        self._destroy_clone_remnants(cursor, parameters, verbosity)
+                        self._execute_test_db_creation(
+                            cursor, parameters, verbosity, keepdb
+                        )
+
+            if self._test_user_create():
+                try:
+                    self._create_test_user(cursor, parameters, verbosity, keepdb)
+                except Exception as e:
+                    if "ORA-01920" not in str(e):
+                        # All errors except "user already exists" cancel tests
+                        self.log("Got an error creating the cloned test user: %s" % e)
+                        sys.exit(2)
+                    if not keepdb:
+                        self._destroy_test_user(cursor, parameters, verbosity)
+                        self._create_test_user(cursor, parameters, verbosity, keepdb)
+
+        # Migrate unconditionally, as create_test_db() does: under keepdb the
+        # clone may have just been created, and migrate() is a no-op on one
+        # that's already built.
+        self._run_migrations_on_clone(suffix, verbosity)
+
+    def _run_migrations_on_clone(self, suffix, verbosity):
+        """
+        Build the clone's schema by running migrations against it, avoiding a
+        dependency on external Oracle tools (exp/imp, expdp/impdp).
+        """
+        from django.apps import apps
+        from django.core.management import call_command
+        from django.db import connections
+
+        # Migrate the clone through a dedicated connection on a temporary
+        # alias. self.connection.settings_dict is settings.DATABASES[alias],
+        # which the parallel runner snapshots by reference, so mutating it here
+        # would leak clone credentials into the workers and the teardown
+        # connection and break them under the spawn/forkserver start methods.
+        clone_settings = self.get_test_db_clone_settings(suffix)
+        clone_alias = "%s__clone_%s" % (self.connection.alias, suffix)
+
+        disable_migrations = clone_settings["TEST"].get("MIGRATE", True) is False
+        if disable_migrations:
+            old_migration_modules = settings.MIGRATION_MODULES
+            settings.MIGRATION_MODULES = {
+                app.label: None for app in apps.get_app_configs()
+            }
+
+        connections.databases[clone_alias] = clone_settings
+        try:
+            call_command(
+                "migrate",
+                verbosity=max(verbosity - 1, 0),
+                interactive=False,
+                database=clone_alias,
+                run_syncdb=True,
+            )
+            call_command("createcachetable", database=clone_alias)
+        finally:
+            if disable_migrations:
+                settings.MIGRATION_MODULES = old_migration_modules
+            connections[clone_alias].close()
+            del connections.databases[clone_alias]
+
+    def _destroy_clone_remnants(self, cursor, parameters, verbosity):
+        """
+        Drop a leftover clone user and tablespaces from an earlier interrupted
+        run. Only some of the objects may have been created before the
+        interruption, so each drop is allowed to fail with the matching "does
+        not exist" error (ORA-01918 for the user, ORA-00959 for a tablespace).
+        """
+        drops = [
+            ("DROP USER %(user)s CASCADE", "ORA-01918"),
+            (
+                "DROP TABLESPACE %(tblspace)s "
+                "INCLUDING CONTENTS AND DATAFILES CASCADE CONSTRAINTS",
+                "ORA-00959",
+            ),
+            (
+                "DROP TABLESPACE %(tblspace_temp)s "
+                "INCLUDING CONTENTS AND DATAFILES CASCADE CONSTRAINTS",
+                "ORA-00959",
+            ),
+        ]
+        for statement, acceptable_ora_err in drops:
+            self._execute_allow_fail_statements(
+                cursor, [statement], parameters, verbosity, acceptable_ora_err
+            )
+
+    def get_test_db_clone_settings(self, suffix):
+        """
+        Return a modified connection settings dict for the n-th clone of a DB.
+        """
+        orig = self.connection.settings_dict
+        user = self._test_database_user(suffix)
+        # TEST["USER"] must follow USER. Unpacking orig only copies a reference
+        # to its TEST dict, and _test_database_user() reads TEST["USER"] back,
+        # so a worker would otherwise report the main test user as its own.
+        return {
+            **orig,
+            "USER": user,
+            "TEST": {**orig["TEST"], "USER": user},
+        }
+
+    def destroy_test_db(
+        self, old_database_name=None, verbosity=1, keepdb=False, suffix=None
+    ):
         """
         Destroy a test database, prompting the user for confirmation if the
-        database already exists. Return the name of the test database created.
+        database already exists.
         """
-        if not self.connection.is_pool:
-            self.connection.settings_dict["USER"] = self.connection.settings_dict[
-                "SAVED_USER"
-            ]
-            self.connection.settings_dict["PASSWORD"] = self.connection.settings_dict[
-                "SAVED_PASSWORD"
-            ]
-        self.connection.close()
+        # Restore main user credentials for cleanup, but only for the main
+        # test database -- clones are dropped while connected as the main user.
+        if suffix is None and not self.connection.is_pool:
+            saved_user = self.connection.settings_dict.get("SAVED_USER")
+            saved_password = self.connection.settings_dict.get("SAVED_PASSWORD")
+            if saved_user:
+                self.connection.settings_dict["USER"] = saved_user
+            if saved_password:
+                self.connection.settings_dict["PASSWORD"] = saved_password
+        # _destroy_test_db() can't take a suffix without breaking its
+        # documented signature, so pass it via an attribute instead.
+        self._suffix = suffix
+        super().destroy_test_db(old_database_name, verbosity, keepdb, suffix)
+
+    def _destroy_test_db(self, test_database_name, verbosity=1):
+        """
+        Drop the test user and tablespace. self._suffix (set by
+        destroy_test_db) selects which clone to drop, or the main test
+        database when None.
+        """
         self.connection.close_pool()
-        parameters = self._get_test_db_params()
+        parameters = self._get_test_db_params(self._suffix)
+
         with self._maindb_connection.cursor() as cursor:
             if self._test_user_create():
                 if verbosity >= 1:
@@ -316,6 +461,10 @@ class DatabaseCreation(BaseDatabaseCreation):
         ]
         self._execute_statements(cursor, statements, parameters, verbosity)
 
+    # How long _destroy_test_user() waits for Oracle to notice that a departed
+    # parallel worker's session is gone, in seconds.
+    destroy_test_user_timeout = 60
+
     def _destroy_test_user(self, cursor, parameters, verbosity):
         if verbosity >= 2:
             self.log("_destroy_test_user(): user=%s" % parameters["user"])
@@ -323,7 +472,27 @@ class DatabaseCreation(BaseDatabaseCreation):
         statements = [
             "DROP USER %(user)s CASCADE",
         ]
-        self._execute_statements(cursor, statements, parameters, verbosity)
+        # Parallel workers have exited by the time their clones are torn down,
+        # but Oracle only reclaims a session once PMON notices the client is
+        # gone, and DROP USER raises ORA-01940 while any session remains. Keep
+        # retrying quietly until it does.
+        deadline = time.monotonic() + self.destroy_test_user_timeout
+        while True:
+            expired = time.monotonic() >= deadline
+            try:
+                self._execute_statements(
+                    cursor,
+                    statements,
+                    parameters,
+                    verbosity,
+                    allow_quiet_fail=not expired,
+                )
+            except DatabaseError as e:
+                if expired or "ORA-01940" not in str(e):
+                    raise
+                time.sleep(0.5)
+            else:
+                return
 
     def _execute_statements(
         self, cursor, statements, parameters, verbosity, allow_quiet_fail=False
@@ -366,15 +535,19 @@ class DatabaseCreation(BaseDatabaseCreation):
                 raise
             return False
 
-    def _get_test_db_params(self):
+    def _get_test_db_params(self, suffix=None):
         return {
             "dbname": self._test_database_name(),
-            "user": self._test_database_user(),
-            "password": self._test_database_passwd(),
-            "tblspace": self._test_database_tblspace(),
-            "tblspace_temp": self._test_database_tblspace_tmp(),
-            "datafile": self._test_database_tblspace_datafile(),
-            "datafile_tmp": self._test_database_tblspace_tmp_datafile(),
+            "user": self._test_database_user(suffix),
+            "password": (
+                self.connection.settings_dict["PASSWORD"]
+                if suffix
+                else self._test_database_passwd()
+            ),
+            "tblspace": self._test_database_tblspace(suffix),
+            "tblspace_temp": self._test_database_tblspace_tmp(suffix),
+            "datafile": self._test_database_tblspace_datafile(suffix),
+            "datafile_tmp": self._test_database_tblspace_tmp_datafile(suffix),
             "maxsize": self._test_database_tblspace_maxsize(),
             "maxsize_tmp": self._test_database_tblspace_tmp_maxsize(),
             "size": self._test_database_tblspace_size(),
@@ -403,8 +576,11 @@ class DatabaseCreation(BaseDatabaseCreation):
     def _test_user_create(self):
         return self._test_settings_get("CREATE_USER", default=True)
 
-    def _test_database_user(self):
-        return self._test_settings_get("USER", prefixed="USER")
+    def _test_database_user(self, suffix=None):
+        user = self._test_settings_get("USER", prefixed="USER")
+        if suffix:
+            user = f"{user}_{suffix}"
+        return user
 
     def _test_database_passwd(self):
         password = self._test_settings_get("PASSWORD")
@@ -414,22 +590,41 @@ class DatabaseCreation(BaseDatabaseCreation):
             password = get_random_string(30)
         return password
 
-    def _test_database_tblspace(self):
-        return self._test_settings_get("TBLSPACE", prefixed="USER")
+    def _test_database_tblspace(self, suffix=None):
+        tblspace = self._test_settings_get("TBLSPACE", prefixed="USER")
+        if suffix:
+            tblspace = f"{tblspace}_{suffix}"
+        return tblspace
 
-    def _test_database_tblspace_tmp(self):
+    def _test_database_tblspace_tmp(self, suffix=None):
         settings_dict = self.connection.settings_dict
-        return settings_dict["TEST"].get(
+        tblspace_tmp = settings_dict["TEST"].get(
             "TBLSPACE_TMP", TEST_DATABASE_PREFIX + settings_dict["USER"] + "_temp"
         )
+        if suffix:
+            tblspace_tmp = f"{tblspace_tmp}_{suffix}"
+        return tblspace_tmp
 
-    def _test_database_tblspace_datafile(self):
-        tblspace = "%s.dbf" % self._test_database_tblspace()
-        return self._test_settings_get("DATAFILE", default=tblspace)
+    def _test_database_tblspace_datafile(self, suffix=None):
+        default = "%s.dbf" % self._test_database_tblspace(suffix)
+        datafile = self._test_settings_get("DATAFILE", default=default)
+        if suffix and datafile != default:
+            datafile = self._insert_datafile_suffix(datafile, suffix)
+        return datafile
 
-    def _test_database_tblspace_tmp_datafile(self):
-        tblspace = "%s.dbf" % self._test_database_tblspace_tmp()
-        return self._test_settings_get("DATAFILE_TMP", default=tblspace)
+    def _test_database_tblspace_tmp_datafile(self, suffix=None):
+        default = "%s.dbf" % self._test_database_tblspace_tmp(suffix)
+        datafile = self._test_settings_get("DATAFILE_TMP", default=default)
+        if suffix and datafile != default:
+            datafile = self._insert_datafile_suffix(datafile, suffix)
+        return datafile
+
+    @staticmethod
+    def _insert_datafile_suffix(datafile, suffix):
+        # Insert the worker suffix before the extension so parallel clones get
+        # distinct datafiles. splitext() handles paths with no extension.
+        root, ext = os.path.splitext(datafile)
+        return f"{root}_{suffix}{ext}"
 
     def _test_database_tblspace_maxsize(self):
         return self._test_settings_get("DATAFILE_MAXSIZE", default="500M")

--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -35,6 +35,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_sequence_reset = False
     can_introspect_materialized_views = True
     atomic_transactions = False
+    can_clone_databases = True
     nulls_order_largest = True
     requires_literal_defaults = True
     supports_default_keyword_in_bulk_insert = False

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1580,8 +1580,7 @@ correctly:
 
     $ python -m pip install tblib
 
-This feature isn't available on Windows. It doesn't work with the Oracle
-database backend either.
+This feature isn't available on Windows.
 
 If you want to use :mod:`pdb` while debugging tests, you must disable parallel
 execution (``--parallel=1``). You'll see something like ``bdb.BdbQuit`` if you

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -372,6 +372,9 @@ Tests
   Previously, they would consume the streaming response's content, causing
   subsequent calls to fail.
 
+* The Oracle database backend now supports running tests in parallel with the
+  :option:`test --parallel` option.
+
 Utilities
 ~~~~~~~~~
 

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -235,6 +235,9 @@ Tests
   :setting:`AUTHENTICATION_BACKENDS` not implementing ``(a)get_user()``, e.g.
   permission-only backends.
 
+* The Oracle database backend now supports running tests in parallel with the
+  :option:`test --parallel` option.
+
 URLs
 ~~~~
 

--- a/tests/backends/oracle/test_creation.py
+++ b/tests/backends/oracle/test_creation.py
@@ -31,6 +31,23 @@ class DatabaseCreationTests(TestCase):
     ):
         raise DatabaseError("ORA-01031: insufficient privileges")
 
+    def _make_execute_record_and_raise_tablespace_exists(self, executed):
+        # Record executed statements and raise "tablespace exists" the first
+        # time a tablespace is created, as a leftover clone would.
+        state = {"raised": False}
+
+        def execute(inner_self, cursor, statements, parameters, verbosity, **kwargs):
+            for statement in statements:
+                executed.append(statement.strip())
+                if (
+                    statement.strip().startswith("CREATE TABLESPACE")
+                    and not state["raised"]
+                ):
+                    state["raised"] = True
+                    raise DatabaseError("ORA-01543: tablespace 'string' already exists")
+
+        return execute
+
     def _test_database_passwd(self):
         # Mocked to avoid test user password changed
         return connection.settings_dict["SAVED_PASSWORD"]
@@ -109,3 +126,83 @@ class DatabaseCreationTests(TestCase):
                     # REUSE cannot be used with OMF.
                     self.assertNotIn("REUSE", tblspace_sql)
                     self.assertNotIn("REUSE", tblspace_tmp_sql)
+
+    def test_get_test_db_params_suffix(self, *mocked_objects):
+        """Test that _get_test_db_params generates correct suffixed names."""
+        creation = DatabaseCreation(connection)
+        # Without suffix
+        params = creation._get_test_db_params()
+        base_user = params["user"]
+        base_tblspace = params["tblspace"]
+        base_tblspace_temp = params["tblspace_temp"]
+
+        # With suffix
+        params_suffixed = creation._get_test_db_params("1")
+        self.assertEqual(params_suffixed["user"], f"{base_user}_1")
+        self.assertEqual(params_suffixed["tblspace"], f"{base_tblspace}_1")
+        self.assertEqual(params_suffixed["tblspace_temp"], f"{base_tblspace_temp}_1")
+        # dbname should not change (Oracle SID/service name stays same)
+        self.assertEqual(params_suffixed["dbname"], params["dbname"])
+
+    def test_get_test_db_clone_settings(self, *mocked_objects):
+        """Test that get_test_db_clone_settings returns correct settings."""
+        creation = DatabaseCreation(connection)
+
+        clone_settings = creation.get_test_db_clone_settings("2")
+        # USER should be suffixed
+        expected_user = creation._test_database_user("2")
+        self.assertEqual(clone_settings["USER"], expected_user)
+        # NAME should remain unchanged (Oracle SID doesn't change)
+        self.assertEqual(clone_settings["NAME"], connection.settings_dict["NAME"])
+
+    def test_datafile_suffix_no_extension(self, *mocked_objects):
+        """A custom DATAFILE without an extension is suffixed, not crashed."""
+        creation = DatabaseCreation(connection)
+        # Bare name, no dot -- previously raised ValueError on rsplit(".", 1).
+        self.assertEqual(
+            creation._insert_datafile_suffix("/u01/oradata/clone", "1"),
+            "/u01/oradata/clone_1",
+        )
+        # Normal case: suffix goes before the extension.
+        self.assertEqual(
+            creation._insert_datafile_suffix("/u01/oradata/clone.dbf", "2"),
+            "/u01/oradata/clone_2.dbf",
+        )
+
+    @mock.patch.object(DatabaseCreation, "_test_user_create", return_value=False)
+    def test_clone_test_db_tablespace_exists_keepdb(self, *mocked_objects):
+        """Test _clone_test_db handles 'tablespace exists' with keepdb=True."""
+        creation = DatabaseCreation(connection)
+        # Simulate tablespace already exists error
+        with self.patch_execute_statements(
+            self._execute_raise_tablespace_already_exists
+        ):
+            # Should not raise when keepdb=True
+            creation._clone_test_db(suffix="1", verbosity=0, keepdb=True)
+
+    @mock.patch.object(DatabaseCreation, "_run_migrations_on_clone")
+    @mock.patch.object(DatabaseCreation, "_test_user_create", return_value=False)
+    def test_clone_test_db_recreates_existing_tablespace(self, *mocked_objects):
+        """
+        Without keepdb, a clone tablespace left over from an earlier
+        interrupted run is dropped and recreated rather than aborting the run.
+        """
+        creation = DatabaseCreation(connection)
+        executed = []
+        execute = self._make_execute_record_and_raise_tablespace_exists(executed)
+        with self.patch_execute_statements(execute):
+            # Should recover instead of raising.
+            creation._clone_test_db(suffix="1", verbosity=0, keepdb=False)
+        # The leftover user and tablespace are dropped before recreating.
+        self.assertTrue(any(s.startswith("DROP USER") for s in executed))
+        self.assertTrue(any(s.startswith("DROP TABLESPACE") for s in executed))
+
+    @mock.patch.object(DatabaseCreation, "_test_user_create", return_value=False)
+    def test_clone_test_db_unexpected_error(self, *mocked_objects):
+        """Test that _clone_test_db exits on unexpected errors."""
+        creation = DatabaseCreation(connection)
+        with self.patch_execute_statements(self._execute_raise_insufficient_privileges):
+            with self.assertRaises(SystemExit):
+                creation._clone_test_db(suffix="1", verbosity=0, keepdb=False)
+            with self.assertRaises(SystemExit):
+                creation._clone_test_db(suffix="1", verbosity=0, keepdb=True)

--- a/tests/backends/oracle/test_creation.py
+++ b/tests/backends/oracle/test_creation.py
@@ -31,6 +31,23 @@ class DatabaseCreationTests(TestCase):
     ):
         raise DatabaseError("ORA-01031: insufficient privileges")
 
+    def _make_execute_record_and_raise_tablespace_exists(self, executed):
+        # Record executed statements and raise "tablespace exists" the first
+        # time a tablespace is created, as a leftover clone would.
+        state = {"raised": False}
+
+        def execute(inner_self, cursor, statements, parameters, verbosity, **kwargs):
+            for statement in statements:
+                executed.append(statement.strip())
+                if (
+                    statement.strip().startswith("CREATE TABLESPACE")
+                    and not state["raised"]
+                ):
+                    state["raised"] = True
+                    raise DatabaseError("ORA-01543: tablespace 'string' already exists")
+
+        return execute
+
     def _test_database_passwd(self):
         # Mocked to avoid test user password changed
         return connection.settings_dict["SAVED_PASSWORD"]
@@ -109,3 +126,132 @@ class DatabaseCreationTests(TestCase):
                     # REUSE cannot be used with OMF.
                     self.assertNotIn("REUSE", tblspace_sql)
                     self.assertNotIn("REUSE", tblspace_tmp_sql)
+
+    def test_get_test_db_params_suffix(self, *mocked_objects):
+        """Test that _get_test_db_params generates correct suffixed names."""
+        creation = DatabaseCreation(connection)
+        # Without suffix
+        params = creation._get_test_db_params()
+        base_user = params["user"]
+        base_tblspace = params["tblspace"]
+        base_tblspace_temp = params["tblspace_temp"]
+
+        # With suffix
+        params_suffixed = creation._get_test_db_params("1")
+        self.assertEqual(params_suffixed["user"], f"{base_user}_1")
+        self.assertEqual(params_suffixed["tblspace"], f"{base_tblspace}_1")
+        self.assertEqual(params_suffixed["tblspace_temp"], f"{base_tblspace_temp}_1")
+        # dbname should not change (Oracle SID/service name stays same)
+        self.assertEqual(params_suffixed["dbname"], params["dbname"])
+
+    def test_get_test_db_clone_settings(self, *mocked_objects):
+        """Test that get_test_db_clone_settings returns correct settings."""
+        creation = DatabaseCreation(connection)
+        orig_test_user = connection.settings_dict["TEST"].get("USER")
+
+        clone_settings = creation.get_test_db_clone_settings("2")
+        # USER should be suffixed
+        expected_user = creation._test_database_user("2")
+        self.assertEqual(clone_settings["USER"], expected_user)
+        # TEST["USER"] follows USER, otherwise _test_database_user() reports
+        # the main test user inside a parallel worker.
+        self.assertEqual(clone_settings["TEST"]["USER"], expected_user)
+        # NAME should remain unchanged (Oracle SID doesn't change)
+        self.assertEqual(clone_settings["NAME"], connection.settings_dict["NAME"])
+        # The connection's own settings are left alone.
+        self.assertEqual(connection.settings_dict["TEST"].get("USER"), orig_test_user)
+
+    def test_datafile_suffix_no_extension(self, *mocked_objects):
+        """A custom DATAFILE without an extension is suffixed, not crashed."""
+        creation = DatabaseCreation(connection)
+        # Bare name, no dot -- previously raised ValueError on rsplit(".", 1).
+        self.assertEqual(
+            creation._insert_datafile_suffix("/u01/oradata/clone", "1"),
+            "/u01/oradata/clone_1",
+        )
+        # Normal case: suffix goes before the extension.
+        self.assertEqual(
+            creation._insert_datafile_suffix("/u01/oradata/clone.dbf", "2"),
+            "/u01/oradata/clone_2.dbf",
+        )
+
+    @mock.patch.object(DatabaseCreation, "_run_migrations_on_clone")
+    @mock.patch.object(DatabaseCreation, "_test_user_create", return_value=False)
+    def test_clone_test_db_tablespace_exists_keepdb(
+        self, mocked_test_user_create, mocked_run_migrations, *mocked_objects
+    ):
+        """
+        With keepdb, a pre-existing clone tablespace is reused rather than
+        recreated, but the clone is still migrated: it may have just been
+        created, and migrate() is a no-op on one that's already built.
+        """
+        creation = DatabaseCreation(connection)
+        # Simulate tablespace already exists error
+        with self.patch_execute_statements(
+            self._execute_raise_tablespace_already_exists
+        ):
+            # Should not raise when keepdb=True
+            creation._clone_test_db(suffix="1", verbosity=0, keepdb=True)
+        mocked_run_migrations.assert_called_once_with("1", 0)
+
+    @mock.patch.object(DatabaseCreation, "_run_migrations_on_clone")
+    @mock.patch.object(DatabaseCreation, "_test_user_create", return_value=False)
+    def test_clone_test_db_recreates_existing_tablespace(self, *mocked_objects):
+        """
+        Without keepdb, a clone tablespace left over from an earlier
+        interrupted run is dropped and recreated rather than aborting the run.
+        """
+        creation = DatabaseCreation(connection)
+        executed = []
+        execute = self._make_execute_record_and_raise_tablespace_exists(executed)
+        with self.patch_execute_statements(execute):
+            # Should recover instead of raising.
+            creation._clone_test_db(suffix="1", verbosity=0, keepdb=False)
+        # The leftover user and tablespace are dropped before recreating.
+        self.assertTrue(any(s.startswith("DROP USER") for s in executed))
+        self.assertTrue(any(s.startswith("DROP TABLESPACE") for s in executed))
+
+    @mock.patch.object(DatabaseCreation, "_test_user_create", return_value=False)
+    def test_clone_test_db_unexpected_error(self, *mocked_objects):
+        """Test that _clone_test_db exits on unexpected errors."""
+        creation = DatabaseCreation(connection)
+        with self.patch_execute_statements(self._execute_raise_insufficient_privileges):
+            with self.assertRaises(SystemExit):
+                creation._clone_test_db(suffix="1", verbosity=0, keepdb=False)
+            with self.assertRaises(SystemExit):
+                creation._clone_test_db(suffix="1", verbosity=0, keepdb=True)
+
+    @mock.patch("django.db.backends.oracle.creation.time.sleep")
+    def test_destroy_test_user_waits_for_lingering_session(self, *mocked_objects):
+        """
+        A departed parallel worker's Oracle session can outlive its process, so
+        DROP USER is retried for as long as it reports ORA-01940.
+        """
+        creation = DatabaseCreation(connection)
+        attempts = []
+
+        def execute(inner_self, cursor, statements, parameters, verbosity, **kwargs):
+            attempts.append(statements[0])
+            if len(attempts) < 3:
+                raise DatabaseError(
+                    "ORA-01940: cannot drop a user who is currently connected"
+                )
+
+        with self.patch_execute_statements(execute):
+            creation._destroy_test_user(None, {"user": "default_test_1"}, 0)
+        self.assertEqual(len(attempts), 3)
+
+    @mock.patch("django.db.backends.oracle.creation.time.sleep")
+    def test_destroy_test_user_gives_up_on_lingering_session(self, *mocked_objects):
+        """DROP USER still raises if the session never goes away."""
+        creation = DatabaseCreation(connection)
+        creation.destroy_test_user_timeout = 0
+
+        def execute(inner_self, cursor, statements, parameters, verbosity, **kwargs):
+            raise DatabaseError(
+                "ORA-01940: cannot drop a user who is currently connected"
+            )
+
+        with self.patch_execute_statements(execute):
+            with self.assertRaises(DatabaseError):
+                creation._destroy_test_user(None, {"user": "default_test_1"}, 0)


### PR DESCRIPTION
#### Trac ticket number

[ticket-31908](https://code.djangoproject.com/ticket/31908)

#### Branch description

This PR adds parallel testing support to the Oracle database backend in Django. In Oracle, this is implemented by creating separate tablespaces and users/schemas for each parallel worker, following the "empty clone + migrations" strategy used by other backends like PostgreSQL.

Key changes include:
- Implementing [_clone_test_db](cci:1://file:///e:/GitHub/django/django/db/backends/base/creation.py:292:4-299:9) to handle the creation of cloned tablespaces and users.
- Overriding [destroy_test_db](cci:1://file:///e:/GitHub/django/django/db/backends/oracle/creation.py:255:4-311:69) to properly clean up these suffixed resources, as Oracle's `NAME` (SID/Service Name) remains constant across clones.
- Updating internal helper methods in [DatabaseCreation](cci:2://file:///e:/GitHub/django/django/db/backends/sqlite3/creation.py:11:0-156:29) to support a [suffix](cci:1://file:///e:/GitHub/django/django/db/backends/oracle/features.py:224:4-226:78) parameter for generating unique resource names (e.g., `test_user_1`, `test_tblspace_1`).
- Enabling the `can_clone_databases` feature flag for the Oracle backend.

This approach avoids external dependencies on Oracle utilities like `expdp` and `impdp`, making it compatible with standard development environments.

#### Checklist
- [x] This PR targets the [main](cci:1://file:///e:/GitHub/django/django/db/backends/oracle/creation.py:14:4-28:74) branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes. (N/A for this backend change)
