### PR TITLE
Fixed #36848 -- Updated defaults.bad_request view documentation

### DIFF
--- a/docs/ref/views.txt
+++ b/docs/ref/views.txt
@@ -148,16 +148,22 @@ The 400 (bad request) view
 
 .. function:: defaults.bad_request(request, exception, template_name='400.html')
 
+Similarly, Django has a view to handle 400 Bad Request errors.
+
+This view either produces a "Bad Request" message or loads and renders the
+template ``400.html`` if you created it in your root template directory.
+It returns with status code 400 indicating that the error condition was the
+result of a client operation.
+By default, nothing related to the exception that triggered the view is passed
+to the template context, as the exception message might contain sensitive
+information like filesystem paths.
+
+``django.views.defaults.bad_request`` is triggered by a
+:exc:`~django.core.exceptions.BadRequest` exception.
+
 When a :exc:`~django.core.exceptions.SuspiciousOperation` is raised in Django,
 it may be handled by a component of Django (for example resetting the session
 data). If not specifically handled, Django will consider the current request a
 'bad request' instead of a server error.
-
-``django.views.defaults.bad_request``, is otherwise very similar to the
-``server_error`` view, but returns with the status code 400 indicating that
-the error condition was the result of a client operation. By default, nothing
-related to the exception that triggered the view is passed to the template
-context, as the exception message might contain sensitive information like
-filesystem paths.
 
 ``bad_request`` views are also only used when :setting:`DEBUG` is ``False``.

--- a/docs/ref/views.txt
+++ b/docs/ref/views.txt
@@ -153,17 +153,15 @@ Similarly, Django has a view to handle 400 Bad Request errors.
 This view either produces a "Bad Request" message or loads and renders the
 template ``400.html`` if you created it in your root template directory.
 It returns with status code 400 indicating that the error condition was the
-result of a client operation.
-By default, nothing related to the exception that triggered the view is passed
-to the template context, as the exception message might contain sensitive
-information like filesystem paths.
+result of a client operation. By default, nothing related to the exception that
+triggered the view is passed to the template context, as the exception message
+might contain sensitive information like filesystem paths.
 
 ``django.views.defaults.bad_request`` is triggered by a
-:exc:`~django.core.exceptions.BadRequest` exception.
-
-When a :exc:`~django.core.exceptions.SuspiciousOperation` is raised in Django,
+:exc:`~django.core.exceptions.BadRequest` exception. Also, when a
+:exc:`~django.core.exceptions.SuspiciousOperation` is raised in Django,
 it may be handled by a component of Django (for example resetting the session
 data). If not specifically handled, Django will consider the current request a
-'bad request' instead of a server error.
+'bad request' instead of a server error, and handle it with ``bad_request``.
 
 ``bad_request`` views are also only used when :setting:`DEBUG` is ``False``.


### PR DESCRIPTION


#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36848

#### Branch description

* Added explicit mention that `BadRequest` exception triggers this `bad_request` view.
* Moved paragraph explaining view behavior to the top, to be more consistent with previous sections about 400/500/403 views.
* Expanded this paragraph to actually details the view's behavior, instead of only saying it's similar to the 500 view.
* In particular mention it renders 400.html.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
