### PR TITLE
Fixed #36575 -- Documented using a link for LogoutView.

### DIFF
--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -1281,6 +1281,17 @@ implementation details see :ref:`using-the-views`.
       :attr:`request.META['SERVER_NAME'] <django.http.HttpRequest.META>`.
       For more on sites, see :doc:`/ref/contrib/sites`.
 
+    To provide a logout link in a template, use a ``POST`` form:
+
+    .. code-block:: html+django
+
+        <form method="post" action="{% url 'logout' %}">
+        {% csrf_token %}
+        <button type="submit">Log out</button>
+        </form>
+
+    Then use CSS to style the form button as a link.
+
 .. function:: logout_then_login(request, login_url=None)
 
     Logs a user out on ``POST`` requests, then redirects to the login page.


### PR DESCRIPTION
#### Trac ticket number

ticket-36575

#### Branch description

The Django 4.1 release notes include an example of creating a logout link that uses `admin:logout`, which requires admin access and isn’t appropriate for general use. 

This PR adds a minimal example to the LogoutView documentation showing how to create a logout link using a POST form and the standard `logout` URL name. The example is placed in the LogoutView docs so the guidance is available in the main documentation rather than only in older release notes.

#### AI Assistance Disclosure (REQUIRED)

- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude Sonnet 4.5 was used to help with grammar correctness, and all output included in this PR has been fully reviewed and verified by me.

#### Checklist

- [x] This PR follows the contribution guidelines.
- [x] This PR **does not** disclose a security vulnerability.
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests. (Not applicable — documentation change only.)
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes. (Not applicable — no UI changes.)
