### PR TITLE
Fixed #36972 -- Added keyboard feedback to createsuperuser and changepassword commands.

### DIFF
--- a/django/contrib/auth/management/commands/changepassword.py
+++ b/django/contrib/auth/management/commands/changepassword.py
@@ -5,6 +5,7 @@ from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError
 from django.core.management.base import BaseCommand, CommandError
 from django.db import DEFAULT_DB_ALIAS, connections
+from django.utils.version import PY314
 
 UserModel = get_user_model()
 
@@ -15,7 +16,10 @@ class Command(BaseCommand):
     requires_system_checks = []
 
     def _get_pass(self, prompt="Password: "):
-        p = getpass.getpass(prompt=prompt)
+        if PY314:
+            p = getpass.getpass(prompt=prompt, echo_char="*")
+        else:
+            p = getpass.getpass(prompt=prompt)
         if not p:
             raise CommandError("aborted")
         return p

--- a/django/contrib/auth/management/commands/createsuperuser.py
+++ b/django/contrib/auth/management/commands/createsuperuser.py
@@ -14,6 +14,7 @@ from django.core.management.base import BaseCommand, CommandError
 from django.db import DEFAULT_DB_ALIAS, connections
 from django.utils.functional import cached_property
 from django.utils.text import capfirst
+from django.utils.version import PY314
 
 
 class NotRunningInTTYException(Exception):
@@ -171,8 +172,12 @@ class Command(BaseCommand):
 
                 # Prompt for a password if the model has one.
                 while PASSWORD_FIELD in user_data and user_data[PASSWORD_FIELD] is None:
-                    password = getpass.getpass()
-                    password2 = getpass.getpass("Password (again): ")
+                    if PY314:
+                        password = getpass.getpass(echo_char="*")
+                        password2 = getpass.getpass("Password (again): ", echo_char="*")
+                    else:
+                        password = getpass.getpass()
+                        password2 = getpass.getpass("Password (again): ")
                     if password != password2:
                         self.stderr.write("Error: Your passwords didn't match.")
                         # Don't validate passwords that don't match.

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -126,6 +126,10 @@ Minor features
 * :attr:`.Permission.name` and :attr:`.Permission.codename` values are now
   renamed when renaming models via a migration.
 
+* The :djadmin:`createsuperuser` and :djadmin:`changepassword` management
+  commands now display ``*`` for each character typed during password input
+  on Python 3.14+.
+
 :mod:`django.contrib.contenttypes`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/auth_tests/test_management.py
+++ b/tests/auth_tests/test_management.py
@@ -2,6 +2,7 @@ import builtins
 import getpass
 import os
 import sys
+import unittest
 from datetime import date
 from io import StringIO
 from unittest import mock
@@ -22,6 +23,7 @@ from django.db import migrations
 from django.test import TestCase, override_settings
 from django.test.testcases import TransactionTestCase
 from django.utils.translation import gettext_lazy as _
+from django.utils.version import PY314
 
 from .models import (
     CustomUser,
@@ -57,7 +59,7 @@ def mock_inputs(inputs):
         def wrapper(*args):
             class mock_getpass:
                 @staticmethod
-                def getpass(prompt=b"Password: ", stream=None):
+                def getpass(prompt=b"Password: ", stream=None, **kwargs):
                     if callable(inputs["password"]):
                         return inputs["password"]()
                     return inputs["password"]
@@ -188,6 +190,14 @@ class ChangepasswordManagementCommandTestCase(TestCase):
     def test_get_pass_no_input(self, mock_get_pass):
         with self.assertRaisesMessage(CommandError, "aborted"):
             call_command("changepassword", username="joe", stdout=self.stdout)
+
+    @unittest.skipUnless(PY314, reason="echo_char is 3.14+")
+    @mock.patch.object(getpass, "getpass", return_value="password")
+    def test_password_prompt_uses_echo_char(self, mock_get_pass):
+        """changepassword provides keyboard feedback."""
+        call_command("changepassword", username="joe", stdout=self.stdout)
+        mock_get_pass.assert_any_call(prompt="Password: ", echo_char="*")
+        mock_get_pass.assert_any_call(prompt="Password (again): ", echo_char="*")
 
     @mock.patch.object(changepassword.Command, "_get_pass", return_value="new_password")
     def test_system_username(self, mock_get_pass):
@@ -910,6 +920,21 @@ class CreatesuperuserManagementCommandTestCase(TestCase):
             )
 
         test(self)
+
+    @unittest.skipUnless(PY314, reason="echo_char is 3.14+")
+    @mock.patch.object(getpass, "getpass", return_value="password")
+    def test_password_prompt_uses_echo_char(self, mock_get_pass):
+        """createsuperuser provides keyboard feedback."""
+        call_command(
+            "createsuperuser",
+            interactive=True,
+            username="echo_char",
+            email="echo_char@example.com",
+            stdin=MockTTY(),
+            stdout=StringIO(),
+        )
+        mock_get_pass.assert_any_call(echo_char="*")
+        mock_get_pass.assert_any_call("Password (again): ", echo_char="*")
 
     @override_settings(
         AUTH_USER_MODEL="auth_tests.CustomUser",


### PR DESCRIPTION

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36972

#### Branch description
Password prompts in createsuperuser and changepassword give no visual feedback while typing, which can confuse beginners into thinking the terminal froze. Python 3.14 added echo_char to getpass.getpass(), so I've used that to show * per keystroke where available. Nothing changes on older Python versions.

The test mock for getpass.getpass() was also updated to accept
additional keyword arguments so it works with the new call.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

AI tool used:  Used Github Copilot  for guidance on Django conventions and code style. Reviewed and tested everything myself locally before submitting.
#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
