### PR TITLE
Fixed #36784 -- Added CSP nonce to media assets.

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -82,14 +82,17 @@ class MediaAsset:
         return hash(self._path)
 
     def __str__(self):
-        return format_html(
-            self.element_template,
-            path=self.path,
-            attributes=flatatt(self.attributes),
-        )
+        return self.render()
 
     def __repr__(self):
         return f"{type(self).__qualname__}({self._path!r})"
+
+    def render(self, *, nonce=None):
+        return format_html(
+            self.element_template,
+            path=self.path,
+            attributes=flatatt({"nonce": nonce} | self.attributes),
+        )
 
     @property
     def path(self):
@@ -108,6 +111,13 @@ class Script(MediaAsset):
     def __init__(self, src, **attributes):
         # Alter the signature to allow src to be passed as a keyword argument.
         super().__init__(src, **attributes)
+
+
+class CSS(MediaAsset):
+    element_template = '<link href="{path}"{attributes}>'
+
+    def __init__(self, href, *, media, **attributes):
+        super().__init__(href, **{"media": media, "rel": "stylesheet"} | attributes)
 
 
 @html_safe
@@ -142,44 +152,45 @@ class Media:
     def _js(self):
         return self.merge(*self._js_lists)
 
-    def render(self):
+    def render(self, *, nonce=None):
         return mark_safe(
             "\n".join(
                 chain.from_iterable(
-                    getattr(self, "render_" + name)() for name in MEDIA_TYPES
+                    getattr(self, "render_" + name)(nonce=nonce) for name in MEDIA_TYPES
                 )
             )
         )
 
-    def render_js(self):
-        return [
+    def render_js(self, *, nonce=None):
+        for path in (
             (
-                path.__html__()
-                if hasattr(path, "__html__")
-                else format_html('<script src="{}"></script>', self.absolute_path(path))
+                path
+                if isinstance(path, MediaAsset) or hasattr(path, "__html__")
+                else Script(path)
             )
             for path in self._js
-        ]
+        ):
+            try:
+                yield path.render(nonce=nonce)
+            except AttributeError:
+                yield path.__html__()
 
-    def render_css(self):
+    def render_css(self, *, nonce=None):
         # To keep rendering order consistent, we can't just iterate over
         # items(). We need to sort the keys, and iterate over the sorted list.
-        media = sorted(self._css)
-        return chain.from_iterable(
-            [
-                (
-                    path.__html__()
-                    if hasattr(path, "__html__")
-                    else format_html(
-                        '<link href="{}" media="{}" rel="stylesheet">',
-                        self.absolute_path(path),
-                        medium,
-                    )
-                )
-                for path in self._css[medium]
-            ]
-            for medium in media
-        )
+        for path in (
+            (
+                path
+                if isinstance(path, MediaAsset) or hasattr(path, "__html__")
+                else CSS(path, media=medium)
+            )
+            for medium in sorted(self._css)
+            for path in self._css[medium]
+        ):
+            try:
+                yield path.render(nonce=nonce)
+            except AttributeError:
+                yield path.__html__()
 
     def absolute_path(self, path):
         """

--- a/django/template/defaulttags.py
+++ b/django/template/defaulttags.py
@@ -95,6 +95,32 @@ class CsrfTokenNode(Node):
             return ""
 
 
+class CSPNonceNode(Node):
+    child_nodelists = ()
+
+    def __init__(self, media_object=None):
+        self.media_object = media_object
+
+    def render(self, context):
+        nonce = context.get("csp_nonce", None)
+        if self.media_object:
+            if media := self.media_object.resolve(context):
+                try:
+                    return media.render(nonce=nonce)
+                except AttributeError as exc:
+                    raise TypeError(
+                        f"{self.media_object!r} must reference a Media object,"
+                        f" not a {type(media)}."
+                    ) from exc
+            else:
+                raise ValueError(
+                    f"{self.media_object!r} must reference a Media object."
+                )
+        if nonce:
+            return format_html('nonce="{}"', nonce)
+        return mark_safe("")
+
+
 class CycleNode(Node):
     def __init__(self, cyclevars, variable_name=None, silent=False):
         self.cyclevars = cyclevars
@@ -704,6 +730,20 @@ def cycle(parser, token):
 @register.tag
 def csrf_token(parser, token):
     return CsrfTokenNode()
+
+
+@register.tag
+def csp_nonce(parser, token):
+    bits = token.split_contents()[1:]
+    match len(bits):
+        case 0:
+            return CSPNonceNode()
+        case 1:
+            return CSPNonceNode(parser.compile_filter(bits[0]))
+        case _:
+            raise TemplateSyntaxError(
+                "'csp_nonce' statement takes at most one argument"
+            )
 
 
 @register.tag

--- a/docs/howto/csp.txt
+++ b/docs/howto/csp.txt
@@ -98,3 +98,28 @@ To use nonces in your CSP policy, beside the basic config, you need to:
    generated within the same request and not served from cache. See the
    reference documentation on :ref:`csp-nonce` for implementation details and
    important caching considerations.
+
+.. _csp-form-media-nonce:
+
+Form media and nonces
+---------------------
+
+.. versionadded:: 6.1
+
+When the :func:`~django.template.context_processors.csp` context processor is
+enabled, nonces may be injected into every ``<script>`` and
+``<link>`` element rendered by
+:ref:`form media<assets-as-a-static-definition>`. This applies for both
+:class:`~django.forms.Script` objects and plain string paths.
+
+Sample usage:
+
+.. code-block:: html+django
+
+    <head>
+        {% csp_nonce form.media.css %}
+    </head>
+    <body>
+        <!-- ... -->
+        {% csp_nonce form.media.js %}
+    </body>

--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -93,6 +93,23 @@ Sample usage:
 
 ``comment`` tags cannot be nested.
 
+.. versionadded:: 6.1
+.. templatetag:: csp_nonce
+
+``csp_nonce``
+--------------
+
+This tag is used for CSP protection, as described in the documentation for
+:doc:`Content Security Policy </ref/csp>`.
+
+Sample usage:
+
+.. code-block:: html+django
+
+    <script {% csp_nonce %}>
+        // This inline JavaScript will be allowed by the CSP policy.
+    </script>
+
 .. templatetag:: csrf_token
 
 ``csrf_token``

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -217,7 +217,10 @@ Cache
 CSP
 ~~~
 
-* ...
+* The new :ttag:`csp_nonce` template tag generates a CSP nonce. For standalone
+  use or in combination with :class:`~django.forms.Script` and
+  :doc:`Media </topics/forms/media>` objects. See :ref:`csp-form-media-nonce`
+  for details.
 
 CSRF
 ~~~~

--- a/tests/forms_tests/tests/test_media.py
+++ b/tests/forms_tests/tests/test_media.py
@@ -1,16 +1,8 @@
 from django.forms import CharField, Form, Media, MultiWidget, TextInput
-from django.forms.widgets import MediaAsset, Script
+from django.forms.widgets import CSS, MediaAsset, Script
 from django.template import Context, Template
 from django.test import SimpleTestCase, override_settings
 from django.utils.html import html_safe
-
-
-class CSS(MediaAsset):
-    element_template = '<link href="{path}"{attributes}>'
-
-    def __init__(self, href, **attributes):
-        super().__init__(href, **attributes)
-        self.attributes["rel"] = "stylesheet"
 
 
 @override_settings(STATIC_URL="http://media.example.com/static/")
@@ -31,7 +23,9 @@ class MediaAssetTestCase(SimpleTestCase):
 
         self.assertNotEqual(MediaAsset("path/to/css"), MediaAsset("path/to/other.css"))
         self.assertNotEqual(MediaAsset("path/to/css"), "path/to/other.css")
-        self.assertNotEqual(MediaAsset("path/to/css", media="all"), CSS("path/to/css"))
+        self.assertNotEqual(
+            MediaAsset("path/to/css", media="all"), CSS("path/to/css", media="all")
+        )
 
     def test_hash(self):
         self.assertEqual(hash(MediaAsset("path/to/css")), hash("path/to/css"))
@@ -71,6 +65,29 @@ class MediaAssetTestCase(SimpleTestCase):
 
         asset = MediaAsset("//absolute/path/to/css")
         self.assertEqual(asset.path, "//absolute/path/to/css")
+
+    def test_render(self):
+        asset = MediaAsset("path/to/css")
+        self.assertEqual(
+            asset.render(),
+            "http://media.example.com/static/path/to/css",
+        )
+
+    def test_render_with_nonce(self):
+        asset = CSS("path/to/css", media="all")
+        self.assertHTMLEqual(
+            asset.render(nonce="abc123"),
+            '<link href="http://media.example.com/static/path/to/css"'
+            ' media="all" nonce="abc123" rel="stylesheet">',
+        )
+
+    def test_render_with_nonce_is_none(self):
+        asset = CSS("path/to/css", media="all")
+        self.assertHTMLEqual(
+            asset.render(nonce=None),
+            '<link href="http://media.example.com/static/path/to/css"'
+            ' media="all" rel="stylesheet">',
+        )
 
 
 @override_settings(STATIC_URL="http://media.example.com/static/")
@@ -904,4 +921,85 @@ class FormsMediaObjectTestCase(SimpleTestCase):
             str(media),
             '<link href="/path/to/css1" media="all" rel="stylesheet">\n'
             '<script src="/path/to/js1"></script>',
+        )
+
+    def test_form_media_render_with_csp_nonce(self):
+        class MyWidget(TextInput):
+            class Media:
+                css = {"all": (CSS("/path/to/style.css", media="all"),)}
+                js = (
+                    "/path/to/app.js",
+                    Script(
+                        "/path/to/analytics.js",
+                        integrity="9d947b87fdeb25030d56d01f7aa75800",
+                    ),
+                )
+
+        class MyForm(Form):
+            field = CharField(widget=MyWidget())
+
+        form = MyForm()
+        context = Context({"form": form, "csp_nonce": "testNonce123"})
+        self.assertHTMLEqual(
+            Template("{% csp_nonce form.media %}").render(context),
+            '<link href="/path/to/style.css" media="all" nonce="testNonce123"'
+            ' rel="stylesheet">\n'
+            '<script src="/path/to/app.js" nonce="testNonce123"></script>\n'
+            '<script src="/path/to/analytics.js"'
+            ' integrity="9d947b87fdeb25030d56d01f7aa75800"'
+            ' nonce="testNonce123"></script>',
+        )
+
+    def test_form_media_render_with_csp_nonce_none(self):
+        class MyWidget(TextInput):
+            class Media:
+                css = {"all": (CSS("/path/to/style.css", media="all"),)}
+                js = (
+                    "/path/to/app.js",
+                    Script(
+                        "/path/to/analytics.js",
+                        integrity="9d947b87fdeb25030d56d01f7aa75800",
+                    ),
+                )
+
+        class MyForm(Form):
+            field = CharField(widget=MyWidget())
+
+        form = MyForm()
+        context = Context({"form": form, "csp_nonce": None})
+        self.assertHTMLEqual(
+            Template("{{ form.media }}").render(context),
+            '<link href="/path/to/style.css" media="all"'
+            ' rel="stylesheet">\n'
+            '<script src="/path/to/app.js"></script>\n'
+            '<script src="/path/to/analytics.js"'
+            ' integrity="9d947b87fdeb25030d56d01f7aa75800"'
+            "></script>",
+        )
+
+    def test_form_media_render_without_csp_nonce_none(self):
+        class MyWidget(TextInput):
+            class Media:
+                css = {"all": (CSS("/path/to/style.css", media="all"),)}
+                js = (
+                    "/path/to/app.js",
+                    Script(
+                        "/path/to/analytics.js",
+                        integrity="9d947b87fdeb25030d56d01f7aa75800",
+                    ),
+                )
+
+        class MyForm(Form):
+            field = CharField(widget=MyWidget())
+
+        form = MyForm()
+        context = Context({"form": form})
+        self.assertHTMLEqual(
+            Template("{% csp_nonce form.media %}").render(context),
+            '<link href="/path/to/style.css" media="all"'
+            ' rel="stylesheet">\n'
+            '<script src="/path/to/app.js"></script>\n'
+            '<script src="/path/to/analytics.js"'
+            ' integrity="9d947b87fdeb25030d56d01f7aa75800"'
+            "></script>",
         )

--- a/tests/template_tests/test_csp.py
+++ b/tests/template_tests/test_csp.py
@@ -1,0 +1,45 @@
+from django.template import Context, Template, TemplateSyntaxError
+from django.test import TestCase
+
+
+class CSPNonceNodeTests(TestCase):
+
+    def test_with_context(self):
+        context = Context({"csp_nonce": "testNonce123"})
+        self.assertHTMLEqual(
+            Template("<script {% csp_nonce %}></script>").render(context),
+            '<script nonce="testNonce123"></script>',
+        )
+
+    def test_without_context(self):
+        context = Context({})
+        self.assertHTMLEqual(
+            Template("<script {% csp_nonce %}></script>").render(context),
+            "<script></script>",
+        )
+
+    def test_variable_does_not_exist(self):
+        context = Context({"csp_nonce": 12345})
+        self.assertRaises(
+            ValueError,
+            lambda: Template("<script {% csp_nonce doesNotExist %}></script>").render(
+                context
+            ),
+        )
+
+    def test_invalid_type(self):
+        context = Context({"csp_nonce": 12345, "notAFormMedia": "sth. else"})
+        self.assertRaises(
+            TypeError,
+            lambda: Template("<script {% csp_nonce notAFormMedia %}></script>").render(
+                context
+            ),
+        )
+
+    def test_too_many_arguments(self):
+        self.assertRaises(
+            TemplateSyntaxError,
+            lambda: Template("<script {% csp_nonce a b %}></script>").render(
+                Context({})
+            ),
+        )


### PR DESCRIPTION
Converted Media and its assets into template nodes that consume the template context and in turn can access the CSP nonce when the context processor has been enabled.

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36784

#### Branch description

Add a `csp_nonce` template tag analogous to CSRF. The tag works standalone and with form media. E. G.:

```html+django
<script {% csp_nonce %}></script>
```

will render to

```html
<script nonce="superRandomNonce"></script>
```

, and

```html+django
{% nonce form.media %}
```

will render to

```html
<script src="path/to/script.js" nonce="superRandonNonce"></script>
```

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

AI disclosure:

- GitHub's Copilot for both autocompletion, sparring, and reviews.
- LanguageTools for spelling.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
