### PR TITLE
Fixed #36998 -- Raised TemplateSyntaxError for 'firstof as var' with no arguments.

### DIFF
--- a/django/template/defaulttags.py
+++ b/django/template/defaulttags.py
@@ -801,6 +801,12 @@ def firstof(parser, token):
     if len(bits) >= 2 and bits[-2] == "as":
         asvar = bits[-1]
         bits = bits[:-2]
+    if not bits:
+        raise TemplateSyntaxError(
+            "'firstof' statement requires at least one argument before 'as'"
+            if asvar
+            else "'firstof' statement requires at least one argument"
+        )
     return FirstOfNode([parser.compile_filter(bit) for bit in bits], asvar)
 
 

--- a/tests/template_tests/syntax_tests/test_firstof.py
+++ b/tests/template_tests/syntax_tests/test_firstof.py
@@ -88,3 +88,11 @@ class FirstOfTagTests(SimpleTestCase):
         output = self.engine.render_to_string("firstof16", ctx)
         self.assertEqual(ctx["myvar"], "")
         self.assertEqual(output, "")
+
+    @setup({"firstof17": "{% firstof as myvar %}"})
+    def test_no_arguments_with_asvar(self):
+        with self.assertRaisesMessage(
+            TemplateSyntaxError,
+            "'firstof' statement requires at least one argument before 'as'",
+        ):
+            self.engine.get_template("firstof17")


### PR DESCRIPTION
The `{% firstof %}` template tag correctly raises `TemplateSyntaxError` when
called with no arguments. However, `{% firstof as var %}` silently
created a `FirstOfNode` with an empty vars list instead of raising
the expected error.

## Problem

```python
>>> engine.from_string("{% firstof %}")
# Correctly raises: TemplateSyntaxError: 'firstof' statement requires at least one argument

>>> engine.from_string("{% firstof as foo %}")
# BUG: No error raised, returns FirstOfNode with empty vars list
```

## Fix

Added a second check after stripping the optional `as var` clause. If
`bits` is empty at that point, raise `TemplateSyntaxError` with a
descriptive message indicating the argument must appear before `as`.

## Ticket

https://code.djangoproject.com/ticket/36998

## Checklist

- [x] I have reviewed the contributing guidelines
- [x] The fix is a minimal change to address the issue
- [x] A regression test is included