### PR TITLE
Fixed #29969 -- Omitted inlines without add permission on save-as-new.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -2646,6 +2646,12 @@ class ModelAdmin(BaseModelAdmin):
             if prefixes[prefix] != 1 or not prefix:
                 prefix = "%s-%s" % (prefix, prefixes[prefix])
             formset_params = self.get_formset_kwargs(request, obj, inline, prefix)
+            if formset_params.get("save_as_new") and not inline.has_add_permission(
+                request, None
+            ):
+                formset_params["data"] = formset_params["data"].copy()
+                formset_params["data"]["%s-TOTAL_FORMS" % prefix] = "0"
+                formset_params["data"]["%s-INITIAL_FORMS" % prefix] = "0"
             formset = FormSet(**formset_params)
 
             def user_deleted_form(request, obj, formset, index, inline):

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -3141,6 +3141,41 @@ class AdminViewPermissionsTest(TestCase):
         formset = response.context["inline_admin_formsets"][0]
         self.assertEqual(len(formset.forms), 3)
 
+    def test_save_as_new_with_view_only_inlines(self):
+        self.viewuser.user_permissions.add(
+            get_perm(Section, get_permission_codename("add", Section._meta))
+        )
+        self.client.force_login(self.viewuser)
+        model_admin = site._registry[Section]
+        get_formset_kwargs = model_admin.get_formset_kwargs
+
+        def get_immutable_formset_kwargs(request, obj, inline, prefix):
+            kwargs = get_formset_kwargs(request, obj, inline, prefix)
+            kwargs["data"] = request.POST
+            return kwargs
+
+        # Simulate immutable formset data to ensure save_as_new copies it
+        # before omitting the inline.
+        with mock.patch.object(
+            model_admin,
+            "get_formset_kwargs",
+            side_effect=get_immutable_formset_kwargs,
+        ):
+            response = self.client.post(
+                reverse("admin:admin_views_section_change", args=(self.s1.pk,)),
+                {
+                    "_saveasnew": "Save as new",
+                    "name": "",
+                    "article_set-TOTAL_FORMS": 1,
+                    "article_set-INITIAL_FORMS": 1,
+                },
+            )
+        self.assertContains(response, "Please correct the error below.")
+        inline_formset = response.context["inline_admin_formsets"][0]
+        self.assertEqual(inline_formset.formset.total_form_count(), 0)
+        self.assertEqual(inline_formset.formset.initial_form_count(), 0)
+        self.assertNotContains(response, self.a1.content)
+
     def test_change_view_with_view_only_last_inline(self):
         self.viewuser.user_permissions.add(
             get_perm(Section, get_permission_codename("view", Section._meta))


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A" if this is a trivial PR. -->

ticket-29969

#### Branch description

Fixes admin `save_as` behavior for view-only inlines.
On `_saveasnew` POSTs, the parent `object_id` is cleared early, which can cause view-only inline formsets to
re-render as empty/editable when the parent form is re-displayed (validation error path) and on rerender flow.
Clear the initial and total form counts when the user doesn't have add permission for the inline, using a copy
of the submitted formset data.

The regression test covers a save-as-new parent validation error with a view-only inline and a custom
`get_formset_kwargs()` implementation returning immutable data.


#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

AI disclosure:

- GitHub Copilot was used to review the initial patch.
- OpenAI Codex was used to analyze reviewer feedback, revise the implementation and regression tests, research
  Django's contribution workflow. All output was manually reviewed and verified.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
