### PR TITLE
Fixed #35768 -- Added User Profile How-To documentation.

### DIFF
--- a/docs/howto/auth-user-profile.txt
+++ b/docs/howto/auth-user-profile.txt
@@ -1,0 +1,186 @@
+==================
+User profile model
+==================
+
+A profile model is a common way to store application-specific user data without
+modifying the authentication model.
+
+This approach keeps authentication-related fields separate from additional user
+information such as display names, biographies, or profile metadata.
+
+Applications that require changes to authentication-related fields or behavior
+should consider using a :ref:`custom user model <auth-custom-user>` instead.
+
+Define a profile model
+======================
+
+To define a profile model, create a model with a
+:class:`~django.db.models.OneToOneField` to
+:setting:`AUTH_USER_MODEL`:
+
+.. code-block:: python
+
+    from django.conf import settings
+    from django.db import models
+
+
+    class Profile(models.Model):
+        user = models.OneToOneField(
+            settings.AUTH_USER_MODEL,
+            on_delete=models.CASCADE,
+            related_name="profile",
+        )
+        display_name = models.CharField(max_length=100, blank=True)
+        bio = models.TextField(blank=True)
+        birth_date = models.DateField(null=True, blank=True)
+
+        def __str__(self):
+            return self.display_name or self.user.get_username()
+
+The :attr:`~django.db.models.ForeignKey.on_delete` argument controls what
+happens to the profile when the related user is deleted. Using
+``models.CASCADE`` deletes the profile when the user is deleted.
+
+Store name-related data
+=======================
+
+The default :class:`~django.contrib.auth.models.User` model includes
+``first_name`` and ``last_name`` fields. Some applications may prefer storing
+display names or other name-related data in a related profile model instead.
+
+For example:
+
+.. code-block:: python
+
+    class Profile(models.Model):
+        user = models.OneToOneField(
+            settings.AUTH_USER_MODEL,
+            on_delete=models.CASCADE,
+            related_name="profile",
+        )
+        display_name = models.CharField(max_length=100)
+
+This allows applications to define naming behavior independently from the
+authentication model.
+
+Create profile instances
+========================
+
+Create profile objects explicitly
+---------------------------------
+
+One approach is to create the profile when creating the user:
+
+.. code-block:: python
+
+    user = User.objects.create_user(
+        username="john",
+        password="example-password",
+    )
+
+    Profile.objects.create(
+        user=user,
+        display_name="John",
+    )
+
+Use ``get_or_create()``
+-----------------------
+
+If a profile may not exist yet, use ``get_or_create()``:
+
+.. code-block:: python
+
+    profile, created = Profile.objects.get_or_create(
+        user=request.user,
+    )
+
+Use a ``post_save`` signal
+--------------------------
+
+Some applications create profile objects automatically using a
+:data:`~django.db.models.signals.post_save` signal:
+
+.. code-block:: python
+
+    from django.conf import settings
+    from django.db.models.signals import post_save
+    from django.dispatch import receiver
+
+
+    @receiver(post_save, sender=settings.AUTH_USER_MODEL)
+    def create_user_profile(sender, instance, created, **kwargs):
+        if created:
+            Profile.objects.create(user=instance)
+
+Signal receivers are commonly defined in a ``signals`` module and imported in
+the :meth:`~django.apps.AppConfig.ready` method of an application
+configuration.
+
+Access profile data
+===================
+
+Access profile data through the reverse relation:
+
+.. code-block:: python
+
+    from django.contrib.auth import get_user_model
+
+    User = get_user_model()
+
+    user = User.objects.get(username="john")
+
+    display_name = user.profile.display_name
+
+In templates, access profile attributes directly:
+
+.. code-block:: html+django
+
+    <p>Welcome, {{ user.profile.display_name }}!</p>
+
+Edit profiles in the admin
+==========================
+
+Use admin inlines
+-----------------
+
+Profiles can be edited alongside users by defining an inline admin model:
+
+.. code-block:: python
+
+    from django.contrib import admin
+    from django.contrib.auth.admin import UserAdmin
+    from django.contrib.auth.models import User
+
+    from .models import Profile
+
+
+    class ProfileInline(admin.StackedInline):
+        model = Profile
+        can_delete = False
+
+
+    class CustomUserAdmin(UserAdmin):
+        inlines = [ProfileInline]
+
+
+    admin.site.unregister(User)
+    admin.site.register(User, CustomUserAdmin)
+
+Cache profile fragments
+=======================
+
+If profile information is displayed frequently, consider using template
+fragment caching to reduce database queries:
+
+.. code-block:: html+django
+
+    {% load cache %}
+
+    {% cache 600 user_profile user.id %}
+        <div class="profile">
+            <h2>{{ user.profile.display_name }}</h2>
+            <p>{{ user.profile.bio }}</p>
+        </div>
+    {% endcache %}
+
+The fragment is cached for 600 seconds and keyed using the user ID.

--- a/docs/howto/index.txt
+++ b/docs/howto/index.txt
@@ -57,6 +57,7 @@ Other guides
    :maxdepth: 1
 
    auth-remote-user
+   auth-user-profile
    csp
    csrf
    custom-file-storage

--- a/docs/topics/auth/customizing.txt
+++ b/docs/topics/auth/customizing.txt
@@ -321,8 +321,9 @@ ordering, custom managers, or custom model methods.
 If you wish to store information related to ``User``, you can use a
 :class:`~django.db.models.OneToOneField` to a model containing the fields for
 additional information. This one-to-one model is often called a profile model,
-as it might store non-auth related information about a site user. For example
-you might create an Employee model::
+as it might store non-auth related information about a site user.
+
+For example you might create an Employee model::
 
     from django.contrib.auth.models import User
 
@@ -334,6 +335,9 @@ you might create an Employee model::
 Assuming an existing Employee Fred Smith who has both a User and Employee
 model, you can access the related information using Django's standard related
 model conventions:
+
+For a more detailed example using a profile model, see
+:doc:`/howto/auth-user-profile`.
 
 .. code-block:: pycon
 


### PR DESCRIPTION
#### Trac ticket number

ticket-35768

#### Branch description

Adds a new documentation page describing how to use a profile model related to Django’s User model.

The page includes:
- An example profile model using `OneToOneField` to `AUTH_USER_MODEL`.
- Guidance on using a profile model instead of relying on `first_name` and `last_name`.
- An example of creating profile instances using a `post_save` signal, with mention of alternatives.
- Examples of accessing profile data in views and templates.
- A short introduction to template fragment caching for profile fragments.

The page is added to the authentication documentation index so it appears in the navigation.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude Sonnet 4.5 was used to ensure grammar correctness. All content has been manually reviewed, corrected, and verified for accuracy and compliance with Django documentation standards.

#### Checklist
- [x] This PR follows the contribution guidelines (https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see https://docs.djangoproject.com/en/stable/internals/security/).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
