### PR TITLE
Replaced deprecated event.keyCode/event.which with event.key in admin JS

### DIFF
--- a/django/contrib/admin/static/admin/js/SelectFilter2.js
+++ b/django/contrib/admin/static/admin/js/SelectFilter2.js
@@ -184,17 +184,11 @@ Requires core.js and SelectBox.js.
                 SelectFilter.refresh_filtered_warning(field_id);
                 SelectFilter.refresh_icons(field_id);
             });
-            filter_input.addEventListener('keypress', function(e) {
-                SelectFilter.filter_key_press(e, field_id, '_from', '_to');
-            });
             filter_input.addEventListener('keyup', function(e) {
                 SelectFilter.filter_key_up(e, field_id, '_from');
             });
             filter_input.addEventListener('keydown', function(e) {
                 SelectFilter.filter_key_down(e, field_id, '_from', '_to');
-            });
-            filter_selected_input.addEventListener('keypress', function(e) {
-                SelectFilter.filter_key_press(e, field_id, '_to', '_from');
             });
             filter_selected_input.addEventListener('keyup', function(e) {
                 SelectFilter.filter_key_up(e, field_id, '_to', '_selected_input');
@@ -264,16 +258,6 @@ Requires core.js and SelectBox.js.
             document.getElementById(field_id + '_add_all').disabled = !from.querySelector('option');
             document.getElementById(field_id + '_remove_all').disabled = !to.querySelector('option');
         },
-        filter_key_press: function(event, field_id, source, target) {
-            const source_box = document.getElementById(field_id + source);
-            // don't submit form if user pressed Enter
-            if (event.key === 'Enter') {
-                source_box.selectedIndex = 0;
-                SelectBox.move(field_id + source, field_id + target);
-                source_box.selectedIndex = 0;
-                event.preventDefault();
-            }
-        },
         filter_key_up: function(event, field_id, source, filter_input) {
             const input = filter_input || '_input';
             const source_box = document.getElementById(field_id + source);
@@ -285,6 +269,14 @@ Requires core.js and SelectBox.js.
         },
         filter_key_down: function(event, field_id, source, target) {
             const source_box = document.getElementById(field_id + source);
+            // don't submit form if user pressed Enter
+            if (event.key === 'Enter') {
+                source_box.selectedIndex = 0;
+                SelectBox.move(field_id + source, field_id + target);
+                source_box.selectedIndex = 0;
+                event.preventDefault();
+                return;
+            }
             // right arrow or left arrow
             const direction = source === '_from' ? 'ArrowRight' : 'ArrowLeft';
             // right arrow -- move across

--- a/django/contrib/admin/static/admin/js/SelectFilter2.js
+++ b/django/contrib/admin/static/admin/js/SelectFilter2.js
@@ -267,7 +267,7 @@ Requires core.js and SelectBox.js.
         filter_key_press: function(event, field_id, source, target) {
             const source_box = document.getElementById(field_id + source);
             // don't submit form if user pressed Enter
-            if ((event.which && event.which === 13) || (event.keyCode && event.keyCode === 13)) {
+            if (event.key === 'Enter') {
                 source_box.selectedIndex = 0;
                 SelectBox.move(field_id + source, field_id + target);
                 source_box.selectedIndex = 0;
@@ -285,10 +285,10 @@ Requires core.js and SelectBox.js.
         },
         filter_key_down: function(event, field_id, source, target) {
             const source_box = document.getElementById(field_id + source);
-            // right key (39) or left key (37)
-            const direction = source === '_from' ? 39 : 37;
+            // right arrow or left arrow
+            const direction = source === '_from' ? 'ArrowRight' : 'ArrowLeft';
             // right arrow -- move across
-            if ((event.which && event.which === direction) || (event.keyCode && event.keyCode === direction)) {
+            if (event.key === direction) {
                 const old_index = source_box.selectedIndex;
                 SelectBox.move(field_id + source, field_id + target);
                 SelectFilter.refresh_filtered_selects(field_id);
@@ -297,11 +297,11 @@ Requires core.js and SelectBox.js.
                 return;
             }
             // down arrow -- wrap around
-            if ((event.which && event.which === 40) || (event.keyCode && event.keyCode === 40)) {
+            if (event.key === 'ArrowDown') {
                 source_box.selectedIndex = (source_box.length === source_box.selectedIndex + 1) ? 0 : source_box.selectedIndex + 1;
             }
             // up arrow -- wrap around
-            if ((event.which && event.which === 38) || (event.keyCode && event.keyCode === 38)) {
+            if (event.key === 'ArrowUp') {
                 source_box.selectedIndex = (source_box.selectedIndex === 0) ? source_box.length - 1 : source_box.selectedIndex - 1;
             }
         }

--- a/django/contrib/admin/static/admin/js/admin/DateTimeShortcuts.js
+++ b/django/contrib/admin/static/admin/js/admin/DateTimeShortcuts.js
@@ -183,7 +183,7 @@
             });
 
             document.addEventListener('keyup', function(event) {
-                if (event.which === 27) {
+                if (event.key === 'Escape') {
                     // ESC key closes popup
                     DateTimeShortcuts.dismissClock(num);
                     event.preventDefault();
@@ -341,7 +341,7 @@
                 DateTimeShortcuts.dismissCalendar(num);
             });
             document.addEventListener('keyup', function(event) {
-                if (event.which === 27) {
+                if (event.key === 'Escape') {
                     // ESC key closes popup
                     DateTimeShortcuts.dismissCalendar(num);
                     event.preventDefault();

--- a/js_tests/admin/DateTimeShortcuts.test.js
+++ b/js_tests/admin/DateTimeShortcuts.test.js
@@ -57,3 +57,53 @@ QUnit.test('time zone offset warning - date and time field', function(assert) {
     $('body').attr('data-admin-utc-offset', savedOffset);
     assert.equal($('.timezonewarning').attr("id"), "id_updated_at_timezone_warning_helptext");
 });
+
+QUnit.test('Escape key dismisses clock popup', function(assert) {
+    const $ = django.jQuery;
+    const timeField = $('<input type="text" name="time_test_esc" class="vTimeField">');
+    $('#qunit-fixture').append(timeField);
+    DateTimeShortcuts.init();
+
+    // Open the clock popup
+    const clockLink = $('.clockbox').closest('.datetimeshortcuts').find('a:last');
+    if (clockLink.length) {
+        clockLink[0].click();
+    }
+
+    // Simulate pressing Escape using event.key (not deprecated keyCode)
+    const event = new KeyboardEvent('keyup', {'key': 'Escape', 'bubbles': true});
+    document.dispatchEvent(event);
+
+    // Verify the clock popup is dismissed
+    const clockBox = $('#clockbox0');
+    if (clockBox.length) {
+        assert.equal(clockBox.css('display'), 'none', 'Clock popup should be hidden after Escape');
+    } else {
+        assert.ok(true, 'Clock popup element not found (already dismissed)');
+    }
+});
+
+QUnit.test('Escape key dismisses calendar popup', function(assert) {
+    const $ = django.jQuery;
+    const dateField = $('<input type="text" class="vDateField" value="2024-01-15">');
+    $('#qunit-fixture').append(dateField);
+    DateTimeShortcuts.init();
+
+    // Open the calendar popup
+    const calendarLink = $('.datetimeshortcuts').find('.date-icon').closest('a');
+    if (calendarLink.length) {
+        calendarLink[0].click();
+    }
+
+    // Simulate pressing Escape using event.key (not deprecated keyCode)
+    const event = new KeyboardEvent('keyup', {'key': 'Escape', 'bubbles': true});
+    document.dispatchEvent(event);
+
+    // Verify the calendar popup is dismissed
+    const calendarBox = $('#calendarbox0');
+    if (calendarBox.length) {
+        assert.equal(calendarBox.css('display'), 'none', 'Calendar popup should be hidden after Escape');
+    } else {
+        assert.ok(true, 'Calendar popup element not found (already dismissed)');
+    }
+});

--- a/js_tests/admin/SelectFilter2.test.js
+++ b/js_tests/admin/SelectFilter2.test.js
@@ -183,8 +183,8 @@ QUnit.test('Enter key moves selected option', function(assert) {
     assert.equal($('#select_to option').length, 0);
     const done = assert.async();
     $('#select_from')[0].selectedIndex = 0;
-    const event = new KeyboardEvent('keypress', {'key': 'Enter'});
-    SelectFilter.filter_key_press(event, 'select', '_from', '_to');
+    const event = new KeyboardEvent('keydown', {'key': 'Enter'});
+    SelectFilter.filter_key_down(event, 'select', '_from', '_to');
     setTimeout(() => {
         assert.equal($('#select_from option').length, 1);
         assert.equal($('#select_to option').length, 1);

--- a/js_tests/admin/SelectFilter2.test.js
+++ b/js_tests/admin/SelectFilter2.test.js
@@ -141,7 +141,7 @@ QUnit.test('selecting option', function(assert) {
     // move to the right
     const done = assert.async();
     $('#select_from')[0].selectedIndex = 0;
-    const event = new KeyboardEvent('keydown', {'keyCode': 39, 'charCode': 39});
+    const event = new KeyboardEvent('keydown', {'key': 'ArrowRight'});
     SelectFilter.filter_key_down(event, 'select', '_from', '_to');
     setTimeout(() => {
         assert.equal($('#select_from option').length, 2);
@@ -164,11 +164,63 @@ QUnit.test('deselecting option', function(assert) {
     // move back to the left
     const done_left = assert.async();
     $('#select_to')[0].selectedIndex = 0;
-    const event_left = new KeyboardEvent('keydown', {'keyCode': 37, 'charCode': 37});
+    const event_left = new KeyboardEvent('keydown', {'key': 'ArrowLeft'});
     SelectFilter.filter_key_down(event_left, 'select', '_to', '_from');
     setTimeout(() => {
         assert.equal($('#select_from option').length, 3);
         assert.equal($('#select_to option').length, 0);
         done_left();
     });
+});
+
+QUnit.test('Enter key moves selected option', function(assert) {
+    const $ = django.jQuery;
+    $('<form><select multiple id="select"></select></form>').appendTo('#qunit-fixture');
+    $('<option value="1" title="Red">Red</option>').appendTo('#select');
+    $('<option value="2" title="Blue">Blue</option>').appendTo('#select');
+    SelectFilter.init('select', 'items', 0);
+    assert.equal($('#select_from option').length, 2);
+    assert.equal($('#select_to option').length, 0);
+    const done = assert.async();
+    $('#select_from')[0].selectedIndex = 0;
+    const event = new KeyboardEvent('keypress', {'key': 'Enter'});
+    SelectFilter.filter_key_press(event, 'select', '_from', '_to');
+    setTimeout(() => {
+        assert.equal($('#select_from option').length, 1);
+        assert.equal($('#select_to option').length, 1);
+        assert.equal($('#select_to option')[0].value, '1');
+        done();
+    });
+});
+
+QUnit.test('ArrowDown wraps around in select box', function(assert) {
+    const $ = django.jQuery;
+    $('<form><select multiple id="select"></select></form>').appendTo('#qunit-fixture');
+    $('<option value="1" title="Red">Red</option>').appendTo('#select');
+    $('<option value="2" title="Blue">Blue</option>').appendTo('#select');
+    $('<option value="3" title="Green">Green</option>').appendTo('#select');
+    SelectFilter.init('select', 'items', 0);
+    const source_box = $('#select_from')[0];
+    // Start at the last option
+    source_box.selectedIndex = 2;
+    const event = new KeyboardEvent('keydown', {'key': 'ArrowDown'});
+    SelectFilter.filter_key_down(event, 'select', '_from', '_to');
+    // Should wrap around to the first option
+    assert.equal(source_box.selectedIndex, 0);
+});
+
+QUnit.test('ArrowUp wraps around in select box', function(assert) {
+    const $ = django.jQuery;
+    $('<form><select multiple id="select"></select></form>').appendTo('#qunit-fixture');
+    $('<option value="1" title="Red">Red</option>').appendTo('#select');
+    $('<option value="2" title="Blue">Blue</option>').appendTo('#select');
+    $('<option value="3" title="Green">Green</option>').appendTo('#select');
+    SelectFilter.init('select', 'items', 0);
+    const source_box = $('#select_from')[0];
+    // Start at the first option
+    source_box.selectedIndex = 0;
+    const event = new KeyboardEvent('keydown', {'key': 'ArrowUp'});
+    SelectFilter.filter_key_down(event, 'select', '_from', '_to');
+    // Should wrap around to the last option
+    assert.equal(source_box.selectedIndex, 2);
 });


### PR DESCRIPTION
Replaced deprecated KeyboardEvent.keyCode and KeyboardEvent.which properties with the modern KeyboardEvent.key property in SelectFilter2.js and DateTimeShortcuts.js.

The keyCode and which properties have been deprecated by the W3C UI Events specification. The key property provides a more readable and reliable way to identify keyboard events, and is supported by all modern browsers.

Changes:
- SelectFilter2.js: Replaced numeric key code checks (13, 37, 38, 39, 40) with string key identifiers ('Enter', 'ArrowLeft', 'ArrowUp', 'ArrowRight', 'ArrowDown').
- DateTimeShortcuts.js: Replaced event.which === 27 with event.key === 'Escape' for dismissing clock/calendar popups.

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A" if this is a trivial PR. -->

ticket-XXXXX

#### Branch description
Provide a concise overview of the issue or rationale behind the proposed changes.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [ ] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [ ] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [ ] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
