### PR TITLE
Fixed #36795 -- Enforced quoting of all database object names.

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -420,10 +420,6 @@ class BaseDatabaseFeatures:
     # Does the Round() database function round to even?
     rounds_to_even = False
 
-    # Should dollar signs be prohibited in column aliases to prevent SQL
-    # injection?
-    prohibits_dollar_signs_in_column_aliases = False
-
     # Should PatternLookup.process_rhs() use self.param_pattern? It's unneeded
     # on databases that don't use LIKE for pattern matching.
     pattern_lookup_needs_param_pattern = True

--- a/django/db/backends/mysql/compiler.py
+++ b/django/db/backends/mysql/compiler.py
@@ -28,10 +28,7 @@ class SQLDeleteCompiler(BaseSQLDeleteCompiler):
             # window functions as it doesn't allow for GROUP BY/HAVING clauses
             # and the subquery wrapping (necessary to emulate QUALIFY).
             return super().as_sql()
-        result = [
-            "DELETE %s FROM"
-            % self.quote_name_unless_alias(self.query.get_initial_alias())
-        ]
+        result = ["DELETE %s FROM" % self.quote_name(self.query.get_initial_alias())]
         from_sql, params = self.get_from_clause()
         result.extend(from_sql)
         try:

--- a/django/db/backends/postgresql/features.py
+++ b/django/db/backends/postgresql/features.py
@@ -70,7 +70,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_nulls_distinct_unique_constraints = True
     supports_no_precision_decimalfield = True
     can_rename_index = True
-    prohibits_dollar_signs_in_column_aliases = True
     test_collations = {
         "deterministic": "C",
         "non_default": "sv-x-icu",

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -1366,7 +1366,7 @@ class Col(Expression):
     def as_sql(self, compiler, connection):
         alias, column = self.alias, self.target.column
         identifiers = (alias, column) if alias else (column,)
-        sql = ".".join(map(compiler.quote_name_unless_alias, identifiers))
+        sql = ".".join(map(compiler.quote_name, identifiers))
         return sql, ()
 
     def relabeled_clone(self, relabels):

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -439,9 +439,7 @@ class SQLCompiler:
                 table, col = col.split(".", 1)
                 yield (
                     OrderBy(
-                        RawSQL(
-                            "%s.%s" % (self.quote_name_unless_alias(table), col), []
-                        ),
+                        RawSQL("%s.%s" % (self.quote_name(table), col), []),
                         descending=descending,
                     ),
                     False,
@@ -547,35 +545,19 @@ class SQLCompiler:
                     extra_select.append((expr, (without_ordering, params), None))
         return extra_select
 
-    def quote_name_unless_alias(self, name):
+    def quote_name(self, name):
         """
-        A wrapper around connection.ops.quote_name that doesn't quote aliases
-        for table names. This avoids problems with some SQL dialects that treat
-        quoted strings specially (e.g. PostgreSQL).
+        A wrapper around connection.ops.quote_name that memoizes quoted
+        name values.
         """
-        if (
-            self.connection.features.prohibits_dollar_signs_in_column_aliases
-            and "$" in name
-        ):
-            raise ValueError(
-                "Dollar signs are not permitted in column aliases on "
-                f"{self.connection.display_name}."
-            )
-        if name in self.quote_cache:
-            return self.quote_cache[name]
-        if (
-            (name in self.query.alias_map and name not in self.query.table_map)
-            or name in self.query.extra_select
-            or (
-                self.query.external_aliases.get(name)
-                and name not in self.query.table_map
-            )
-        ):
-            self.quote_cache[name] = name
-            return name
-        r = self.connection.ops.quote_name(name)
-        self.quote_cache[name] = r
-        return r
+        if (quoted := self.quote_cache.get(name)) is not None:
+            return quoted
+        quoted = self.connection.ops.quote_name(name)
+        self.quote_cache[name] = quoted
+        return quoted
+
+    # Kept for backward compatiblity until duly done deprecation.
+    quote_name_unless_alias = quote_name
 
     def compile(self, node):
         vendor_impl = getattr(node, "as_" + self.connection.vendor, None)
@@ -1175,7 +1157,7 @@ class SQLCompiler:
                 alias not in self.query.alias_map
                 or self.query.alias_refcount[alias] == 1
             ):
-                result.append(", %s" % self.quote_name_unless_alias(alias))
+                result.append(", %s" % self.quote_name(alias))
         return result, params
 
     def get_related_selections(
@@ -1504,7 +1486,7 @@ class SQLCompiler:
                 if self.connection.features.select_for_update_of_column:
                     result.append(self.compile(col)[0])
                 else:
-                    result.append(self.quote_name_unless_alias(col.alias))
+                    result.append(self.quote_name(col.alias))
         if invalid_names:
             raise FieldError(
                 "Invalid field name(s) given in select_for_update(of=(...)): %s. "
@@ -1805,9 +1787,7 @@ class SQLInsertCompiler(SQLCompiler):
         return placeholder_rows, param_rows
 
     def as_sql(self):
-        # We don't need quote_name_unless_alias() here, since these are all
-        # going to be column names (so we can avoid the extra overhead).
-        qn = self.connection.ops.quote_name
+        qn = self.quote_name
         opts = self.query.get_meta()
         insert_statement = self.connection.ops.insert_statement(
             on_conflict=self.query.on_conflict,
@@ -2006,7 +1986,7 @@ class SQLDeleteCompiler(SQLCompiler):
         )
 
     def _as_sql(self, query):
-        delete = "DELETE FROM %s" % self.quote_name_unless_alias(query.base_table)
+        delete = "DELETE FROM %s" % self.quote_name(query.base_table)
         try:
             where, params = self.compile(query.where)
         except FullResultSet:
@@ -2050,7 +2030,7 @@ class SQLUpdateCompiler(SQLCompiler):
         self.pre_sql_setup()
         if not self.query.values:
             return "", ()
-        qn = self.quote_name_unless_alias
+        qn = self.quote_name
         values, update_params = [], []
         for field, model, val in self.query.values:
             if hasattr(val, "resolve_expression"):

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -1,6 +1,7 @@
 import collections
 import json
 import re
+import warnings
 from functools import partial
 from itertools import chain
 
@@ -23,6 +24,7 @@ from django.db.models.sql.constants import (
 )
 from django.db.models.sql.query import Query, get_order_dir
 from django.db.transaction import TransactionManagementError
+from django.utils.deprecation import RemovedInDjango70Warning, django_file_prefixes
 from django.utils.functional import cached_property
 from django.utils.hashable import make_hashable
 from django.utils.regex_helper import _lazy_re_compile
@@ -556,8 +558,17 @@ class SQLCompiler:
         self.quote_cache[name] = quoted
         return quoted
 
-    # Kept for backward compatiblity until duly done deprecation.
-    quote_name_unless_alias = quote_name
+    # RemovedInDjango70Warning: When the deprecation ends, remove.
+    def quote_name_unless_alias(self, name):
+        warnings.warn(
+            (
+                "SQLCompiler.quote_name_unless_alias() is deprecated. "
+                "Use .quote_name() instead."
+            ),
+            category=RemovedInDjango70Warning,
+            skip_file_prefixes=django_file_prefixes(),
+        )
+        return self.quote_name(name)
 
     def compile(self, node):
         vendor_impl = getattr(node, "as_" + self.connection.vendor, None)

--- a/django/db/models/sql/datastructures.py
+++ b/django/db/models/sql/datastructures.py
@@ -82,7 +82,7 @@ class Join:
         """
         join_conditions = []
         params = []
-        qn = compiler.quote_name_unless_alias
+        qn = compiler.quote_name
         # Add a join condition for each pair of joining columns.
         for lhs, rhs in self.join_fields:
             lhs, rhs = connection.ops.prepare_join_on_clause(
@@ -120,7 +120,9 @@ class Join:
             )
         on_clause_sql = " AND ".join(join_conditions)
         alias_str = (
-            "" if self.table_alias == self.table_name else (" %s" % self.table_alias)
+            ""
+            if self.table_alias == self.table_name
+            else (" %s" % qn(self.table_alias))
         )
         sql = "%s %s%s ON (%s)" % (
             self.join_type,
@@ -193,10 +195,13 @@ class BaseTable:
         self.table_alias = alias
 
     def as_sql(self, compiler, connection):
+        qn = compiler.quote_name
         alias_str = (
-            "" if self.table_alias == self.table_name else (" %s" % self.table_alias)
+            ""
+            if self.table_alias == self.table_name
+            else (" %s" % qn(self.table_alias))
         )
-        base_sql = compiler.quote_name_unless_alias(self.table_name)
+        base_sql = qn(self.table_name)
         return base_sql + alias_str, []
 
     def relabeled_clone(self, change_map):

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -67,6 +67,8 @@ details on these changes.
 * The ``Field.get_placeholder_sql`` shim over the deprecated
   ``get_placeholder`` method will be removed.
 
+* The ``SQLCompiler.quote_name_unless_alias()`` method will be removed.
+
 .. _deprecation-removed-in-6.1:
 
 6.1

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -519,6 +519,11 @@ Miscellaneous
   to be provided expressions meant to be compiled via the provided ``compiler``
   argument.
 
+* The ``quote_name_unless_alias()`` method of ``SQLCompiler``, the type of
+  object passed as the ``compiler`` argument to the ``as_sql()`` method of
+  :ref:`expressions <writing-your-own-query-expressions>`, is deprecated in
+  favor of the newly introduced ``quote_name()`` method.
+
 Features removed in 6.1
 =======================
 

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -400,6 +400,9 @@ backends.
 * Set the new ``DatabaseFeatures.supports_inspectdb`` attribute to ``False``
   if the management command isn't supported.
 
+* The ``DatabaseFeatures.prohibits_dollar_signs_in_column_aliases`` feature
+  flag is removed.
+
 * The ``DatabaseOperations.binary_placeholder_sql()`` method now expects a
   query compiler as an extra positional argument and should return a
   two-elements tuple composed of an SQL format string and a tuple of associated

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -434,6 +434,16 @@ backends.
   instead of the JSON ``null`` primitive. This matches the behavior of a
   standalone :class:`~django.db.models.JSONField` when storing ``None`` values.
 
+Models
+------
+
+* SQL ``SELECT`` aliases originating from :meth:`.QuerySet.annotate`
+  calls as well as table and ``JOIN`` aliases are now systematically quoted to
+  prevent special character collisions. Because quoted aliases are
+  case-sensitive, *raw* SQL references to aliases mixing case, such as when
+  using :class:`.RawSQL`, might have to be adjusted to also make use of
+  quoting.
+
 System checks
 -------------
 

--- a/tests/annotations/tests.py
+++ b/tests/annotations/tests.py
@@ -1574,20 +1574,6 @@ class AliasTests(TestCase):
                 with self.assertRaisesMessage(ValueError, msg):
                     Book.objects.alias(**{crafted_alias: FilteredRelation("authors")})
 
-    def test_alias_filtered_relation_sql_injection_dollar_sign(self):
-        qs = Book.objects.alias(
-            **{"crafted_alia$": FilteredRelation("authors")}
-        ).values("name", "crafted_alia$")
-        if connection.features.prohibits_dollar_signs_in_column_aliases:
-            msg = (
-                "Dollar signs are not permitted in column aliases on "
-                f"{connection.display_name}."
-            )
-            with self.assertRaisesMessage(ValueError, msg):
-                list(qs)
-        else:
-            self.assertEqual(qs.first()["name"], self.b1.name)
-
     def test_values_wrong_alias(self):
         expected_message = (
             "Cannot resolve keyword 'alias_typo' into field. Choices are: %s"

--- a/tests/filtered_relation/tests.py
+++ b/tests/filtered_relation/tests.py
@@ -210,8 +210,9 @@ class FilteredRelationTests(TestCase):
             ),
         ).filter(book_alice__isnull=False)
         self.assertIn(
-            "INNER JOIN {} book_alice ON".format(
-                connection.ops.quote_name("filtered_relation_book")
+            "INNER JOIN {} {} ON".format(
+                connection.ops.quote_name("filtered_relation_book"),
+                connection.ops.quote_name("book_alice"),
             ),
             str(queryset.query),
         )

--- a/tests/foreign_object/models/article.py
+++ b/tests/foreign_object/models/article.py
@@ -22,7 +22,7 @@ class ColConstraint:
         self.alias, self.col, self.value = alias, col, value
 
     def as_sql(self, compiler, connection):
-        qn = compiler.quote_name_unless_alias
+        qn = compiler.quote_name
         return "%s.%s = %%s" % (qn(self.alias), qn(self.col)), [self.value]
 
 

--- a/tests/queries/test_sqlcompiler.py
+++ b/tests/queries/test_sqlcompiler.py
@@ -4,6 +4,7 @@ from django.db import DEFAULT_DB_ALIAS, DatabaseError, connection
 from django.db.models.sql import Query
 from django.db.models.sql.compiler import SQLCompiler
 from django.test import TestCase
+from django.utils.deprecation import RemovedInDjango70Warning
 
 from .models import Item
 
@@ -39,3 +40,19 @@ class SQLCompilerTest(TestCase):
         self.assertIs(exc, execute_err)
         self.assertIsNone(exc.__cause__)
         self.assertTrue(exc.__suppress_context__)
+
+    # RemovedInDjango70Warning: When the deprecation ends, remove this
+    # test.
+    def test_quote_name_unless_alias_deprecation(self):
+        query = Query(Item)
+        compiler = SQLCompiler(query, connection, None)
+        msg = (
+            "SQLCompiler.quote_name_unless_alias() is deprecated. "
+            "Use .quote_name() instead."
+        )
+        with self.assertWarnsMessage(RemovedInDjango70Warning, msg) as ctx:
+            self.assertEqual(
+                compiler.quote_name_unless_alias("name"),
+                compiler.quote_name("name"),
+            )
+        self.assertEqual(ctx.filename, __file__)

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -195,7 +195,8 @@ class Queries1Tests(TestCase):
         # It is possible to reuse U for the second subquery, no need to use W.
         self.assertNotIn("w0", str(qs4.query).lower())
         # So, 'U0."id"' is referenced in SELECT and WHERE twice.
-        self.assertEqual(str(qs4.query).lower().count("u0."), 4)
+        id_col = "%s." % connection.ops.quote_name("u0").lower()
+        self.assertEqual(str(qs4.query).lower().count(id_col), 4)
 
     def test_ticket1050(self):
         self.assertSequenceEqual(


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36795

#### Branch description

Currenly trying to learn more about why we started not quoting users probided aliases as 9c52d56f6f8a9cdafb231adf9f4110473099c9b5 which introduced the change has very little details about its origin.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
