### PR TITLE
Fixed #37007 -- Added "Voice" section to writing style docs.

### DIFF
--- a/docs/internals/contributing/writing-documentation.txt
+++ b/docs/internals/contributing/writing-documentation.txt
@@ -289,15 +289,16 @@ The Django documentation is successful because it contains human rhythms and
 patterns. It speaks in the way an expert would speak to help a fellow
 developer. It expresses things in lively and imaginative ways.
 
-The documentation doesn't efface the personality of its authors, or smooth
-everything into a slippery, frictionless surface. The documentation should not
+The documentation doesn't efface the personality of its authors or smooth
+everything into a slippery, dull surface. The documentation should not
 reach for high-sounding but empty descriptions: for example, overusing
 superlatives such as *clear*, *robust*, or *structured*. We find ways to write
 systematically without being mechanical.
 
 To make this more concrete, we present the same information in two versions:
-once in a "human" voice, and a second version from prompting an AI tool to
-produce a version "suitable for a pull request (smooth and professional)":
+human and indistinct. The "human" example is excerpted from this documentation.
+The "indistinct" version was produced by prompting an AI tool for a version
+"suitable for a pull request (smooth and professional)":
 
 .. admonition:: Human version (excerpted from Django's documentation)
 
@@ -315,7 +316,7 @@ produce a version "suitable for a pull request (smooth and professional)":
   primary-key value explicitly when saving new objects, if you cannot guarantee
   the primary-key value is unused.
 
-.. admonition:: Frictionless version
+.. admonition:: Indistinct version
 
   How Django determines UPDATE vs. INSERT
 
@@ -332,12 +333,14 @@ produce a version "suitable for a pull request (smooth and professional)":
   database errors.
 
 Notice how the revision does not address the reader (originally: "you may have
-noticed"), removed the figurative language (originally: "Django knows"),
-impaired the sense that the design was intentional (originally: "Django
-abstracts"), avoided a technical term appropriate for the context (originally:
-"algorithm"), added an unnecessary preamble (revised: "based on the state of
-..."), and belabored a self-evident point (revised: "may lead to unexpected
-behavior or database errors").
+noticed"), removes the figurative language (originally: "Django knows"),
+impairs the sense that the design was intentional (originally: "Django
+abstracts"), avoids a technical term appropriate for the context (originally:
+"algorithm"), and belabors a self-evident point (revised: "may lead to
+unexpected behavior or database errors"). Also notice how the original version
+poses a problem (an abstraction is accomplished: how?), whereas the revised
+version begins with a dry summary ("Django determines ... based on the state of
+...").
 
 Without a doubt, a different prompt would produce a different, perhaps improved
 result. Still, we include this example to illustrate how easily the

--- a/docs/internals/contributing/writing-documentation.txt
+++ b/docs/internals/contributing/writing-documentation.txt
@@ -303,26 +303,28 @@ produce a version "suitable for a pull request (smooth and professional)":
 
   How Django knows to UPDATE vs. INSERT
 
-  You may have noticed Django database objects use the same save() method for
-  creating and changing objects. Django abstracts the need to use INSERT or
-  UPDATE SQL statements. Specifically, when you call save() and the object’s
-  primary key attribute does not define a default or db_default, Django follows
-  this algorithm: ...
+  You may have noticed Django database objects use the same ``save()`` method
+  for creating and changing objects. Django abstracts the need to use
+  ``INSERT`` or ``UPDATE`` SQL statements. Specifically, when you call
+  ``save()`` and the object's primary key attribute does **not** define a
+  :attr:`~django.db.models.Field.default` or
+  :attr:`~django.db.models.Field.db_default`, Django follows this algorithm:
+  ...
 
   The one gotcha here is that you should be careful not to specify a
   primary-key value explicitly when saving new objects, if you cannot guarantee
   the primary-key value is unused.
 
 .. admonition:: Frictionless version
-  
+
   How Django determines UPDATE vs. INSERT
 
-  Django model instances use a single method, save(), for both creating and
-  updating records. Internally, Django determines whether to issue an INSERT or
-  UPDATE SQL statement based on the state of the model instance and its primary
-  key.
+  Django model instances use a single method, ``save()``, for both creating and
+  updating records. Internally, Django determines whether to issue an
+  ``INSERT`` or ``UPDATE`` SQL statement based on the state of the model
+  instance and its primary key.
 
-  When calling save(), Django follows this general logic: ...
+  When calling ``save()``, Django follows this general logic: ...
 
   One important caveat is to avoid explicitly assigning a primary key value
   when creating new objects unless you can guarantee that the value is unique.

--- a/docs/internals/contributing/writing-documentation.txt
+++ b/docs/internals/contributing/writing-documentation.txt
@@ -296,6 +296,29 @@ so on. People's experience may not match your expectations, and they may become
 frustrated when they do not find a step as "straightforward" or "simple" as it
 is implied to be.
 
+.. _documentation-voice:
+
+Voice
+=====
+
+Django's documentation is written in the voice of an experienced user of the
+framework addressing a peer developer, even if that developer is new to Django
+or new to web development.
+
+Avoid:
+
+* Platitudes: Remember you are speaking to another developer.
+
+* Overly digested, zippy advice: Although concision is important, artificially
+  concise text expressed in predictable rhythms of bullet points sound more
+  like advertising than technical documentation.
+
+* Architectural superlatives: Overusing words like *robust*, *clear*, and
+  *structured* can ring false by making too much out of very little, or
+  glossing over the fact that opinions differ about what makes software
+  well-designed. The author should not appear unaware of alternative viewpoints
+  or inherent design trade-offs.
+
 Commonly used terms
 ===================
 

--- a/docs/internals/contributing/writing-documentation.txt
+++ b/docs/internals/contributing/writing-documentation.txt
@@ -277,6 +277,70 @@ cases, we do not want to update a "redirected" link, e.g. a rewrite to always
 point to the latest or stable version of the documentation, e.g.
 ``/en/stable/`` → ``/en/3.2/``.
 
+.. _documentation-voice:
+
+Voice
+=====
+
+We value the human voice in Django's documentation, in which the reader can
+have the experience of one person addressing another.
+
+The Django documentation is successful because it contains human rhythms and
+patterns. It speaks in the way an expert would speak to help a fellow
+developer. It expresses things in lively and imaginative ways.
+
+The documentation doesn't efface the personality of its authors, or smooth
+everything into a slippery, frictionless surface. The documentation should not
+reach for high-sounding but empty descriptions: for example, overusing
+superlatives such as *clear*, *robust*, or *structured*. We find ways to write
+systematically without being mechanical.
+
+To make this more concrete, we present the same information in two versions:
+once in a "human" voice, and a second version from prompting an AI tool to
+produce a version "suitable for a pull request (smooth and professional)":
+
+.. admonition:: Human version (excerpted from Django's documentation)
+
+  How Django knows to UPDATE vs. INSERT
+
+  You may have noticed Django database objects use the same save() method for
+  creating and changing objects. Django abstracts the need to use INSERT or
+  UPDATE SQL statements. Specifically, when you call save() and the object’s
+  primary key attribute does not define a default or db_default, Django follows
+  this algorithm: ...
+
+  The one gotcha here is that you should be careful not to specify a
+  primary-key value explicitly when saving new objects, if you cannot guarantee
+  the primary-key value is unused.
+
+.. admonition:: Frictionless version
+  
+  How Django determines UPDATE vs. INSERT
+
+  Django model instances use a single method, save(), for both creating and
+  updating records. Internally, Django determines whether to issue an INSERT or
+  UPDATE SQL statement based on the state of the model instance and its primary
+  key.
+
+  When calling save(), Django follows this general logic: ...
+
+  One important caveat is to avoid explicitly assigning a primary key value
+  when creating new objects unless you can guarantee that the value is unique.
+  Providing a conflicting primary key may lead to unexpected behavior or
+  database errors.
+
+Notice how the revision does not address the reader (originally: "you may have
+noticed"), removed the figurative language (originally: "Django knows"),
+impaired the sense that the design was intentional (originally: "Django
+abstracts"), avoided a technical term appropriate for the context (originally:
+"algorithm"), added an unnecessary preamble (revised: "based on the state of
+..."), and belabored a self-evident point (revised: "may lead to unexpected
+behavior or database errors").
+
+Without a doubt, a different prompt would produce a different, perhaps improved
+result. Still, we include this example to illustrate how easily the
+documentation can be polluted when attention is not given to voice.
+
 Writing style
 =============
 
@@ -295,29 +359,6 @@ operation, such as "easily", "simply", "just", "merely", "straightforward", and
 so on. People's experience may not match your expectations, and they may become
 frustrated when they do not find a step as "straightforward" or "simple" as it
 is implied to be.
-
-.. _documentation-voice:
-
-Voice
-=====
-
-Django's documentation is written in the voice of an experienced user of the
-framework addressing a peer developer, even if that developer is new to Django
-or new to web development.
-
-Avoid:
-
-* Platitudes: Remember you are speaking to another developer.
-
-* Overly digested, zippy advice: Although concision is important, artificially
-  concise text expressed in predictable rhythms of bullet points sound more
-  like advertising than technical documentation.
-
-* Architectural superlatives: Overusing words like *robust*, *clear*, and
-  *structured* can ring false by making too much out of very little, or
-  glossing over the fact that opinions differ about what makes software
-  well-designed. The author should not appear unaware of alternative viewpoints
-  or inherent design trade-offs.
 
 Commonly used terms
 ===================

--- a/docs/internals/contributing/writing-documentation.txt
+++ b/docs/internals/contributing/writing-documentation.txt
@@ -287,18 +287,20 @@ have the experience of one person addressing another.
 
 The Django documentation is successful because it contains human rhythms and
 patterns. It speaks in the way an expert would speak to help a fellow
-developer. It expresses things in lively and imaginative ways.
+developer. It expresses things in lively and imaginative ways. It's systematic
+but not mechanical.
 
-The documentation doesn't efface the personality of its authors or smooth
-everything into a slippery, dull surface. The documentation should not
-reach for high-sounding but empty descriptions: for example, overusing
-superlatives such as *clear*, *robust*, or *structured*. We find ways to write
-systematically without being mechanical.
+The documentation doesn't erase the personality of its authors or smooth
+everything into a slippery, dull surface. Some friction is necessary for a
+reader to grasp a concept.
+
+The documentation should not reach for grandiose but empty descriptions: for
+example, by overusing superlatives such as *clear*, *robust*, or *structured*.
 
 To make this more concrete, we present the same information in two versions:
-human and indistinct. The "human" example is excerpted from this documentation.
-The "indistinct" version was produced by prompting an AI tool for a version
-"suitable for a pull request (smooth and professional)":
+human and frictionless. The "human" example is excerpted from this
+documentation. The "frictionless" version was produced by prompting an AI tool
+for a version "suitable for a pull request (smooth and professional)":
 
 .. admonition:: Human version (excerpted from Django's documentation)
 
@@ -316,7 +318,7 @@ The "indistinct" version was produced by prompting an AI tool for a version
   primary-key value explicitly when saving new objects, if you cannot guarantee
   the primary-key value is unused.
 
-.. admonition:: Indistinct version
+.. admonition:: Frictionless version
 
   How Django determines UPDATE vs. INSERT
 
@@ -333,18 +335,17 @@ The "indistinct" version was produced by prompting an AI tool for a version
   database errors.
 
 Notice how the revision does not address the reader (originally: "you may have
-noticed"), removes the figurative language (originally: "Django knows"),
-impairs the sense that the design was intentional (originally: "Django
-abstracts"), avoids a technical term appropriate for the context (originally:
-"algorithm"), and belabors a self-evident point (revised: "may lead to
-unexpected behavior or database errors"). Also notice how the original version
-poses a problem (an abstraction is accomplished: how?), whereas the revised
-version begins with a dry summary ("Django determines ... based on the state of
-...").
+noticed"). Notice the deleted figurative language (originally: "Django knows")
+and a deleted technical term appropriate for the context (originally:
+"algorithm"). Notice how a self-evident point is belabored (revised: "may lead
+to unexpected behavior or database errors"). Finally, notice how the original
+version poses a problem (an abstraction is provided: how?), whereas the revised
+version merely summarizes ("Django determines ... based on the state of ..."),
+impairing the sense that the design was intentional.
 
 Without a doubt, a different prompt would produce a different, perhaps improved
 result. Still, we include this example to illustrate how easily the
-documentation can be polluted when attention is not given to voice.
+documentation can be undermined when attention is not given to voice.
 
 Writing style
 =============

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -176,6 +176,7 @@ formfield
 formset
 formsets
 formtools
+frictionless
 Frysian
 geo
 Geoff


### PR DESCRIPTION
#### Trac ticket number
ticket-37007

#### Branch description
At the time of writing, we are facing a flood of proposed documentation edits driven by generative AI tools. On the whole, these proposals need significant redirection to maintain consistency with the voice of Django's documentation.

See https://forum.djangoproject.com/t/discouraging-the-voice-from-nowhere-llms-in-documentation/44699

Thanks @tim-schilling, @medmunds, and others for initial feedback.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

As suggested by @evildmp below, I used an LLM (ChatGPT: GPT-5.3) to produce the "bad" example.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
