### PR TITLE
Refs #12227 -- Added test for PREPEND_WWW redirect following in test client.

### DIFF
--- a/tests/test_client/tests.py
+++ b/tests/test_client/tests.py
@@ -884,6 +884,16 @@ class ClientTest(TestCase):
         )
         self.assertEqual(response.content, b"hostname2")
 
+    @override_settings(PREPEND_WWW=True, ALLOWED_HOSTS=["testserver", "www.testserver"])
+    def test_prepend_www_follow_redirect(self):
+        response = self.client.get("/get_view/", follow=True)
+        self.assertRedirects(
+            response,
+            "http://www.testserver/get_view/",
+            status_code=301,
+            target_status_code=200,
+        )
+
     def test_external_redirect_without_trailing_slash(self):
         """
         Client._handle_redirects() with an empty path.


### PR DESCRIPTION
#### Trac ticket number

ticket-12227

#### Branch description

When `PREPEND_WWW=True`, the test client previously entered an infinite
redirect loop because the follow-redirect logic did not update the
`SERVER_NAME` and `HTTP_HOST` environ variables for the subsequent
request. This has since been fixed by improvements to the
`_follow_redirect` method.

This PR adds a regression test to verify that the test client correctly
follows `PREPEND_WWW` redirects to completion (301 → 200) without
looping.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

AI tool used: Claude Code (Anthropic) — assisted with codebase analysis and test writing. All output was reviewed and verified.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.