### PR TITLE
Corrected signature for EmailMessage.message() in docs.

### DIFF
--- a/docs/topics/email.txt
+++ b/docs/topics/email.txt
@@ -431,7 +431,7 @@ email backend API :ref:`provides an alternative
             Older versions ignored ``fail_silently=True`` when a ``connection``
             was also provided. This now raises a ``TypeError``.
 
-    .. method:: message(policy=email.policy.default)
+    .. method:: message(*, policy=email.policy.default)
 
         Constructs and returns a Python :class:`email.message.EmailMessage`
         object representing the message to be sent.


### PR DESCRIPTION

#### Trac ticket number
N/A

#### Branch description
Corrected the EmailMessage.message() method signature in the docs to reinforce that the `policy` argument is keyword-only. (The text already describes it correctly as keyword-only.)

(I don't feel that strongly about including the `*,` in docs method signatures, but this make it consistent with other functions on the page that *do* show that.)

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- n/a I have checked the "Has patch" ticket flag in the Trac system.
- n/a I have added or updated relevant tests.
- n/a I have added or updated relevant docs, including release notes if applicable.
- n/a I have attached screenshots in both light and dark modes for any UI changes.
