### PR TITLE
Fixed #36997 -- Invalidated importlib caches after writing migration files.

### DIFF
--- a/django/core/management/commands/makemigrations.py
+++ b/django/core/management/commands/makemigrations.py
@@ -1,3 +1,4 @@
+import importlib
 import os
 import sys
 import warnings
@@ -395,6 +396,7 @@ class Command(BaseCommand):
                     )
                     self.log(writer.as_string())
         run_formatters(self.written_files, stderr=self.stderr)
+        importlib.invalidate_caches()
 
     @staticmethod
     def get_relative_path(path):
@@ -502,6 +504,7 @@ class Command(BaseCommand):
                     with open(writer.path, "w", encoding="utf-8") as fh:
                         fh.write(writer.as_string())
                     run_formatters([writer.path], stderr=self.stderr)
+                    importlib.invalidate_caches()
                     if self.verbosity > 0:
                         self.log("\nCreated new merge migration %s" % writer.path)
                         if self.scriptable:

--- a/django/core/management/commands/squashmigrations.py
+++ b/django/core/management/commands/squashmigrations.py
@@ -1,3 +1,4 @@
+import importlib
 import os
 import shutil
 
@@ -208,6 +209,7 @@ class Command(BaseCommand):
         with open(writer.path, "w", encoding="utf-8") as fh:
             fh.write(writer.as_string())
         run_formatters([writer.path], stderr=self.stderr)
+        importlib.invalidate_caches()
 
         if self.verbosity > 0:
             self.stdout.write(

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -269,7 +269,10 @@ Management Commands
 Migrations
 ~~~~~~~~~~
 
-* ...
+* Fixed a race condition on filesystems with non-deterministic mtime flushing
+  (e.g. WSL/HyperV) where :djadmin:`makemigrations` and
+  :djadmin:`squashmigrations` could write migration files that were not
+  immediately visible to the import system.
 
 Models
 ~~~~~~

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -269,10 +269,10 @@ Management Commands
 Migrations
 ~~~~~~~~~~
 
-* Fixed a race condition on filesystems with non-deterministic mtime flushing
-  (e.g. WSL/HyperV) where :djadmin:`makemigrations` and
-  :djadmin:`squashmigrations` could write migration files that were not
-  immediately visible to the import system.
+* Fixed a race condition where :djadmin:`makemigrations` and
+  :djadmin:`squashmigrations` could write migration files not immediately
+  visible to subsequent import system lookups due to delayed filesystem
+  modification time updates.
 
 Models
 ~~~~~~


### PR DESCRIPTION
#### Trac ticket number
ticket-36997

#### Branch description
On filesystems that delay mtime updates (notably WSL/HyperV), calling
\`makemigrations\` or \`squashmigrations\` followed by \`migrate\` in the same
process could fail with \`ModuleNotFoundError\` because Python's \`FileFinder\`
served a stale directory listing. Added \`importlib.invalidate_caches()\`
after each migration file write in both commands.

The existing test \`test_double_replaced_migrations_are_checked_correctly\`
reproduces this scenario and was already failing intermittently on WSL before
this fix.

#### AI Assistance Disclosure (REQUIRED)
- [x] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the \`main\` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.