### PR TITLE
Clarified that FORM_RENDERER applies to the admin.

### DIFF
--- a/docs/ref/forms/renderers.txt
+++ b/docs/ref/forms/renderers.txt
@@ -28,7 +28,9 @@ setting. It defaults to
 
 By specifying a custom form renderer and overriding
 :attr:`~.BaseRenderer.form_template_name` you can adjust the default form
-markup across your project from a single place.
+markup across your project from a single place. Note that this will include
+forms in :doc:`the admin site </ref/contrib/admin/index>` and third-party
+packages that use the default renderer.
 
 You can also provide a custom renderer per-form or per-widget by setting the
 :attr:`.Form.default_renderer` attribute or by using the ``renderer`` argument

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -1785,13 +1785,17 @@ generate correct URLs when ``FORCE_SCRIPT_NAME`` is provided.
 
 Default: ``'``:class:`django.forms.renderers.DjangoTemplates`\ ``'``
 
-The class that renders forms and form widgets. It must implement
+The default class that renders forms and form widgets. It must implement
 :ref:`the low-level render API <low-level-widget-render-api>`. Included form
 renderers are:
 
 * ``'``:class:`django.forms.renderers.DjangoTemplates`\ ``'``
 * ``'``:class:`django.forms.renderers.Jinja2`\ ``'``
 * ``'``:class:`django.forms.renderers.TemplatesSetting`\ ``'``
+
+Note that changing this setting affects all forms using the default renderer,
+including those in :doc:`the admin site </ref/contrib/admin/index>` or
+third-party packages.
 
 .. setting:: FORMAT_MODULE_PATH
 


### PR DESCRIPTION
#### Trac ticket number

N/A

#### Branch description

I changed `FORM_RENDERER` on a project, and my site forms looked good, but I accidentally broke widgets in the admin where custom CSS and JS was not loaded. I needed to use `Form.default_renderer` instead. I propose adding a note to the renderer and setting reference sections that points out this setting affects the admin.n

#### AI Assistance Disclosure (REQUIRED)
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
