### PR TITLE
Fixed #36542 -- Marked authenticate() with @sensitive_variables() decorator.

### DIFF
--- a/django/contrib/auth/backends.py
+++ b/django/contrib/auth/backends.py
@@ -3,6 +3,7 @@ from asgiref.sync import sync_to_async
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
 from django.db.models import Exists, OuterRef, Q
+from django.views.decorators.debug import sensitive_variables
 
 UserModel = get_user_model()
 
@@ -56,6 +57,7 @@ class ModelBackend(BaseBackend):
     Authenticates against settings.AUTH_USER_MODEL.
     """
 
+    @sensitive_variables("password")
     def authenticate(self, request, username=None, password=None, **kwargs):
         if username is None:
             username = kwargs.get(UserModel.USERNAME_FIELD)
@@ -71,6 +73,7 @@ class ModelBackend(BaseBackend):
             if user.check_password(password) and self.user_can_authenticate(user):
                 return user
 
+    @sensitive_variables("password")
     async def aauthenticate(self, request, username=None, password=None, **kwargs):
         if username is None:
             username = kwargs.get(UserModel.USERNAME_FIELD)

--- a/tests/auth_tests/models/custom_user.py
+++ b/tests/auth_tests/models/custom_user.py
@@ -143,3 +143,17 @@ with RemoveGroupsAndPermissions():
         custom_objects = UserManager()
 
         REQUIRED_FIELDS = AbstractUser.REQUIRED_FIELDS + ["date_of_birth"]
+
+
+class ErrorUserManager(BaseUserManager):
+    def get_by_natural_key(self, _):
+        raise TypeError
+
+    async def aget_by_natural_key(self, _):
+        raise TypeError
+
+
+with RemoveGroupsAndPermissions():
+
+    class ErrorAdminUser(AbstractUser):
+        custom_objects = ErrorUserManager()

--- a/tests/auth_tests/test_auth_backends.py
+++ b/tests/auth_tests/test_auth_backends.py
@@ -1146,6 +1146,42 @@ class AuthenticateTests(TestCase):
             status_code=500,
         )
 
+    @override_settings(AUTH_USER_MODEL="auth_tests.ErrorAdminUser")
+    def test_model_backend_authenticate_sensitive_variables(self):
+        try:
+            authenticate(username="testusername", password=self.sensitive_password)
+        except TypeError:
+            exc_info = sys.exc_info()
+        rf = RequestFactory()
+        response = technical_500_response(rf.get("/"), *exc_info)
+        self.assertNotContains(response, self.sensitive_password, status_code=500)
+        self.assertContains(
+            response,
+            '<tr><td>password</td><td class="code">'
+            "<pre>&#39;********************&#39;</pre></td></tr>",
+            html=True,
+            status_code=500,
+        )
+
+    @override_settings(AUTH_USER_MODEL="auth_tests.ErrorAdminUser")
+    async def test_model_backend_async_authenticate_sensitive_variables(self):
+        try:
+            await aauthenticate(
+                username="testusername", password=self.sensitive_password
+            )
+        except TypeError:
+            exc_info = sys.exc_info()
+        rf = RequestFactory()
+        response = technical_500_response(rf.get("/"), *exc_info)
+        self.assertNotContains(response, self.sensitive_password, status_code=500)
+        self.assertContains(
+            response,
+            '<tr><td>password</td><td class="code">'
+            "<pre>&#39;********************&#39;</pre></td></tr>",
+            html=True,
+            status_code=500,
+        )
+
     def test_clean_credentials_sensitive_variables(self):
         try:
             # Passing in a list to cause an exception


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A" if this is a trivial PR. -->

[ticket-36542](https://code.djangoproject.com/ticket/36542)

#### Branch description
There are still sensitive information exposure at POST parameters including `password, old_password, new_password1, new_password2` if `DEBUG=True`. Though we informed such risk in documentation, there is reasonable to handle these cases properly.

I imitated `hidden_settings` approach we use to hide sensitive settings by adding `hidden_post_parameters` and filter those expecting fields in POST parameters out.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
