### PR TITLE
Fixed #16429 -- Extracted set_choices() method from FilePathField init

### DIFF
--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -1197,7 +1197,9 @@ class FilePathField(ChoiceField):
         self.path, self.match, self.recursive = path, match, recursive
         self.allow_files, self.allow_folders = allow_files, allow_folders
         super().__init__(choices=(), **kwargs)
+        self.set_choices()
 
+    def set_choices(self):
         if self.required:
             self.choices = []
         else:
@@ -1206,20 +1208,20 @@ class FilePathField(ChoiceField):
         if self.match is not None:
             self.match_re = re.compile(self.match)
 
-        if recursive:
+        if self.recursive:
             for root, dirs, files in sorted(os.walk(self.path)):
                 if self.allow_files:
                     for f in sorted(files):
                         if self.match is None or self.match_re.search(f):
                             f = os.path.join(root, f)
-                            self.choices.append((f, f.replace(path, "", 1)))
+                            self.choices.append((f, f.replace(self.path, "", 1)))
                 if self.allow_folders:
                     for f in sorted(dirs):
                         if f == "__pycache__":
                             continue
                         if self.match is None or self.match_re.search(f):
                             f = os.path.join(root, f)
-                            self.choices.append((f, f.replace(path, "", 1)))
+                            self.choices.append((f, f.replace(self.path, "", 1)))
         else:
             choices = []
             with os.scandir(self.path) as entries:

--- a/docs/ref/forms/fields.txt
+++ b/docs/ref/forms/fields.txt
@@ -724,6 +724,26 @@ For each field, we describe the default widget used if you don't specify
         whether folders in the specified location should be included. Either
         this or :attr:`allow_files` must be ``True``.
 
+    ``FilePathField`` has the following method:
+
+    .. method:: set_choices()
+
+        .. versionadded:: 6.1
+
+        Scans the directory at :attr:`path` and refreshes the field's
+        choices. This is called automatically during ``__init__()``, but it can
+        also be called explicitly to pick up files added to the directory
+        after the field was first instantiated (usually at server startup). For
+        example, call it in a form's ``__init__()`` to get fresh choices per
+        request::
+
+            class MyForm(forms.Form):
+                my_file = forms.FilePathField(path="/path/to/dir")
+
+                def __init__(self, *args, **kwargs):
+                    super().__init__(*args, **kwargs)
+                    self.fields["my_file"].set_choices()
+
 ``FloatField``
 --------------
 

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -258,6 +258,12 @@ Forms
   :setting:`USE_BLANK_CHOICE_DASH` allows you to revert back to the old
   default label.
 
+* :class:`~django.forms.FilePathField` now provides a
+  :meth:`~django.forms.FilePathField.set_choices` method to scan the
+  directory at :attr:`~django.forms.FilePathField.path` and refresh the
+  field's choices. This allows per-request refreshing when called in a form's
+  ``__init__()``.
+
 Generic Views
 ~~~~~~~~~~~~~
 

--- a/tests/forms_tests/field_tests/test_filepathfield.py
+++ b/tests/forms_tests/field_tests/test_filepathfield.py
@@ -1,4 +1,5 @@
 import os.path
+import tempfile
 
 from django.core.exceptions import ValidationError
 from django.forms import FilePathField
@@ -97,6 +98,16 @@ class FilePathFieldTest(SimpleTestCase):
             path=self.path, recursive=True, allow_folders=False, allow_files=False
         )
         self.assertChoices(f, [])
+
+    def test_set_choices_picks_up_new_files(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            f = FilePathField(path=tmp_dir)
+            self.assertEqual(f.choices, [])
+            tmp_file = os.path.join(tmp_dir, "new_file.txt")
+            open(tmp_file, "w").close()
+            f.set_choices()
+            self.assertIn((tmp_file, "new_file.txt"), f.choices)
+            self.assertIn((tmp_file, "new_file.txt"), f.widget.choices)
 
     def test_recursive_folders_without_files(self):
         f = FilePathField(


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-16429

#### Branch description
This change extracts the directory scanning logic from `FilePathField.__init__()` into a public `set_choices()` method, allowing users to refresh choices on a per-request basis by calling it in their form's `__init__()`. Implements the approach agreed upon in PR [#17416](https://github.com/django/django/pull/17416#pullrequestreview-1779132698).

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
