### PR TITLE
Fixed #35875 -- Added dark mode support to technical 404 and 500 error views.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -432,6 +432,7 @@ answer newbie questions, and generally made Django that much better:
     Hannes Struß <x@hannesstruss.de>
     Hao Dong <https://github.com/RelaxedDong>
     Harm Geerts <hgeerts@gmail.com>
+    Harvey Bellini <harveybellini@gmail.com>
     Hasan Ramezani <hasan.r67@gmail.com>
     Hawkeye
     Helen Sherwood-Taylor <helen@rrdlabs.co.uk>

--- a/django/views/templates/csrf_403.html
+++ b/django/views/templates/csrf_403.html
@@ -9,15 +9,16 @@
     html * { padding:0; margin:0; }
     body * { padding:10px 20px; }
     body * * { padding:0; }
-    body { font-family: sans-serif; background:#eee; color:#000; }
-    body>div { border-bottom:1px solid #ddd; }
+    body { font-family: sans-serif; background: light-dark(#eee, #121212); color: light-dark(#000, #e0e0e0); }
+    body>div { border-bottom:1px solid light-dark(#ddd, #444); }
     h1 { font-weight:normal; margin-bottom:.4em; }
-    h1 span { font-size:60%; color:#666; font-weight:normal; }
-    #info { background:#f6f6f6; }
+    h1 span { font-size:60%; color: light-dark(#666, #aaa); font-weight:normal; }
+    #info { background: light-dark(#f6f6f6, #1e1e1e); }
     #info ul { margin: 0.5em 4em; }
     #info p, #summary p { padding-top:10px; }
-    #summary { background: #ffc; }
-    #explanation { background:#eee; border-bottom: 0px none; }
+    #summary { background: light-dark(#ffc, #2b2b2b); }
+    #explanation { background: light-dark(#eee, #1f1f1f); border-bottom: 0px none; }
+    code { color: light-dark(#000, #e0e0e0); }
   </style>
 </head>
 <body>

--- a/django/views/templates/technical_404.html
+++ b/django/views/templates/technical_404.html
@@ -3,25 +3,26 @@
 <head>
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
   <title>Page not found at {{ request.path_info }}</title>
-  <meta name="color-scheme" content="light" />
+  <meta name="color-scheme" content="light dark" />
   <meta name="robots" content="NONE,NOARCHIVE">
   <style>
     html * { padding:0; margin:0; }
     body * { padding:10px 20px; }
     body * * { padding:0; }
-    body { font-family: sans-serif; background:#eee; color:#000; }
-    body > header, body > main, body > footer { border-bottom:1px solid #ddd; }
+    body { font-family: sans-serif; background: light-dark(#eee, #121212); color: light-dark(#000, #e0e0e0); }
+    body > header, body > main, body > footer { border-bottom:1px solid light-dark(#ddd, #444); }
     h1 { font-weight:normal; margin-bottom:.4em; }
-    h1 small { font-size:60%; color:#666; font-weight:normal; }
+    h1 small { font-size:60%; color: light-dark(#666, #aaa); font-weight:normal; }
     table { border:none; border-collapse: collapse; width:100%; }
     td, th { vertical-align:top; padding:2px 3px; }
-    th { width:12em; text-align:right; color:#666; padding-right:.5em; }
-    #info { background:#f6f6f6; }
+    th { width:12em; text-align:right; color: light-dark(#666, #aaa); padding-right:.5em; }
+    #info { background: light-dark(#f6f6f6, #1e1e1e); }
     #info ol { margin: 0.5em 4em; }
     #info ol li { font-family: monospace; }
-    #summary { background: #ffc; }
-    #explanation { background:#eee; border-bottom: 0px none; }
-    pre.exception_value { font-family: sans-serif; color: #575757; font-size: 1.5em; margin: 10px 0 10px 0; }
+    #summary { background: light-dark(#ffc, #2b2b2b); }
+    #explanation { background: light-dark(#eee, #1f1f1f); border-bottom: 0px none; }
+    pre.exception_value { font-family: sans-serif; color: light-dark(#575757, #e0e0e0); font-size: 1.5em; margin: 10px 0 10px 0; }
+    code { color: light-dark(#000, #e0e0e0); }
   </style>
 </head>
 <body>

--- a/django/views/templates/technical_500.html
+++ b/django/views/templates/technical_500.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  <meta name="color-scheme" content="light" />
+  <meta name="color-scheme" content="light dark" />
   <meta name="robots" content="NONE,NOARCHIVE">
   <title>{% if exception_type %}{{ exception_type }}{% else %}Report{% endif %}
          {% if request %} at {{ request.path_info }}{% endif %}</title>
@@ -10,63 +10,67 @@
     html * { padding:0; margin:0; }
     body * { padding:10px 20px; }
     body * * { padding:0; }
-    body { font-family: sans-serif; background-color:#fff; color:#000; }
-    body > header, body > main, body > footer { border-bottom:1px solid #ddd; }
+    body { font-family: sans-serif; background-color: light-dark(#fff, #121212); color: light-dark(#000, #e0e0e0); }
+    body > header, body > main, body > footer { border-bottom:1px solid light-dark(#ddd, #444); }
     h1 { font-weight:normal; }
     h2 { margin-bottom:.8em; }
     h3 { margin:1em 0 .5em 0; }
     h4 { margin:0 0 .5em 0; font-weight: normal; }
     code, pre { font-size: 100%; white-space: pre-wrap; word-break: break-word; }
     summary { cursor: pointer; }
-    table { border:1px solid #ccc; border-collapse: collapse; width:100%; background:white; }
+    table { border:1px solid light-dark(#ccc, #444); border-collapse: collapse; width:100%; background: light-dark(white, #1e1e1e); }
     tbody td, tbody th { vertical-align:top; padding:2px 3px; }
     thead th {
-      padding:1px 6px 1px 3px; background:#fefefe; text-align:left;
-      font-weight:normal; font-size: 0.6875rem; border:1px solid #ddd;
+      padding:1px 6px 1px 3px; background: light-dark(#fefefe, #2a2a2a); text-align:left;
+      font-weight:normal; font-size: 0.6875rem; border:1px solid light-dark(#ddd, #444);
     }
-    tbody th { width:12em; text-align:right; color:#666; padding-right:.5em; }
+    tbody th { width:12em; text-align:right; color: light-dark(#666, #aaa); padding-right:.5em; }
     table.vars { margin:5px 10px 2px 40px; width: auto; }
     table.vars td, table.req td { font-family:monospace; }
     table td.code { width:100%; }
     table td.code pre { overflow:hidden; }
-    table.source th { color:#666; }
-    table.source td { font-family:monospace; white-space:pre; border-bottom:1px solid #eee; }
-    ul.traceback { list-style-type:none; color: #222; }
+    table.source th { color: light-dark(#666, #aaa); }
+    table.source td { font-family:monospace; white-space:pre; border-bottom:1px solid light-dark(#eee, #444); }
+    ul.traceback { list-style-type:none; color: light-dark(#222, #e0e0e0); }
     ul.traceback li.cause { word-break: break-word; }
-    ul.traceback li.frame { padding-bottom:1em; color:#4f4f4f; }
-    ul.traceback li.user { background-color:#e0e0e0; color:#000 }
+    ul.traceback li.frame { padding-bottom:1em; color: light-dark(#4f4f4f, #bbb); }
+    ul.traceback li.user { background-color: light-dark(#e0e0e0, #2a2a2a); color: light-dark(#000, #e0e0e0); }
     div.context { padding:10px 0; overflow:hidden; }
     div.context ol { padding-left:30px; margin:0 10px; list-style-position: inside; }
-    div.context ol li { font-family:monospace; white-space:pre; color:#777; cursor:pointer; padding-left: 2px; }
+    div.context ol li { font-family:monospace; white-space:pre; color: light-dark(#777, #e0e0e0); cursor:pointer; padding-left: 2px; }
     div.context ol li pre { display:inline; }
-    div.context ol.context-line li { color:#464646; background-color:#dfdfdf; padding: 3px 2px; }
+    div.context ol.context-line li { color: light-dark(#464646, #fff); background-color: light-dark(#dfdfdf, #333333); padding: 3px 2px; }
     div.context ol.context-line li span { position:absolute; right:32px; }
-    .user div.context ol.context-line li { background-color:#bbb; color:#000; }
-    .user div.context ol li { color:#666; }
+    .user div.context ol.context-line li { background-color: light-dark(#bbb, #444); color: light-dark(#000, #fff); }
+    .user div.context ol li { color: light-dark(#666, #bbb); }
     div.commands, summary.commands { margin-left: 40px; }
-    div.commands a, summary.commands { color:#555; text-decoration:none; }
-    .user div.commands a { color: black; }
-    #summary { background: #ffc; }
-    #summary h2 { font-weight: normal; color: #666; }
+    div.commands a, summary.commands { color: light-dark(#555, #aaa); text-decoration:none; }
+    .user div.commands a { color: light-dark(black, #e0e0e0); }
+    #summary { background: light-dark(#ffc, #2b2b2b); }
+    #summary h2 { font-weight: normal; color: light-dark(#666, #aaa); }
     #info { padding: 0; }
     #info > * { padding:10px 20px; }
-    #explanation { background:#eee; }
-    #template, #template-not-exist { background:#f6f6f6; }
+    #explanation { background: light-dark(#eee, #1f1f1f); }
+    #template, #template-not-exist { background: light-dark(#f6f6f6, #1e1e1e); }
     #template-not-exist ul { margin: 0 0 10px 20px; }
     #template-not-exist .postmortem-section { margin-bottom: 3px; }
-    #unicode-hint { background:#eee; }
-    #traceback { background:#eee; }
-    #requestinfo { background:#f6f6f6; padding-left:120px; }
+    #unicode-hint { background: light-dark(#eee, #1e1e1e); }
+    #traceback { background: light-dark(#eee, #121212); }
+    #requestinfo { background: light-dark(#f6f6f6, #1e1e1e); padding-left:120px; }
     #summary table { border:none; background:transparent; }
     #requestinfo h2, #requestinfo h3 { position:relative; margin-left:-100px; }
     #requestinfo h3 { margin-bottom:-1em; }
-    .error { background: #ffc; }
-    .specific { color:#cc3300; font-weight:bold; }
+    .error { background: light-dark(#ffc, #3d3d00); }
+    .specific { color: light-dark(#cc3300, #ff6b6b); font-weight:bold; }
     h2 span.commands { font-size: 0.7rem; font-weight:normal; }
-    span.commands a:link {color:#5E5694;}
-    pre.exception_value { font-family: sans-serif; color: #575757; font-size: 1.5rem; margin: 10px 0 10px 0; }
+    span.commands a:link { color: light-dark(#5E5694, #a29bfe); }
+    pre.exception_value { font-family: sans-serif; color: light-dark(#575757, #e0e0e0); font-size: 1.5rem; margin: 10px 0 10px 0; }
     .append-bottom { margin-bottom: 10px; }
     .fname { user-select: all; }
+    code { color: light-dark(#000, #e0e0e0); }
+    #pastebinTraceback { background: light-dark(#fff, #1e1e1e); }
+    textarea { background: light-dark(#fff, #1e1e1e); color: light-dark(#000, #e0e0e0); border: 1px solid light-dark(#ccc, #444); }
+    input[type="submit"] { background: light-dark(#efefef, #333); color: light-dark(#000, #e0e0e0); border: 1px solid light-dark(#ccc, #555); }
   </style>
   {% if not is_email %}
   <script>


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A" if this is a trivial PR. -->

[ticket-35875](https://code.djangoproject.com/ticket/35875)

#### Branch description
Implemented prefers-color-scheme: dark CSS overrides for the technical 500 (traceback) and 404 debug views.

This completes the work for ticket #35875. The previous PR (#18801) enabled dark mode for other default views but explicitly excluded the technical error pages (hardcoding them to light) to avoid contrast issues with the syntax highlighting. This PR adds the necessary CSS to `technical_500.html` and `technical_404.html` to make the traceback and debug information readable in dark mode.

#### AI Assistance Disclosure (REQUIRED)
- [X] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Deepseek V4 PRO in Copilot chat for output, used my eyes and brain to read it and checked it.

#### Checklist
- [X] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [X] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [X] I have attached screenshots in both light and dark modes for any UI changes.

#### Screenshots
500:
<img width="989" height="713" alt="image" src="https://github.com/user-attachments/assets/1de25b06-4c24-4605-a931-ab98208c5e22" />

404:
<img width="542" height="194" alt="image" src="https://github.com/user-attachments/assets/87874095-3bfd-4196-9e34-cbee8c07d719" />

CSRF 403:
<img width="449" height="300" alt="image" src="https://github.com/user-attachments/assets/418fd634-78d4-4ac3-90df-bc04e4a86759" />


