### PR TITLE
Fixed #33685 -- Supported PostgreSQL service names in tests.

### DIFF
--- a/django/db/backends/postgresql/base.py
+++ b/django/db/backends/postgresql/base.py
@@ -273,7 +273,6 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             }
         elif settings_dict["NAME"] is None:
             # Connect to the default 'postgres' db.
-            settings_dict["OPTIONS"].pop("service", None)
             conn_params = {"dbname": "postgres", **settings_dict["OPTIONS"]}
         else:
             conn_params = {**settings_dict["OPTIONS"]}

--- a/django/db/backends/postgresql/creation.py
+++ b/django/db/backends/postgresql/creation.py
@@ -7,6 +7,15 @@ from django.db.backends.utils import strip_quotes
 
 
 class DatabaseCreation(BaseDatabaseCreation):
+    def _get_test_db_name(self):
+        if (
+            not self.connection.settings_dict["NAME"]
+            and not self.connection.settings_dict["TEST"]["NAME"]
+            and (service := self.connection.settings_dict["OPTIONS"].get("service"))
+        ):
+            return "test_" + service
+        return super()._get_test_db_name()
+
     def _quote_name(self, name):
         return self.connection.ops.quote_name(name)
 

--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -174,11 +174,6 @@ PostgreSQL documentation.
 .. _password file: https://www.postgresql.org/docs/current/libpq-pgpass.html
 .. _parameters: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS
 
-.. warning::
-
-    Using a service name for testing purposes is not supported. This
-    :ticket:`may be implemented later <33685>`.
-
 Optimizing PostgreSQL's configuration
 -------------------------------------
 

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -416,6 +416,8 @@ Tests
   Previously, they would consume the streaming response's content, causing
   subsequent calls to fail.
 
+* PostgreSQL service names are now supported by the test runner.
+
 URLs
 ~~~~
 

--- a/tests/backends/postgresql/tests.py
+++ b/tests/backends/postgresql/tests.py
@@ -180,7 +180,17 @@ class Tests(TestCase):
         settings["OPTIONS"] = {"service": "django_test"}
         params = DatabaseWrapper(settings).get_connection_params()
         self.assertEqual(params["dbname"], "postgres")
-        self.assertNotIn("service", params)
+        self.assertEqual(params["service"], "django_test")
+
+    def test_service_name_test_db(self):
+        from django.db.backends.postgresql.base import DatabaseWrapper
+
+        settings = connection.settings_dict.copy()
+        settings["NAME"] = ""
+        settings["OPTIONS"] = {"service": "my_service"}
+        settings["TEST"] = {**settings["TEST"], "NAME": None}
+        wrapper = DatabaseWrapper(settings)
+        self.assertEqual(wrapper.creation._get_test_db_name(), "test_my_service")
 
     def test_connect_and_rollback(self):
         """


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A" if this is a trivial PR. -->

ticket-33685

#### Branch description
This PR implemented support for PostgreSQL service names in Django's test runner. This allows users to run tests when their database connection is defined via a PostgreSQL service instead of a direct database name.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
