### PR TITLE
Fixed #10919 -- Added ModelAdmin option to truncate delete confirmation object list.

### DIFF
--- a/django/contrib/admin/actions.py
+++ b/django/contrib/admin/actions.py
@@ -70,6 +70,7 @@ def delete_selected(modeladmin, request, queryset):
         "subtitle": None,
         "objects_name": str(objects_name),
         "deletable_objects": [deletable_objects],
+        "delete_confirmation_max_display": modeladmin.delete_confirmation_max_display,
         "model_count": dict(model_count).items(),
         "queryset": queryset,
         "perms_lacking": perms_needed,

--- a/django/contrib/admin/checks.py
+++ b/django/contrib/admin/checks.py
@@ -842,6 +842,7 @@ class ModelAdminChecks(BaseModelAdminChecks):
             *self._check_search_fields(admin_obj),
             *self._check_date_hierarchy(admin_obj),
             *self._check_actions(admin_obj),
+            *self._check_delete_confirmation_max_display(admin_obj),
         ]
 
     def _check_save_as(self, obj):
@@ -1085,6 +1086,25 @@ class ModelAdminChecks(BaseModelAdminChecks):
                 option="list_select_related",
                 obj=obj,
                 id="admin.E117",
+            )
+        else:
+            return []
+
+    def _check_delete_confirmation_max_display(self, obj):
+        """Check that delete_confirmation_max_display is
+        a non-negative integer or None."""
+
+        if obj.delete_confirmation_max_display is None:
+            return []
+        if (
+            not isinstance(obj.delete_confirmation_max_display, int)
+            or obj.delete_confirmation_max_display < 0
+        ):
+            return must_be(
+                "a non-negative integer or None",
+                option="delete_confirmation_max_display",
+                obj=obj,
+                id="admin.E131",
             )
         else:
             return []

--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -661,6 +661,7 @@ class ModelAdmin(BaseModelAdmin):
     add_form_template = None
     change_form_template = None
     change_list_template = None
+    delete_confirmation_max_display = None
     delete_confirmation_template = None
     delete_selected_confirmation_template = None
     object_history_template = None
@@ -2284,6 +2285,7 @@ class ModelAdmin(BaseModelAdmin):
             "object": obj,
             "escaped_object": display_for_value(str(obj), EMPTY_VALUE_STRING),
             "deleted_objects": deleted_objects,
+            "delete_confirmation_max_display": self.delete_confirmation_max_display,
             "model_count": dict(model_count).items(),
             "perms_lacking": perms_needed,
             "protected": protected,

--- a/django/contrib/admin/templates/admin/delete_confirmation.html
+++ b/django/contrib/admin/templates/admin/delete_confirmation.html
@@ -23,19 +23,21 @@
 {% if perms_lacking %}
   {% block delete_forbidden %}
     <p>{% blocktranslate %}Deleting the {{ object_name }} “{{ escaped_object }}” would result in deleting related objects, but your account doesn't have permission to delete the following types of objects:{% endblocktranslate %}</p>
-    <ul id="deleted-objects">{{ perms_lacking|unordered_list }}</ul>
+    <ul id="deleted-objects">{{ perms_lacking|truncated_unordered_list:delete_confirmation_max_display }}</ul>
   {% endblock %}
 {% elif protected %}
   {% block delete_protected %}
     <p>{% blocktranslate %}Deleting the {{ object_name }} “{{ escaped_object }}” would require deleting the following protected related objects:{% endblocktranslate %}</p>
-    <ul id="deleted-objects">{{ protected|unordered_list }}</ul>
+    <ul id="deleted-objects">{{ protected|truncated_unordered_list:delete_confirmation_max_display }}</ul>
   {% endblock %}
 {% else %}
   {% block delete_confirm %}
     <p>{% blocktranslate %}Are you sure you want to delete the {{ object_name }} “{{ escaped_object }}”? All of the following related items will be deleted:{% endblocktranslate %}</p>
     {% include "admin/includes/object_delete_summary.html" %}
+    {% if delete_confirmation_max_display is None or delete_confirmation_max_display > 0 %}
     <h2>{% translate "Objects" %}</h2>
-    <ul id="deleted-objects">{{ deleted_objects|unordered_list }}</ul>
+    <ul id="deleted-objects">{{ deleted_objects|truncated_unordered_list:delete_confirmation_max_display }}</ul>
+    {% endif %}
     <form method="post">{% csrf_token %}
     <div>
     <input type="hidden" name="post" value="yes">

--- a/django/contrib/admin/templates/admin/delete_selected_confirmation.html
+++ b/django/contrib/admin/templates/admin/delete_selected_confirmation.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n l10n admin_urls static %}
+{% load i18n l10n admin_urls static admin_filters %}
 
 {% block extrahead %}
     {{ block.super }}
@@ -21,16 +21,16 @@
 {% block content %}
 {% if perms_lacking %}
     <p>{% blocktranslate %}Deleting the selected {{ objects_name }} would result in deleting related objects, but your account doesn't have permission to delete the following types of objects:{% endblocktranslate %}</p>
-    <ul>{{ perms_lacking|unordered_list }}</ul>
+    <ul>{{ perms_lacking|truncated_unordered_list:delete_confirmation_max_display }}</ul>
 {% elif protected %}
     <p>{% blocktranslate %}Deleting the selected {{ objects_name }} would require deleting the following protected related objects:{% endblocktranslate %}</p>
-    <ul>{{ protected|unordered_list }}</ul>
+    <ul>{{ protected|truncated_unordered_list:delete_confirmation_max_display }}</ul>
 {% else %}
     <p>{% blocktranslate %}Are you sure you want to delete the selected {{ objects_name }}? All of the following objects and their related items will be deleted:{% endblocktranslate %}</p>
     {% include "admin/includes/object_delete_summary.html" %}
     <h2>{% translate "Objects" %}</h2>
     {% for deletable_object in deletable_objects %}
-        <ul>{{ deletable_object|unordered_list }}</ul>
+        <ul>{{ deletable_object|truncated_unordered_list:delete_confirmation_max_display }}</ul>
     {% endfor %}
     <form method="post">{% csrf_token %}
     <div>

--- a/django/contrib/admin/templatetags/admin_filters.py
+++ b/django/contrib/admin/templatetags/admin_filters.py
@@ -1,7 +1,10 @@
 from django import template
 from django.contrib.admin.options import EMPTY_VALUE_STRING
 from django.contrib.admin.utils import display_for_value
-from django.template.defaultfilters import stringfilter
+from django.template.defaultfilters import _walk_items, stringfilter
+from django.utils.html import conditional_escape
+from django.utils.safestring import mark_safe
+from django.utils.translation import ngettext
 
 register = template.Library()
 
@@ -10,3 +13,67 @@ register = template.Library()
 @stringfilter
 def to_object_display_value(value):
     return display_for_value(str(value), EMPTY_VALUE_STRING)
+
+
+@register.filter(is_safe=True, needs_autoescape=True)
+def truncated_unordered_list(value, max_items, autoescape=True):
+    """
+    Render an unordered list, showing at most ``max_items`` items and a
+    "...and N more objects." item at the end.
+
+    Usage::
+
+        {{ deleted_objects|truncated_unordered_list:100 }}
+    """
+
+    has_unlimited_items = max_items is None
+    if not has_unlimited_items:
+        max_items = int(max_items)
+        if max_items <= 0:
+            return mark_safe("")
+
+    if autoescape:
+        escaper = conditional_escape
+    else:
+
+        def escaper(x):
+            return x
+
+    item_count = 0
+
+    def list_formatter(item_list, tabs=1):
+        nonlocal item_count
+        indent = "\t" * tabs
+        output = []
+        for item, children in _walk_items(item_list):
+            sublist = ""
+            item_count += 1
+            should_display_item = has_unlimited_items or 0 < item_count <= max_items
+            if children:
+                sublist = "\n%s<ul>\n%s\n%s</ul>\n%s" % (
+                    indent,
+                    list_formatter(children, tabs + 1),
+                    indent,
+                    indent,
+                )
+
+            if should_display_item:
+                output.append("%s<li>%s%s</li>" % (indent, escaper(item), sublist))
+
+        return "\n".join(output)
+
+    rendered_object_list = list_formatter(value)
+    remaining_objects_message = ""
+
+    if not has_unlimited_items and item_count > max_items:
+        remaining_object_count = item_count - max_items
+        remaining_objects_message = "\n\t<li>%s</li>" % (
+            ngettext(
+                "…and %(count)d more object.",
+                "…and %(count)d more objects.",
+                remaining_object_count,
+            )
+            % {"count": remaining_object_count}
+        )
+
+    return mark_safe(rendered_object_list + remaining_objects_message)

--- a/django/contrib/admin/utils.py
+++ b/django/contrib/admin/utils.py
@@ -130,7 +130,8 @@ def get_deleted_objects(objs, request, admin_site):
     must be a homogeneous iterable of objects (e.g. a QuerySet).
 
     Return a nested list of strings suitable for display in the
-    template with the ``unordered_list`` filter.
+    template with the ``unordered_list``
+    and ``truncated_unordered_list`` filters.
     """
     from django.contrib.admin.options import EMPTY_VALUE_STRING
 

--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -666,6 +666,31 @@ def slice_filter(value, arg):
         return value  # Fail silently.
 
 
+def _walk_items(item_list):
+    item_iterator = iter(item_list)
+    try:
+        item = next(item_iterator)
+        while True:
+            try:
+                next_item = next(item_iterator)
+            except StopIteration:
+                yield item, None
+                break
+            if isinstance(next_item, (list, tuple, types.GeneratorType)):
+                try:
+                    iter(next_item)
+                except TypeError:
+                    pass
+                else:
+                    yield item, next_item
+                    item = next(item_iterator)
+                    continue
+            yield item, None
+            item = next_item
+    except StopIteration:
+        pass
+
+
 @register.filter(is_safe=True, needs_autoescape=True)
 def unordered_list(value, autoescape=True):
     """
@@ -695,34 +720,10 @@ def unordered_list(value, autoescape=True):
         def escaper(x):
             return x
 
-    def walk_items(item_list):
-        item_iterator = iter(item_list)
-        try:
-            item = next(item_iterator)
-            while True:
-                try:
-                    next_item = next(item_iterator)
-                except StopIteration:
-                    yield item, None
-                    break
-                if isinstance(next_item, (list, tuple, types.GeneratorType)):
-                    try:
-                        iter(next_item)
-                    except TypeError:
-                        pass
-                    else:
-                        yield item, next_item
-                        item = next(item_iterator)
-                        continue
-                yield item, None
-                item = next_item
-        except StopIteration:
-            pass
-
     def list_formatter(item_list, tabs=1):
         indent = "\t" * tabs
         output = []
-        for item, children in walk_items(item_list):
+        for item, children in _walk_items(item_list):
             sublist = ""
             if children:
                 sublist = "\n%s<ul>\n%s\n%s</ul>\n%s" % (

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -816,6 +816,8 @@ with the admin site:
   method for the ``<action>`` action.
 * **admin.E130**: ``__name__`` attributes of actions defined in
   ``<modeladmin>`` must be unique. Name ``<name>`` is not unique.
+* **admin.E131**: The value of ``delete_confirmation_max_display`` must be a
+  non-negative integer or ``None``.
 
 ``InlineModelAdmin``
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1386,6 +1386,21 @@ default templates used by the :class:`ModelAdmin` views:
     for displaying a confirmation page when deleting one or more objects. See
     the :doc:`actions documentation</ref/contrib/admin/actions>`.
 
+.. attribute:: ModelAdmin.delete_confirmation_max_display
+
+    .. versionadded:: 6.1
+
+    Set ``delete_confirmation_max_display`` to control how many objects are
+    displayed on the delete confirmation pages before truncating the remainder
+    with an ellipsis.
+
+    The limit applies to the total number of displayed objects across the
+    relationship hierarchy. This is purely a display setting and does not
+    affect the total number of objects retrieved from the database.
+
+    This applies to both :meth:`delete_view` and the ``delete_selected``
+    action. By default, this is ``None`` (no truncation).
+
 .. attribute:: ModelAdmin.object_history_template
 
     Path to a custom template, used by :meth:`history_view`.
@@ -2283,6 +2298,7 @@ adds some of its own (the shared features are actually defined in the
 - :attr:`~ModelAdmin.fieldsets`
 - :attr:`~ModelAdmin.fields`
 - :attr:`~ModelAdmin.formfield_overrides`
+- :attr:`~ModelAdmin.delete_confirmation_max_display`
 - :attr:`~ModelAdmin.exclude`
 - :attr:`~ModelAdmin.filter_horizontal`
 - :attr:`~ModelAdmin.filter_vertical`

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -99,6 +99,11 @@ Minor features
   preserve :ref:`named groups <field-choices-named-groups>` (e.g.
   ``choices=[("Group", [("1", "Item")]), ...]``).
 
+* The :attr:`~django.contrib.admin.ModelAdmin.delete_confirmation_max_display`
+  option allows customizing how many objects are displayed on admin delete
+  confirmation pages before the remainder is truncated. The default is
+  ``None`` (no truncation).
+
 * In order to improve accessibility of the admin change forms:
 
   * Form fields are now shown below their respective labels instead of next to

--- a/tests/admin_views/customadmin.py
+++ b/tests/admin_views/customadmin.py
@@ -60,8 +60,19 @@ class CustomPwdTemplateUserAdmin(UserAdmin):
 
 
 class BookAdmin(admin.ModelAdmin):
+    delete_confirmation_max_display = 1
+
     def get_deleted_objects(self, objs, request):
-        return ["a deletable object"], {"books": 1}, set(), []
+        return (
+            ["a deletable object", "another object", "last object"],
+            {"books": 1},
+            set(),
+            [],
+        )
+
+
+class BookAdminZeroDisplay(BookAdmin):
+    delete_confirmation_max_display = 0
 
 
 site = Admin2(name="admin2")
@@ -80,3 +91,6 @@ site.register(models.Simple, base_admin.AttributeErrorRaisingAdmin)
 
 simple_site = Admin2(name="admin4")
 simple_site.register(User, CustomPwdTemplateUserAdmin)
+
+zero_display_site = Admin2(name="admin_zero_display")
+zero_display_site.register(models.Book, BookAdminZeroDisplay)

--- a/tests/admin_views/test_actions.py
+++ b/tests/admin_views/test_actions.py
@@ -220,6 +220,19 @@ class AdminActionsTest(TestCase):
         # BookAdmin.get_deleted_objects() returns custom text.
         self.assertContains(response, "a deletable object")
 
+    def test_delete_selected_uses_delete_confirmation_max_display(self):
+        book = Book.objects.create(name="Test Book")
+        data = {
+            ACTION_CHECKBOX_NAME: [book.pk],
+            "action": "delete_selected",
+            "index": 0,
+        }
+        response = self.client.post(reverse("admin2:admin_views_book_changelist"), data)
+        self.assertContains(response, "a deletable object")
+        self.assertContains(response, "…and 2 more objects.")
+        self.assertNotContains(response, "another object")
+        self.assertNotContains(response, "last object")
+
     def test_custom_function_mail_action(self):
         """A custom action may be defined in a function."""
         action_data = {

--- a/tests/admin_views/test_templatetags.py
+++ b/tests/admin_views/test_templatetags.py
@@ -1,7 +1,9 @@
 import datetime
 import unittest
 
+from django import template
 from django.contrib.admin import ModelAdmin
+from django.contrib.admin.templatetags.admin_filters import truncated_unordered_list
 from django.contrib.admin.templatetags.admin_list import date_hierarchy
 from django.contrib.admin.templatetags.admin_modify import submit_row
 from django.contrib.admin.templatetags.base import InclusionAdminNode
@@ -9,13 +11,127 @@ from django.contrib.auth import get_permission_codename
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.models import User
 from django.template.base import Token, TokenType
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, SimpleTestCase, TestCase
 from django.urls import reverse
 from django.utils.version import PY314
 
 from .admin import ArticleAdmin, site
 from .models import Article, Question
 from .tests import AdminViewBasicTestCase, get_perm
+
+
+class TruncatedUnorderedListTests(SimpleTestCase):
+    def test_no_max_items(self):
+        result = truncated_unordered_list(["item 1", "item 2"], None)
+        self.assertEqual(result, ("\t<li>item 1</li>\n" "\t<li>item 2</li>"))
+        self.assertNotIn("more object", result)
+
+    def test_max_items_zero(self):
+        result = truncated_unordered_list(["a", "b", "c"], 0)
+        self.assertEqual(result, "")
+        self.assertNotIn("more object", result)
+
+    def test_flat_list_truncated(self):
+        self.assertEqual(
+            truncated_unordered_list(["a", "b", "c", "d", "e"], 3),
+            (
+                "\t<li>a</li>\n"
+                "\t<li>b</li>\n"
+                "\t<li>c</li>\n"
+                "\t<li>…and 2 more objects.</li>"
+            ),
+        )
+
+    def test_nested_two_levels_truncated(self):
+        self.assertEqual(
+            truncated_unordered_list(["a", ["a1", "a2"], "b", "c", "d", "e"], 3),
+            (
+                "\t<li>a\n"
+                "\t<ul>\n"
+                "\t\t<li>a1</li>\n"
+                "\t\t<li>a2</li>\n"
+                "\t</ul>\n"
+                "\t</li>\n"
+                "\t<li>…and 4 more objects.</li>"
+            ),
+        )
+
+    def test_nested_and_top_level_truncated(self):
+        self.assertEqual(
+            truncated_unordered_list(
+                ["a", ["n1", "n2", "n3", "n4", "n5"], "b", "c", "d", "e"],
+                3,
+            ),
+            (
+                "\t<li>a\n"
+                "\t<ul>\n"
+                "\t\t<li>n1</li>\n"
+                "\t\t<li>n2</li>\n"
+                "\t</ul>\n"
+                "\t</li>\n"
+                "\t<li>…and 7 more objects.</li>"
+            ),
+        )
+
+    def test_nested_three_levels_truncated(self):
+        self.assertEqual(
+            truncated_unordered_list(["a", ["a1", ["a1x"]], "b", "c", "d", "e"], 3),
+            (
+                "\t<li>a\n"
+                "\t<ul>\n"
+                "\t\t<li>a1\n"
+                "\t\t<ul>\n"
+                "\t\t\t<li>a1x</li>\n"
+                "\t\t</ul>\n"
+                "\t\t</li>\n"
+                "\t</ul>\n"
+                "\t</li>\n"
+                "\t<li>…and 4 more objects.</li>"
+            ),
+        )
+
+    def test_max_items_equal_to_length(self):
+        self.assertEqual(
+            truncated_unordered_list(["a", "b", "c"], 3),
+            ("\t<li>a</li>\n" "\t<li>b</li>\n" "\t<li>c</li>"),
+        )
+
+    def test_max_items_greater_than_length(self):
+        self.assertEqual(
+            truncated_unordered_list(["a", "b"], 10),
+            ("\t<li>a</li>\n" "\t<li>b</li>"),
+        )
+
+    def test_truncated_single_remaining(self):
+        self.assertEqual(
+            truncated_unordered_list(["a", "b", "c"], 2),
+            ("\t<li>a</li>\n" "\t<li>b</li>\n" "\t<li>…and 1 more object.</li>"),
+        )
+
+    def test_autoescape(self):
+        self.assertEqual(
+            truncated_unordered_list(["<a>item</a>", "safe"], 1),
+            ("\t<li>&lt;a&gt;item&lt;/a&gt;</li>\n" "\t<li>…and 1 more object.</li>"),
+        )
+
+    def test_autoescape_off(self):
+        self.assertEqual(
+            truncated_unordered_list(["<a>item</a>", "safe"], 1, autoescape=False),
+            ("\t<li><a>item</a></li>\n" "\t<li>…and 1 more object.</li>"),
+        )
+
+    def test_empty_list(self):
+        self.assertEqual(truncated_unordered_list([], 5), "")
+
+    def test_template_rendering(self):
+        t = template.Template(
+            "{% load admin_filters %}{{ items|truncated_unordered_list:2 }}"
+        )
+        result = t.render(template.Context({"items": ["a", "b", "c"]}))
+        self.assertIn("<li>a</li>", result)
+        self.assertIn("<li>b</li>", result)
+        self.assertIn("<li>…and 1 more object.</li>", result)
+        self.assertNotIn("<li>c</li>", result)
 
 
 class AdminTemplateTagsTest(AdminViewBasicTestCase):

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -4197,6 +4197,26 @@ class AdminViewDeletedObjectsTest(TestCase):
         # BookAdmin.get_deleted_objects() returns custom text.
         self.assertContains(response, "a deletable object")
 
+    def test_delete_view_uses_delete_confirmation_max_display(self):
+        book = Book.objects.create(name="Test Book")
+        response = self.client.get(
+            reverse("admin2:admin_views_book_delete", args=(book.pk,))
+        )
+        self.assertContains(response, "a deletable object")
+        self.assertContains(response, "…and 2 more objects.")
+        self.assertNotContains(response, "another object")
+        self.assertNotContains(response, "last object")
+
+    def test_delete_view_hides_objects_when_delete_confirmation_max_display_is_zero(
+        self,
+    ):
+        book = Book.objects.create(name="Test Book")
+        response = self.client.get(
+            reverse("admin_zero_display:admin_views_book_delete", args=(book.pk,))
+        )
+        self.assertNotContains(response, "<h2>Objects</h2>")
+        self.assertNotContains(response, 'id="deleted-objects"')
+
 
 @override_settings(ROOT_URLCONF="admin_views.urls")
 class TestGenericRelations(TestCase):

--- a/tests/admin_views/urls.py
+++ b/tests/admin_views/urls.py
@@ -35,6 +35,7 @@ urlpatterns = [
     path("test_admin/admin11/", admin.site11.urls),
     path("test_admin/admin12/", admin.site12.urls),
     path("test_admin/admin13/", admin.site13.urls),
+    path("test_admin/admin_zero_display/", customadmin.zero_display_site.urls),
     path("test_admin/has_permission_admin/", custom_has_permission_admin.site.urls),
     path("test_admin/autocomplete_admin/", autocomplete_site.urls),
     # Shares the admin URL prefix.

--- a/tests/modeladmin/test_checks.py
+++ b/tests/modeladmin/test_checks.py
@@ -1020,6 +1020,50 @@ class ListMaxShowAllCheckTests(CheckTestCase):
         self.assertIsValid(TestModelAdmin, ValidationTestModel)
 
 
+class DeleteConfirmationMaxObjectsCheckTests(CheckTestCase):
+    def test_not_integer(self):
+        class TestModelAdmin(ModelAdmin):
+            delete_confirmation_max_display = "hello"
+
+        self.assertIsInvalid(
+            TestModelAdmin,
+            ValidationTestModel,
+            (
+                "The value of "
+                "'delete_confirmation_max_display'"
+                " must be a non-negative integer or None."
+            ),
+            "admin.E131",
+        )
+
+    def test_negative_integer(self):
+        class TestModelAdmin(ModelAdmin):
+            delete_confirmation_max_display = -1
+
+        self.assertIsInvalid(
+            TestModelAdmin,
+            ValidationTestModel,
+            (
+                "The value of "
+                "'delete_confirmation_max_display'"
+                " must be a non-negative integer or None."
+            ),
+            "admin.E131",
+        )
+
+    def test_valid_case(self):
+        class TestModelAdmin(ModelAdmin):
+            delete_confirmation_max_display = 100
+
+        self.assertIsValid(TestModelAdmin, ValidationTestModel)
+
+    def test_valid_none(self):
+        class TestModelAdmin(ModelAdmin):
+            delete_confirmation_max_display = None
+
+        self.assertIsValid(TestModelAdmin, ValidationTestModel)
+
+
 class SearchFieldsCheckTests(CheckTestCase):
     def test_not_iterable(self):
         class TestModelAdmin(ModelAdmin):

--- a/tests/template_tests/filter_tests/test_unordered_list.py
+++ b/tests/template_tests/filter_tests/test_unordered_list.py
@@ -160,6 +160,19 @@ class FunctionTests(SimpleTestCase):
             "<li>D</li>",
         )
 
+    def test_non_iterable_list_subclass(self):
+        class NonIterableList(list):
+            def __iter__(self):
+                raise TypeError
+
+            def __str__(self):
+                return "non-iterable-list"
+
+        self.assertEqual(
+            unordered_list(["A", NonIterableList(["x"]), "B"]),
+            "\t<li>A</li>\n\t<li>non-iterable-list</li>\n\t<li>B</li>",
+        )
+
     def test_ulitem_autoescape_off(self):
         class ULItem:
             def __init__(self, title):


### PR DESCRIPTION
#### Trac ticket number

ticket-10919

#### Branch description

The original ticket proposed adding an option to limit or hide the list of related objects shown on the delete confirmation page. This list can become very long, especially for complex object graphs, because related items are rendered recursively. As a result, the confirmation button is pushed far down the page.

<img height="400" alt="image" src="https://github.com/user-attachments/assets/6a9a05f5-72f6-47b9-b89d-ecc23475bb96" />


This PR implements a suggestion by @terminator14 ([comment 13](https://code.djangoproject.com/ticket/10919#comment:13)) to truncate the list at a given number, which is configurable, and complement the list with `…and N more objects`.

The setting is called `delete_confirmation_max_display` and its default value is `None`, **which means it's an opt-in setting**.

```python
class PostAdmin(admin.ModelAdmin):
    delete_confirmation_max_display = 100
    # .... more settings
```

It renders like the screenshot below. Note that it limits the number of objects globally; in the example below it's set to **10**.

<img width="735" height="554" alt="image" src="https://github.com/user-attachments/assets/0f6b86bc-724a-4c09-9a03-5849c3ac4f14" />

Dark mode

<img width="735" height="554" alt="image" src="https://github.com/user-attachments/assets/cf467623-4008-47d5-8cdc-8647f436d396" />

This still gives the user a good sense of the impact of the deletion, but keeps the page size predictable.


#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Used GitHub Copilot to request an initial review, considering the practices found on the codebase, and also to generate HTML for test cases. I fully reviewed and verified all output before submitting this PR. The solution/algorithm is mine.


#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
