### PR TITLE
Micro-optimized SQL compilation methods.

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -1167,14 +1167,16 @@ class Value(Expression):
     def as_sql(self, compiler, connection):
         connection.ops.check_expression_support(self)
         val = self.value
-        output_field = self._output_field_or_none
-        if output_field is not None:
+        try:
+            output_field = self.output_field
             if self.for_save:
                 val = output_field.get_db_prep_save(val, connection=connection)
             else:
                 val = output_field.get_db_prep_value(val, connection=connection)
             if hasattr(output_field, "get_placeholder"):
                 return output_field.get_placeholder(val, compiler, connection), [val]
+        except OutputFieldIsNoneError:
+            pass
         if val is None:
             # oracledb does not always convert None to the appropriate
             # NULL type (like in case expressions using numbers), so we

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -578,12 +578,8 @@ class SQLCompiler:
         return r
 
     def compile(self, node):
-        vendor_impl = getattr(node, "as_" + self.connection.vendor, None)
-        if vendor_impl:
-            sql, params = vendor_impl(self, self.connection)
-        else:
-            sql, params = node.as_sql(self, self.connection)
-        return sql, params
+        as_sql = getattr(node, f"as_{self.connection.vendor}", None) or node.as_sql
+        return as_sql(self, self.connection)
 
     def get_combinator_sql(self, combinator, all):
         features = self.connection.features


### PR DESCRIPTION
#### Trac ticket number

N/A

(How would I ticket this sort of thing, btw?)

#### Branch description

This PR applies two small micro-optimizations in the guts of the ORM/SQL compiler that came to me while (like with https://github.com/django/asgiref/pull/551) staring closely at a Viztracer trace.

`pytest-benchmark` micro-benchmarks targetting these two changes seem to indicate (on my machine)

* `compile()` is 5-10% faster (less local variables, less tuple manipulation)
* `Value.as_sql()` is ~1.5% faster (no trampolining through a property that would do the same `try: except:`).

#### AI Assistance Disclosure (REQUIRED)

- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, ~mentions the ticket number~, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
  - No tests updated. IMO that's a good thing – everything should pass, just like before.
- [ ] I have added or updated relevant docs, including release notes if applicable.
  - Should this be documented somehow?
- [x] I have attached screenshots in both light and dark modes for any UI changes.
  - No UI changes.
