### PR TITLE
fixed #14035 -- Can access POST after request.encoding was set to a c…

### DIFF
--- a/django/http/request.py
+++ b/django/http/request.py
@@ -340,7 +340,23 @@ class HttpRequest:
         if hasattr(self, "GET"):
             del self.GET
         if hasattr(self, "_post"):
-            del self._post
+            if self._read_started and not hasattr(self, "_body"):
+
+                old_post = self._post
+                self._post = QueryDict(mutable=True)
+                for key, values in old_post.lists():
+                    new_key = key.encode(old_post.encoding).decode(val, "replace")
+                    for value in values:
+                        new_value = value.encode(old_post.encoding).decode(
+                            val, "replace"
+                        )
+                        self._post.appendlist(new_key, new_value)
+                self._post._mutable = False
+            else:
+                del self._post
+
+        self.__dict__.pop("POST", None)
+        self.__dict__.pop("FILES", None)
 
     def _initialize_handlers(self):
         self._upload_handlers = [

--- a/tests/requests_tests/tests.py
+++ b/tests/requests_tests/tests.py
@@ -1072,9 +1072,7 @@ class RequestsTests(SimpleTestCase):
         )
         self.assertEqual(request.POST, {"name": ["Hello Günter"]})
         request.encoding = "iso-8859-16"
-        # FIXME: POST should be accessible after changing the encoding
-        # (refs #14035).
-        # self.assertEqual(request.POST, {"name": ["Hello GĂŒnter"]})
+        self.assertEqual(request.POST, {"name": ["Hello GĂŒnter"]})
 
     def test_set_encoding_clears_GET(self):
         payload = FakePayload("")


### PR DESCRIPTION
#### Trac ticket number  
ticket-14035  

#### Branch description  
This PR fixes a long-standing issue. Changing `request.encoding` on a `multipart/form-data` request causes `request.POST` to become an empty `QueryDict`, resulting in data loss.  

Multipart requests use the HTTP input stream during the initial parse to save memory. Because of this, the standard cache-clearing mechanism (`del self._post`) fails on subsequent accesses since the stream cannot be read again.  

This patch checks if the multipart stream is exhausted. If it is, instead of trying to re-parse an empty stream, it loops through and re-decodes the existing `QueryDict` in memory using the new encoding. It also removes the `# FIXME` comment in `requests_tests` and activates the test assertion to enforce this behavior.  

#### AI Assistance Disclosure (REQUIRED)  
- [x] **No AI tools were used** in preparing this PR.  
- [ ] **If AI tools were used**, I have disclosed which ones and fully reviewed and verified their output.

#### Checklist  
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).  
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).  
- [x] This PR targets the `main` branch.  
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.  
- [x] I have checked the "Has patch" ticket flag in the Trac system.  
- [x] I have added or updated relevant tests.  
- [ ] I have added or updated relevant docs, including release notes if applicable.  
- [ ] I have attached screenshots in both light and dark modes for any UI changes.  

#### Test Output  
<details>  
<summary>Click to expand test results</summary>  

```text  
> python tests/runtests.py requests_tests                                    
Testing against Django installed in 'E:\django\django' with up to 12 processes
Found 114 test(s).
System check identified no issues (0 silenced).
..................................................................................................................
----------------------------------------------------------------------
Ran 114 tests in 2.000s

OK
```  