### PR TITLE
Fixed #17631 -- Handled fields and files with the same name in encode_multipart().

### DIFF
--- a/django/test/client.py
+++ b/django/test/client.py
@@ -295,7 +295,10 @@ def encode_multipart(boundary, data):
     # Each bit of the multipart form data could be either a form value or a
     # file, or a *list* of form values and/or files. Remember that HTTP field
     # names can be duplicated!
-    for key, value in data.items():
+    # Use lists() if data is a MultiValueDict, so that all values for a key
+    # are preserved (e.g. a form field and a file sharing the same name).
+    raw_data = getattr(data, "lists", data.items)()
+    for key, value in raw_data:
         if value is None:
             raise TypeError(
                 "Cannot encode None for key '%s' as POST data. Did you mean "

--- a/tests/test_client/tests.py
+++ b/tests/test_client/tests.py
@@ -27,6 +27,7 @@ from unittest import mock
 
 from django.contrib.auth.models import Permission, User
 from django.core import mail
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.http import HttpResponse, HttpResponseNotAllowed
 from django.test import (
     AsyncRequestFactory,
@@ -38,6 +39,7 @@ from django.test import (
     override_settings,
 )
 from django.urls import reverse_lazy
+from django.utils.datastructures import MultiValueDict
 from django.utils.decorators import async_only_middleware
 from django.views.generic import RedirectView
 
@@ -1044,6 +1046,23 @@ class ClientTest(TestCase):
                 data={"named_temp_file": test_file},
             )
         self.assertEqual(response.content, b"named_temp_file")
+
+    def test_uploading_file_and_field_with_same_name(self):
+        """
+        A form field and file uploads sharing the same name in a
+        MultiValueDict are both preserved when posted by the test client.
+        """
+        file = SimpleUploadedFile("file.txt", b"content")
+        response = self.client.post(
+            "/upload_view/",
+            data=MultiValueDict({"shared": ["field_value", file]}),
+        )
+        request = response.wsgi_request
+        self.assertEqual(request.POST.getlist("shared"), ["field_value"])
+        self.assertEqual(
+            [f.name for f in request.FILES.getlist("shared")],
+            ["file.txt"],
+        )
 
     def test_query_params(self):
         tests = (


### PR DESCRIPTION
#### Trac ticket number

ticket-17631

#### Branch description

When `data` passed to `encode_multipart()` is a `MultiValueDict`, calling `data.items()` only returns the last value for each key. This means that if a form field and a file upload share the same name, the form field value is silently dropped.

This PR switches to `data.lists()` (when available) so that all values per key are preserved during multipart encoding. A regression test is included that verifies both a form field value and a file are encoded when they share the same name in a `MultiValueDict`.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

AI tool used: Claude Code (Anthropic) — assisted with codebase analysis and fix implementation. All output was reviewed and verified.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.