### PR TITLE
Fixed #36825 -- Added CSP nonce support to admin.

### DIFF
--- a/django/contrib/admin/templates/admin/base.html
+++ b/django/contrib/admin/templates/admin/base.html
@@ -1,4 +1,4 @@
-{% load i18n static %}<!DOCTYPE html>
+{% load i18n static admin_list %}<!DOCTYPE html>
 {% get_current_language as LANGUAGE_CODE %}{% get_current_language_bidi as LANGUAGE_BIDI %}
 <html lang="{{ LANGUAGE_CODE|default:"en-us" }}" dir="{{ LANGUAGE_BIDI|yesno:'rtl,ltr,auto' }}">
 <head>
@@ -7,11 +7,11 @@
 <link rel="stylesheet" href="{% block stylesheet %}{% static "admin/css/base.css" %}{% endblock %}">
 {% block dark-mode-vars %}
   <link rel="stylesheet" href="{% static "admin/css/dark_mode.css" %}">
-  <script src="{% static "admin/js/theme.js" %}"></script>
+  <script src="{% static "admin/js/theme.js" %}"{% csp_nonce_attr %}></script>
 {% endblock %}
 {% if not is_popup and is_nav_sidebar_enabled %}
   <link rel="stylesheet" href="{% static "admin/css/nav_sidebar.css" %}">
-  <script src="{% static 'admin/js/nav_sidebar.js' %}" defer></script>
+  <script src="{% static 'admin/js/nav_sidebar.js' %}"{% csp_nonce_attr %} defer></script>
 {% endif %}
 {% block extrastyle %}{% endblock %}
 {% if LANGUAGE_BIDI %}<link rel="stylesheet" href="{% block stylesheet_rtl %}{% static "admin/css/rtl.css" %}{% endblock %}">{% endif %}

--- a/django/contrib/admin/templates/admin/change_form.html
+++ b/django/contrib/admin/templates/admin/change_form.html
@@ -1,9 +1,9 @@
 {% extends "admin/base_site.html" %}
-{% load i18n admin_urls static admin_modify admin_filters %}
+{% load i18n admin_urls static admin_modify admin_filters admin_list %}
 
 {% block title %}{% if errors %}{% translate "Error:" %} {% endif %}{{ block.super }}{% endblock %}
 {% block extrahead %}{{ block.super }}
-<script src="{% url 'admin:jsi18n' %}"></script>
+<script src="{% url 'admin:jsi18n' %}"{% csp_nonce_attr %}></script>
 {{ media }}
 {% endblock %}
 

--- a/django/contrib/admin/templates/admin/change_list.html
+++ b/django/contrib/admin/templates/admin/change_list.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="{% static "admin/css/forms.css" %}">
   {% endif %}
   {% if cl.formset or action_form %}
-    <script src="{% url 'admin:jsi18n' %}"></script>
+    <script src="{% url 'admin:jsi18n' %}"{% csp_nonce_attr %}></script>
   {% endif %}
   {{ media.css }}
   {% if not actions_on_top and not actions_on_bottom %}
@@ -22,7 +22,7 @@
 {% block extrahead %}
 {{ block.super }}
 {{ media.js }}
-<script src="{% static 'admin/js/filters.js' %}" defer></script>
+<script src="{% static 'admin/js/filters.js' %}"{% csp_nonce_attr %} defer></script>
 {% endblock %}
 
 {% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} change-list{% endblock %}

--- a/django/contrib/admin/templates/admin/delete_confirmation.html
+++ b/django/contrib/admin/templates/admin/delete_confirmation.html
@@ -1,10 +1,10 @@
 {% extends "admin/base_site.html" %}
-{% load i18n admin_urls static admin_filters %}
+{% load i18n admin_urls static admin_filters admin_list %}
 
 {% block extrahead %}
     {{ block.super }}
     {{ media }}
-    <script src="{% static 'admin/js/cancel.js' %}" async></script>
+    <script src="{% static 'admin/js/cancel.js' %}"{% csp_nonce_attr %} async></script>
 {% endblock %}
 
 {% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} delete-confirmation{% endblock %}

--- a/django/contrib/admin/templates/admin/delete_selected_confirmation.html
+++ b/django/contrib/admin/templates/admin/delete_selected_confirmation.html
@@ -1,10 +1,10 @@
 {% extends "admin/base_site.html" %}
-{% load i18n l10n admin_urls static %}
+{% load i18n l10n admin_urls static admin_list %}
 
 {% block extrahead %}
     {{ block.super }}
     {{ media }}
-    <script src="{% static 'admin/js/cancel.js' %}" async></script>
+    <script src="{% static 'admin/js/cancel.js' %}"{% csp_nonce_attr %} async></script>
 {% endblock %}
 
 {% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} delete-confirmation delete-selected-confirmation{% endblock %}

--- a/django/contrib/admin/templates/admin/popup_response.html
+++ b/django/contrib/admin/templates/admin/popup_response.html
@@ -1,10 +1,11 @@
-{% load i18n static %}<!DOCTYPE html>
+{% load i18n static admin_list %}<!DOCTYPE html>
 <html>
   <head><title>{% translate 'Popup closing…' %}</title></head>
   <body>
     <script id="django-admin-popup-response-constants"
             src="{% static "admin/js/popup_response.js" %}"
-            data-popup-response="{{ popup_response_data }}">
+            data-popup-response="{{ popup_response_data }}"
+            {% csp_nonce_attr %}>
     </script>
   </body>
 </html>

--- a/django/contrib/admin/templates/admin/prepopulated_fields_js.html
+++ b/django/contrib/admin/templates/admin/prepopulated_fields_js.html
@@ -1,5 +1,6 @@
-{% load static %}
+{% load static admin_list %}
 <script id="django-admin-prepopulated-fields-constants"
         src="{% static "admin/js/prepopulate_init.js" %}"
-        data-prepopulated-fields="{{ prepopulated_fields_json }}">
+        data-prepopulated-fields="{{ prepopulated_fields_json }}"
+        {% csp_nonce_attr %}>
 </script>

--- a/django/contrib/admin/templatetags/admin_list.py
+++ b/django/contrib/admin/templatetags/admin_list.py
@@ -19,6 +19,7 @@ from django.contrib.admin.views.main import (
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.db.models.constants import LOOKUP_SEP
+from django.middleware.csp import get_nonce
 from django.template import Library
 from django.template.loader import get_template
 from django.templatetags.static import static
@@ -553,3 +554,12 @@ def change_list_object_tools_tag(parser, token):
         func=lambda context: context,
         template_name="change_list_object_tools.html",
     )
+
+
+@register.simple_tag(name="csp_nonce_attr", takes_context=True)
+def csp_nonce_attr(context):
+    request = context.get("request")
+    nonce = str(get_nonce(request))
+    if nonce != "None":
+        return mark_safe(f' nonce="{nonce}"')
+    return ""

--- a/tests/admin_views/test_csp.py
+++ b/tests/admin_views/test_csp.py
@@ -1,0 +1,191 @@
+from django.contrib.admin.options import IS_POPUP_VAR
+from django.contrib.auth.models import User
+from django.middleware.csp import get_nonce
+from django.test import TestCase, modify_settings, override_settings
+from django.urls import reverse
+from django.utils.csp import CSP
+
+from .models import Recipe
+
+
+@modify_settings(
+    MIDDLEWARE={"append": "django.middleware.csp.ContentSecurityPolicyMiddleware"}
+)
+@override_settings(
+    ROOT_URLCONF="admin_views.urls",
+    TEMPLATES=[
+        {
+            "BACKEND": "django.template.backends.django.DjangoTemplates",
+            "APP_DIRS": True,
+            "OPTIONS": {
+                "context_processors": [
+                    "django.template.context_processors.request",
+                    "django.contrib.auth.context_processors.auth",
+                    "django.contrib.messages.context_processors.messages",
+                    "django.template.context_processors.csp",
+                ],
+            },
+        },
+    ],
+    SECURE_CSP={
+        "script-src": [CSP.NONCE],
+    },
+)
+class AdminCSPNonceTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.superuser = User.objects.create_superuser(
+            username="super", password="secret", email="super@example.com"
+        )
+        cls.recipe = Recipe.objects.create(rname="pizza")
+
+    def setUp(self):
+        self.client.force_login(self.superuser)
+
+    def test_base(self):
+        response = self.client.get(reverse("admin:index"))
+        expected_nonce = get_nonce(response.wsgi_request)
+        self.assertContains(
+            response,
+            f'<script src="/static/admin/js/theme.js" nonce="{expected_nonce}">',
+        )
+        self.assertContains(
+            response,
+            '<script src="/static/admin/js/nav_sidebar.js"'
+            f' nonce="{expected_nonce}" defer>',
+        )
+
+    def test_changeform(self):
+        response = self.client.get(
+            reverse("admin:admin_views_recipe_change", args=(self.recipe.pk,))
+        )
+        expected_nonce = get_nonce(response.wsgi_request)
+        self.assertContains(
+            response,
+            f'<script src="/test_admin/admin/jsi18n/" nonce="{expected_nonce}">',
+        )
+        self.assertContains(
+            response,
+            '<script id="django-admin-prepopulated-fields-constants"'
+            ' src="/static/admin/js/prepopulate_init.js"'
+            f' data-prepopulated-fields="[]" nonce="{expected_nonce}"></script>',
+            html=True,
+        )
+
+    def test_changelist(self):
+        response = self.client.get(reverse("admin:admin_views_recipe_changelist"))
+        expected_nonce = get_nonce(response.wsgi_request)
+        self.assertContains(
+            response,
+            f'<script src="/test_admin/admin/jsi18n/" nonce="{expected_nonce}">',
+        )
+        self.assertContains(
+            response,
+            '<script src="/static/admin/js/filters.js"'
+            f' nonce="{expected_nonce}" defer>',
+        )
+
+    def test_delete_confirmation(self):
+        response = self.client.get(
+            reverse("admin:admin_views_recipe_delete", args=(self.recipe.pk,))
+        )
+        expected_nonce = get_nonce(response.wsgi_request)
+        self.assertContains(
+            response,
+            f'<script src="/static/admin/js/cancel.js" nonce="{expected_nonce}" async>',
+        )
+
+    def test_delete_selected_confirmation(self):
+        post_data = {
+            "action": "delete_selected",
+            "selected_across": "0",
+            "index": "0",
+            "_selected_action": self.recipe.pk,
+        }
+        response = self.client.post(
+            reverse("admin:admin_views_recipe_changelist"), post_data, follow=True
+        )
+        expected_nonce = get_nonce(response.wsgi_request)
+        self.assertContains(
+            response,
+            f'<script src="/static/admin/js/cancel.js" nonce="{expected_nonce}" async>',
+        )
+
+    def test_popup_response(self):
+        post_data = {"rname": "chicken", "_save": "Save", IS_POPUP_VAR: "1"}
+        response = self.client.post(
+            reverse("admin:admin_views_recipe_add") + "?%s=1" % IS_POPUP_VAR,
+            post_data,
+            follwo=True,
+        )
+        expected_nonce = get_nonce(response.wsgi_request)
+        self.assertContains(response, f'nonce="{expected_nonce}"')
+
+
+@override_settings(
+    ROOT_URLCONF="admin_views.urls",
+)
+class AdminWithoutCSPNonceTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.superuser = User.objects.create_superuser(
+            username="super", password="secret", email="super@example.com"
+        )
+        cls.recipe = Recipe.objects.create(rname="snow")
+
+    def setUp(self):
+        self.client.force_login(self.superuser)
+
+    def test_base(self):
+        response = self.client.get(reverse("admin:index"))
+        self.assertContains(response, '<script src="/static/admin/js/theme.js">')
+        self.assertContains(
+            response, '<script src="/static/admin/js/nav_sidebar.js" defer>'
+        )
+
+    def test_chaneform(self):
+        response = self.client.get(
+            reverse("admin:admin_views_recipe_change", args=(self.recipe.pk,))
+        )
+        self.assertContains(response, '<script src="/test_admin/admin/jsi18n/">')
+        self.assertContains(
+            response,
+            '<script id="django-admin-prepopulated-fields-constants"'
+            ' src="/static/admin/js/prepopulate_init.js"'
+            ' data-prepopulated-fields="[]"></script>',
+            html=True,
+        )
+
+    def test_changelist(self):
+        response = self.client.get(reverse("admin:admin_views_recipe_changelist"))
+        self.assertContains(response, '<script src="/test_admin/admin/jsi18n/">')
+        self.assertContains(
+            response, '<script src="/static/admin/js/filters.js" defer>'
+        )
+
+    def test_delete_confirmation(self):
+        response = self.client.get(
+            reverse("admin:admin_views_recipe_delete", args=(self.recipe.pk,))
+        )
+        self.assertContains(response, '<script src="/static/admin/js/cancel.js" async>')
+
+    def test_delete_selected_confirmation(self):
+        post_data = {
+            "action": "delete_selected",
+            "selected_across": "0",
+            "index": "0",
+            "_selected_action": self.recipe.pk,
+        }
+        response = self.client.post(
+            reverse("admin:admin_views_recipe_changelist"), post_data, follow=True
+        )
+        self.assertContains(response, '<script src="/static/admin/js/cancel.js" async>')
+
+    def test_popup_response(self):
+        post_data = {"rname": "hamburger", "_save": "Save", IS_POPUP_VAR: "1"}
+        response = self.client.post(
+            reverse("admin:admin_views_recipe_add") + "?%s=1" % IS_POPUP_VAR,
+            post_data,
+            follwo=True,
+        )
+        self.assertNotContains(response, "nonce=")


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36825

#### Branch description
Provide a concise overview of the issue or rationale behind the proposed changes.

Fixes an issue where script tags in the admin failed to load when a CSP nonce was configured.
Conditionally adds a nonce attribute to script tags used in the admin templates.


#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
