### PR TITLE
Fixed #27157 -- Required model_admin in admin form helpers.

### DIFF
--- a/django/contrib/admin/helpers.py
+++ b/django/contrib/admin/helpers.py
@@ -44,7 +44,8 @@ class AdminForm:
         fieldsets,
         prepopulated_fields,
         readonly_fields=None,
-        model_admin=None,
+        *,
+        model_admin,
     ):
         self.form, self.fieldsets = form, fieldsets
         self.prepopulated_fields = [
@@ -201,7 +202,7 @@ class AdminField:
 
 
 class AdminReadonlyField:
-    def __init__(self, form, field, is_first, model_admin=None):
+    def __init__(self, form, field, is_first, model_admin):
         # Make self.field look a little bit like a field. This means that
         # {{ field.name }} must be a useful class name to identify the field.
         # For convenience, store other field-related data here too.
@@ -478,7 +479,8 @@ class InlineAdminForm(AdminForm):
         prepopulated_fields,
         original,
         readonly_fields=None,
-        model_admin=None,
+        *,
+        model_admin,
         view_on_site_url=None,
     ):
         self.formset = formset
@@ -487,7 +489,11 @@ class InlineAdminForm(AdminForm):
         self.show_url = original and view_on_site_url is not None
         self.absolute_url = view_on_site_url
         super().__init__(
-            form, fieldsets, prepopulated_fields, readonly_fields, model_admin
+            form,
+            fieldsets,
+            prepopulated_fields,
+            readonly_fields,
+            model_admin=model_admin,
         )
 
     def __iter__(self):

--- a/django/contrib/auth/admin.py
+++ b/django/contrib/auth/admin.py
@@ -200,7 +200,7 @@ class UserAdmin(admin.ModelAdmin):
             form = self.change_password_form(user)
 
         fieldsets = [(None, {"fields": list(form.base_fields)})]
-        admin_form = admin.helpers.AdminForm(form, fieldsets, {})
+        admin_form = admin.helpers.AdminForm(form, fieldsets, {}, model_admin=self)
 
         if user.has_usable_password():
             title = _("Change password: %s")

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -276,6 +276,12 @@ backends.
   consistently returning an HTTP 403 response for staff users without the view
   or change permission regardless of whether the object exists.
 
+* The undocumented ``django.contrib.admin.helpers.AdminForm``,
+  ``InlineAdminForm``, and ``AdminReadonlyField`` classes now require the
+  ``model_admin`` argument, which must be passed as a keyword argument to
+  ``AdminForm`` and ``InlineAdminForm``. Previously it defaulted to ``None``,
+  which raised ``AttributeError`` as soon as a read-only field was rendered.
+
 Miscellaneous
 -------------
 

--- a/tests/admin_inlines/tests.py
+++ b/tests/admin_inlines/tests.py
@@ -955,7 +955,9 @@ class TestInlineAdminForm(TestCase):
         john = Parent.objects.create(name="John")
         joe = Child.objects.create(name="Joe", teacher=sally, parent=john)
 
-        iaf = InlineAdminForm(None, None, {}, {}, joe)
+        iaf = InlineAdminForm(
+            None, None, {}, {}, joe, model_admin=ModelAdmin(Child, admin_site)
+        )
         parent_ct = ContentType.objects.get_for_model(Parent)
         self.assertEqual(iaf.original.content_type, parent_ct)
 

--- a/tests/admin_views/test_forms.py
+++ b/tests/admin_views/test_forms.py
@@ -1,9 +1,11 @@
 from django.contrib.admin.forms import AdminAuthenticationForm
-from django.contrib.admin.helpers import AdminForm
+from django.contrib.admin.helpers import AdminForm, AdminReadonlyField
+from django.contrib.admin.sites import AdminSite
 from django.contrib.auth.models import User
 from django.test import SimpleTestCase, TestCase, override_settings
 
-from .admin import ArticleForm
+from .admin import ArticleAdmin, ArticleForm
+from .models import Article
 
 
 # To verify that the login form rejects inactive users, use an authentication
@@ -28,6 +30,9 @@ class AdminAuthenticationFormTests(TestCase):
 
 
 class AdminFormTests(SimpleTestCase):
+    def setUp(self):
+        self.model_admin = ArticleAdmin(Article, AdminSite())
+
     def test_repr(self):
         fieldsets = (
             (
@@ -39,10 +44,43 @@ class AdminFormTests(SimpleTestCase):
             ),
         )
         form = ArticleForm()
-        admin_form = AdminForm(form, fieldsets, {})
+        admin_form = AdminForm(form, fieldsets, {}, model_admin=self.model_admin)
         self.assertEqual(
             repr(admin_form),
             "<AdminForm: form=ArticleForm fieldsets=(('My fields', "
             "{'classes': ['collapse'], "
             "'fields': ('url', 'title', 'content', 'sites')}),)>",
         )
+
+    def test_model_admin_is_required(self):
+        fieldsets = ((None, {"fields": ("title",)}),)
+        msg = "missing 1 required keyword-only argument: 'model_admin'"
+        with self.assertRaisesMessage(TypeError, msg):
+            AdminForm(ArticleForm(), fieldsets, {})
+
+    def test_model_admin_reaches_readonly_fields(self):
+        fieldsets = ((None, {"fields": ("title",)}),)
+        self.model_admin.empty_value_display = "???"
+        admin_form = AdminForm(
+            ArticleForm(),
+            fieldsets,
+            {},
+            readonly_fields=("title",),
+            model_admin=self.model_admin,
+        )
+        readonly_fields = [
+            field for fieldset in admin_form for line in fieldset for field in line
+        ]
+        self.assertEqual(
+            [field.empty_value_display for field in readonly_fields], ["???"]
+        )
+
+
+class AdminReadonlyFieldTests(SimpleTestCase):
+    def test_empty_value_display_from_model_admin(self):
+        model_admin = ArticleAdmin(Article, AdminSite())
+        model_admin.empty_value_display = "???"
+        readonly_field = AdminReadonlyField(
+            ArticleForm(), "title", is_first=True, model_admin=model_admin
+        )
+        self.assertEqual(readonly_field.empty_value_display, "???")

--- a/tests/auth_tests/test_views.py
+++ b/tests/auth_tests/test_views.py
@@ -9,6 +9,7 @@ from django.apps import apps
 from django.conf import settings
 from django.contrib.admin.models import LogEntry
 from django.contrib.auth import BACKEND_SESSION_KEY, REDIRECT_FIELD_NAME, SESSION_KEY
+from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.forms import (
     AuthenticationForm,
     PasswordChangeForm,
@@ -1695,6 +1696,13 @@ class ChangelistTests(MessagesTestMixin, AuthViewsTestCase):
             reverse("auth_test_admin:auth_user_password_change", args=("foobar",))
         )
         self.assertEqual(response.status_code, 404)
+
+    def test_user_change_password_admin_form_has_model_admin(self):
+        response = self.client.get(
+            reverse("auth_test_admin:auth_user_password_change", args=(self.admin.pk,))
+        )
+        admin_form = response.context["adminForm"]
+        self.assertIsInstance(admin_form.model_admin, UserAdmin)
 
     @mock.patch("django.contrib.auth.admin.UserAdmin.has_change_permission")
     def test_user_change_password_passes_user_to_has_change_permission(


### PR DESCRIPTION
#### Trac ticket number

ticket-27157

#### Branch description

`AdminForm`, `InlineAdminForm`, and `AdminReadonlyField` accepted `model_admin=None` as a default, but the code unconditionally dereferences it: `AdminReadonlyField.__init__` calls `model_admin.get_empty_value_display()` and `get_admin_url()` accesses `self.model_admin.admin_site.name`, both raising `AttributeError` as soon as a read-only field is rendered. `UserAdmin.user_change_password()` also constructed an `AdminForm` without `model_admin` ([comment:4](https://code.djangoproject.com/ticket/27157#comment:4)).

Following @blighj's review, this no longer goes through a deprecation cycle. These helpers are undocumented internal APIs, so the misleading default is simply removed instead.

**Changes:**
- **`django/contrib/admin/helpers.py`**: `model_admin` is now required. It is keyword-only on `AdminForm` and `InlineAdminForm` (it sits after the defaulted `readonly_fields`, so reordering it positionally would silently misinterpret existing 4-positional-argument calls), and a plain required argument on `AdminReadonlyField`. All `None` handling is gone.
- **`django/contrib/auth/admin.py`**: `UserAdmin.user_change_password()` now passes `model_admin=self`.
- **`docs/releases/6.2.txt`**: Backwards incompatible note under `django.contrib.admin`.
- **Tests**: `AdminFormTests.test_model_admin_is_required`, `test_model_admin_reaches_readonly_fields`, `AdminReadonlyFieldTests.test_empty_value_display_from_model_admin`, and `ChangelistTests.test_user_change_password_admin_form_has_model_admin`. Existing `test_repr` and `test_immutable_content_type` updated to pass a `ModelAdmin`.

All internal call sites (`ModelAdmin._changeform_view()`, `ModelAdmin.get_inline_formsets()`, `InlineAdminFormSet.__iter__()`) already passed `model_admin` as a keyword, so only `InlineAdminForm`'s `super().__init__()` call needed updating.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Opencode (Claude Opus and GPT-5.5) was used to explore `django/contrib/admin/helpers.py`, to weigh the possible signature changes, and to draft the patch and tests. Every design decision -- dropping the deprecation cycle, choosing keyword-only over reordering the parameters, limiting the scope to the three classes that actually dereference `model_admin`, and deciding which tests to add -- was made and reviewed by me. I reviewed every line of the result, ran the `admin_*`, `generic_inline_admin`, `modeladmin`, and `auth_tests` suites, and separately confirmed that the two new regression tests fail when the helper changes are reverted to `main`.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.

