### PR TITLE
Fixed #31317 -- Avoided crash in CreateModel with unique_together and AlterUniqueTogether.

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -661,6 +661,26 @@ class BaseDatabaseSchemaEditor:
         }
         meta_index_names = {constraint.name for constraint in model._meta.indexes}
         columns = [model._meta.get_field(field).column for field in fields]
+
+        # Check if the constraint is still in deferred_sql. This happens when
+        # CreateModel with unique_together is followed by AlterUniqueTogether
+        # in the same migration. index_together is not affected because its
+        # indexes are created immediately in CreateModel.database_forwards.
+        is_unique_constraint = constraint_kwargs.get("unique") is True
+        table = model._meta.db_table
+        if is_unique_constraint:
+            for deferred in list(self.deferred_sql):
+                if (
+                    isinstance(deferred, Statement)
+                    and deferred.references_table(table)
+                    and all(
+                        deferred.references_column(table, column) for column in columns
+                    )
+                    and deferred.parts["columns"].columns == columns
+                ):
+                    self.deferred_sql.remove(deferred)
+                    return
+
         constraint_names = self._constraint_names(
             model,
             columns,
@@ -668,7 +688,7 @@ class BaseDatabaseSchemaEditor:
             **constraint_kwargs,
         )
         if (
-            constraint_kwargs.get("unique") is True
+            is_unique_constraint
             and constraint_names
             and self.connection.features.allows_multiple_constraints_on_same_fields
         ):

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -3861,6 +3861,62 @@ class OperationTests(OperationTestBase):
             operation.describe(), "Alter unique_together for Pony (0 constraint(s))"
         )
 
+    def test_alter_unique_together_deferred(self):
+        """
+        AlterUniqueTogether handles deferred SQL constraints from previous
+        operations. Regression test for #31317.
+        """
+        app_label = "test_aluntod"
+        self.apply_operations(
+            app_label,
+            ProjectState(),
+            operations=[
+                migrations.CreateModel(
+                    "Pony",
+                    fields=[
+                        ("id", models.AutoField(primary_key=True)),
+                        ("pink", models.IntegerField(default=3)),
+                        ("weight", models.FloatField()),
+                    ],
+                    options={"unique_together": {("pink",)}},
+                ),
+                migrations.AlterUniqueTogether(
+                    name="Pony",
+                    unique_together={("pink", "weight")},
+                ),
+            ],
+        )
+
+        table_name = f"{app_label}_pony"
+        self.assertUniqueConstraintExists(table_name, ("pink", "weight"), value=True)
+        self.assertUniqueConstraintExists(table_name, ("pink",), value=False)
+
+    def test_alter_unique_together_deferred_overlapping_columns(self):
+        app_label = "test_aluntodoc"
+        self.apply_operations(
+            app_label,
+            ProjectState(),
+            operations=[
+                migrations.CreateModel(
+                    "Pony",
+                    fields=[
+                        ("id", models.AutoField(primary_key=True)),
+                        ("pink", models.IntegerField(default=3)),
+                        ("weight", models.FloatField()),
+                    ],
+                    options={"unique_together": [("pink", "weight"), ("pink",)]},
+                ),
+                migrations.AlterUniqueTogether(
+                    name="Pony",
+                    unique_together={("pink", "weight")},
+                ),
+            ],
+        )
+
+        table_name = f"{app_label}_pony"
+        self.assertUniqueConstraintExists(table_name, ("pink", "weight"), value=True)
+        self.assertUniqueConstraintExists(table_name, ("pink",), value=False)
+
     @skipUnlessDBFeature("allows_multiple_constraints_on_same_fields")
     def test_remove_unique_together_on_pk_field(self):
         app_label = "test_rutopkf"
@@ -4451,6 +4507,35 @@ class OperationTests(OperationTestBase):
             operation.database_forwards(app_label, editor, project_state, new_state)
         self.assertIndexNotExists(table_name, ["pink", "weight"])
         self.assertUniqueConstraintExists(table_name, ["pink", "weight"])
+
+    def test_alter_index_together_deferred_overlapping_columns(self):
+        app_label = "test_alintodoc"
+        self.apply_operations(
+            app_label,
+            ProjectState(),
+            operations=[
+                migrations.CreateModel(
+                    "Pony",
+                    fields=[
+                        ("id", models.AutoField(primary_key=True)),
+                        ("pink", models.IntegerField(default=3)),
+                        ("weight", models.FloatField()),
+                    ],
+                    options={
+                        "unique_together": [("pink",)],
+                        "index_together": [("pink",)],
+                    },
+                ),
+                migrations.AlterIndexTogether(
+                    name="Pony",
+                    index_together=set(),
+                ),
+            ],
+        )
+
+        table_name = f"{app_label}_pony"
+        self.assertIndexNotExists(table_name, ["pink"])
+        self.assertUniqueConstraintExists(table_name, ("pink",), value=True)
 
     def test_add_constraint(self):
         project_state = self.set_up_test_model("test_addconstraint")


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A" if this is a trivial PR. -->

ticket-31317

#### Branch description
When a migration contains a `CreateModel` with a `unique_together`, the unique constraint is defined in the `deferred_sql`.
So when the same migration also contains a `AlterUniqueTogether`, the operation will try to first remove the `unique_together` before re-creating the new unique constraint.

But since the first constraint was not executed, but stored in the `deferred_sql` list, it was not yet executed, leading to the issue at hand.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

I used Claude 4.6 Opus to help be pinpoint the core issue.
Yes, I have reviewed the entire output (and re-written most of it hehe).

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
