### PR TITLE
Fixed #31834 -- Fixed sqlmigrate failure when altering unique_together.

### DIFF
--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -1108,6 +1108,17 @@ class MigrateTests(MigrationTestBase):
         self.assertIn("-- create model tribble", output)
 
     @override_settings(
+        MIGRATION_MODULES={
+            "migrations": "migrations.test_migrations_alter_unique_together"
+        }
+    )
+    def test_sqlmigrate_alter_unique_together_change(self):
+        out = io.StringIO()
+        call_command("sqlmigrate", "migrations", "0002", stdout=out)
+        output = out.getvalue()
+        self.assertIn("-- Alter unique_together for company (1 constraint(s))", output)
+
+    @override_settings(
         MIGRATION_MODULES={"migrations": "migrations.test_migrations_no_operations"}
     )
     def test_sqlmigrate_no_operations(self):

--- a/tests/migrations/test_migrations_alter_unique_together/0001_initial.py
+++ b/tests/migrations/test_migrations_alter_unique_together/0001_initial.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    initial = True
+    operations = [
+        migrations.CreateModel(
+            name="Company",
+            fields=[
+                ("id", models.AutoField(primary_key=True)),
+                ("name", models.CharField(max_length=255)),
+                ("slug", models.SlugField()),
+                ("age", models.IntegerField()),
+            ],
+            options={
+                "unique_together": {("name", "slug")},
+            },
+        ),
+    ]

--- a/tests/migrations/test_migrations_alter_unique_together/0002_alter_unique_together.py
+++ b/tests/migrations/test_migrations_alter_unique_together/0002_alter_unique_together.py
@@ -1,0 +1,11 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [("migrations", "0001_initial")]
+    operations = [
+        migrations.AlterUniqueTogether(
+            name="company",
+            unique_together={("name", "slug", "age")},
+        ),
+    ]


### PR DESCRIPTION
#### Trac ticket number

ticket-31834

#### Branch description
When an  AlterUniqueTogether operation is used to change existing constraints in sqlmigrate. During SQL collection, if a constraint cannot be found in the database, a ```placeholder``` name is now generated to allow the DDL generation to proceed. 
Added  tests in tests/migrations/test_commands.py.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

(Used AI for generating test cases)

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
