### PR TITLE
Fixed #36858 -- Optimized `Field._get_default()` for `db_default` case.

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1032,9 +1032,9 @@ class Field(RegisterLookupMixin):
         if self.has_db_default():
             from django.db.models.expressions import DatabaseDefault
 
-            return lambda: DatabaseDefault(
-                self._db_default_expression, output_field=self
-            )
+            default = DatabaseDefault(self._db_default_expression, output_field=self)
+
+            return lambda: default
 
         if (
             not self.empty_strings_allowed


### PR DESCRIPTION
#### Trac ticket number

ticket-36858

#### Branch description

Create and share a single instance of `DatabaseDefault` instead of making a new one each time the lambda is called. The quick benchmark on the ticket shows a ~12% speedup for a large `bulk_create()` operation.

#### AI Assistance Disclosure (REQUIRED)
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
