### PR TITLE
Fixed #22125 -- Removed redundant index on ManyToManyField intermediary tables.

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1435,6 +1435,9 @@ def create_many_to_many_intermediary_model(field, klass):
                 db_tablespace=field.db_tablespace,
                 db_constraint=field.remote_field.db_constraint,
                 on_delete=CASCADE,
+                # Ticket #22125: index is redundant with
+                # unique_together (from_, to).
+                db_index=False,
             ),
             to: models.ForeignKey(
                 to_model,

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1443,6 +1443,9 @@ def create_many_to_many_intermediary_model(field, klass):
                 db_tablespace=field.db_tablespace,
                 db_constraint=field.remote_field.db_constraint,
                 on_delete=CASCADE,
+                # Ticket #22125: index is redundant with
+                # unique_together (from_, to).
+                db_index=False,
             ),
             to: models.ForeignKey(
                 to_model,

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -196,7 +196,10 @@ Migrations
 Models
 ~~~~~~
 
-* ...
+* Intermediary tables created for ``ManyToManyField`` no longer declare a
+  redundant single-column index on the first foreign key column, as it is
+  covered by the leftmost prefix of the table's unique constraint. Only newly
+  created tables are affected.
 
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -195,7 +195,10 @@ Migrations
 Models
 ~~~~~~
 
-* ...
+* Intermediary tables created for ``ManyToManyField`` no longer declare a
+  redundant single-column index on the first foreign key column, as it is
+  covered by the leftmost prefix of the table's unique constraint. Only newly
+  created tables are affected.
 
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/model_options/test_tablespaces.py
+++ b/tests/model_options/test_tablespaces.py
@@ -111,9 +111,9 @@ class TablespacesTests(TransactionTestCase):
         # The ManyToManyField declares no db_tablespace, its indexes go to
         # the model's tablespace, unless DEFAULT_INDEX_TABLESPACE is set.
         if settings.DEFAULT_INDEX_TABLESPACE:
-            self.assertNumContains(sql, settings.DEFAULT_INDEX_TABLESPACE, 2)
+            self.assertNumContains(sql, settings.DEFAULT_INDEX_TABLESPACE, 1)
         else:
-            self.assertNumContains(sql, "tbl_tbsp", 2)
+            self.assertNumContains(sql, "tbl_tbsp", 1)
         self.assertNumContains(sql, "idx_tbsp", 0)
 
         sql = sql_for_table(Reviewers).lower()
@@ -132,4 +132,4 @@ class TablespacesTests(TransactionTestCase):
         sql = sql_for_index(Reviewers).lower()
         # The ManyToManyField declares db_tablespace, its indexes go there.
         self.assertNumContains(sql, "tbl_tbsp", 0)
-        self.assertNumContains(sql, "idx_tbsp", 2)
+        self.assertNumContains(sql, "idx_tbsp", 1)

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -2615,6 +2615,41 @@ class SchemaTests(TransactionTestCase):
     def test_m2m_create_inherited(self):
         self._test_m2m_create(InheritedManyToManyField)
 
+    def _test_m2m_create_skips_redundant_source_fk_index(self, M2MFieldClass):
+        class LocalBookWithM2M(Model):
+            tags = M2MFieldClass("TagM2MTest", related_name="books")
+
+            class Meta:
+                app_label = "schema"
+                apps = new_apps
+
+        self.local_models = [LocalBookWithM2M]
+
+        with connection.schema_editor() as editor:
+            editor.create_model(TagM2MTest)
+            editor.create_model(LocalBookWithM2M)
+
+        through = LocalBookWithM2M._meta.get_field("tags").remote_field.through
+        through_table = through._meta.db_table
+
+        self.assertNotIn("localbookwithm2m_id", self.get_indexes(through_table))
+        self.assertIn("tagm2mtest_id", self.get_indexes(through_table))
+
+        constraints = self.get_constraints(through_table).values()
+        unique_columns = [
+            constraint["columns"] for constraint in constraints if constraint["unique"]
+        ]
+        self.assertIn(["localbookwithm2m_id", "tagm2mtest_id"], unique_columns)
+
+    def test_m2m_create_skips_redundant_source_fk_index(self):
+        self._test_m2m_create_skips_redundant_source_fk_index(ManyToManyField)
+
+    def test_m2m_create_skips_redundant_source_fk_index_custom(self):
+        self._test_m2m_create_skips_redundant_source_fk_index(CustomManyToManyField)
+
+    def test_m2m_create_skips_redundant_source_fk_index_inherited(self):
+        self._test_m2m_create_skips_redundant_source_fk_index(InheritedManyToManyField)
+
     def _test_m2m_create_through(self, M2MFieldClass):
         """
         Tests M2M fields on models during creation with through models

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -2666,6 +2666,41 @@ class SchemaTests(TransactionTestCase):
     def test_m2m_create_inherited(self):
         self._test_m2m_create(InheritedManyToManyField)
 
+    def _test_m2m_create_skips_redundant_source_fk_index(self, M2MFieldClass):
+        class LocalBookWithM2M(Model):
+            tags = M2MFieldClass("TagM2MTest", related_name="books")
+
+            class Meta:
+                app_label = "schema"
+                apps = new_apps
+
+        self.local_models = [LocalBookWithM2M]
+
+        with connection.schema_editor() as editor:
+            editor.create_model(TagM2MTest)
+            editor.create_model(LocalBookWithM2M)
+
+        through = LocalBookWithM2M._meta.get_field("tags").remote_field.through
+        through_table = through._meta.db_table
+
+        self.assertNotIn("localbookwithm2m_id", self.get_indexes(through_table))
+        self.assertIn("tagm2mtest_id", self.get_indexes(through_table))
+
+        constraints = self.get_constraints(through_table).values()
+        unique_columns = [
+            constraint["columns"] for constraint in constraints if constraint["unique"]
+        ]
+        self.assertIn(["localbookwithm2m_id", "tagm2mtest_id"], unique_columns)
+
+    def test_m2m_create_skips_redundant_source_fk_index(self):
+        self._test_m2m_create_skips_redundant_source_fk_index(ManyToManyField)
+
+    def test_m2m_create_skips_redundant_source_fk_index_custom(self):
+        self._test_m2m_create_skips_redundant_source_fk_index(CustomManyToManyField)
+
+    def test_m2m_create_skips_redundant_source_fk_index_inherited(self):
+        self._test_m2m_create_skips_redundant_source_fk_index(InheritedManyToManyField)
+
     def _test_m2m_create_through(self, M2MFieldClass):
         """
         Tests M2M fields on models during creation with through models


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-22125

#### Branch description

This patch is to avoid creating a redundant index on the source (`from_`) foreign key in auto-generated many-to-many through tables. It resumes the work started on [this PR](https://github.com/django/django/pull/10435/) by @tuffnatty, which apparently was closed due to inactivity, but seemed to be in the right direction.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude Sonnet (via Copilot) was used for feedback on the quality of the tests. I reviewed and verified the final diff and test results.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.

