### PR TITLE
Fixed #36933 -- Changed admin yes icon from circle to square for accessibility.

### DIFF
--- a/django/contrib/admin/static/admin/img/icon-yes-dark.svg
+++ b/django/contrib/admin/static/admin/img/icon-yes-dark.svg
@@ -1,9 +1,9 @@
-<svg width="13" height="13" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+<svg width="13" height="13" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
   <!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
   <!--
-    Icon Name: circle-check
+    Icon Name: square-check
     Icon Family: classic
     Icon Style: solid
   -->
-  <path fill="#73c12f" d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209L241 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L335 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z"/>
+  <path fill="#73c12f" d="M64 32C28.7 32 0 60.7 0 96L0 416c0 35.3 28.7 64 64 64l320 0c35.3 0 64-28.7 64-64l0-320c0-35.3-28.7-64-64-64L64 32zM337 209L209 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L303 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z"/>
 </svg>

--- a/django/contrib/admin/static/admin/img/icon-yes.svg
+++ b/django/contrib/admin/static/admin/img/icon-yes.svg
@@ -1,9 +1,9 @@
-<svg width="13" height="13" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+<svg width="13" height="13" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
   <!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
   <!--
-    Icon Name: circle-check
+    Icon Name: square-check
     Icon Family: classic
     Icon Style: solid
   -->
-  <path fill="#649c35" d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209L241 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L335 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z"/>
+  <path fill="#649c35" d="M64 32C28.7 32 0 60.7 0 96L0 416c0 35.3 28.7 64 64 64l320 0c35.3 0 64-28.7 64-64l0-320c0-35.3-28.7-64-64-64L64 32zM337 209L209 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L303 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z"/>
 </svg>


### PR DESCRIPTION
## Summary
- Changed admin boolean "yes" icons (`icon-yes.svg`, `icon-yes-dark.svg`) from Font Awesome's `circle-check` to `square-check` shape
- Introduces shape differentiation between yes (square) and no (circle) icons
- Makes icons distinguishable for users with dichromatic color vision deficiency who cannot rely on green/red color differences alone

## Visual Change
| Icon | Before | After |
|------|--------|-------|
| Yes | Green **circle** with checkmark | Green **square** with checkmark |
| No | Red circle with X | Red circle with X *(unchanged)* |

## Ticket
https://code.djangoproject.com/ticket/36933

## Test plan
- [ ] Verify icons render correctly in admin list views for BooleanField columns
- [ ] Verify both light and dark theme variants display properly
- [ ] Confirm shape difference is visible at 13x13px rendering size