### PR TITLE
Fixed #36912 -- Added connector validation to Q.create().

### DIFF
--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -51,14 +51,23 @@ class Q(tree.Node):
     connectors = (None, AND, OR, XOR)
 
     def __init__(self, *args, _connector=None, _negated=False, **kwargs):
-        if _connector not in self.connectors:
-            connector_reprs = ", ".join(f"{conn!r}" for conn in self.connectors[1:])
-            raise ValueError(f"_connector must be one of {connector_reprs}, or None.")
+        self._check_connector(_connector)
         super().__init__(
             children=[*args, *sorted(kwargs.items())],
             connector=_connector,
             negated=_negated,
         )
+
+    @classmethod
+    def create(cls, children=None, connector=None, negated=False):
+        cls._check_connector(connector)
+        return super().create(children=children, connector=connector, negated=negated)
+
+    @classmethod
+    def _check_connector(cls, connector):
+        if connector not in cls.connectors:
+            connector_reprs = ", ".join(f"{conn!r}" for conn in cls.connectors[1:])
+            raise ValueError(f"connector must be one of {connector_reprs}, or None.")
 
     def _combine(self, other, conn):
         if getattr(other, "conditional", False) is False:

--- a/tests/queries/test_q.py
+++ b/tests/queries/test_q.py
@@ -273,7 +273,7 @@ class QTests(SimpleTestCase):
                 )
 
     def test_connector_validation(self):
-        msg = f"_connector must be one of {Q.AND!r}, {Q.OR!r}, {Q.XOR!r}, or None."
+        msg = f"connector must be one of {Q.AND!r}, {Q.OR!r}, {Q.XOR!r}, or None."
         with self.assertRaisesMessage(ValueError, msg):
             Q(_connector="evil")
 


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

[ticket-36912](https://code.djangoproject.com/ticket/36912)

#### Branch description
Added validation to Q.create() to ensure that it validates connectors similar to what Q.__init__() does. 

The pull request required investigating how expensive it would be to add validation to Q.create(), so I created benchmarks for both Q and Q.create() to be used in determining whether validation should be added to Q.create() or if refactoring should be used to prevent Q.create() from being called in loops. Other instances where Q.create is used in loops apart from the two mentioned in the ticket are:
https://github.com/django/django/blob/main/django/db/models/query.py#L907-L909
https://github.com/django/django/blob/main/django/db/models/fields/related.py#L439-L444
https://github.com/django/django/blob/main/django/db/models/sql/query.py#L141-L146

Since the ticket is exploratory, for now I only added validation for Q.create() and wrote benchmarks found in this pull request https://github.com/django/django-asv/pull/98. I have not done any refactoring yet and will wait for feedback on how to proceed.

I am not familiar with `django-asv`, which I needed to write benchmarks for this ticket, so I used AI to research how to write benchmarks for Q and Q.create(). The code in the benchmarks of the [django-asv pull request 98](https://github.com/django/django-asv/pull/98) included AI input, but I adapted it to ensure it works and fits the `django-asv` benchmark format.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
