### PR TITLE
Fixed #36964 -- Clarified persistent connections behavior.

### DIFF
--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -89,9 +89,19 @@ In such cases, you should set :setting:`CONN_MAX_AGE` to a low value or even
 to be reused. This will help keep the number of simultaneous connections to
 this database small.
 
-The development server creates a new thread for each request it handles,
-negating the effect of persistent connections. Don't enable them during
-development.
+The development server uses a thread-per-request model. While persistent
+connections (controlled by CONN_MAX_AGE) may appear to work during
+sequential requests due to HTTP keep-alive and thread reuse, this behavior
+is not guaranteed.
+
+In particular:
+
+- Database connections are thread-local.
+- The development server may create new threads even for sequential requests.
+- Connections are reset when the auto-reloader restarts the server.
+
+As a result, persistent connections in development may not behave the same
+as in production environments, and their use is generally discouraged.
 
 When Django establishes a connection to the database, it sets up appropriate
 parameters, depending on the backend being used. If you enable persistent


### PR DESCRIPTION
#### Trac ticket number

ticket-36964

#### Branch description

Clarified how persistent database connections behave when using the development server (`runserver`). The previous documentation implied that persistent connections do not work during development, which can be misleading.

This update explains that while persistent connections may appear to work in some cases (e.g., sequential requests with HTTP keep-alive), their behavior is not guaranteed due to thread-local connections, possible thread changes, and the auto-reloader. It also clarifies that development behavior may differ from production environments.

#### AI Assistance Disclosure (REQUIRED)

* [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist

* [x] This PR follows the contribution guidelines.
* [x] This PR does not disclose a security vulnerability.
* [x] This PR targets the `main` branch.
* [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
* [x] I have not requested, and will not request, an automated AI review for this PR.
* [x] I have checked the "Has patch" ticket flag in the Trac system.
* [ ] I have added or updated relevant tests.
* [x] I have added or updated relevant docs, including release notes if applicable.
* [ ] I have attached screenshots in both light and dark modes for any UI changes.
