### PR TITLE
 Fixed #36947 -- Avoided altering column type when only db_comment changes.

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -377,6 +377,8 @@ class BaseDatabaseFeatures:
     supports_comments = False
     # Does the backend support column comments in ADD COLUMN statements?
     supports_comments_inline = False
+    # Does the backend support changing column comments without altering type?
+    supports_independent_comment_alteration = False
 
     # Does the backend support stored generated columns?
     supports_stored_generated_columns = False

--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -1151,6 +1151,7 @@ class BaseDatabaseSchemaEditor:
             or (
                 self.connection.features.supports_comments
                 and old_field.db_comment != new_field.db_comment
+                and not self.connection.features.supports_independent_comment_alteration
             )
         ):
             fragment, other_actions = self._alter_column_type_sql(
@@ -1158,6 +1159,15 @@ class BaseDatabaseSchemaEditor:
             )
             actions.append(fragment)
             post_actions.extend(other_actions)
+        elif (
+            self.connection.features.supports_comments
+            and old_field.db_comment != new_field.db_comment
+            and self.connection.features.supports_independent_comment_alteration
+        ):
+            sql, params = self._alter_column_comment_sql(
+                model, new_field, new_type, new_field.db_comment
+            )
+            post_actions.append((sql, params))
 
         if new_field.has_db_default():
             if (

--- a/django/db/backends/mysql/schema.py
+++ b/django/db/backends/mysql/schema.py
@@ -226,7 +226,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         return super()._rename_field_sql(table, old_field, new_field, new_type)
 
     def _alter_column_comment_sql(self, model, new_field, new_type, new_db_comment):
-        # Comment is alter when altering the column type.
+        # Comment is altered when altering the column type.
         return "", []
 
     def _comment_sql(self, comment):

--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -31,6 +31,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_deferrable_unique_constraints = True
     truncates_names = True
     supports_comments = True
+    supports_independent_comment_alteration = True
     supports_tablespaces = True
     supports_sequence_reset = False
     can_introspect_materialized_views = True

--- a/django/db/backends/postgresql/features.py
+++ b/django/db/backends/postgresql/features.py
@@ -25,6 +25,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     has_select_for_no_key_update = True
     can_release_savepoints = True
     supports_comments = True
+    supports_independent_comment_alteration = True
     supports_tablespaces = True
     supports_transactions = True
     can_introspect_materialized_views = True

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -1061,6 +1061,40 @@ class SchemaTests(TransactionTestCase):
         )
 
     @isolate_apps("schema")
+    @skipUnlessDBFeature(
+        "supports_stored_generated_columns",
+        "supports_independent_comment_alteration",
+    )
+    def test_altering_base_field_comment_for_a_generated_field(self):
+        class GenFieldModelComment(Model):
+            name = CharField(max_length=100)
+            name_lower = GeneratedField(
+                expression=Lower("name"), db_persist=True, output_field=CharField()
+            )
+
+            class Meta:
+                app_label = "schema"
+
+        with connection.schema_editor() as editor:
+            editor.create_model(GenFieldModelComment)
+
+        old_field = GenFieldModelComment._meta.get_field("name")
+        new_field = CharField(max_length=100, db_comment="Super useful comment")
+        new_field.set_attributes_from_name("name")
+        new_field.model = GenFieldModelComment
+        with (
+            connection.schema_editor() as editor,
+            CaptureQueriesContext(connection) as ctx,
+        ):
+            editor.alter_field(GenFieldModelComment, old_field, new_field, strict=True)
+
+        self.assertEqual(len(ctx), 1)
+        self.assertEqual(
+            self.get_column_comment(GenFieldModelComment._meta.db_table, "name"),
+            "Super useful comment",
+        )
+
+    @isolate_apps("schema")
     def test_add_auto_field(self):
         class AddAutoFieldModel(Model):
             name = CharField(max_length=255, primary_key=True)
@@ -5052,12 +5086,19 @@ class SchemaTests(TransactionTestCase):
     def test_alter_db_comment(self):
         with connection.schema_editor() as editor:
             editor.create_model(Author)
-        # Add comment.
         old_field = Author._meta.get_field("name")
         new_field = CharField(max_length=255, db_comment="Custom comment")
         new_field.set_attributes_from_name("name")
-        with connection.schema_editor() as editor:
+        with (
+            connection.schema_editor() as editor,
+            CaptureQueriesContext(connection) as ctx,
+        ):
             editor.alter_field(Author, old_field, new_field, strict=True)
+        self.assertEqual(len(ctx), 1)
+        if connection.features.supports_independent_comment_alteration:
+            self.assertIn("COMMENT ON COLUMN", ctx.captured_queries[0]["sql"])
+        else:
+            self.assertIn("ALTER TABLE", ctx.captured_queries[0]["sql"])
         self.assertEqual(
             self.get_column_comment(Author._meta.db_table, "name"),
             "Custom comment",


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36947

Backends that allow altering column comments without altering the column type should set `supports_independent_comment_alteration=True`.

Thanks @a-p-f for the report.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
