### PR TITLE
Fixed #36849 -- Improved GEOS exceptions messages.

### DIFF
--- a/django/contrib/gis/geos/error.py
+++ b/django/contrib/gis/geos/error.py
@@ -2,3 +2,9 @@ class GEOSException(Exception):
     "The base GEOS exception, indicates a GEOS-related error."
 
     pass
+
+
+class GEOSLibraryError(Exception):
+    """Error raised by the GEOS C library."""
+
+    pass

--- a/django/contrib/gis/geos/libgeos.py
+++ b/django/contrib/gis/geos/libgeos.py
@@ -95,12 +95,14 @@ ERRORFUNC = CFUNCTYPE(None, c_char_p, c_char_p)
 
 
 def error_h(fmt, lst):
+    from django.contrib.gis.geos.prototypes.threadsafe import thread_context
+
     fmt, lst = fmt.decode(), lst.decode()
     try:
         err_msg = fmt % lst
     except TypeError:
         err_msg = fmt
-    logger.error("GEOS_ERROR: %s\n", err_msg)
+    thread_context.last_error = err_msg
 
 
 error_h = ERRORFUNC(error_h)

--- a/django/contrib/gis/geos/prototypes/threadsafe.py
+++ b/django/contrib/gis/geos/prototypes/threadsafe.py
@@ -20,6 +20,7 @@ class GEOSContextHandle(GEOSBase):
 # to hold a reference to GEOSContextHandle for this thread.
 class GEOSContext(threading.local):
     handle = None
+    last_error = None
 
 
 thread_context = GEOSContext()

--- a/tests/gis_tests/geos_tests/test_geos.py
+++ b/tests/gis_tests/geos_tests/test_geos.py
@@ -23,7 +23,9 @@ from django.contrib.gis.geos import (
     fromfile,
     fromstr,
 )
+from django.contrib.gis.geos.error import GEOSLibraryError
 from django.contrib.gis.geos.libgeos import geos_version_tuple
+from django.contrib.gis.geos.prototypes import geos_isclosed, get_nrings
 from django.contrib.gis.shortcuts import numpy
 from django.template import Context
 from django.template.engine import Engine
@@ -122,6 +124,58 @@ class GEOSTest(SimpleTestCase, TestDataMixin):
                 self.assertRaisesMessage((GEOSException, ValueError), err.msg),
             ):
                 fromstr(err.wkt)
+
+        msg = (
+            "Error encountered checking Geometry returned from GEOS C "
+            'function "GEOSWKTReader_read_r".'
+        )
+        with self.assertRaisesMessage(GEOSException, msg) as context:
+            GEOSGeometry("Point(5, 2)")
+        self.assertIsInstance(context.exception.__cause__, GEOSLibraryError)
+        self.assertEqual(
+            str(context.exception.__cause__),
+            "ParseException: Expected number but encountered ','",
+        )
+
+        point = Point(0, 0)
+        msg = 'Error encountered in GEOS C function "GEOSGetNumInteriorRings_r".'
+        with self.assertRaisesMessage(GEOSException, msg) as context:
+            get_nrings(point.ptr)
+        self.assertIsInstance(context.exception.__cause__, GEOSLibraryError)
+        if geos_version_tuple() < (3, 13):
+            msg = "IllegalArgumentException: Argument is not a Polygon"
+        else:
+            msg = "IllegalArgumentException: Argument is not a Surface"
+        self.assertEqual(str(context.exception.__cause__), msg)
+
+        msg = 'Error encountered on GEOS C predicate function "GEOSisClosed_r".'
+        with self.assertRaisesMessage(GEOSException, msg) as context:
+            geos_isclosed(point.ptr)
+        self.assertIsInstance(context.exception.__cause__, GEOSLibraryError)
+        if geos_version_tuple() < (3, 13):
+            msg = (
+                "IllegalArgumentException: Argument "
+                "is not a LineString or MultiLineString"
+            )
+        else:
+            msg = (
+                "IllegalArgumentException: Argument is not "
+                "a Curve, MultiLineString, or MultiCurve"
+            )
+        self.assertEqual(str(context.exception.__cause__), msg)
+
+        invalid_wkb = "01990000"
+        msg = (
+            "Error encountered checking Geometry returned from "
+            'GEOS C function "GEOSWKBReader_readHEX_r".'
+        )
+        with self.assertRaisesMessage(GEOSException, msg) as context:
+            GEOSGeometry(invalid_wkb)
+        self.assertIsInstance(context.exception.__cause__, GEOSLibraryError)
+        self.assertEqual(
+            str(context.exception.__cause__),
+            "ParseException: Unexpected EOF parsing WKB",
+        )
 
         # Bad WKB
         with self.assertRaisesMessage(


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36849

#### Branch description
See ticket for detailed rationale. In summary I'd like to move the GEOS error messages from being logged to being reported with the exception. This will make them more visible as they are reported with the exception. Personally, I'd find this particularly helpful when working on Django itself, as logs are disabled by default in the test runner. 

This is the result of me exploring adding curved geometry support for GEOS. It has partial support and therefore many functions raise exceptions, but the error messages are quite generic. I wanted to improve them and thought about using a decorator to guard against curved geometry support. This was becoming overly complex as it is tricky to test (there are _many_ functions) and would become a maintenance burden long term. However, I was struggling to show the underlying error message from GEOS to the end user. 

I asked Anthropic's Claude code for ideas and it came up with the suggestion of using thread local storage and is therefore the basis of this patch. 

I'm not sure about testing for leakage across threads. I tested it with the following:

<details>

``` python
    def test_thread_safety_of_error_handling(self):
        import concurrent.futures
        import random

        test_cases = [
            (
                "POLYGON((0 0, 1 1))",
                "Error encountered checking Geometry returned from GEOS C function "
                '"GEOSWKTReader_read_r". IllegalArgumentException: Points of LinearRing '
                "do not form a closed linestring",
            ),
            (
                "LINESTRING(0 0)",
                "Error encountered checking Geometry returned from GEOS C function "
                '"GEOSWKTReader_read_r". IllegalArgumentException: point array must '
                "contain 0 or >1 elements\n",
            ),
            (
                "POINT()",
                "Error encountered checking Geometry returned from GEOS C function "
                "\"GEOSWKTReader_read_r\". ParseException: Expected number but encountered ')'",
            ),
        ]

        def worker_thread(thread_id, num_operations):
            failures = []
            for i in range(num_operations):
                wkt, expected_error = random.choice(test_cases)
                try:
                    GEOSGeometry(wkt)
                    failures.append((i, expected_error, "no_error"))
                except GEOSException as e:
                    if str(e) != expected_error:
                        failures.append((i, expected_error, str(e)))
            return thread_id, failures

        num_threads = 20
        operations_per_thread = 500

        with concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as executor:
            futures = [
                executor.submit(worker_thread, i, operations_per_thread)
                for i in range(num_threads)
            ]

            all_failures = []
            for future in concurrent.futures.as_completed(futures):
                thread_id, failures = future.result()
                for op_num, expected, actual in failures:
                    all_failures.append((thread_id, op_num, expected, actual))

        self.assertEqual(all_failures, [])


```

</detail>

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [X] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [X] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [X] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
