### PR TITLE
Fixed #36919 -- Allowed Task and TaskResult to be pickled.

### DIFF
--- a/django/tasks/base.py
+++ b/django/tasks/base.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field, fields, replace
 from datetime import datetime
 from inspect import isclass, iscoroutinefunction
 from typing import Any
@@ -54,6 +54,23 @@ class Task:
 
     def __post_init__(self):
         self.get_backend().validate_task(self)
+
+    @classmethod
+    def _reconstruct(cls, kwargs):
+        func_path = kwargs["func"]
+        try:
+            func = import_string(func_path)
+            kwargs["func"] = func.func
+        except (ImportError, AttributeError) as e:
+            msg = f"Expected {func_path!r} to point to a Task instance."
+            raise ValueError(msg) from e
+        return cls(**kwargs)
+
+    def __reduce__(self):
+        kwargs = {f.name: getattr(self, f.name) for f in fields(self)}
+        kwargs["func"] = self.module_path
+
+        return (self.__class__._reconstruct, (kwargs,))
 
     @property
     def name(self):

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -369,6 +369,9 @@ Tasks
   forwarded to the backend's
   :attr:`~django.tasks.backends.base.BaseTaskBackend.task_class`.
 
+* :class:`~django.tasks.Task` and :class:`~django.tasks.TaskResult` instances
+  can now be pickled and unpickled.
+
 Templates
 ~~~~~~~~~
 

--- a/tests/tasks/test_tasks.py
+++ b/tests/tasks/test_tasks.py
@@ -1,4 +1,5 @@
 import dataclasses
+import pickle
 from datetime import datetime
 
 from django.tasks import (
@@ -268,6 +269,31 @@ class TaskTestCase(SimpleTestCase):
             import_string(test_tasks.noop_task_async.module_path),
             test_tasks.noop_task_async,
         )
+
+    def test_pickle_task(self):
+        pickled_task = pickle.dumps(test_tasks.noop_task)
+        unpickled_task = pickle.loads(pickled_task)
+
+        self.assertEqual(unpickled_task, test_tasks.noop_task)
+
+    def test_unpickle_arbitrary_string(self):
+        kwargs = {"func": "does.not.exist.fake_task"}
+        msg = "Expected 'does.not.exist.fake_task' to point to a Task instance."
+        with self.assertRaisesMessage(ValueError, msg):
+            Task._reconstruct(kwargs)
+
+    def test_unpickle_non_task_object(self):
+        kwargs = {"func": "builtins.any"}
+        msg = "Expected 'builtins.any' to point to a Task instance."
+        with self.assertRaisesMessage(ValueError, msg):
+            Task._reconstruct(kwargs)
+
+    def test_pickle_task_result(self):
+        result = test_tasks.noop_task.enqueue()
+        pickled_result = pickle.dumps(result)
+        unpickled_result = pickle.loads(pickled_result)
+
+        self.assertEqual(unpickled_result, result)
 
     @override_settings(TASKS={})
     def test_no_backends(self):


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36919 

#### Branch description
Task instances couldn’t be pickled earlier. 

The change serializes the function as a dotted import path and reconstructs it during unpickling.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

I used GitHub Copilot (Gemini 3) to assist me in writing the tests.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
