### PR TITLE
Fixed #35943 -- Replaced unload event listener with pagehide.

### DIFF
--- a/django/contrib/admin/static/admin/js/admin/RelatedObjectLookups.js
+++ b/django/contrib/admin/static/admin/js/admin/RelatedObjectLookups.js
@@ -283,7 +283,7 @@
     window.showAddAnotherPopup = showRelatedObjectPopup;
     window.dismissAddAnotherPopup = dismissAddRelatedObjectPopup;
 
-    window.addEventListener("unload", function (evt) {
+    window.addEventListener("pagehide", function (evt) {
         window.dismissChildPopups();
     });
 

--- a/tests/admin_views/test_related_object_lookups.py
+++ b/tests/admin_views/test_related_object_lookups.py
@@ -1,3 +1,5 @@
+from selenium.common.exceptions import TimeoutException
+
 from django.contrib.admin.tests import AdminSeleniumTestCase
 from django.contrib.auth.models import User
 from django.test import override_settings
@@ -179,3 +181,26 @@ class SeleniumTests(AdminSeleniumTestCase):
             m2m_to.get_attribute("innerHTML"),
             f"""<option title="{name}" value="{id_value}">{name}</option>""",
         )
+
+    def test_child_popup_not_closed_when_parent_minimized(self):
+        from selenium.webdriver.common.by import By
+
+        album_add_url = reverse("admin:admin_views_album_add")
+        self.selenium.get(self.live_server_url + album_add_url)
+
+        # Open a popup window using the "+" icon next to the "owner" field.
+        self.selenium.find_element(By.ID, "add_id_owner").click()
+        self.wait_for_and_switch_to_popup()
+
+        # Minimize the main window.
+        self.selenium.switch_to.window(self.selenium.window_handles[0])
+        self.wait_page_ready()
+        self.selenium.minimize_window()
+
+        # The popup should not be closed by dismissChildPopups().
+        try:
+            self.wait_until(lambda d: len(d.window_handles) == 1, 1)
+        except TimeoutException:
+            pass  # expected
+        else:
+            self.fail("The popup was unexpectedly closed.")


### PR DESCRIPTION
#### Trac ticket number

ticket-35943

#### Branch description
Continues the work from #20611 , adding the Selenium test requested by Jacob Walls.  thanks to @petervanderdoes for the research and initial fix.

  Replaced `unload` with `pagehide` in `RelatedObjectLookups.js`. The `unload` event triggers a permissions policy violation in Chrome 117+ and blocks bfcache. `pagehide` gives us the same behavior without the warnings.

#### AI Assistance Disclosure (REQUIRED)
  - [x] **No AI tools were used** in preparing this PR.
  - [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).  
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).  
- [x] This PR targets the `main` branch.  
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.  
- [x] I have checked the "Has patch" ticket flag in the Trac system.  
- [x] I have added or updated relevant tests.  
- [ ] I have added or updated relevant docs, including release notes if applicable.  
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
