### PR TITLE
Fixed #36888 -- Made QuerySet.acreate() call asave().

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -672,10 +672,6 @@ class QuerySet(AltersData):
         return await sync_to_async(self.get)(*args, **kwargs)
 
     def _prepare_for_create(self, **kwargs):
-        """
-        Create a new object with the given kwargs, saving it to the database
-        and returning the created object.
-        """
         reverse_one_to_one_fields = frozenset(kwargs).intersection(
             self.model._meta._reverse_one_to_one_field_names
         )
@@ -690,6 +686,10 @@ class QuerySet(AltersData):
         return obj
 
     def create(self, **kwargs):
+        """
+        Create a new object with the given kwargs, saving it to the database
+        and returning the created object.
+        """
         obj = self._prepare_for_create(**kwargs)
         obj.save(force_insert=True, using=self.db)
         obj._state.fetch_mode = self._fetch_mode

--- a/tests/async/models.py
+++ b/tests/async/models.py
@@ -13,3 +13,11 @@ class SimpleModel(models.Model):
 
 class ManyToManyModel(models.Model):
     simples = models.ManyToManyField("SimpleModel")
+
+
+class IncrementASaveModel(models.Model):
+    field = models.IntegerField()
+
+    async def asave(self, *args, **kwargs):
+        self.field += 1
+        await super().asave(*args, **kwargs)

--- a/tests/async/test_async_queryset.py
+++ b/tests/async/test_async_queryset.py
@@ -9,7 +9,7 @@ from django.db import NotSupportedError, connection
 from django.db.models import Prefetch, Sum
 from django.test import TestCase, skipIfDBFeature, skipUnlessDBFeature
 
-from .models import RelatedModel, SimpleModel, IncrementASaveModel
+from .models import IncrementASaveModel, RelatedModel, SimpleModel
 
 
 class AsyncQuerySetTest(TestCase):


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36888

#### Branch description
When you use async Django methods and you want to add custom logic in asave method, when you create your object with acreate, it doesn't call your asave method.

## Example
```
class SimpleModel(models.Model):
    field = models.IntegerField()

    async def asave(self, *args, **kwargs):
        self.field += 1
        await super().asave(*args, **kwargs)

obj = await SimpleModel.objects.acreate(field=4)
obj.field # returns 4, should be 5
```


#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
