### PR TITLE
Fixed #36901 -- Centralized and cleaned_up mitigations against timing attacks targeting user enumeration

### DIFF
--- a/django/contrib/auth/__init__.py
+++ b/django/contrib/auth/__init__.py
@@ -391,3 +391,22 @@ async def aupdate_session_auth_hash(request, user):
     await request.session.acycle_key()
     if hasattr(user, "get_session_auth_hash") and await request.auser() == user:
         await request.session.aset(HASH_SESSION_KEY, user.get_session_auth_hash())
+
+
+def check_password_with_timing_attack_mitigation(user, password):
+    """
+    Checks password against the user's hash if there is a user, otherwise runs
+    the default password hasher to prevent user enumeration attacks (#20760).
+    """
+    if user is None:
+        get_user_model()().set_password(password)
+    else:
+        return user.check_password(password)
+
+
+async def acheck_password_with_timing_attack_mitigation(user, password):
+    """See check_user_with_timing_attack_mitigation."""
+    if user is None:
+        get_user_model()().set_password(password)
+    else:
+        return await user.acheck_password(password)

--- a/django/contrib/auth/backends.py
+++ b/django/contrib/auth/backends.py
@@ -1,6 +1,10 @@
 from asgiref.sync import sync_to_async
 
-from django.contrib.auth import get_user_model
+from django.contrib.auth import (
+    acheck_password_with_timing_attack_mitigation,
+    check_password_with_timing_attack_mitigation,
+    get_user_model,
+)
 from django.contrib.auth.models import Permission
 from django.db.models import Exists, OuterRef, Q
 
@@ -64,12 +68,12 @@ class ModelBackend(BaseBackend):
         try:
             user = UserModel._default_manager.get_by_natural_key(username)
         except UserModel.DoesNotExist:
-            # Run the default password hasher once to reduce the timing
-            # difference between an existing and a nonexistent user (#20760).
-            UserModel().set_password(password)
-        else:
-            if user.check_password(password) and self.user_can_authenticate(user):
-                return user
+            user = None
+
+        if check_password_with_timing_attack_mitigation(
+            user, password
+        ) and self.user_can_authenticate(user):
+            return user
 
     async def aauthenticate(self, request, username=None, password=None, **kwargs):
         if username is None:
@@ -79,14 +83,12 @@ class ModelBackend(BaseBackend):
         try:
             user = await UserModel._default_manager.aget_by_natural_key(username)
         except UserModel.DoesNotExist:
-            # Run the default password hasher once to reduce the timing
-            # difference between an existing and a nonexistent user (#20760).
-            UserModel().set_password(password)
-        else:
-            if await user.acheck_password(password) and self.user_can_authenticate(
-                user
-            ):
-                return user
+            user = None
+
+        if await acheck_password_with_timing_attack_mitigation(
+            user, password
+        ) and self.user_can_authenticate(user):
+            return user
 
     def user_can_authenticate(self, user):
         """

--- a/django/contrib/auth/handlers/modwsgi.py
+++ b/django/contrib/auth/handlers/modwsgi.py
@@ -8,8 +8,7 @@ def _get_user(username):
     """
     Return the UserModel instance for `username`.
 
-    If no matching user exists, or if the user is inactive, return None, in
-    which case the default password hasher is run to mitigate timing attacks.
+    If no matching user exists, or if the user is inactive, return None.
     """
     try:
         user = UserModel._default_manager.get_by_natural_key(username)
@@ -18,12 +17,6 @@ def _get_user(username):
     else:
         if not user.is_active:
             user = None
-
-    if user is None:
-        # Run the default password hasher once to reduce the timing difference
-        # between existing/active and nonexistent/inactive users (#20760).
-        UserModel().set_password("")
-
     return user
 
 
@@ -43,8 +36,7 @@ def check_password(environ, username, password):
     db.reset_queries()
     try:
         user = _get_user(username)
-        if user:
-            return user.check_password(password)
+        return auth.check_password_with_timing_attack_mitigation(user, password)
     finally:
         db.close_old_connections()
 


### PR DESCRIPTION

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-36901

#### Branch description
Centralized and cleaned_up mitigations against timing attacks targeting user enumeration

Created two utility functions called get_user_with_mitigation() and aget_user_with_mitigation() in the file auth.__init__.py. Refactored auth.handlers.modwsgi.check_password(), auth.backend.authenticate() and auth.backend.aauthenticate().

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output. 

I have used Gemini to understand what really means  timing attacks targeting user enumeration and how does it work.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
