### PR TITLE
Fixed #22536 -- Fixed AttributeError in date-based generic views with MySQL invalid dates and USE_TZ=True

### DIFF
--- a/django/views/generic/dates.py
+++ b/django/views/generic/dates.py
@@ -802,6 +802,10 @@ def _get_next_prev(generic_view, date, is_previous, period):
         # means there's no next/previous link available.
         try:
             result = getattr(qs[0], date_field)
+            # If result is None (e.g. from invalid dates like MySQL's 0000-00-00
+            # being converted to None by the ORM), there's no valid date to return.
+            if result is None:
+                return None
         except IndexError:
             return None
 

--- a/django/views/generic/dates.py
+++ b/django/views/generic/dates.py
@@ -802,8 +802,9 @@ def _get_next_prev(generic_view, date, is_previous, period):
         # means there's no next/previous link available.
         try:
             result = getattr(qs[0], date_field)
-            # If result is None (e.g. from invalid dates like MySQL's 0000-00-00
-            # being converted to None by the ORM), there's no valid date to return.
+            # If result is None (e.g. from invalid dates like MySQL's
+            # 0000-00-00 being converted to None by the ORM), there's
+            # no valid date to return.
             if result is None:
                 return None
         except IndexError:

--- a/tests/generic_views/models.py
+++ b/tests/generic_views/models.py
@@ -43,7 +43,7 @@ class Book(models.Model):
     slug = models.SlugField()
     pages = models.IntegerField()
     authors = models.ManyToManyField(Author)
-    pubdate = models.DateField()
+    pubdate = models.DateField(null=True)
 
     objects = models.Manager()
     does_not_exist = DoesNotExistBookManager()

--- a/tests/generic_views/test_dates.py
+++ b/tests/generic_views/test_dates.py
@@ -819,8 +819,8 @@ class DayArchiveViewTests(TestDataMixin, TestCase):
     def test_day_view_null_date_field(self):
         """
         If the date field value is None (e.g. from MySQL's 0000-00-00 converted
-        to None by the ORM), the view returns None for next/previous day instead
-        of raising AttributeError (#22536).
+        to None by the ORM), the view returns None for next/previous day
+        instead of raising AttributeError (#22536).
         """
         Book.objects.create(name="Nulldate", slug="nulldate", pages=1, pubdate=None)
         res = self.client.get("/dates/books/2008/oct/01/")

--- a/tests/generic_views/test_dates.py
+++ b/tests/generic_views/test_dates.py
@@ -816,6 +816,18 @@ class DayArchiveViewTests(TestDataMixin, TestCase):
         res = self.client.get("/dates/booksignings/2008/apr/2/")
         self.assertEqual(res.status_code, 404)
 
+    def test_day_view_null_date_field(self):
+        """
+        If the date field value is None (e.g. from MySQL's 0000-00-00 converted
+        to None by the ORM), the view returns None for next/previous day instead
+        of raising AttributeError (#22536).
+        """
+        Book.objects.create(name="Nulldate", slug="nulldate", pages=1, pubdate=None)
+        res = self.client.get("/dates/books/2008/oct/01/")
+        self.assertEqual(res.status_code, 200)
+        self.assertIsNone(res.context["next_day"])
+        self.assertEqual(res.context["previous_day"], datetime.date(2006, 5, 1))
+
 
 @override_settings(ROOT_URLCONF="generic_views.urls")
 class DateDetailViewTests(TestDataMixin, TestCase):


### PR DESCRIPTION
   date fields.

#### Trac ticket number
ticket-#22536

#### Branch description
Date-based generic views can raise an AttributeError when used with MySQL, USE_TZ=True, and rows containing invalid date values such as 0000-00-00. MySQL allows these invalid dates, and Django’s ORM converts them to None. The view logic assumes a valid datetime and attempts timezone conversion, resulting in a crash ('NoneType' object has no attribute 'astimezone').

This change adds a defensive check to gracefully handle None date values and prevent the exception.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
