### PR TITLE
Fixed #23902 -- Fixed altering PostGIS geography and geometry columns.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -555,6 +555,7 @@ answer newbie questions, and generally made Django that much better:
     John Paulett <john@paulett.org>
     John Shaffer <jshaffer2112@gmail.com>
     Jökull Sólberg Auðunsson <jokullsolberg@gmail.com>
+    Jon Culver <jon.c.culver@gmail.com>
     Jon Dufresne <jon.dufresne@gmail.com>
     Jon Janzen <jon@jonjanzen.com>
     Jonas Haag <jonas@lophus.org>

--- a/django/contrib/gis/db/backends/postgis/schema.py
+++ b/django/contrib/gis/db/backends/postgis/schema.py
@@ -30,14 +30,14 @@ class PostGISSchemaEditor(DatabaseSchemaEditor):
         return self._create_spatial_index_sql(model, fields[0], **kwargs)
 
     def _alter_column_type_sql(
-        self, table, old_field, new_field, new_type, old_collation, new_collation
+        self, model, old_field, new_field, new_type, old_collation, new_collation
     ):
         """
         Special case when dimension changed.
         """
         if not hasattr(old_field, "dim") or not hasattr(new_field, "dim"):
             return super()._alter_column_type_sql(
-                table, old_field, new_field, new_type, old_collation, new_collation
+                model, old_field, new_field, new_type, old_collation, new_collation
             )
 
         if old_field.dim == 2 and new_field.dim == 3:

--- a/django/contrib/gis/db/backends/postgis/schema.py
+++ b/django/contrib/gis/db/backends/postgis/schema.py
@@ -8,11 +8,15 @@ class PostGISSchemaEditor(DatabaseSchemaEditor):
     geom_index_ops_nd = "GIST_GEOMETRY_OPS_ND"
     rast_index_template = "ST_ConvexHull(%(expressions)s)"
 
+    # ST_Force2D()/ST_Force3D() only accept geometries, so the column is cast
+    # before being forced. The cast is a no-op for geometry columns.
     sql_alter_column_to_3d = (
-        "ALTER COLUMN %(column)s TYPE %(type)s USING ST_Force3D(%(column)s)::%(type)s"
+        "ALTER COLUMN %(column)s TYPE %(type)s "
+        "USING ST_Force3D(%(column)s::geometry)::%(type)s"
     )
     sql_alter_column_to_2d = (
-        "ALTER COLUMN %(column)s TYPE %(type)s USING ST_Force2D(%(column)s)::%(type)s"
+        "ALTER COLUMN %(column)s TYPE %(type)s "
+        "USING ST_Force2D(%(column)s::geometry)::%(type)s"
     )
 
     def geo_quote_name(self, name):
@@ -33,7 +37,8 @@ class PostGISSchemaEditor(DatabaseSchemaEditor):
         self, model, old_field, new_field, new_type, old_collation, new_collation
     ):
         """
-        Special case when dimension changed.
+        Special case changes in dimensions and conversions from
+        geography to geometry.
         """
         if not hasattr(old_field, "dim") or not hasattr(new_field, "dim"):
             return super()._alter_column_type_sql(
@@ -45,7 +50,9 @@ class PostGISSchemaEditor(DatabaseSchemaEditor):
         elif old_field.dim == 3 and new_field.dim == 2:
             sql_alter = self.sql_alter_column_to_2d
         else:
-            sql_alter = self.sql_alter_column_type
+            return super()._alter_column_type_sql(
+                model, old_field, new_field, new_type, old_collation, new_collation
+            )
         return (
             (
                 sql_alter

--- a/django/contrib/gis/db/backends/postgis/schema.py
+++ b/django/contrib/gis/db/backends/postgis/schema.py
@@ -8,11 +8,15 @@ class PostGISSchemaEditor(DatabaseSchemaEditor):
     geom_index_ops_nd = "GIST_GEOMETRY_OPS_ND"
     rast_index_template = "ST_ConvexHull(%(expressions)s)"
 
+    # ST_Force2D()/ST_Force3D() only accept geometries, so the column is cast
+    # before being forced. The cast is a no-op for geometry columns.
     sql_alter_column_to_3d = (
-        "ALTER COLUMN %(column)s TYPE %(type)s USING ST_Force3D(%(column)s)::%(type)s"
+        "ALTER COLUMN %(column)s TYPE %(type)s "
+        "USING ST_Force3D(%(column)s::geometry)::%(type)s"
     )
     sql_alter_column_to_2d = (
-        "ALTER COLUMN %(column)s TYPE %(type)s USING ST_Force2D(%(column)s)::%(type)s"
+        "ALTER COLUMN %(column)s TYPE %(type)s "
+        "USING ST_Force2D(%(column)s::geometry)::%(type)s"
     )
 
     def geo_quote_name(self, name):
@@ -30,14 +34,16 @@ class PostGISSchemaEditor(DatabaseSchemaEditor):
         return self._create_spatial_index_sql(model, fields[0], **kwargs)
 
     def _alter_column_type_sql(
-        self, table, old_field, new_field, new_type, old_collation, new_collation
+        self, model, old_field, new_field, new_type, old_collation, new_collation
     ):
         """
-        Special case when dimension changed.
+        Special case when the dimension changed. Conversions between geography
+        and geometry are delegated to the PostgreSQL backend, which adds the
+        USING clause required to cast between the two (#23902).
         """
         if not hasattr(old_field, "dim") or not hasattr(new_field, "dim"):
             return super()._alter_column_type_sql(
-                table, old_field, new_field, new_type, old_collation, new_collation
+                model, old_field, new_field, new_type, old_collation, new_collation
             )
 
         if old_field.dim == 2 and new_field.dim == 3:
@@ -45,7 +51,10 @@ class PostGISSchemaEditor(DatabaseSchemaEditor):
         elif old_field.dim == 3 and new_field.dim == 2:
             sql_alter = self.sql_alter_column_to_2d
         else:
-            sql_alter = self.sql_alter_column_type
+            return super()._alter_column_type_sql(
+                model, old_field, new_field, new_type, old_collation, new_collation
+            )
+
         return (
             (
                 sql_alter
@@ -70,6 +79,16 @@ class PostGISSchemaEditor(DatabaseSchemaEditor):
         new_db_params,
         strict=False,
     ):
+        old_spatial_index = self._spatial_index_type(old_field)
+        new_spatial_index = self._spatial_index_type(new_field)
+
+        # A no longer applicable index must be dropped before the column type
+        # changes, as PostgreSQL rebuilds indexes as part of ALTER COLUMN TYPE
+        # and fails when the existing operator class doesn't accept the new
+        # type.
+        if old_spatial_index is not None and old_spatial_index != new_spatial_index:
+            self.execute(self._delete_spatial_index_sql(model, old_field))
+
         super()._alter_field(
             model,
             old_field,
@@ -81,16 +100,22 @@ class PostGISSchemaEditor(DatabaseSchemaEditor):
             strict=strict,
         )
 
-        old_field_spatial_index = (
-            isinstance(old_field, BaseSpatialField) and old_field.spatial_index
-        )
-        new_field_spatial_index = (
-            isinstance(new_field, BaseSpatialField) and new_field.spatial_index
-        )
-        if not old_field_spatial_index and new_field_spatial_index:
+        if new_spatial_index is not None and new_spatial_index != old_spatial_index:
             self.execute(self._create_spatial_index_sql(model, new_field))
-        elif old_field_spatial_index and not new_field_spatial_index:
-            self.execute(self._delete_spatial_index_sql(model, old_field))
+
+    def _spatial_index_type(self, field):
+        """
+        Return a value identifying the spatial index a field requires, or None
+        if it requires none. Alterations that change this value invalidate any
+        existing index, which must then be recreated.
+        """
+        if not isinstance(field, BaseSpatialField) or not field.spatial_index:
+            return None
+        if field.geom_type == "RASTER":
+            return self.rast_index_template
+        if field.dim > 2 and not field.geography:
+            return self.geom_index_ops_nd
+        return self.geom_index_type
 
     def _create_spatial_index_name(self, model, field):
         return self._create_index_name(model._meta.db_table, [field.column], "_id")

--- a/tests/gis_tests/gis_migrations/test_operations.py
+++ b/tests/gis_tests/gis_migrations/test_operations.py
@@ -1,9 +1,9 @@
 from unittest import skipUnless
 
-from django.contrib.gis.db.models import fields
+from django.contrib.gis.db.models import Extent, fields
 from django.contrib.gis.geos import MultiPolygon, Polygon
 from django.core.exceptions import ImproperlyConfigured
-from django.db import connection, migrations, models
+from django.db import ProgrammingError, connection, migrations, models
 from django.db.migrations.migration import Migration
 from django.db.migrations.state import ProjectState
 from django.test import TransactionTestCase, skipIfDBFeature, skipUnlessDBFeature
@@ -22,6 +22,13 @@ class OperationTestCase(TransactionTestCase):
         JOIN pg_index as i on oc.oid = ANY(i.indclass)
         JOIN pg_class as c on c.oid = i.indexrelid
         WHERE c.relname = %s
+    """
+    get_column_opclass_query = """
+        SELECT opcname FROM pg_index AS i
+        JOIN pg_class AS t on t.oid = i.indrelid
+        JOIN pg_attribute AS a on a.attrelid = t.oid AND a.attnum = i.indkey[0]
+        JOIN pg_opclass AS oc on oc.oid = i.indclass[0]
+        WHERE t.relname = %s AND a.attname = %s
     """
 
     def tearDown(self):
@@ -434,6 +441,124 @@ class OperationTests(OperationTestCase):
             field_class_kwargs={"dim": 2},
         )
         self.assertFalse(Neighborhood.objects.first().geom.hasz)
+
+    @skipUnlessDBFeature("can_alter_geometry_field", "supports_geography")
+    def test_alter_geom_field_geography(self):
+        """
+        Altering between geometry and geography casts the column in both
+        directions (#23902).
+        """
+        Neighborhood = self.current_state.apps.get_model("gis", "Neighborhood")
+        p1 = Polygon(((0, 0), (0, 1), (1, 1), (1, 0), (0, 0)))
+        Neighborhood.objects.create(name="TestGeography", geom=MultiPolygon(p1, p1))
+        self.assertEqual(
+            Neighborhood.objects.aggregate(Extent("geom")),
+            {"geom__extent": (0.0, 0.0, 1.0, 1.0)},
+        )
+        # Convert to geography. Extent() is not defined for geography columns.
+        self.alter_gis_model(
+            migrations.AlterField,
+            "Neighborhood",
+            "geom",
+            fields.MultiPolygonField,
+            field_class_kwargs={"geography": True},
+        )
+        msg = "function st_extent(geography) does not exist"
+        with self.assertRaisesMessage(ProgrammingError, msg):
+            Neighborhood.objects.aggregate(Extent("geom"))
+        # Rewind to geometry.
+        self.alter_gis_model(
+            migrations.AlterField,
+            "Neighborhood",
+            "geom",
+            fields.MultiPolygonField,
+            field_class_kwargs={"geography": False},
+        )
+        self.assertEqual(
+            Neighborhood.objects.aggregate(Extent("geom")),
+            {"geom__extent": (0.0, 0.0, 1.0, 1.0)},
+        )
+
+    @skipUnlessDBFeature(
+        "can_alter_geometry_field", "supports_geography", "supports_3d_storage"
+    )
+    def test_alter_geom_field_geography_and_dim(self):
+        """
+        Altering the geography flag and the number of dimensions in a single
+        operation casts the column before forcing its dimension (#23902).
+        """
+        Neighborhood = self.current_state.apps.get_model("gis", "Neighborhood")
+        p1 = Polygon(((0, 0), (0, 1), (1, 1), (1, 0), (0, 0)))
+        Neighborhood.objects.create(name="TestGeography", geom=MultiPolygon(p1, p1))
+        self.assertFalse(Neighborhood.objects.first().geom.hasz)
+        # Add a 3rd dimension and convert to geography at the same time.
+        self.alter_gis_model(
+            migrations.AlterField,
+            "Neighborhood",
+            "geom",
+            fields.MultiPolygonField,
+            field_class_kwargs={"geography": True, "dim": 3},
+        )
+        self.assertTrue(Neighborhood.objects.first().geom.hasz)
+        msg = "function st_extent(geography) does not exist"
+        with self.assertRaisesMessage(ProgrammingError, msg):
+            Neighborhood.objects.aggregate(Extent("geom"))
+        # Rewind to a 2D geometry.
+        self.alter_gis_model(
+            migrations.AlterField,
+            "Neighborhood",
+            "geom",
+            fields.MultiPolygonField,
+            field_class_kwargs={"geography": False, "dim": 2},
+        )
+        self.assertFalse(Neighborhood.objects.first().geom.hasz)
+        self.assertEqual(
+            Neighborhood.objects.aggregate(Extent("geom")),
+            {"geom__extent": (0.0, 0.0, 1.0, 1.0)},
+        )
+
+    @skipUnlessDBFeature(
+        "can_alter_geometry_field", "supports_geography", "supports_3d_storage"
+    )
+    def test_alter_geom_field_opclass(self):
+        """
+        The spatial index is recreated when an alteration changes the operator
+        class it requires (#23902).
+        """
+        # Operator classes are a PostgreSQL concept with no corresponding
+        # database feature, so unlike the tests above this cannot be gated on
+        # one. Matches test_add_3d_field_opclass().
+        if not connection.ops.postgis:
+            self.skipTest("PostGIS-specific test.")
+
+        def assertOpclass(expected):
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    self.get_column_opclass_query, ["gis_neighborhood", "geom"]
+                )
+                self.assertEqual(cursor.fetchone(), (expected,))
+
+        def alter(**kwargs):
+            self.alter_gis_model(
+                migrations.AlterField,
+                "Neighborhood",
+                "geom",
+                fields.MultiPolygonField,
+                field_class_kwargs=kwargs,
+            )
+
+        assertOpclass("gist_geometry_ops_2d")
+        # Multidimensional geometries use the "nd" operator class.
+        alter(dim=3)
+        assertOpclass("gist_geometry_ops_nd")
+        # Which geography doesn't accept, so the index must be recreated.
+        alter(dim=3, geography=True)
+        assertOpclass("gist_geography_ops")
+        alter(dim=3)
+        assertOpclass("gist_geometry_ops_nd")
+        # Rewinding to two dimensions drops the "nd" operator class again.
+        alter(dim=2)
+        assertOpclass("gist_geometry_ops_2d")
 
     @skipUnlessDBFeature(
         "supports_column_check_constraints", "can_introspect_check_constraints"

--- a/tests/gis_tests/gis_migrations/test_operations.py
+++ b/tests/gis_tests/gis_migrations/test_operations.py
@@ -1,9 +1,9 @@
 from unittest import skipUnless
 
-from django.contrib.gis.db.models import fields
+from django.contrib.gis.db.models import Extent, fields
 from django.contrib.gis.geos import MultiPolygon, Polygon
 from django.core.exceptions import ImproperlyConfigured
-from django.db import connection, migrations, models
+from django.db import ProgrammingError, connection, migrations, models
 from django.db.migrations.migration import Migration
 from django.db.migrations.state import ProjectState
 from django.test import TransactionTestCase, skipIfDBFeature, skipUnlessDBFeature
@@ -434,6 +434,73 @@ class OperationTests(OperationTestCase):
             field_class_kwargs={"dim": 2},
         )
         self.assertFalse(Neighborhood.objects.first().geom.hasz)
+
+    @skipUnlessDBFeature("can_alter_geometry_field", "supports_geography")
+    def test_alter_geom_field_geography(self):
+        Neighborhood = self.current_state.apps.get_model("gis", "Neighborhood")
+        p1 = Polygon(((0, 0), (0, 1), (1, 1), (1, 0), (0, 0)))
+        Neighborhood.objects.create(name="TestGeography", geom=MultiPolygon(p1, p1))
+        self.assertEqual(
+            Neighborhood.objects.aggregate(Extent("geom")),
+            {"geom__extent": (0.0, 0.0, 1.0, 1.0)},
+        )
+        # Convert to geography. Extent() is not defined for geography columns.
+        self.alter_gis_model(
+            migrations.AlterField,
+            "Neighborhood",
+            "geom",
+            fields.MultiPolygonField,
+            field_class_kwargs={"geography": True},
+        )
+        msg = "function st_extent(geography) does not exist"
+        with self.assertRaisesMessage(ProgrammingError, msg):
+            Neighborhood.objects.aggregate(Extent("geom"))
+        # Rewind to geometry.
+        self.alter_gis_model(
+            migrations.AlterField,
+            "Neighborhood",
+            "geom",
+            fields.MultiPolygonField,
+            field_class_kwargs={"geography": False},
+        )
+        self.assertEqual(
+            Neighborhood.objects.aggregate(Extent("geom")),
+            {"geom__extent": (0.0, 0.0, 1.0, 1.0)},
+        )
+
+    @skipUnlessDBFeature(
+        "can_alter_geometry_field", "supports_geography", "supports_3d_storage"
+    )
+    def test_alter_geom_field_geography_and_dim(self):
+        Neighborhood = self.current_state.apps.get_model("gis", "Neighborhood")
+        p1 = Polygon(((0, 0), (0, 1), (1, 1), (1, 0), (0, 0)))
+        Neighborhood.objects.create(name="TestGeography", geom=MultiPolygon(p1, p1))
+        self.assertIs(Neighborhood.objects.first().geom.hasz, False)
+        # Add a 3rd dimension and convert to geography at the same time.
+        self.alter_gis_model(
+            migrations.AlterField,
+            "Neighborhood",
+            "geom",
+            fields.MultiPolygonField,
+            field_class_kwargs={"geography": True, "dim": 3},
+        )
+        self.assertIs(Neighborhood.objects.first().geom.hasz, True)
+        msg = "function st_extent(geography) does not exist"
+        with self.assertRaisesMessage(ProgrammingError, msg):
+            Neighborhood.objects.aggregate(Extent("geom"))
+        # Rewind to a 2D geometry.
+        self.alter_gis_model(
+            migrations.AlterField,
+            "Neighborhood",
+            "geom",
+            fields.MultiPolygonField,
+            field_class_kwargs={"geography": False, "dim": 2},
+        )
+        self.assertIs(Neighborhood.objects.first().geom.hasz, False)
+        self.assertEqual(
+            Neighborhood.objects.aggregate(Extent("geom")),
+            {"geom__extent": (0.0, 0.0, 1.0, 1.0)},
+        )
 
     @skipUnlessDBFeature(
         "supports_column_check_constraints", "can_introspect_check_constraints"


### PR DESCRIPTION
Fixed altering a PostGIS column between geography and geometry, altering the dimension of a geography column, and the spatial index left behind by both.

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A" if this is a trivial PR. -->

ticket-23902

#### Branch description

Three things fail when altering a PostGIS geography column.

**The column type.** PostgreSQL has no assignment cast from `geography` to `geometry`, so altering a field from `geography=True` to `geography=False` needs a `USING` clause on `ALTER COLUMN`:

```
django.db.utils.ProgrammingError: column "geom" cannot be cast automatically to type geometry
```

`PostGISSchemaEditor._alter_column_type_sql()` now handles only the dimension change and delegates everything else to the PostgreSQL backend, which already appends a cast when the data type changes:

```sql
ALTER TABLE "gis_neighborhood" ALTER COLUMN "geom" TYPE geometry(MULTIPOLYGON,4326) USING "geom"::geometry(MULTIPOLYGON,4326);
```

**The dimension.** `ST_Force2D()`/`ST_Force3D()` have no `geography` overload, so a dimension change on a geography column fails whether or not the geography flag changes with it:

```
django.db.utils.ProgrammingError: function st_force3d(geography) does not exist
```

The templates now cast the column before forcing it, which is a no-op when it is already a geometry, so a dimension change works from either source type and composes with the conversion:

```sql
ALTER TABLE "gis_neighborhood" ALTER COLUMN "geom" TYPE geometry(MULTIPOLYGONZ,4326) USING ST_Force3D("geom"::geometry)::geometry(MULTIPOLYGONZ,4326);

ALTER TABLE "gis_neighborhood" ALTER COLUMN "geom" TYPE geography(MULTIPOLYGONZ,4326) USING ST_Force3D("geom"::geometry)::geography(MULTIPOLYGONZ,4326);
```

**The spatial index.** The `gist_geometry_ops_nd` operator class applies only to multidimensional geometries, and geography rejects it outright:

```
django.db.utils.ProgrammingError: operator class "gist_geometry_ops_nd" does not accept data type geography
```

`_alter_field()` previously only touched the index when the `spatial_index` flag itself toggled, so an index was never reconsidered when `dim` or `geography` changed underneath it. It now compares the index each side of the alteration requires and recreates it when that changes. The drop has to precede the type change, because PostgreSQL rebuilds indexes as part of `ALTER COLUMN TYPE` and fails there. PostgreSQL swaps the default operator class by itself (`gist_geometry_ops_2d` ↔ `gist_geography_ops`); only `_nd` needs managing.

All twelve `(geography, dim)` → `(geography, dim)` transitions now succeed and leave the correct operator class behind. Six fail on `main` on the column type, two more fail on the index, and four others leave a stale operator class.

Three tests cover this: `test_alter_geom_field_geography` for the conversion on its own, `test_alter_geom_field_geography_and_dim` for both changing in a single operation, and `test_alter_geom_field_opclass` for the index. All three fail without the patch. The first two are gated on the `supports_geography` and `supports_3d_storage` features rather than on PostGIS directly, so another backend gaining geography support would pick them up; the third inspects `pg_opclass` and so is PostgreSQL-specific, matching the existing `test_add_3d_field_opclass()`.

Verified against PostgreSQL 17.4 / PostGIS 3.6.2 with a one-off settings file, `tests/test_postgis.py`:

```python
# PostGIS specific settings file for testing. Requires:
# - Two databases ("geo" and "other")
# - [ uv add / pip install ] "psycopg[pool]"

from test_sqlite import PASSWORD_HASHERS, SECRET_KEY, USE_TZ

DATABASES = {
    "default": {
        "ENGINE": "django.contrib.gis.db.backends.postgis",
        "NAME": "geo",
    },
    "other": {
        "ENGINE": "django.contrib.gis.db.backends.postgis",
        "NAME": "other",
    },
}
```

`gis_tests`, `schema` and `migrations` all pass.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [X] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Used Claude Opus 5 code generation and testing. All output was manually reviewed, tested, and verified for correctness.

#### Checklist
- [X] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [X] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
