### PR TITLE
Fixed #36979 -- Made GenericInlineModelAdmin.get_formset() use get_exclude().

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -668,6 +668,7 @@ answer newbie questions, and generally made Django that much better:
     Mads Jensen <https://github.com/atombrella>
     Makoto Tsuyuki <mtsuyuki@gmail.com>
     Malcolm Tredinnick
+    Manas Madeshiya <manas112madeshiya@gmail.com>
     Manav Agarwal <dpsman13016@gmail.com>
     Manuel Saelices <msaelices@yaco.es>
     Manuzhai

--- a/django/contrib/contenttypes/admin.py
+++ b/django/contrib/contenttypes/admin.py
@@ -100,12 +100,12 @@ class GenericInlineModelAdmin(InlineModelAdmin):
             fields = kwargs.pop("fields")
         else:
             fields = flatten_fieldsets(self.get_fieldsets(request, obj))
-        exclude = [*(self.exclude or []), *self.get_readonly_fields(request, obj)]
-        if (
-            self.exclude is None
-            and hasattr(self.form, "_meta")
-            and self.form._meta.exclude
-        ):
+        excluded = self.get_exclude(request, obj)
+        exclude = [
+            *(excluded or []),
+            *self.get_readonly_fields(request, obj),
+        ]
+        if excluded is None and hasattr(self.form, "_meta") and self.form._meta.exclude:
             # Take the custom ModelForm's Meta.exclude into account only if the
             # GenericInlineModelAdmin doesn't define its own.
             exclude.extend(self.form._meta.exclude)

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -2316,6 +2316,7 @@ adds some of its own (the shared features are actually defined in the
 - :attr:`~ModelAdmin.filter_vertical`
 - :attr:`~ModelAdmin.ordering`
 - :attr:`~ModelAdmin.prepopulated_fields`
+- :meth:`~ModelAdmin.get_exclude`
 - :meth:`~ModelAdmin.get_fieldsets`
 - :meth:`~ModelAdmin.get_queryset`
 - :attr:`~ModelAdmin.radio_fields`

--- a/tests/generic_inline_admin/tests.py
+++ b/tests/generic_inline_admin/tests.py
@@ -577,3 +577,14 @@ class GenericInlineModelAdminTest(SimpleTestCase):
             request.name = name
             self.assertEqual(ma.get_inlines(request, None), (inline_class,))
             self.assertEqual(type(ma.get_inline_instances(request)[0]), inline_class)
+
+    def test_get_exclude_is_respected(self):
+        class GetExcludeInline(GenericTabularInline):
+            model = Media
+
+            def get_exclude(self, request, obj=None):
+                return ["url"]
+
+        ma = GetExcludeInline(Media, self.site)
+        formset = ma.get_formset(request)
+        self.assertNotIn("url", formset.form.base_fields)


### PR DESCRIPTION
#### Trac ticket number
ticket-36979

#### Branch description
The ModelAdmin.get_exclude() hook was added in #24941,
however GenericInlineModelAdmin.get_formset() was not
updated to use it, instead directly accessing self.exclude.

This fix updates GenericInlineModelAdmin.get_formset()
to call self.get_exclude(request, obj) instead of
directly accessing self.exclude attribute.

Changes made:
- django/contrib/contenttypes/admin.py: Updated
  get_formset() to use self.get_exclude(request, obj)
  instead of self.exclude
- tests/generic_inline_admin/tests.py: Added regression
  test test_get_exclude_is_respected()

#### AI Assistance Disclosure (REQUIRED)
- [x] **If AI tools were used**, I have disclosed which
ones, and fully reviewed and verified their output.

I used Claude (claude.ai) to help understand the
codebase structure. All code changes were reviewed,
understood, and tested by me personally. The full
test suite was run locally with 21 tests passing.

#### Checklist
- [x] This PR follows the contribution guidelines
- [x] This PR targets the `main` branch
- [x] The commit message is written in past tense
- [x] I have checked the "Has patch" ticket flag in Trac