### PR TITLE
Fixed #25243 -- Added inspectdb regression test for sqlite_master FK.

### DIFF
--- a/tests/inspectdb/tests.py
+++ b/tests/inspectdb/tests.py
@@ -662,6 +662,36 @@ class InspectDBTransactionalTests(TransactionTestCase):
         self.assertIn(foreign_table_model, output)
         self.assertIn(foreign_table_managed, output)
 
+    @skipUnless(connection.vendor == "sqlite", "SQLite specific SQL")
+    @skipUnlessDBFeature("can_introspect_foreign_keys")
+    def test_foreign_key_to_sqlite_master(self):
+        with connection.constraint_checks_disabled():
+            cursor_execute(
+                """
+                CREATE TABLE inspectdb_sqlite_master_fk (
+                    id INTEGER PRIMARY KEY,
+                    table_name VARCHAR(64)
+                        REFERENCES sqlite_master (tbl_name),
+                    content TEXT NOT NULL
+                )
+                """
+            )
+
+        def cleanup():
+            with connection.constraint_checks_disabled():
+                cursor_execute("DROP TABLE IF EXISTS inspectdb_sqlite_master_fk")
+
+        self.addCleanup(cleanup)
+        out = StringIO()
+        call_command("inspectdb", "inspectdb_sqlite_master_fk", stdout=out)
+        output = out.getvalue()
+        self.assertIn("class InspectdbSqliteMasterFk(models.Model):", output)
+        self.assertIn(
+            "table_name = models.ForeignKey('SqliteMaster', models.DO_NOTHING, "
+            "db_column='table_name', blank=True, null=True)",
+            output,
+        )
+
     def test_composite_primary_key(self):
         out = StringIO()
         field_type = connection.features.introspected_field_types["IntegerField"]

--- a/tests/inspectdb/tests.py
+++ b/tests/inspectdb/tests.py
@@ -666,16 +666,14 @@ class InspectDBTransactionalTests(TransactionTestCase):
     @skipUnlessDBFeature("can_introspect_foreign_keys")
     def test_foreign_key_to_sqlite_master(self):
         with connection.constraint_checks_disabled():
-            cursor_execute(
-                """
+            cursor_execute("""
                 CREATE TABLE inspectdb_sqlite_master_fk (
                     id INTEGER PRIMARY KEY,
                     table_name VARCHAR(64)
                         REFERENCES sqlite_master (tbl_name),
                     content TEXT NOT NULL
                 )
-                """
-            )
+                """)
 
         def cleanup():
             with connection.constraint_checks_disabled():

--- a/tests/inspectdb/tests.py
+++ b/tests/inspectdb/tests.py
@@ -664,28 +664,28 @@ class InspectDBTransactionalTests(TransactionTestCase):
 
     @skipUnless(connection.vendor == "sqlite", "SQLite specific SQL")
     @skipUnlessDBFeature("can_introspect_foreign_keys")
-    def test_foreign_key_to_sqlite_master(self):
+    def test_foreign_key_to_sqlite_schema(self):
         with connection.constraint_checks_disabled():
             cursor_execute("""
-                CREATE TABLE inspectdb_sqlite_master_fk (
+                CREATE TABLE inspectdb_sqlite_schema_fk (
                     id INTEGER PRIMARY KEY,
                     table_name VARCHAR(64)
-                        REFERENCES sqlite_master (tbl_name),
+                        REFERENCES sqlite_schema (tbl_name),
                     content TEXT NOT NULL
                 )
                 """)
 
         def cleanup():
             with connection.constraint_checks_disabled():
-                cursor_execute("DROP TABLE IF EXISTS inspectdb_sqlite_master_fk")
+                cursor_execute("DROP TABLE IF EXISTS inspectdb_sqlite_schema_fk")
 
         self.addCleanup(cleanup)
         out = StringIO()
-        call_command("inspectdb", "inspectdb_sqlite_master_fk", stdout=out)
+        call_command("inspectdb", "inspectdb_sqlite_schema_fk", stdout=out)
         output = out.getvalue()
-        self.assertIn("class InspectdbSqliteMasterFk(models.Model):", output)
+        self.assertIn("class InspectdbSqliteSchemaFk(models.Model):", output)
         self.assertIn(
-            "table_name = models.ForeignKey('SqliteMaster', models.DO_NOTHING, "
+            "table_name = models.ForeignKey('SqliteSchema', models.DO_NOTHING, "
             "db_column='table_name', blank=True, null=True)",
             output,
         )


### PR DESCRIPTION


#### Trac ticket number

ticket-25243

#### Branch description

Added a SQLite regression test for `inspectdb` when a table has a foreign key that references `sqlite_master`.

The ticket's original crash path no longer reproduces on current `main`, but this test ensures the scenario remains supported and `inspectdb` output is generated without errors.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Used OpenAI Codex assistance and manually reviewed the final patch before submission.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.

Not applicable for this PR:

- Documentation/release notes: regression test coverage only.
- UI screenshots: no UI changes.

