### PR TITLE
Fixed #36924 -- Allowed select_related() on ForeignObject with defer() or only().

### DIFF
--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -458,7 +458,7 @@ def select_related_descend(field, restricted, requested, select_mask):
         return False
     # Prevent invalid usages of `select_related()` and `only()`/`defer()` such
     # as `select_related("a").only("b")` and `select_related("a").defer("a")`.
-    if select_mask and field not in select_mask:
+    if getattr(field, "column", False) and select_mask and field not in select_mask:
         raise FieldError(
             f"Field {field.model._meta.object_name}.{field.name} cannot be both "
             "deferred and traversed using select_related at the same time."

--- a/tests/select_related/models.py
+++ b/tests/select_related/models.py
@@ -84,3 +84,24 @@ class TaggedItem(models.Model):
 class Bookmark(models.Model):
     url = models.URLField()
     tags = GenericRelation(TaggedItem)
+
+
+class Biome(models.Model):
+    name = models.CharField(max_length=50)
+
+
+class Tree(models.Model):
+    code = models.IntegerField(primary_key=True)
+
+
+class Moss(models.Model):
+    biome = models.ForeignKey(Biome, models.CASCADE)
+
+    tree_code = models.IntegerField()
+    tree = models.ForeignObject(
+        Tree,
+        from_fields=["tree_code"],
+        to_fields=["code"],
+        on_delete=models.CASCADE,
+        related_name="+",
+    )

--- a/tests/select_related/tests.py
+++ b/tests/select_related/tests.py
@@ -7,6 +7,7 @@ from django.test.utils import garbage_collect, ignore_warnings
 from django.utils.deprecation import RemovedInDjango70Warning
 
 from .models import (
+    Biome,
     Bookmark,
     Domain,
     Family,
@@ -14,11 +15,13 @@ from .models import (
     HybridSpecies,
     Kingdom,
     Klass,
+    Moss,
     Order,
     Phylum,
     Pizza,
     Species,
     TaggedItem,
+    Tree,
 )
 
 
@@ -348,3 +351,26 @@ class SelectRelatedValidationTests(SimpleTestCase):
             FieldError, self.invalid_error % ("content_object", "content_type")
         ):
             list(TaggedItem.objects.select_related("content_object"))
+
+
+class SelectRelatedForeignObjectTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        biome = Biome.objects.create(name="Tundra")
+        Tree.objects.create(code=999)
+        Moss.objects.create(biome=biome, tree_code=999)
+
+    def test_select_related_foreign_object_with_defer(self):
+        """
+        select_related() including a ForeignObject should not raise a
+        FieldError when unrelated fields are deferred.
+
+        ForeignObject has no physical column, so it's not present in
+        select_mask. This test ensures the ORM doesn't treat that as
+        explicit deferral.
+        """
+        qs = Moss.objects.select_related("tree", "biome").defer("biome__name")
+        results = list(qs)
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].tree.code, 999)


### PR DESCRIPTION
#### Description

select_related() raises a `django.core.exceptions.FieldError` when it includes a `ForeignObject` relation and is used with `only()` or `defer()`. Since the `ForeignObject` relation doesn't contain a concrete column, it is absent from the generated `select_mask` leading to the error. 

#### Trac ticket number
ticket-36924

#### Branch description
Adds a validation in `select_related_descend` to only enforce the mask check on fields that map to concrete database columns.

Introduces a new test class, `SelectRelatedForeignObjectTests` in `tests/select_related/tests.py`. It includes a targeted regression test using isolated models (Biome, Tree & Moss) to ensure `ForeignObject` traversals succeed even when unrelated fields are explicitly deferred. 

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
