### PR TITLE
Fixed #28461 -- Clarified `create_superuser()` with ForeignKey in `REQUIRED_FIELDS`.

### DIFF
--- a/docs/topics/auth/customizing.txt
+++ b/docs/topics/auth/customizing.txt
@@ -613,6 +613,19 @@ password resets. You must then provide some key implementation details:
             model, but should *not* contain the ``USERNAME_FIELD`` or
             ``password`` as these fields will always be prompted for.
 
+        .. note::
+ 
+            If ``REQUIRED_FIELDS`` contains a
+            :class:`~django.db.models.ForeignKey`, the
+            :djadmin:`createsuperuser` prompt will ask for the value of the
+            :attr:`~django.db.models.ForeignKey.to_field` (the
+            :attr:`~django.db.models.Field.primary_key` by default) of an
+            existing instance. You must define a custom manager with a
+            ``create_superuser()`` that resolves this raw value into the
+            required model instance. See
+            :meth:`~models.CustomUserManager.create_superuser` for an
+            example.
+
     .. attribute:: is_active
 
         A boolean attribute that indicates whether the user is considered
@@ -782,7 +795,29 @@ methods:
 For a :class:`~.ForeignKey` in :attr:`.USERNAME_FIELD` or
 :attr:`.REQUIRED_FIELDS`, these methods receive the value of the
 :attr:`~.ForeignKey.to_field` (the :attr:`~django.db.models.Field.primary_key`
-by default) of an existing instance.
+by default) of an existing instance. You must resolve this raw value into the
+required model instance yourself. For example, if your user model has a
+``ForeignKey`` to a ``Company`` model in ``REQUIRED_FIELDS``::
+
+    class MyUserManager(BaseUserManager):
+        def create_user(self, email, company, password=None):
+            company_instance = Company.objects.get(pk=company)
+            user = self.model(email=email, company=company_instance)
+            user.set_password(password)
+            user.save(using=self._db)
+            return user
+
+        def create_superuser(self, email, company, password=None):
+            company_instance = Company.objects.get(pk=company)
+            user = self.model(email=email, company=company_instance)
+            user.set_password(password)
+            user.is_admin = True
+            user.save(using=self._db)
+            return user
+
+Without this, ``createsuperuser`` will pass the raw primary key value (e.g.
+a string) directly to ``self.model()``, causing a ``ValueError`` since Django
+expects a model instance for ``ForeignKey`` fields.
 
 :class:`~django.contrib.auth.models.BaseUserManager` provides the following
 utility methods:

--- a/docs/topics/auth/customizing.txt
+++ b/docs/topics/auth/customizing.txt
@@ -614,7 +614,7 @@ password resets. You must then provide some key implementation details:
             ``password`` as these fields will always be prompted for.
 
         .. note::
- 
+
             If ``REQUIRED_FIELDS`` contains a
             :class:`~django.db.models.ForeignKey`, the
             :djadmin:`createsuperuser` prompt will ask for the value of the


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A" if this is a trivial PR. -->

ticket-28461

#### Branch description
The docs for `REQUIRED_FIELDS` and `create_superuser()` did not explain that when a ForeignKey is in `REQUIRED_FIELDS`, the raw `to_field` value is passed to the manager methods and must be manually resolved into a model instance.

Added a note in `REQUIRED_FIELDS` pointing to `create_superuser()`, and expanded the ForeignKey note under `create_superuser()` with a concrete code example showing how to resolve the raw pk value into a model instance.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [ ] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
