### PR TITLE
Fixed #36991 -- Raised BadRequest for invalid encodings in Content-Type headers.

### DIFF
--- a/django/http/request.py
+++ b/django/http/request.py
@@ -155,9 +155,12 @@ class HttpRequest:
 
     def _set_content_type_params(self, meta):
         """Set content_type, content_params, and encoding."""
-        self.content_type, self.content_params = parse_header_parameters(
-            meta.get("CONTENT_TYPE", "")
-        )
+        try:
+            self.content_type, self.content_params = parse_header_parameters(
+                meta.get("CONTENT_TYPE", "")
+            )
+        except ValueError as exc:
+            raise BadRequest("Invalid Content-Type header.") from exc
         if "charset" in self.content_params:
             try:
                 codecs.lookup(self.content_params["charset"])

--- a/django/utils/http.py
+++ b/django/utils/http.py
@@ -366,7 +366,11 @@ def parse_header_parameters(line, max_length=MAX_HEADER_LENGTH):
                 value = value.replace("\\\\", "\\").replace('\\"', '"')
             if has_encoding:
                 encoding, lang, value = value.split("'")
-                value = unquote(value, encoding=encoding)
+                try:
+                    value = unquote(value, encoding=encoding)
+                except (LookupError, UnicodeDecodeError):
+                    msg = f"Invalid encoding {encoding!r} for RFC 2231 param."
+                    raise ValueError(msg)
             pdict[name] = value
     return key, pdict
 

--- a/tests/requests_tests/tests.py
+++ b/tests/requests_tests/tests.py
@@ -456,6 +456,20 @@ class RequestsTests(SimpleTestCase):
         with self.assertRaises(RawPostDataException):
             request.body
 
+    def test_malformed_header(self):
+        tests = [
+            # Invalid encoding name with percent-encoded value
+            "text/plain; charset*=BOGUS''%20",
+            # Another invalid encoding with different value
+            "text/plain; filename*=INVALID''%s%s%s",
+            # Invalid encoding with multi-line encoded content
+            "text/plain; title*=NOTACODEC''%E2%80%A6",
+        ]
+        msg = "Invalid Content-Type header."
+        for header in tests:
+            with self.subTest(header=header), self.assertRaisesMessage(BadRequest, msg):
+                WSGIRequest({"REQUEST_METHOD": "GET", "CONTENT_TYPE": header})
+
     def test_malformed_multipart_header(self):
         tests = [
             ('Content-Disposition : form-data; name="name"', {"name": ["value"]}),

--- a/tests/utils_tests/test_http.py
+++ b/tests/utils_tests/test_http.py
@@ -521,6 +521,20 @@ class ParseHeaderParameterTests(unittest.TestCase):
             parsed = parse_header_parameters(raw_line)
             self.assertEqual(parsed[1]["title"], expected_title)
 
+    def test_rfc2231_invalid_encoding(self):
+        test_data = [
+            # Invalid encoding name with percent-encoded value
+            "text/plain; charset*=BOGUS''%20",
+            # Another invalid encoding with different value
+            "text/plain; filename*=INVALID''%s%s%s",
+            # Invalid encoding with multi-line encoded content
+            "text/plain; title*=NOTACODEC''%E2%80%A6",
+        ]
+        msg = "Invalid encoding"
+        for header in test_data:
+            with self.subTest(raw_line=header), self.assertRaisesRegex(ValueError, msg):
+                parse_header_parameters(header)
+
     def test_header_max_length(self):
         base_header = "Content-Type: application/x-stuff; title*="
         base_header_len = len(base_header)


### PR DESCRIPTION

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36991

#### Trac ticket number
#36991

#### Branch description
Fixed LookupError crash in parse_header_parameters() when Content-Type header contains RFC 2231 parameter with invalid encoding name.

**Problem:** When a Content-Type header contains an RFC 2231 encoded parameter with an invalid encoding name (e.g., `charset*=BOGUS''value`), the function would pass the unvalidated encoding to urllib.parse.unquote(), causing an uncaught LookupError that resulted in HTTP 500 instead of HTTP 400.

**Solution:** Added try/except block to catch LookupError and UnicodeDecodeError, then raises BadRequest (which Django's exception handler correctly converts to HTTP 400 Bad Request).


#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

   I received suggestions from Claude Copilot to use `BadRequest` exception instead of `ValueError`. This was crucial because `ValueError` would still return HTTP 500, while `BadRequest` correctly triggers Django's exception handler to return HTTP 400.  but it cause multipart form to raise error instead of handling gracefully so  raise ValueError  but handle it in _set_content_type_params and raise BadRequest there when caught an ValueError I have fully tested and verified the solution.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
