### PR TITLE
Fixed #36825 -- Extended admin templates so CSP nonce is included if available.

### DIFF
--- a/django/contrib/admin/templates/admin/auth/user/add_form.html
+++ b/django/contrib/admin/templates/admin/auth/user/add_form.html
@@ -8,5 +8,5 @@
 {% endblock %}
 {% block extrahead %}
   {{ block.super }}
-  <link rel="stylesheet" href="{% static 'admin/css/unusable_password_field.css' %}">
+  <link rel="stylesheet" href="{% static 'admin/css/unusable_password_field.css' %}" {% csp_nonce_attr %}>
 {% endblock %}

--- a/django/contrib/admin/templates/admin/auth/user/change_password.html
+++ b/django/contrib/admin/templates/admin/auth/user/change_password.html
@@ -5,8 +5,8 @@
 {% block title %}{% if form.errors %}{% translate "Error:" %} {% endif %}{{ block.super }}{% endblock %}
 {% block extrastyle %}
   {{ block.super }}
-  <link rel="stylesheet" href="{% static "admin/css/forms.css" %}">
-  <link rel="stylesheet" href="{% static 'admin/css/unusable_password_field.css' %}">
+  <link rel="stylesheet" href="{% static "admin/css/forms.css" %}" {% csp_nonce_attr %}>
+  <link rel="stylesheet" href="{% static 'admin/css/unusable_password_field.css' %}" {% csp_nonce_attr %}>
 {% endblock %}
 {% block bodyclass %}{{ block.super }} {{ opts.app_label }}-{{ opts.model_name }} change-form{% endblock %}
 {% if not is_popup %}

--- a/django/contrib/admin/templates/admin/base.html
+++ b/django/contrib/admin/templates/admin/base.html
@@ -4,22 +4,22 @@
 <head>
 <title>{% block title %}{% endblock %}</title>
 <meta name="color-scheme" content="light dark" />
-<link rel="stylesheet" href="{% block stylesheet %}{% static "admin/css/base.css" %}{% endblock %}">
+<link rel="stylesheet" href="{% block stylesheet %}{% static "admin/css/base.css" %}{% endblock %}" {% csp_nonce_attr %}>
 {% block dark-mode-vars %}
-  <link rel="stylesheet" href="{% static "admin/css/dark_mode.css" %}">
-  <script src="{% static "admin/js/theme.js" %}"></script>
+  <link rel="stylesheet" href="{% static "admin/css/dark_mode.css" %}" {% csp_nonce_attr %}>
+  <script src="{% static "admin/js/theme.js" %}" {% csp_nonce_attr %}></script>
 {% endblock %}
 {% if not is_popup and is_nav_sidebar_enabled %}
-  <link rel="stylesheet" href="{% static "admin/css/nav_sidebar.css" %}">
-  <script src="{% static 'admin/js/nav_sidebar.js' %}" defer></script>
+  <link rel="stylesheet" href="{% static "admin/css/nav_sidebar.css" %}" {% csp_nonce_attr %}>
+  <script src="{% static 'admin/js/nav_sidebar.js' %}" defer {% csp_nonce_attr %}></script>
 {% endif %}
 {% block extrastyle %}{% endblock %}
-{% if LANGUAGE_BIDI %}<link rel="stylesheet" href="{% block stylesheet_rtl %}{% static "admin/css/rtl.css" %}{% endblock %}">{% endif %}
+{% if LANGUAGE_BIDI %}<link rel="stylesheet" href="{% block stylesheet_rtl %}{% static "admin/css/rtl.css" %}{% endblock %}" {% csp_nonce_attr %}>{% endif %}
 {% block extrahead %}{% endblock %}
 {% block responsive %}
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="{% static "admin/css/responsive.css" %}">
-    {% if LANGUAGE_BIDI %}<link rel="stylesheet" href="{% static "admin/css/responsive_rtl.css" %}">{% endif %}
+    <link rel="stylesheet" href="{% static "admin/css/responsive.css" %}" {% csp_nonce_attr %}>
+    {% if LANGUAGE_BIDI %}<link rel="stylesheet" href="{% static "admin/css/responsive_rtl.css" %}" {% csp_nonce_attr %}>{% endif %}
 {% endblock %}
 {% block blockbots %}<meta name="robots" content="NONE,NOARCHIVE">{% endblock %}
 </head>

--- a/django/contrib/admin/templates/admin/change_form.html
+++ b/django/contrib/admin/templates/admin/change_form.html
@@ -4,7 +4,7 @@
 {% block title %}{% if errors %}{% translate "Error:" %} {% endif %}{{ block.super }}{% endblock %}
 {% block extrahead %}{{ block.super }}
 <script src="{% url 'admin:jsi18n' %}" {% csp_nonce_attr %}></script>
-{{ media }}
+{% csp_nonce_attr media %}
 {% endblock %}
 
 {% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static "admin/css/forms.css" %}" {% csp_nonce_attr %}>{% endblock %}

--- a/django/contrib/admin/templates/admin/change_form.html
+++ b/django/contrib/admin/templates/admin/change_form.html
@@ -3,11 +3,11 @@
 
 {% block title %}{% if errors %}{% translate "Error:" %} {% endif %}{{ block.super }}{% endblock %}
 {% block extrahead %}{{ block.super }}
-<script src="{% url 'admin:jsi18n' %}"></script>
+<script src="{% url 'admin:jsi18n' %}" {% csp_nonce_attr %}></script>
 {{ media }}
 {% endblock %}
 
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static "admin/css/forms.css" %}">{% endblock %}
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static "admin/css/forms.css" %}" {% csp_nonce_attr %}>{% endblock %}
 
 {% block coltype %}colM{% endblock %}
 
@@ -72,6 +72,7 @@
             {% if adminform and add %}
                 data-model-name="{{ opts.model_name }}"
             {% endif %}
+            {% csp_nonce_attr %}
             async>
     </script>
 {% endblock %}

--- a/django/contrib/admin/templates/admin/change_list.html
+++ b/django/contrib/admin/templates/admin/change_list.html
@@ -11,7 +11,7 @@
   {% if cl.formset or action_form %}
     <script src="{% url 'admin:jsi18n' %}" {% csp_nonce_attr %}></script>
   {% endif %}
-  {{ media.css }}
+  {% csp_nonce_attr media.css %}
   {% if not actions_on_top and not actions_on_bottom %}
     <style>
       #changelist table thead th:first-child {width: inherit}
@@ -21,7 +21,7 @@
 
 {% block extrahead %}
 {{ block.super }}
-{{ media.js }}
+{% csp_nonce_attr media.js %}
 <script src="{% static 'admin/js/filters.js' %}" defer {% csp_nonce_attr %}></script>
 {% endblock %}
 

--- a/django/contrib/admin/templates/admin/change_list.html
+++ b/django/contrib/admin/templates/admin/change_list.html
@@ -4,12 +4,12 @@
 {% block title %}{% if cl.formset and cl.formset.errors %}{% translate "Error:" %} {% endif %}{{ block.super }}{% endblock %}
 {% block extrastyle %}
   {{ block.super }}
-  <link rel="stylesheet" href="{% static "admin/css/changelists.css" %}">
+  <link rel="stylesheet" href="{% static "admin/css/changelists.css" %}" {% csp_nonce_attr %}>
   {% if cl.formset %}
-    <link rel="stylesheet" href="{% static "admin/css/forms.css" %}">
+    <link rel="stylesheet" href="{% static "admin/css/forms.css" %}" {% csp_nonce_attr %}>
   {% endif %}
   {% if cl.formset or action_form %}
-    <script src="{% url 'admin:jsi18n' %}"></script>
+    <script src="{% url 'admin:jsi18n' %}" {% csp_nonce_attr %}></script>
   {% endif %}
   {{ media.css }}
   {% if not actions_on_top and not actions_on_bottom %}
@@ -22,7 +22,7 @@
 {% block extrahead %}
 {{ block.super }}
 {{ media.js }}
-<script src="{% static 'admin/js/filters.js' %}" defer></script>
+<script src="{% static 'admin/js/filters.js' %}" defer {% csp_nonce_attr %}></script>
 {% endblock %}
 
 {% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} change-list{% endblock %}

--- a/django/contrib/admin/templates/admin/delete_confirmation.html
+++ b/django/contrib/admin/templates/admin/delete_confirmation.html
@@ -3,7 +3,7 @@
 
 {% block extrahead %}
     {{ block.super }}
-    {{ media }}
+    {% csp_nonce_attr media %}
     <script src="{% static 'admin/js/cancel.js' %}" async {% csp_nonce_attr %}></script>
 {% endblock %}
 

--- a/django/contrib/admin/templates/admin/delete_confirmation.html
+++ b/django/contrib/admin/templates/admin/delete_confirmation.html
@@ -4,7 +4,7 @@
 {% block extrahead %}
     {{ block.super }}
     {{ media }}
-    <script src="{% static 'admin/js/cancel.js' %}" async></script>
+    <script src="{% static 'admin/js/cancel.js' %}" async {% csp_nonce_attr %}></script>
 {% endblock %}
 
 {% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} delete-confirmation{% endblock %}

--- a/django/contrib/admin/templates/admin/delete_selected_confirmation.html
+++ b/django/contrib/admin/templates/admin/delete_selected_confirmation.html
@@ -3,7 +3,7 @@
 
 {% block extrahead %}
     {{ block.super }}
-    {{ media }}
+    {% csp_nonce_attr media %}
     <script src="{% static 'admin/js/cancel.js' %}" async {% csp_nonce_attr %}></script>
 {% endblock %}
 

--- a/django/contrib/admin/templates/admin/delete_selected_confirmation.html
+++ b/django/contrib/admin/templates/admin/delete_selected_confirmation.html
@@ -4,7 +4,7 @@
 {% block extrahead %}
     {{ block.super }}
     {{ media }}
-    <script src="{% static 'admin/js/cancel.js' %}" async></script>
+    <script src="{% static 'admin/js/cancel.js' %}" async {% csp_nonce_attr %}></script>
 {% endblock %}
 
 {% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} delete-confirmation delete-selected-confirmation{% endblock %}

--- a/django/contrib/admin/templates/admin/index.html
+++ b/django/contrib/admin/templates/admin/index.html
@@ -1,7 +1,7 @@
 {% extends "admin/base_site.html" %}
 {% load i18n static admin_filters %}
 
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static "admin/css/dashboard.css" %}">{% endblock %}
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static "admin/css/dashboard.css" %}" {% csp_nonce_attr %}>{% endblock %}
 
 {% block coltype %}colMS{% endblock %}
 

--- a/django/contrib/admin/templates/admin/login.html
+++ b/django/contrib/admin/templates/admin/login.html
@@ -2,7 +2,7 @@
 {% load i18n static %}
 
 {% block title %}{% if form.errors %}{% translate "Error:" %} {% endif %}{{ block.super }}{% endblock %}
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static "admin/css/login.css" %}">
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static "admin/css/login.css" %}" {% csp_nonce_attr %}>
 {{ form.media }}
 {% endblock %}
 

--- a/django/contrib/admin/templates/admin/popup_response.html
+++ b/django/contrib/admin/templates/admin/popup_response.html
@@ -4,7 +4,8 @@
   <body>
     <script id="django-admin-popup-response-constants"
             src="{% static "admin/js/popup_response.js" %}"
-            data-popup-response="{{ popup_response_data }}">
+            data-popup-response="{{ popup_response_data }}"
+            {% csp_nonce_attr %}>
     </script>
   </body>
 </html>

--- a/django/contrib/admin/templates/admin/prepopulated_fields_js.html
+++ b/django/contrib/admin/templates/admin/prepopulated_fields_js.html
@@ -1,5 +1,6 @@
 {% load static %}
 <script id="django-admin-prepopulated-fields-constants"
         src="{% static "admin/js/prepopulate_init.js" %}"
-        data-prepopulated-fields="{{ prepopulated_fields_json }}">
+        data-prepopulated-fields="{{ prepopulated_fields_json }}"
+        {% csp_nonce_attr %}>
 </script>

--- a/django/contrib/admin/templates/registration/password_change_form.html
+++ b/django/contrib/admin/templates/registration/password_change_form.html
@@ -2,7 +2,7 @@
 {% load i18n static %}
 
 {% block title %}{% if form.errors %}{% translate "Error:" %} {% endif %}{{ block.super }}{% endblock %}
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static "admin/css/forms.css" %}">{% endblock %}
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static "admin/css/forms.css" %}" {% csp_nonce_attr %}>{% endblock %}
 {% block userlinks %}
   {% url 'django-admindocs-docroot' as docsroot %}{% if docsroot %}<a href="{{ docsroot }}">{% translate 'Documentation' %}</a> / {% endif %} {% translate 'Change password' %} /
   <form id="logout-form" method="post" action="{% url 'admin:logout' %}">

--- a/django/contrib/admin/templates/registration/password_reset_confirm.html
+++ b/django/contrib/admin/templates/registration/password_reset_confirm.html
@@ -2,7 +2,7 @@
 {% load i18n static %}
 
 {% block title %}{% if form.new_password1.errors or form.new_password2.errors %}{% translate "Error:" %} {% endif %}{{ block.super }}{% endblock %}
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static "admin/css/forms.css" %}">{% endblock %}
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static "admin/css/forms.css" %}" {% csp_nonce_attr %}>{% endblock %}
 {% block breadcrumbs %}
 <ol class="breadcrumbs">
 <li><a href="{% url 'admin:index' %}">{% translate 'Home' %}</a></li>

--- a/django/contrib/admin/templates/registration/password_reset_form.html
+++ b/django/contrib/admin/templates/registration/password_reset_form.html
@@ -2,7 +2,7 @@
 {% load i18n static %}
 
 {% block title %}{% if form.email.errors %}{% translate "Error:" %} {% endif %}{{ block.super }}{% endblock %}
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static "admin/css/forms.css" %}">{% endblock %}
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static "admin/css/forms.css" %}" {% csp_nonce_attr %}>{% endblock %}
 {% block breadcrumbs %}
 <ol class="breadcrumbs">
 <li><a href="{% url 'admin:index' %}">{% translate 'Home' %}</a></li>

--- a/django/middleware/csp.py
+++ b/django/middleware/csp.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.utils.cache import patch_cache_control
 from django.utils.csp import CSP, LazyNonce, build_policy
 from django.utils.deprecation import MiddlewareMixin
 
@@ -29,5 +30,15 @@ class ContentSecurityPolicyMiddleware(MiddlewareMixin):
             # An empty config means CSP headers are not added to the response.
             if config and header not in response:
                 response.headers[str(header)] = build_policy(config, nonce)
+
+        # If the nonce is included in a CSP header, prevent shared/public
+        # caching. A nonce discoverable by multiple users defeats its security
+        # guarantee. Browser caching (private) is still allowed since the nonce
+        # is only reused by the same user on the same device.
+        if nonce and any(
+            f"'nonce-{nonce}'" in response.get(str(header), "")
+            for header in (CSP.HEADER_ENFORCE, CSP.HEADER_REPORT_ONLY)
+        ):
+            patch_cache_control(response, private=True)
 
         return response

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -120,6 +120,10 @@ Minor features
 * :attr:`~django.contrib.admin.ModelAdmin.list_display` now uses boolean icons
   for boolean fields on related models.
 
+* Templates now include the CSP nonce on ``<script>`` and ``<link>`` elements
+  when the :func:`~django.template.context_processors.csp` context processor is
+  configured. See :ref:`csp-nonce-config` for setup instructions.
+
 :mod:`django.contrib.admindocs`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/admin_views/test_csp.py
+++ b/tests/admin_views/test_csp.py
@@ -1,0 +1,117 @@
+from django.contrib.auth.models import User
+from django.test import TestCase, modify_settings, override_settings
+from django.urls import reverse
+
+CSP_TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+                "django.template.context_processors.csp",
+            ],
+        },
+    }
+]
+
+csp_settings = override_settings(
+    TEMPLATES=CSP_TEMPLATES,
+)
+csp_middleware = modify_settings(
+    MIDDLEWARE={"append": "django.middleware.csp.ContentSecurityPolicyMiddleware"}
+)
+
+
+@override_settings(ROOT_URLCONF="admin_views.urls")
+class AdminCspNonceTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.superuser = User.objects.create_superuser(
+            username="super", password="secret", email="super@example.com"
+        )
+
+    def setUp(self):
+        self.client.force_login(self.superuser)
+
+    def test_no_nonce_without_csp_context_processor(self):
+        response = self.client.get(reverse("admin:index"))
+        self.assertNotContains(response, 'nonce="')
+
+    @csp_settings
+    @csp_middleware
+    def test_index_base_scripts_have_nonce(self):
+        response = self.client.get(reverse("admin:index"))
+        content = response.content.decode()
+        self.assertRegex(content, r'<script src="[^"]*theme\.js"[^>]*nonce="[^"]+"')
+        self.assertRegex(
+            content, r'<script src="[^"]*nav_sidebar\.js"[^>]*nonce="[^"]+"'
+        )
+
+    @csp_settings
+    @csp_middleware
+    def test_index_base_links_have_nonce(self):
+        response = self.client.get(reverse("admin:index"))
+        content = response.content.decode()
+        self.assertRegex(content, r'<link[^>]+base\.css"[^>]*nonce="[^"]+"')
+        self.assertRegex(content, r'<link[^>]+dashboard\.css"[^>]*nonce="[^"]+"')
+
+    @csp_settings
+    @csp_middleware
+    def test_change_form_scripts_have_nonce(self):
+        response = self.client.get(
+            reverse("admin:auth_user_change", args=[self.superuser.pk])
+        )
+        content = response.content.decode()
+        self.assertRegex(
+            content, r'<script[^>]*src="[^"]*change_form\.js"[^>]*nonce="[^"]+"'
+        )
+
+    @csp_settings
+    @csp_middleware
+    def test_change_form_links_have_nonce(self):
+        response = self.client.get(
+            reverse("admin:auth_user_change", args=[self.superuser.pk])
+        )
+        self.assertRegex(
+            response.content.decode(), r'<link[^>]+forms\.css"[^>]*nonce="[^"]+"'
+        )
+
+    @csp_settings
+    @csp_middleware
+    def test_change_list_scripts_have_nonce(self):
+        response = self.client.get(reverse("admin:auth_user_changelist"))
+        self.assertRegex(
+            response.content.decode(),
+            r'<script src="[^"]*filters\.js"[^>]*nonce="[^"]+"',
+        )
+
+    @csp_settings
+    @csp_middleware
+    def test_change_list_links_have_nonce(self):
+        response = self.client.get(reverse("admin:auth_user_changelist"))
+        self.assertRegex(
+            response.content.decode(), r'<link[^>]+changelists\.css"[^>]*nonce="[^"]+"'
+        )
+
+    @csp_settings
+    @csp_middleware
+    def test_delete_confirmation_script_has_nonce(self):
+        response = self.client.get(
+            reverse("admin:auth_user_delete", args=[self.superuser.pk])
+        )
+        self.assertRegex(
+            response.content.decode(),
+            r'<script src="[^"]*cancel\.js"[^>]*nonce="[^"]+"',
+        )
+
+    @csp_settings
+    @csp_middleware
+    def test_login_link_has_nonce(self):
+        self.client.logout()
+        response = self.client.get(reverse("admin:login"))
+        self.assertRegex(
+            response.content.decode(), r'<link[^>]+login\.css"[^>]*nonce="[^"]+"'
+        )

--- a/tests/middleware/test_csp.py
+++ b/tests/middleware/test_csp.py
@@ -55,6 +55,28 @@ class CSPMiddlewareTest(SimpleTestCase):
         self.assertIsNotNone(nonce)
         self.assertEqual(response[CSP.HEADER_ENFORCE], basic_policy)
 
+    @override_settings(SECURE_CSP={"default-src": [CSP.SELF, CSP.NONCE]})
+    def test_nonce_in_policy_sets_cache_control(self):
+        response = self.client.get("/csp-nonce-used/")
+        self.assertIn("private", response.get("Cache-Control", ""))
+
+    @override_settings(SECURE_CSP={"default-src": [CSP.SELF, CSP.NONCE]})
+    def test_nonce_in_policy_merges_with_existing_cache_control(self):
+        response = self.client.get("/csp-nonce-used-with-cache-control/")
+        cache_control = response.get("Cache-Control", "")
+        self.assertIn("private", cache_control)
+        self.assertIn("max-age=3600", cache_control)
+
+    @override_settings(SECURE_CSP={"default-src": [CSP.SELF, CSP.NONCE]})
+    def test_nonce_unused_does_not_set_cache_control(self):
+        response = self.client.get("/csp-base/")
+        self.assertIsNone(response.get("Cache-Control"))
+
+    @override_settings(SECURE_CSP=basic_config)
+    def test_nonce_used_but_absent_from_policy_does_not_set_cache_control(self):
+        response = self.client.get("/csp-nonce-used/")
+        self.assertIsNone(response.get("Cache-Control"))
+
     @override_settings(SECURE_CSP=None, SECURE_CSP_REPORT_ONLY=basic_config)
     def test_csp_report_only_basic(self):
         """

--- a/tests/middleware/urls.py
+++ b/tests/middleware/urls.py
@@ -17,6 +17,8 @@ urlpatterns = [
     path("csp-report/", views.csp_report_view),
     path("csp-base/", views.empty_view),
     path("csp-nonce/", views.csp_nonce),
+    path("csp-nonce-used/", views.csp_nonce_used),
+    path("csp-nonce-used-with-cache-control/", views.csp_nonce_used_with_cache_control),
     path("csp-disabled-both/", views.csp_disabled_both),
     path("csp-disabled-enforced/", views.csp_disabled_enforced),
     path("csp-disabled-report-only/", views.csp_disabled_ro),

--- a/tests/middleware/views.py
+++ b/tests/middleware/views.py
@@ -31,6 +31,18 @@ def csp_nonce(request):
     return HttpResponse(get_nonce(request))
 
 
+def csp_nonce_used(request):
+    nonce = get_nonce(request)
+    return HttpResponse(f'<script nonce="{nonce}"></script>')
+
+
+def csp_nonce_used_with_cache_control(request):
+    nonce = get_nonce(request)
+    response = HttpResponse(f'<script nonce="{nonce}"></script>')
+    response["Cache-Control"] = "max-age=3600"
+    return response
+
+
 @csp_override({})
 def csp_disabled_enforced(request):
     return HttpResponse()


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-36825

#### Branch description
See related tickets and forum post at https://forum.djangoproject.com/t/csp-nonce-support-for-form-media-classes-and-admin-scripts/44698

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [X] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude Sonnet 4.6 was used to evaluate potential options, assist the forum post writing, apply changes in the admin templates, and build an initial set of tests. I reviewed all the output though we should revisit the test names and the docs (these are draft).

#### Checklist
- [X] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [X] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [X] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
