### PR TITLE
Fixed #29098 -- Added SimpleTestCase.assertRedirectsRegex().

### DIFF
--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -3,6 +3,7 @@ import json
 import logging
 import pickle
 import posixpath
+import re
 import sys
 import threading
 import unittest
@@ -405,26 +406,18 @@ class SimpleTestCase(unittest.TestCase):
         """
         return modify_settings(**kwargs)
 
-    def assertRedirects(
+    def _assert_redirect_response(
         self,
         response,
-        expected_url,
         status_code=302,
         target_status_code=200,
         msg_prefix="",
         fetch_redirect_response=True,
     ):
         """
-        Assert that a response redirected to a specific URL and that the
-        redirect URL can be loaded.
-
-        Won't work for external links since it uses the test client to do a
-        request (use fetch_redirect_response=False to check such links without
-        fetching them).
+        Validate the redirect status codes and optionally fetch the redirect
+        target. Return the final redirect URL.
         """
-        if msg_prefix:
-            msg_prefix += ": "
-
         if hasattr(response, "redirect_chain"):
             # The request was a followed redirect
             self.assertTrue(
@@ -517,12 +510,79 @@ class SimpleTestCase(unittest.TestCase):
                     % (path, redirect_response.status_code, target_status_code),
                 )
 
+        return url
+
+    def assertRedirects(
+        self,
+        response,
+        expected_url,
+        status_code=302,
+        target_status_code=200,
+        msg_prefix="",
+        fetch_redirect_response=True,
+    ):
+        """
+        Assert that a response redirected to a specific URL and that the
+        redirect URL can be loaded.
+
+        Won't work for external links since it uses the test client to do a
+        request (use fetch_redirect_response=False to check such links without
+        fetching them).
+        """
+        if msg_prefix:
+            msg_prefix += ": "
+
+        url = self._assert_redirect_response(
+            response,
+            status_code,
+            target_status_code,
+            msg_prefix,
+            fetch_redirect_response,
+        )
+
         self.assertURLEqual(
             url,
             expected_url,
             msg_prefix
             + "Response redirected to '%s', expected '%s'" % (url, expected_url),
         )
+
+    def assertRedirectsRegex(
+        self,
+        response,
+        expected_url_regex,
+        status_code=302,
+        target_status_code=200,
+        msg_prefix="",
+        fetch_redirect_response=True,
+    ):
+        """
+        Assert that a response redirected to a URL that matches the given
+        regex pattern, and that the redirect URL can be loaded.
+
+        Won't work for external links since it uses the test client to do a
+        request (use fetch_redirect_response=False to check such links without
+        fetching them).
+        """
+        if msg_prefix:
+            msg_prefix += ": "
+
+        url = self._assert_redirect_response(
+            response,
+            status_code,
+            target_status_code,
+            msg_prefix,
+            fetch_redirect_response,
+        )
+
+        if isinstance(expected_url_regex, str):
+            expected_url_regex = re.compile(expected_url_regex)
+        if not expected_url_regex.search(url):
+            self.fail(
+                msg_prefix
+                + "Response redirected to '%s', expected a match for regex '%s'"
+                % (url, expected_url_regex.pattern),
+            )
 
     def assertURLEqual(self, url1, url2, msg_prefix=""):
         """

--- a/tests/test_client/tests.py
+++ b/tests/test_client/tests.py
@@ -906,6 +906,45 @@ class ClientTest(TestCase):
         with self.assertRaisesMessage(ValueError, msg):
             self.assertRedirects(response, "https://www.djangoproject.com/")
 
+    def test_redirect_regex(self):
+        """assertRedirectsRegex matches the redirect URL against a pattern."""
+        response = self.client.get("/redirect_view/")
+        self.assertRedirectsRegex(response, r"/get_view/")
+
+    def test_redirect_regex_with_pattern(self):
+        """assertRedirectsRegex works with dynamic URL patterns."""
+        response = self.client.get("/redirect_view/", {"var": "value"})
+        self.assertRedirectsRegex(response, r"/get_view/\?var=value")
+
+    def test_redirect_regex_with_compiled_pattern(self):
+        """assertRedirectsRegex accepts a compiled regex."""
+        import re
+
+        response = self.client.get("/redirect_view/")
+        self.assertRedirectsRegex(response, re.compile(r"/get_\w+/"))
+
+    def test_redirect_regex_no_match(self):
+        """assertRedirectsRegex fails when the URL doesn't match."""
+        response = self.client.get("/redirect_view/")
+        with self.assertRaises(AssertionError):
+            self.assertRedirectsRegex(response, r"/nonexistent/")
+
+    def test_redirect_regex_follow(self):
+        """assertRedirectsRegex works with followed redirects."""
+        response = self.client.get("/double_redirect_view/", follow=True)
+        self.assertRedirectsRegex(
+            response, r"/get_view/", status_code=302, target_status_code=200
+        )
+
+    def test_redirect_regex_external(self):
+        """assertRedirectsRegex works with external redirects."""
+        response = self.client.get("/django_project_redirect/")
+        self.assertRedirectsRegex(
+            response,
+            r"https://www\.djangoproject\.com/",
+            fetch_redirect_response=False,
+        )
+
     def test_session_modifying_view(self):
         "Request a page that modifies the session"
         # Session value isn't set initially


### PR DESCRIPTION
#### Trac ticket number

ticket-29098

#### Branch description

Added `assertRedirectsRegex()` to `SimpleTestCase`, allowing redirect URL matching against regex patterns instead of exact strings. This is useful for testing views that redirect to dynamic URLs (e.g., `/items/12345/detail/`) where the exact URL is not known in advance.

**Implementation approach:**

- Extracted the common redirect validation logic (status code checks, redirect chain handling, fetch redirect response) from `assertRedirects()` into a private `_assert_redirect_response()` helper that returns the final redirect URL.
- `assertRedirects()` now calls the helper, then compares using `assertURLEqual()` (unchanged behavior).
- `assertRedirectsRegex()` calls the same helper, then matches against the regex pattern using `re.search()`.
- Accepts both string patterns and pre-compiled regex objects, consistent with Python's `assertRegex()`.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

AI tool used: Claude Code (Anthropic) — assisted with codebase analysis, implementation, and test writing. All output was reviewed and verified.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.