### PR TITLE
Fixed #36967 -- Use TopologicalSorter for resolving dependencies in collectstatic.

### DIFF
--- a/django/contrib/staticfiles/storage.py
+++ b/django/contrib/staticfiles/storage.py
@@ -2,6 +2,7 @@ import json
 import os
 import posixpath
 import re
+from graphlib import CycleError, TopologicalSorter
 from hashlib import md5
 from urllib.parse import unquote, urldefrag, urlsplit, urlunsplit
 
@@ -64,7 +65,6 @@ class StaticFilesStorage(FileSystemStorage):
 
 class HashedFilesMixin:
     default_template = """url("%(url)s")"""
-    max_post_process_passes = 5
     support_js_module_import_aggregation = False
     _js_module_import_aggregation_patterns = (
         "*.js",
@@ -128,7 +128,6 @@ class HashedFilesMixin:
             ),
         ),
     )
-    keep_intermediate_files = True
 
     def __init__(self, *args, **kwargs):
         if self.support_js_module_import_aggregation:
@@ -251,9 +250,14 @@ class HashedFilesMixin:
                 return False
         return False
 
-    def url_converter(self, name, hashed_files, template=None, ignored_blocks=None):
+    def _make_url_handler(self, name, hashed_files, template=None, ignored_blocks=None):
         """
-        Return the custom URL converter for the given file name.
+        Return a (handle_match, substitutions) pair for the given file.
+
+        handle_match is a regex match callback that rewrites each matched URL
+        to its hashed version. substitutions is the list that handle_match
+        populates with (matched, replacement, hash_key, old_filename) tuples
+        as it runs.
         """
         if template is None:
             template = self.default_template
@@ -268,13 +272,9 @@ class HashedFilesMixin:
                 return f"\n{line_num}"
             return msg
 
-        def converter(matchobj):
-            """
-            Convert the matched URL to a normalized and hashed URL.
+        substitutions = []
 
-            This requires figuring out which files the matched URL resolves
-            to and calling the url() method of the storage.
-            """
+        def handle_match(matchobj):
             matches = matchobj.groupdict()
             matched = matches["matched"]
             url = matches["url"]
@@ -335,11 +335,18 @@ class HashedFilesMixin:
             if fragment:
                 transformed_url += ("?#" if "?#" in url else "#") + fragment
 
-            # Return the hashed version to the file
             matches["url"] = unquote(transformed_url)
-            return template % matches
+            replacement = template % matches
 
-        return converter
+            hash_key = self.hash_key(
+                self.clean_name(posixpath.normpath(unquote(target_name).strip()))
+            )
+            old_filename = hashed_url.split("/")[-1]
+            substitutions.append((matched, replacement, hash_key, old_filename))
+
+            return replacement
+
+        return handle_match, substitutions
 
     def post_process(self, paths, dry_run=False, **options):
         """
@@ -367,128 +374,181 @@ class HashedFilesMixin:
             path for path in paths if matches_patterns(path, self._patterns)
         ]
 
-        # Adjustable files to yield at end, keyed by the original path.
-        processed_adjustable_paths = {}
+        adjustable_set = set(adjustable_paths)
 
-        # Do a single pass first. Post-process all files once, yielding not
-        # adjustable files and exceptions, and collecting adjustable files.
-        for name, hashed_name, processed, _ in self._post_process(
-            paths, adjustable_paths, hashed_files
-        ):
-            if name not in adjustable_paths or isinstance(processed, Exception):
-                yield name, hashed_name, processed
-            else:
-                processed_adjustable_paths[name] = (name, hashed_name, processed)
-
-        paths = {path: paths[path] for path in adjustable_paths}
-        unresolved_paths = []
-        for i in range(self.max_post_process_passes):
-            unresolved_paths = []
-            for name, hashed_name, processed, subst in self._post_process(
-                paths, adjustable_paths, hashed_files
+        # Scan all adjustable files once to collect substitutions and build
+        # the dependency graph.
+        file_subs = {}
+        if adjustable_paths:
+            for error in self._scan_substitutions(
+                paths, adjustable_paths, hashed_files, file_subs
             ):
-                # Overwrite since hashed_name may be newer.
-                processed_adjustable_paths[name] = (name, hashed_name, processed)
-                if subst:
-                    unresolved_paths.append(name)
+                yield error
 
-            if not unresolved_paths:
-                break
+        # Step 1: Process non-adjustable files
+        non_adjustable_paths = {
+            name: paths[name] for name in paths if name not in adjustable_set
+        }
+        for name, hashed_name, processed in self._post_process(
+            non_adjustable_paths, hashed_files, file_subs
+        ):
+            yield name, hashed_name, processed
 
-        if unresolved_paths:
-            problem_paths = ", ".join(sorted(unresolved_paths))
-            yield problem_paths, None, RuntimeError("Max post-process passes exceeded.")
+        # Step 2: Process adjustable files
+        if adjustable_paths:
+            clean_to_name = {self.clean_name(name): name for name in adjustable_paths}
+            clean_adjustable = set(clean_to_name)
+            graph = {
+                name: {
+                    clean_to_name[hk]
+                    for _, _, hk, _ in file_subs.get(name, [])
+                    if hk in clean_adjustable
+                }
+                for name in adjustable_paths
+            }
 
-        # Store the processed paths
+            processing_order = self._sort_adjustable_paths(graph)
+
+            ordered_paths = {name: paths[name] for name in processing_order}
+            for name, hashed_name, processed in self._post_process(
+                ordered_paths, hashed_files, file_subs
+            ):
+                yield name, hashed_name, processed
+
+            # Process and yield circular dependencies.
+            circular_nodes = set(graph) - set(processing_order)
+            if circular_nodes:
+                circular_nodes = sorted(circular_nodes)
+                circular_paths = {name: paths[name] for name in circular_nodes}
+                self._calculate_combined_hash(
+                    circular_nodes, paths, hashed_files, file_subs
+                )
+                for name, hashed_name, processed in self._post_process(
+                    circular_paths, hashed_files, file_subs
+                ):
+                    yield name, hashed_name, processed
+
+        # Store the processed paths.
         self.hashed_files.update(hashed_files)
 
-        # Yield adjustable files with final, hashed name.
-        yield from processed_adjustable_paths.values()
-
-    def _post_process(self, paths, adjustable_paths, hashed_files):
-        # Sort the files by directory level
-        def path_level(name):
-            return len(name.split(os.sep))
-
-        for name in sorted(paths, key=path_level, reverse=True):
-            substitutions = True
+    def _post_process(self, paths, hashed_files, file_subs):
+        for name in paths:
             # use the original, local file, not the copied-but-unprocessed
             # file, which might be somewhere far away, like S3
             storage, path = paths[name]
             with storage.open(path) as original_file:
                 cleaned_name = self.clean_name(name)
                 hash_key = self.hash_key(cleaned_name)
-
-                # generate the hash with the original content, even for
-                # adjustable files.
-                if hash_key not in hashed_files:
-                    hashed_name = self.hashed_name(name, original_file)
-                else:
-                    hashed_name = hashed_files[hash_key]
-
-                # then get the original's file content..
-                if hasattr(original_file, "seek"):
-                    original_file.seek(0)
-
-                hashed_file_exists = self.exists(hashed_name)
-                processed = False
-
-                # ..to apply each replacement pattern to the content
-                if name in adjustable_paths:
-                    old_hashed_name = hashed_name
-                    try:
-                        content = original_file.read().decode("utf-8")
-                    except UnicodeDecodeError as exc:
-                        yield name, None, exc, False
-                    for extension, patterns in self._patterns.items():
-                        if matches_patterns(path, (extension,)):
-                            if not any(p.search(content) for p, _, _ in patterns):
-                                continue
-                            for pattern, template, ignored_re in patterns:
-                                converter = self.url_converter(
-                                    name,
-                                    hashed_files,
-                                    template,
-                                    self.get_ignored_blocks(
-                                        content,
-                                        ignored_re,
-                                    ),
-                                )
-                                try:
-                                    content = pattern.sub(converter, content)
-                                except ValueError as exc:
-                                    yield name, None, exc, False
-                    if hashed_file_exists:
-                        self.delete(hashed_name)
-                    # then save the processed result
+                subs = file_subs.get(name)
+                if subs:
+                    content = original_file.read().decode("utf-8")
+                    content = self._apply_substitutions(content, subs, hashed_files)
                     content_file = ContentFile(content.encode())
-                    if self.keep_intermediate_files:
-                        # Save intermediate file for reference
-                        self._save(hashed_name, content_file)
-                    hashed_name = self.hashed_name(name, content_file)
-
-                    if self.exists(hashed_name):
-                        self.delete(hashed_name)
-
+                    # Use pre-computed hashed name if available (circular deps)
+                    hashed_name = hashed_files.get(hash_key) or self.hashed_name(
+                        name, content_file
+                    )
+                    processed = True
+                else:
+                    hashed_name = self.hashed_name(name, original_file)
+                    if hasattr(original_file, "seek"):
+                        original_file.seek(0)
+                    content_file = original_file
+                    processed = False
+                if not self.exists(hashed_name):
+                    processed = True
                     saved_name = self._save(hashed_name, content_file)
                     hashed_name = self.clean_name(saved_name)
-                    # If the file hash stayed the same, this file didn't change
-                    if old_hashed_name == hashed_name:
-                        substitutions = False
-                    processed = True
-
-                if not processed:
-                    # or handle the case in which neither processing nor
-                    # a change to the original file happened
-                    if not hashed_file_exists:
-                        processed = True
-                        saved_name = self._save(hashed_name, original_file)
-                        hashed_name = self.clean_name(saved_name)
-
-                # and then set the cache accordingly
                 hashed_files[hash_key] = hashed_name
+                yield name, hashed_name, processed
 
-                yield name, hashed_name, processed, substitutions
+    def _sort_adjustable_paths(self, graph):
+        # Topological sort; process and return linear dependencies.
+        sorter = TopologicalSorter(graph)
+        try:
+            sorter.prepare()
+        except CycleError:
+            pass
+
+        processing_order = []
+        while sorter.is_active():
+            node_group = sorter.get_ready()
+            processing_order.extend(node_group)
+            sorter.done(*node_group)
+        return processing_order
+
+    def _scan_substitutions(self, paths, adjustable_paths, hashed_files, file_subs):
+        # Read each adjustable file once, running url patterns to collect
+        # substitutions and build the dependency graph data.
+        for name in adjustable_paths:
+            storage, path = paths[name]
+            with storage.open(path) as f:
+                try:
+                    content = f.read().decode("utf-8")
+                except UnicodeDecodeError as exc:
+                    yield name, None, exc
+            subs = []
+            try:
+                for extension, patterns in self._patterns.items():
+                    if matches_patterns(path, (extension,)):
+                        if not any(p.search(content) for p, _, _ in patterns):
+                            continue
+                        for pattern, template, ignored_re in patterns:
+                            handler, handler_subs = self._make_url_handler(
+                                name,
+                                hashed_files,
+                                template,
+                                self.get_ignored_blocks(content, ignored_re),
+                            )
+                            for matchobj in pattern.finditer(content):
+                                handler(matchobj)
+                            subs.extend(handler_subs)
+            except ValueError as exc:
+                yield name, None, exc
+            file_subs[name] = subs
+
+    def _apply_substitutions(self, content, subs, hashed_files):
+        # Apply stored substitutions, updating any hashed filenames that have
+        # changed since the scan (e.g. adjustable files processed before this
+        # one whose final hash differed from the unprocessed hash).
+        for matched, replacement_text, hash_key, old_filename in subs:
+            new_hashed_name = hashed_files.get(hash_key)
+            if new_hashed_name:
+                new_filename = new_hashed_name.split("/")[-1]
+                if new_filename != old_filename:
+                    replacement_text = replacement_text.replace(
+                        old_filename, new_filename
+                    )
+            content = content.replace(matched, replacement_text)
+        return content
+
+    def _calculate_combined_hash(self, circular_nodes, paths, hashed_files, file_subs):
+        # Resolve linear dependencies in circular file contents so the
+        # combined hash changes when any linear dependency changes.
+        circular_contents = {}
+        for name in circular_nodes:
+            storage_inst, path = paths[name]
+            with storage_inst.open(path) as original_file:
+                content = original_file.read().decode("utf-8")
+                subs = file_subs.get(name, [])
+                content = self._apply_substitutions(content, subs, hashed_files)
+                circular_contents[name] = content
+
+        # Calculate a stable hash for all circular dependencies combined
+        combined_content = "".join(circular_contents[name] for name in circular_nodes)
+        combined_file = ContentFile(combined_content.encode())
+        combined_hash = self.file_hash("_combined", combined_file)
+
+        # Register hashed names for circular files using the combined hash.
+        for name in circular_nodes:
+            cleaned_name = self.clean_name(name)
+            hash_key = self.hash_key(cleaned_name)
+            file_path, filename = os.path.split(cleaned_name)
+            root, ext = os.path.splitext(filename)
+            hashed_name = os.path.join(
+                file_path, "%s.%s%s" % (root, combined_hash, ext)
+            )
+            hashed_files[hash_key] = hashed_name
 
     def clean_name(self, name):
         return name.replace("\\", "/")
@@ -508,36 +568,11 @@ class HashedFilesMixin:
             cache_name = self.clean_name(self.hashed_name(name))
         return cache_name
 
-    def stored_name(self, name):
-        cleaned_name = self.clean_name(name)
-        hash_key = self.hash_key(cleaned_name)
-        cache_name = self.hashed_files.get(hash_key)
-        if cache_name:
-            return cache_name
-        # No cached name found, recalculate it from the files.
-        intermediate_name = name
-        for i in range(self.max_post_process_passes + 1):
-            cache_name = self.clean_name(
-                self.hashed_name(name, content=None, filename=intermediate_name)
-            )
-            if intermediate_name == cache_name:
-                # Store the hashed name if there was a miss.
-                self.hashed_files[hash_key] = cache_name
-                return cache_name
-            else:
-                # Move on to the next intermediate file.
-                intermediate_name = cache_name
-        # If the cache name can't be determined after the max number of passes,
-        # the intermediate files on disk may be corrupt; avoid an infinite
-        # loop.
-        raise ValueError("The name '%s' could not be hashed with %r." % (name, self))
-
 
 class ManifestFilesMixin(HashedFilesMixin):
     manifest_version = "1.1"  # the manifest format standard
     manifest_name = "staticfiles.json"
     manifest_strict = True
-    keep_intermediate_files = False
 
     def __init__(self, *args, manifest_storage=None, **kwargs):
         super().__init__(*args, **kwargs)

--- a/docs/ref/contrib/staticfiles.txt
+++ b/docs/ref/contrib/staticfiles.txt
@@ -355,18 +355,6 @@ This attribute provides a single hash that changes whenever a file in the
 manifest changes. This can be useful to communicate to SPAs that the assets on
 the server have changed (due to a new deployment).
 
-.. attribute:: storage.ManifestStaticFilesStorage.max_post_process_passes
-
-Since static files might reference other static files that need to have their
-paths replaced, multiple passes of replacing paths may be needed until the file
-hashes converge. To prevent an infinite loop due to hashes not converging (for
-example, if ``'foo.css'`` references ``'bar.css'`` which references
-``'foo.css'``) there is a maximum number of passes before post-processing is
-abandoned. In cases with a large number of references, a higher number of
-passes might be needed. Increase the maximum number of passes by subclassing
-``ManifestStaticFilesStorage`` and setting the ``max_post_process_passes``
-attribute. It defaults to 5.
-
 To enable the ``ManifestStaticFilesStorage`` you have to make sure the
 following requirements are met:
 

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -486,7 +486,7 @@ Backwards incompatible changes in 1.11
   references ``'bar.css'`` which itself references ``'foo.css'``) or if the
   chain of files referencing other files is too deep to resolve in several
   passes. In the latter case, increase the number of passes using
-  :attr:`.ManifestStaticFilesStorage.max_post_process_passes`.
+  ``ManifestStaticFilesStorage.max_post_process_passes``.
 
 * When using ``ManifestStaticFilesStorage``, static files not found in the
   manifest at runtime now raise a ``ValueError`` instead of returning an

--- a/tests/staticfiles_tests/project/documents/cached/css/window.css
+++ b/tests/staticfiles_tests/project/documents/cached/css/window.css
@@ -1,3 +1,4 @@
+@import url("../styles.css");
 body {
     background: #d3d6d8 url("img/window.png");
 }

--- a/tests/staticfiles_tests/storage.py
+++ b/tests/staticfiles_tests/storage.py
@@ -98,7 +98,3 @@ class ExtraPatternsStorage(ManifestStaticFilesStorage):
 class NoneHashStorage(ManifestStaticFilesStorage):
     def file_hash(self, name, content=None):
         return None
-
-
-class NoPostProcessReplacedPathStorage(ManifestStaticFilesStorage):
-    max_post_process_passes = 0

--- a/tests/staticfiles_tests/test_storage.py
+++ b/tests/staticfiles_tests/test_storage.py
@@ -197,11 +197,13 @@ class TestHashedFiles:
 
     def test_template_tag_deep_relative(self):
         relpath = self.hashed_file_path("cached/css/window.css")
-        self.assertEqual(relpath, "cached/css/window.5d5c10836967.css")
+        self.assertEqual(relpath, "cached/css/window.5b34ef58c5a5.css")
         with storage.staticfiles_storage.open(relpath) as relfile:
             content = relfile.read()
             self.assertNotIn(b"url(img/window.png)", content)
             self.assertIn(b'url("img/window.acae32e4532b.png")', content)
+            self.assertNotIn(b"../styles.css", content)
+            self.assertIn(b"styles.5e0040571e1a.css", content)
         self.assertPostCondition()
 
     def test_template_tag_url(self):
@@ -218,13 +220,21 @@ class TestHashedFiles:
     def test_import_loop(self):
         finders.get_finder.cache_clear()
         err = StringIO()
-        msg = "Max post-process passes exceeded"
-        with self.assertRaisesMessage(CommandError, msg) as cm:
-            call_command("collectstatic", interactive=False, verbosity=0, stderr=err)
-        self.assertIsInstance(cm.exception.__cause__, RuntimeError)
-        self.assertEqual(
-            "Post-processing 'bar.css, foo.css' failed!\n\n", err.getvalue()
-        )
+        call_command("collectstatic", interactive=False, verbosity=0, stderr=err)
+        self.assertEqual(err.getvalue(), "")
+        # Both circular files get the same combined hash.
+        foo_relpath = self.hashed_file_path("foo.css")
+        bar_relpath = self.hashed_file_path("bar.css")
+        foo_hash = foo_relpath.split(".")[1]
+        bar_hash = bar_relpath.split(".")[1]
+        self.assertEqual(foo_hash, bar_hash)
+        # References inside the files are resolved to the combined-hash names.
+        with storage.staticfiles_storage.open(foo_relpath) as f:
+            foo_content = f.read()
+            self.assertIn(os.path.basename(bar_relpath).encode(), foo_content)
+        with storage.staticfiles_storage.open(bar_relpath) as f:
+            bar_content = f.read()
+            self.assertIn(os.path.basename(foo_relpath).encode(), bar_content)
         self.assertPostCondition()
 
     def test_post_processing(self):
@@ -665,23 +675,6 @@ class TestCollectionNoneHashStorage(CollectionTestCase):
     def test_hashed_name(self):
         relpath = self.hashed_file_path("cached/styles.css")
         self.assertEqual(relpath, "cached/styles.css")
-
-
-@override_settings(
-    STORAGES={
-        **settings.STORAGES,
-        STATICFILES_STORAGE_ALIAS: {
-            "BACKEND": "staticfiles_tests.storage.NoPostProcessReplacedPathStorage",
-        },
-    }
-)
-class TestCollectionNoPostProcessReplacedPaths(CollectionTestCase):
-    run_collectstatic_in_setUp = False
-
-    def test_collectstatistic_no_post_process_replaced_paths(self):
-        stdout = StringIO()
-        self.run_collectstatic(verbosity=1, stdout=stdout)
-        self.assertIn("post-processed", stdout.getvalue())
 
 
 @override_settings(


### PR DESCRIPTION
#### Trac ticket number
ticket-36967

#### Branch description
Use graphlib's TopologicalSorter to handle circular imports during post_process of ManifestStaticFilesStorage. 

Benefits
 - Instead of throwing an exception on circular loops or complex dependency trees it will successfully process those files.
 - Slightly less loops, should have a negligible performance improvement in most scenarios. Benchmarked against 50~ projects you see an average 0.1s improvement. In rare cases where a project has lots of import loops this can result in substantial performance improvements.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [X] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
I came up with an initial version of this myself, and then used claude (sonnet and opus) to review and refine the approach until I landed on something I was satisfied with.

#### Checklist
- [X] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [X] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
- [X] I have attached screenshots in both light and dark modes for any UI changes.

<details><summary><h4 dir=auto>Details</h4></summary>

 - A new initial pass with _scan_substitutions, reads each adjustable file once, runs regex
   patterns via finditer (not sub), to collect what changes need to be made.
 - The files that don't need adjusting like images, fonts, etc are then processed first.
 - The adjustable files are then processed in topological order (dependencies before dependents), guaranteeing a single correct pass rather than relying on repeated passes to converge.
 - Circular dependencies are handled by giving them a shared combined hash for all files in the cycle with _calculate_combined_hash.
 - Removes max_post_process_passes, and the "Max post-process passes exceeded" RuntimeError - these were workarounds for the lack of explicit dependency ordering.
 - Removes the HashedFilesMixin.stored_name() function that was not being used, as ManifestFilesMixin.stored_name() always takes precedence, the old function is left over from when there was a CachedStaticFilesStorage
 - Removes the keep_intermediate_files attribute, there are no intermediate files now
 - Changes the url_converter to a more explicit factory method that no longer does the substitutions but is used by _scan_substitutions to find the urls.
 - Updates test_import_loop to check the files are successfully hashed instead of checking for an exception
 - Updates test to prove it can correctly handle imports from a parent folder
 - Updates docs to remove max_post_process_passes

##### Tradeoffs
 - The combined hash for circular dependencies is calculated against all found loops, so for example if there were two distinct loops between A.css <--> B.css & C.css <--> D.css. The combined hash is calculated across all 4 files, and any change in one will update the hash for all 4 files causing them all to be cache busting even though two of them could have been excluded. I judge that the extra complexity to handle this is not worth the small benefit. Most projects won't have two distinct loops, and the penalty is not that high considering most of the web doesn't even use cache/cache busting techniques today.
 - There seems to be some confusion in this [ticket #32716](https://code.djangoproject.com/ticket/32716) that setting max_post_process_passes to 0 would stop the processing of files. Which would make a case for keeping the attribute, but in my testing it does not stop processing, it still happens, but it means that you won't get the further passes that correct the dependency files. So I don't think any barrier to removing it.
 - I'm not familiar with how to remove attributes like max_post_process_passes/keep_intermediate_files, how does deprecation work max_post_process_passes is mentioned in docs keep_intermediate_files isn't
 - Similarly for changing the name and behaviour of url_converter, it's not a private method but not a documented method either. What is the deprecation policy there?

##### Potential future work that surfaced while working on this
1. It would be easy now to have --dry-run surface errors that will show up in post-processing, like references to missing files
2. The command currently reports non adjustable files as "processed" when first copied, this seems wrong to me, they are already reported in copied, it feels like processed would be more useful if it called out the number of files that replacements were done on.
</details>
<details><summary><h4 dir=auto>Visualisation</h4></summary>

https://github.com/user-attachments/assets/96d87022-d51e-484c-a0d2-18e73c46b409


https://blighj.github.io/experiments/collectstatic_animation.html
</details>


