### PR TITLE
Fixed #35514 -- Implemented dictionary-based EMAIL_PROVIDERS.

### DIFF
--- a/django/conf/__init__.py
+++ b/django/conf/__init__.py
@@ -147,21 +147,6 @@ class LazySettings(LazyObject):
         """Return True if the settings have already been configured."""
         return self._wrapped is not empty
 
-    def _show_deprecation_warning(self, message, category):
-        """Issue a warning when external code uses a deprecated setting.
-
-        Allow Django's own code to use it without emitting the warning. This
-        function should only be called from within LazySettings methods.
-        """
-        warn_about_external_use(
-            message,
-            category,
-            skip_name_prefixes=(
-                "django.conf.LazySettings",
-                "django.utils.functional.LazyObject",
-            ),
-        )
-
 
 class Settings:
     def __init__(self, settings_module):
@@ -273,6 +258,35 @@ class UserSettingsHolder:
         return "<%(cls)s>" % {
             "cls": self.__class__.__name__,
         }
+
+
+def _show_settings_deprecation_warning(message, category):
+    """Issue a warning when external code uses a deprecated setting.
+
+    Allow Django's own code to use the setting without emitting the warning.
+    This function should only be called from within settings-related code.
+    """
+    warn_about_external_use(
+        message,
+        category,
+        skip_name_prefixes=(
+            # Include all settings-related code here. (Do not include all of
+            # "django.conf", which would incorrectly identify any deprecated
+            # settings usage inside django.conf.urls as external.)
+            "django.conf.LazySettings",
+            "django.conf.Settings",
+            "django.conf.UserSettingsHolder",
+            "django.utils.functional.LazyObject",  # LazySettings superclass.
+            # override_settings() and similar test utils must be treated as
+            # settings-related code, else deprecated settings usage in tests
+            # would be incorrectly identified as internal.
+            "django.test.utils.override_settings",
+            "django.test.utils.modify_settings",
+            "django.test.utils.TestContextDecorator",
+            "django.test.testcases.SimpleTestCase.settings",
+            "django.test.testcases.SimpleTestCase.modify_settings",
+        ),
+    )
 
 
 settings = LazySettings()

--- a/django/conf/__init__.py
+++ b/django/conf/__init__.py
@@ -31,6 +31,37 @@ USE_BLANK_CHOICE_DASH_DEPRECATED_MSG = (
     "django.db.models.fields.BLANK_CHOICE_LABEL in your app's ready() method."
 )
 
+# RemovedInDjango70Warning.
+DEPRECATED_EMAIL_SETTINGS = {
+    "EMAIL_BACKEND",
+    "EMAIL_FILE_PATH",
+    "EMAIL_HOST",
+    "EMAIL_HOST_PASSWORD",
+    "EMAIL_HOST_USER",
+    "EMAIL_PORT",
+    "EMAIL_SSL_CERTFILE",
+    "EMAIL_SSL_KEYFILE",
+    "EMAIL_TIMEOUT",
+    "EMAIL_USE_SSL",
+    "EMAIL_USE_TLS",
+}
+EMAIL_SETTING_DEPRECATED_MSG = (
+    "The {name} setting is deprecated. Migrate to EMAIL_PROVIDERS before Django 7.0."
+)
+
+
+# RemovedInDjango70Warning.
+# Must be called with the complete set of user-defined setting names (but no
+# default settings).
+def _check_email_settings_conflicts(explicit_settings):
+    deprecated = DEPRECATED_EMAIL_SETTINGS.intersection(explicit_settings)
+    if deprecated and "EMAIL_PROVIDERS" in explicit_settings:
+        deprecated_str = ", ".join(sorted(deprecated))
+        raise ImproperlyConfigured(
+            "Deprecated email settings are not allowed when EMAIL_PROVIDERS "
+            f"is defined: {deprecated_str}."
+        )
+
 
 class SettingsReference(str):
     """
@@ -85,6 +116,17 @@ class LazySettings(LazyObject):
             _wrapped = self._wrapped
         val = getattr(_wrapped, name)
 
+        # RemovedInDjango70Warning.
+        if name in DEPRECATED_EMAIL_SETTINGS:
+            if hasattr(_wrapped, "EMAIL_PROVIDERS"):
+                raise AttributeError(
+                    f"The {name} setting is not available when "
+                    "EMAIL_PROVIDERS is defined"
+                )
+            _show_settings_deprecation_warning(
+                EMAIL_SETTING_DEPRECATED_MSG.format(name=name), RemovedInDjango70Warning
+            )
+
         # Special case some settings which require further modification.
         # This is done here for performance reasons so the modified value is
         # cached.
@@ -105,12 +147,37 @@ class LazySettings(LazyObject):
             self.__dict__.clear()
         else:
             self.__dict__.pop(name, None)
+
+        # RemovedInDjango70Warning.
+        # Clear cached values of deprecated settings if EMAIL_PROVIDERS added.
+        if name == "EMAIL_PROVIDERS":
+            for setting in DEPRECATED_EMAIL_SETTINGS:
+                self.__dict__.pop(setting, None)
+        if name in DEPRECATED_EMAIL_SETTINGS:
+            _show_settings_deprecation_warning(
+                EMAIL_SETTING_DEPRECATED_MSG.format(name=name), RemovedInDjango70Warning
+            )
+
         super().__setattr__(name, value)
 
     def __delattr__(self, name):
         """Delete a setting and clear it from cache if needed."""
         super().__delattr__(name)
         self.__dict__.pop(name, None)
+
+    # RemovedInDjango70Warning.
+    # When EMAIL_PROVIDERS is defined, filter out deprecated email settings
+    # resulting from default global_settings.
+    def __dir__(self):
+        attrs = super().__dir__()
+        if hasattr(self._wrapped, "EMAIL_PROVIDERS"):
+            attrs = [
+                name
+                for name in attrs
+                if name not in DEPRECATED_EMAIL_SETTINGS
+                or self._wrapped.is_overridden(name)
+            ]
+        return attrs
 
     def configure(self, default_settings=global_settings, **options):
         """
@@ -120,6 +187,10 @@ class LazySettings(LazyObject):
         """
         if self._wrapped is not empty:
             raise RuntimeError("Settings already configured.")
+
+        # RemovedInDjango70Warning.
+        _check_email_settings_conflicts(options.keys())
+
         holder = UserSettingsHolder(default_settings)
         for name, value in options.items():
             if not name.isupper():
@@ -182,6 +253,13 @@ class Settings:
                 setattr(self, setting, setting_value)
                 self._explicit_settings.add(setting)
 
+        # RemovedInDjango70Warning.
+        _check_email_settings_conflicts(self._explicit_settings)
+        for name in DEPRECATED_EMAIL_SETTINGS.intersection(self._explicit_settings):
+            _show_settings_deprecation_warning(
+                EMAIL_SETTING_DEPRECATED_MSG.format(name=name), RemovedInDjango70Warning
+            )
+
         if hasattr(time, "tzset") and self.TIME_ZONE:
             # When we can, attempt to validate the timezone. If we can't find
             # this file, no check happens and it's harmless.
@@ -232,6 +310,12 @@ class UserSettingsHolder:
                 RemovedInDjango70Warning,
                 skip_file_prefixes=django_file_prefixes(),
             )
+        # RemovedInDjango70Warning.
+        if name in DEPRECATED_EMAIL_SETTINGS:
+            _show_settings_deprecation_warning(
+                EMAIL_SETTING_DEPRECATED_MSG.format(name=name), RemovedInDjango70Warning
+            )
+
         super().__setattr__(name, value)
 
     def __delattr__(self, name):

--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -187,21 +187,29 @@ DATABASES = {}
 # Classes used to implement DB routing behavior.
 DATABASE_ROUTERS = []
 
+# Email provider configurations. No providers are defined by default.
+# RemovedInDjango70Warning: uncomment the next line.
+# EMAIL_PROVIDERS = {}
+
+# RemovedInDjango70Warning.
 # The email backend to use. For possible shortcuts see django.core.mail.
 # The default is to use the SMTP backend.
 # Third-party backends can be specified by providing a Python path
 # to a module that defines an EmailBackend class.
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 
+# RemovedInDjango70Warning.
 # Host for sending email.
 EMAIL_HOST = "localhost"
 
+# RemovedInDjango70Warning.
 # Port for sending email.
 EMAIL_PORT = 25
 
 # Whether to send SMTP 'Date' header in the local time zone or in UTC.
 EMAIL_USE_LOCALTIME = False
 
+# RemovedInDjango70Warning.
 # Optional SMTP authentication information for EMAIL_HOST.
 EMAIL_HOST_USER = ""
 EMAIL_HOST_PASSWORD = ""

--- a/django/conf/project_template/project_name/settings.py-tpl
+++ b/django/conf/project_template/project_name/settings.py-tpl
@@ -115,3 +115,13 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/{{ docs_version }}/howto/static-files/
 
 STATIC_URL = 'static/'
+
+
+# Email providers
+# https://docs.djangoproject.com/en/{{ docs_version }}/topics/email/#topic-email-configuration
+
+EMAIL_PROVIDERS = {
+    'default': {
+        'BACKEND': 'django.core.mail.backends.console.EmailBackend',
+    },
+}

--- a/django/core/mail/__init__.py
+++ b/django/core/mail/__init__.py
@@ -6,6 +6,7 @@ import warnings
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django.core.mail.exceptions import InvalidEmailProvider
 
 # Imported for backwards compatibility and for the sake
 # of a cleaner namespace. These symbols used to be in
@@ -26,6 +27,7 @@ from django.utils.functional import Promise
 from django.utils.module_loading import import_string
 
 __all__ = [
+    "InvalidEmailProvider",
     "CachedDnsName",
     "DNS_NAME",
     "EmailMessage",
@@ -94,7 +96,14 @@ def send_mail(
     Note: The API for this method is frozen. New code wanting to extend the
     functionality should use the EmailMessage class directly.
     """
-    if connection is not None:
+    if connection is None:
+        options = {"fail_silently": fail_silently}
+        if auth_user is not None:
+            options["username"] = auth_user
+        if auth_password is not None:
+            options["password"] = auth_password
+        connection = get_connection(**options)
+    else:
         if fail_silently:
             raise TypeError(
                 "fail_silently cannot be used with a connection. "
@@ -105,11 +114,6 @@ def send_mail(
                 "auth_user and auth_password cannot be used with a connection. "
                 "Pass auth_user and auth_password to get_connection() instead."
             )
-    connection = connection or get_connection(
-        username=auth_user,
-        password=auth_password,
-        fail_silently=fail_silently,
-    )
     mail = EmailMultiAlternatives(
         subject, message, from_email, recipient_list, connection=connection
     )
@@ -148,7 +152,14 @@ def send_mass_mail(
     Note: The API for this method is frozen. New code wanting to extend the
     functionality should use the EmailMessage class directly.
     """
-    if connection is not None:
+    if connection is None:
+        options = {"fail_silently": fail_silently}
+        if auth_user is not None:
+            options["username"] = auth_user
+        if auth_password is not None:
+            options["password"] = auth_password
+        connection = get_connection(**options)
+    else:
         if fail_silently:
             raise TypeError(
                 "fail_silently cannot be used with a connection. "
@@ -159,11 +170,6 @@ def send_mass_mail(
                 "auth_user and auth_password cannot be used with a connection. "
                 "Pass auth_user and auth_password to get_connection() instead."
             )
-    connection = connection or get_connection(
-        username=auth_user,
-        password=auth_password,
-        fail_silently=fail_silently,
-    )
     messages = [
         EmailMessage(subject, message, sender, recipient, connection=connection)
         for subject, message, sender, recipient in datatuple

--- a/django/core/mail/__init__.py
+++ b/django/core/mail/__init__.py
@@ -6,7 +6,8 @@ import warnings
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.core.mail.exceptions import InvalidEmailProvider
+from django.core.mail.exceptions import EmailProviderDoesNotExist, InvalidEmailProvider
+from django.core.mail.handler import DEFAULT_EMAIL_PROVIDER_ALIAS, EmailProvidersHandler
 
 # Imported for backwards compatibility and for the sake
 # of a cleaner namespace. These symbols used to be in
@@ -26,7 +27,10 @@ from django.utils.deprecation import RemovedInDjango70Warning, deprecate_posargs
 from django.utils.functional import Promise
 from django.utils.module_loading import import_string
 
+from .deprecation import report_using_incompatibility
+
 __all__ = [
+    "EmailProviderDoesNotExist",
     "InvalidEmailProvider",
     "CachedDnsName",
     "DNS_NAME",
@@ -34,6 +38,7 @@ __all__ = [
     "EmailMultiAlternatives",
     "DEFAULT_ATTACHMENT_MIME_TYPE",
     "make_msgid",
+    "providers",
     "get_connection",
     "send_mail",
     "send_mass_mail",
@@ -50,6 +55,10 @@ __all__ = [
 ]
 
 
+providers = EmailProvidersHandler()
+
+
+# RemovedInDjango70Warning.
 @deprecate_posargs(RemovedInDjango70Warning, ["fail_silently"])
 def get_connection(backend=None, *, fail_silently=False, **kwds):
     """Load an email backend and return an instance of it.
@@ -59,8 +68,21 @@ def get_connection(backend=None, *, fail_silently=False, **kwds):
     Both fail_silently and other keyword arguments are used in the
     constructor of the backend.
     """
+    if fail_silently:
+        kwds["fail_silently"] = fail_silently
+
+    if providers._is_configured:
+        # Support get_connection(**kwargs) from EMAIL_PROVIDERS["default"].
+        if backend is not None:
+            raise RuntimeError(
+                "get_connection(backend, ...) is not supported with EMAIL_PROVIDERS."
+            )
+        return providers.create_connection(
+            DEFAULT_EMAIL_PROVIDER_ALIAS, _deprecated_kwargs=kwds
+        )
+
     klass = import_string(backend or settings.EMAIL_BACKEND)
-    return klass(fail_silently=fail_silently, **kwds)
+    return klass(**kwds)
 
 
 @deprecate_posargs(
@@ -84,6 +106,7 @@ def send_mail(
     auth_password=None,
     connection=None,
     html_message=None,
+    using=None,
 ):
     """
     Easy wrapper for sending a single message to a recipient list. All members
@@ -96,7 +119,18 @@ def send_mail(
     Note: The API for this method is frozen. New code wanting to extend the
     functionality should use the EmailMessage class directly.
     """
-    if connection is None:
+    # RemovedInDjango70Warning: change entire implementation to:
+    #   email = EmailMultiAlternatives(
+    #       subject, message, from_email, recipient_list
+    #   )
+    #   if html_message:
+    #       email.attach_alternative(html_message, "text/html")
+    #   return email.send(using=using)
+    if using is not None:
+        report_using_incompatibility(
+            connection, fail_silently, auth_user, auth_password
+        )
+    elif connection is None:
         options = {"fail_silently": fail_silently}
         if auth_user is not None:
             options["username"] = auth_user
@@ -120,7 +154,7 @@ def send_mail(
     if html_message:
         mail.attach_alternative(html_message, "text/html")
 
-    return mail.send()
+    return mail.send(using=using)
 
 
 @deprecate_posargs(
@@ -139,6 +173,7 @@ def send_mass_mail(
     auth_user=None,
     auth_password=None,
     connection=None,
+    using=None,
 ):
     """
     Given a datatuple of (subject, message, from_email, recipient_list), send
@@ -152,7 +187,16 @@ def send_mass_mail(
     Note: The API for this method is frozen. New code wanting to extend the
     functionality should use the EmailMessage class directly.
     """
-    if connection is None:
+    # RemovedInDjango70Warning: change entire implementation to:
+    #   messages = [...]
+    #   provider = providers.default if using is None else providers[using]
+    #   return provider.send_messages(messages)
+    if using is not None:
+        report_using_incompatibility(
+            connection, fail_silently, auth_user, auth_password
+        )
+        connection = providers[using]
+    elif connection is None:
         options = {"fail_silently": fail_silently}
         if auth_user is not None:
             options["username"] = auth_user
@@ -185,12 +229,16 @@ def _send_server_message(
     html_message=None,
     fail_silently=False,
     connection=None,
+    using=None,
 ):
-    if connection is not None and fail_silently:
+    if using is not None:
+        report_using_incompatibility(connection, fail_silently)
+    elif connection is not None and fail_silently:
         raise TypeError(
             "fail_silently cannot be used with a connection. "
             "Pass fail_silently to get_connection() instead."
         )
+
     recipients = getattr(settings, setting_name)
     if not recipients:
         return
@@ -221,14 +269,20 @@ def _send_server_message(
     )
     if html_message:
         mail.attach_alternative(html_message, "text/html")
-    mail.send(fail_silently=fail_silently)
+    mail.send(using=using, fail_silently=fail_silently)
 
 
 @deprecate_posargs(
     RemovedInDjango70Warning, ["fail_silently", "connection", "html_message"]
 )
 def mail_admins(
-    subject, message, *, fail_silently=False, connection=None, html_message=None
+    subject,
+    message,
+    *,
+    fail_silently=False,
+    connection=None,
+    html_message=None,
+    using=None,
 ):
     """Send a message to the admins, as defined by the ADMINS setting."""
     _send_server_message(
@@ -238,6 +292,7 @@ def mail_admins(
         html_message=html_message,
         fail_silently=fail_silently,
         connection=connection,
+        using=using,
     )
 
 
@@ -245,7 +300,13 @@ def mail_admins(
     RemovedInDjango70Warning, ["fail_silently", "connection", "html_message"]
 )
 def mail_managers(
-    subject, message, *, fail_silently=False, connection=None, html_message=None
+    subject,
+    message,
+    *,
+    fail_silently=False,
+    connection=None,
+    html_message=None,
+    using=None,
 ):
     """Send a message to the managers, as defined by the MANAGERS setting."""
     _send_server_message(
@@ -255,6 +316,7 @@ def mail_managers(
         html_message=html_message,
         fail_silently=fail_silently,
         connection=connection,
+        using=using,
     )
 
 

--- a/django/core/mail/__init__.py
+++ b/django/core/mail/__init__.py
@@ -27,7 +27,10 @@ from django.utils.deprecation import RemovedInDjango70Warning, deprecate_posargs
 from django.utils.functional import Promise
 from django.utils.module_loading import import_string
 
-from .deprecation import report_using_incompatibility
+from .deprecation import (
+    report_using_incompatibility,
+    warn_about_default_email_providers_if_needed,
+)
 
 __all__ = [
     "EmailProviderDoesNotExist",
@@ -68,6 +71,8 @@ def get_connection(backend=None, *, fail_silently=False, **kwds):
     Both fail_silently and other keyword arguments are used in the
     constructor of the backend.
     """
+    warn_about_default_email_providers_if_needed()
+
     if fail_silently:
         kwds["fail_silently"] = fail_silently
 

--- a/django/core/mail/__init__.py
+++ b/django/core/mail/__init__.py
@@ -23,11 +23,18 @@ from django.core.mail.message import (
     make_msgid,
 )
 from django.core.mail.utils import DNS_NAME, CachedDnsName
-from django.utils.deprecation import RemovedInDjango70Warning, deprecate_posargs
+from django.utils.deprecation import (
+    RemovedInDjango70Warning,
+    deprecate_posargs,
+    warn_about_external_use,
+)
 from django.utils.functional import Promise
 from django.utils.module_loading import import_string
 
 from .deprecation import (
+    AUTH_ARGS_WARNING,
+    CONNECTION_ARG_WARNING,
+    FAIL_SILENTLY_ARG_WARNING,
     report_using_incompatibility,
     warn_about_default_email_providers_if_needed,
 )
@@ -71,6 +78,11 @@ def get_connection(backend=None, *, fail_silently=False, **kwds):
     Both fail_silently and other keyword arguments are used in the
     constructor of the backend.
     """
+    msg = (
+        "get_connection() is deprecated. See 'Migrating to EMAIL_PROVIDERS' "
+        "in Django's documentation for recommended replacements."
+    )
+    warn_about_external_use(msg, RemovedInDjango70Warning, skip_frames=1)
     warn_about_default_email_providers_if_needed()
 
     if fail_silently:
@@ -118,8 +130,6 @@ def send_mail(
     of the recipient list will see the other recipients in the 'To' field.
 
     If from_email is None, use the DEFAULT_FROM_EMAIL setting.
-    If auth_user is None, use the EMAIL_HOST_USER setting.
-    If auth_password is None, use the EMAIL_HOST_PASSWORD setting.
 
     Note: The API for this method is frozen. New code wanting to extend the
     functionality should use the EmailMessage class directly.
@@ -131,6 +141,19 @@ def send_mail(
     #   if html_message:
     #       email.attach_alternative(html_message, "text/html")
     #   return email.send(using=using)
+    if fail_silently:
+        warn_about_external_use(
+            FAIL_SILENTLY_ARG_WARNING, RemovedInDjango70Warning, skip_frames=1
+        )
+    if auth_user is not None or auth_password is not None:
+        warn_about_external_use(
+            AUTH_ARGS_WARNING, RemovedInDjango70Warning, skip_frames=1
+        )
+    if connection is not None:
+        warn_about_external_use(
+            CONNECTION_ARG_WARNING, RemovedInDjango70Warning, skip_frames=1
+        )
+
     if using is not None:
         report_using_incompatibility(
             connection, fail_silently, auth_user, auth_password
@@ -185,9 +208,6 @@ def send_mass_mail(
     each message to each recipient list. Return the number of emails sent.
 
     If from_email is None, use the DEFAULT_FROM_EMAIL setting.
-    If auth_user and auth_password are set, use them to log in.
-    If auth_user is None, use the EMAIL_HOST_USER setting.
-    If auth_password is None, use the EMAIL_HOST_PASSWORD setting.
 
     Note: The API for this method is frozen. New code wanting to extend the
     functionality should use the EmailMessage class directly.
@@ -196,6 +216,19 @@ def send_mass_mail(
     #   messages = [...]
     #   provider = providers.default if using is None else providers[using]
     #   return provider.send_messages(messages)
+    if fail_silently:
+        warn_about_external_use(
+            FAIL_SILENTLY_ARG_WARNING, RemovedInDjango70Warning, skip_frames=1
+        )
+    if auth_user is not None or auth_password is not None:
+        warn_about_external_use(
+            AUTH_ARGS_WARNING, RemovedInDjango70Warning, skip_frames=1
+        )
+    if connection is not None:
+        warn_about_external_use(
+            CONNECTION_ARG_WARNING, RemovedInDjango70Warning, skip_frames=1
+        )
+
     if using is not None:
         report_using_incompatibility(
             connection, fail_silently, auth_user, auth_password
@@ -226,6 +259,7 @@ def send_mass_mail(
     return connection.send_messages(messages)
 
 
+# RemovedInDjango70Warning: fail_silently and connection args.
 def _send_server_message(
     *,
     setting_name,
@@ -236,6 +270,17 @@ def _send_server_message(
     connection=None,
     using=None,
 ):
+    # RemovedInDjango70Warning: everything before `recipients = getattr(...)`.
+    # skip_frames=2: this helper's caller + its @deprecate_posargs decorator.
+    if fail_silently:
+        warn_about_external_use(
+            FAIL_SILENTLY_ARG_WARNING, RemovedInDjango70Warning, skip_frames=2
+        )
+    if connection is not None:
+        warn_about_external_use(
+            CONNECTION_ARG_WARNING, RemovedInDjango70Warning, skip_frames=2
+        )
+
     if using is not None:
         report_using_incompatibility(connection, fail_silently)
     elif connection is not None and fail_silently:
@@ -243,6 +288,7 @@ def _send_server_message(
             "fail_silently cannot be used with a connection. "
             "Pass fail_silently to get_connection() instead."
         )
+    # ... end of RemovedInDjango70Warning.
 
     recipients = getattr(settings, setting_name)
     if not recipients:
@@ -277,6 +323,7 @@ def _send_server_message(
     mail.send(using=using, fail_silently=fail_silently)
 
 
+# RemovedInDjango70Warning: fail_silently and connection args.
 @deprecate_posargs(
     RemovedInDjango70Warning, ["fail_silently", "connection", "html_message"]
 )
@@ -301,6 +348,7 @@ def mail_admins(
     )
 
 
+# RemovedInDjango70Warning: fail_silently and connection args.
 @deprecate_posargs(
     RemovedInDjango70Warning, ["fail_silently", "connection", "html_message"]
 )

--- a/django/core/mail/backends/base.py
+++ b/django/core/mail/backends/base.py
@@ -21,9 +21,17 @@ class BaseEmailBackend:
            pass
     """
 
-    def __init__(self, fail_silently=False, *, alias=None, **kwargs):
+    # RemovedInDjango70Warning: _ignore_unknown_kwargs.
+    def __init__(
+        self, fail_silently=False, *, alias=None, _ignore_unknown_kwargs=None, **kwargs
+    ):
         self.alias = alias
         self.fail_silently = fail_silently
+
+        # RemovedInDjango70Warning.
+        if _ignore_unknown_kwargs:
+            for ignored in _ignore_unknown_kwargs:
+                kwargs.pop(ignored, None)
 
         if kwargs:
             kwarg_names = ", ".join(repr(key) for key in kwargs.keys())

--- a/django/core/mail/backends/base.py
+++ b/django/core/mail/backends/base.py
@@ -1,11 +1,17 @@
 """Base email backend class."""
 
+from django.core.mail import InvalidEmailProvider
+from django.utils.deprecation import RemovedInDjango70Warning, warn_about_external_use
+
 
 class BaseEmailBackend:
     """
     Base class for email backend implementations.
 
-    Subclasses must at least overwrite send_messages().
+    Subclasses must implement at least send_messages().
+
+    Subclass __init__() should pass alias and unknown **kwargs to
+    super().__init__() for proper error reporting.
 
     open() and close() can be called indirectly by using a backend object as a
     context manager:
@@ -15,8 +21,32 @@ class BaseEmailBackend:
            pass
     """
 
-    def __init__(self, fail_silently=False, **kwargs):
+    def __init__(self, fail_silently=False, *, alias=None, **kwargs):
+        self.alias = alias
         self.fail_silently = fail_silently
+
+        if kwargs:
+            kwarg_names = ", ".join(repr(key) for key in kwargs.keys())
+
+            # RemovedInDjango70Warning.
+            if alias is None:
+                # Not being initialized from mail.providers. Unknown kwargs are
+                # ignored -- with a deprecation warning if they originated from
+                # outside Django (either direct construction of a built-in
+                # backend or a super.__init__() call from a custom subclass).
+                # Use something more precise than self.__class__.__name__,
+                # which is often just "EmailBackend".
+                class_name = f"{type(self).__module__}.{type(self).__qualname__}"
+                warn_about_external_use(
+                    f"{class_name}.__init__() does not support {kwarg_names}. "
+                    "In Django 7.0, BaseEmailBackend will raise a TypeError "
+                    "for unknown keyword arguments.",
+                    RemovedInDjango70Warning,
+                    skip_name_prefixes="django.core.mail.backends",
+                )
+                return
+
+            raise InvalidEmailProvider(f"Unknown options {kwarg_names}.", alias=alias)
 
     def open(self):
         """

--- a/django/core/mail/backends/base.py
+++ b/django/core/mail/backends/base.py
@@ -3,6 +3,9 @@
 from django.core.mail import InvalidEmailProvider
 from django.utils.deprecation import RemovedInDjango70Warning, warn_about_external_use
 
+# RemovedInDjango70Warning.
+_NOT_PROVIDED = object()
+
 
 class BaseEmailBackend:
     """
@@ -21,14 +24,24 @@ class BaseEmailBackend:
            pass
     """
 
-    # RemovedInDjango70Warning: _ignore_unknown_kwargs.
+    # RemovedInDjango70Warning: fail_silently, _ignore_unknown_kwargs.
     def __init__(
-        self, fail_silently=False, *, alias=None, _ignore_unknown_kwargs=None, **kwargs
+        self,
+        fail_silently=_NOT_PROVIDED,
+        *,
+        alias=None,
+        _ignore_unknown_kwargs=None,
+        **kwargs,
     ):
         self.alias = alias
-        self.fail_silently = fail_silently
 
         # RemovedInDjango70Warning.
+        if fail_silently is _NOT_PROVIDED:
+            self._fail_silently = False
+        else:
+            self._fail_silently = fail_silently
+            # Force deprecation warning unless in _ignore_unknown_kwargs.
+            kwargs["fail_silently"] = fail_silently
         if _ignore_unknown_kwargs:
             for ignored in _ignore_unknown_kwargs:
                 kwargs.pop(ignored, None)
@@ -55,6 +68,19 @@ class BaseEmailBackend:
                 return
 
             raise InvalidEmailProvider(f"Unknown options {kwarg_names}.", alias=alias)
+
+    # RemovedInDjango70Warning.
+    def __getattr__(self, name):
+        if name == "fail_silently":
+            msg = (
+                "BaseEmailBackend.fail_silently is deprecated. A subclass "
+                "that supports fail_silently must set its own attribute."
+            )
+            warn_about_external_use(msg, RemovedInDjango70Warning)
+            return self._fail_silently
+        raise AttributeError(
+            f"{type(self).__name__!r} object has no attribute {name!r}"
+        )
 
     def open(self):
         """

--- a/django/core/mail/backends/console.py
+++ b/django/core/mail/backends/console.py
@@ -9,10 +9,11 @@ from django.core.mail.backends.base import BaseEmailBackend
 
 
 class EmailBackend(BaseEmailBackend):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, fail_silently=False, **kwargs):
         self.stream = kwargs.pop("stream", sys.stdout)
         self._lock = threading.RLock()
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
+        self.fail_silently = fail_silently
 
     def write_message(self, message):
         msg = message.message()

--- a/django/core/mail/backends/filebased.py
+++ b/django/core/mail/backends/filebased.py
@@ -15,6 +15,11 @@ class EmailBackend(ConsoleEmailBackend):
             self.file_path = file_path
         else:
             self.file_path = getattr(settings, "EMAIL_FILE_PATH", None)
+        if self.file_path is None:
+            raise ImproperlyConfigured(
+                "The EMAIL_FILE_PATH setting must be defined to use the file "
+                "EmailBackend."
+            )
         self.file_path = os.path.abspath(self.file_path)
         try:
             os.makedirs(self.file_path, exist_ok=True)

--- a/django/core/mail/backends/filebased.py
+++ b/django/core/mail/backends/filebased.py
@@ -5,44 +5,72 @@ import os
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django.core.mail import InvalidEmailProvider
 from django.core.mail.backends.console import EmailBackend as ConsoleEmailBackend
 
 
 class EmailBackend(ConsoleEmailBackend):
     def __init__(self, *args, file_path=None, **kwargs):
         self._fname = None
-        if file_path is not None:
-            self.file_path = file_path
-        else:
-            self.file_path = getattr(settings, "EMAIL_FILE_PATH", None)
-        if self.file_path is None:
-            raise ImproperlyConfigured(
-                "The EMAIL_FILE_PATH setting must be defined to use the file "
-                "EmailBackend."
+        # Since we're using the console-based backend as a base, force the
+        # stream to be None, so we don't default to stdout.
+        kwargs["stream"] = None
+        super().__init__(*args, **kwargs)
+
+        # RemovedInDjango70Warning.
+        if self.alias is None:
+            # Use deprecated settings when EMAIL_PROVIDERS not enabled.
+            if file_path is not None:
+                self.file_path = file_path
+            else:
+                self.file_path = getattr(settings, "EMAIL_FILE_PATH", None)
+            if self.file_path is None:
+                raise ImproperlyConfigured(
+                    "The EMAIL_FILE_PATH setting must be defined to use the file "
+                    "EmailBackend."
+                )
+            self.file_path = os.path.abspath(self.file_path)
+            try:
+                os.makedirs(self.file_path, exist_ok=True)
+            except FileExistsError:
+                raise ImproperlyConfigured(
+                    "Path for saving email messages exists, but is not a directory: %s"
+                    % self.file_path
+                )
+            except OSError as err:
+                raise ImproperlyConfigured(
+                    "Could not create directory for saving email messages: %s (%s)"
+                    % (self.file_path, err)
+                )
+            # Make sure that self.file_path is writable.
+            if not os.access(self.file_path, os.W_OK):
+                raise ImproperlyConfigured(
+                    "Could not write to directory: %s" % self.file_path
+                )
+            return
+
+        if file_path is None:
+            raise InvalidEmailProvider(
+                "OPTIONS must define 'file_path'.", alias=self.alias
             )
-        self.file_path = os.path.abspath(self.file_path)
+        self.file_path = os.path.abspath(file_path)
         try:
             os.makedirs(self.file_path, exist_ok=True)
         except FileExistsError:
-            raise ImproperlyConfigured(
-                "Path for saving email messages exists, but is not a directory: %s"
-                % self.file_path
+            raise InvalidEmailProvider(
+                f"'file_path' is not a directory: {self.file_path}",
+                alias=self.alias,
             )
         except OSError as err:
-            raise ImproperlyConfigured(
-                "Could not create directory for saving email messages: %s (%s)"
-                % (self.file_path, err)
+            raise InvalidEmailProvider(
+                f"Could not create 'file_path': {self.file_path} ({err})",
+                alias=self.alias,
             )
-        # Make sure that self.file_path is writable.
         if not os.access(self.file_path, os.W_OK):
-            raise ImproperlyConfigured(
-                "Could not write to directory: %s" % self.file_path
+            raise InvalidEmailProvider(
+                f"'file_path' is not writeable: {self.file_path}",
+                alias=self.alias,
             )
-        # Finally, call super().
-        # Since we're using the console-based backend as a base,
-        # force the stream to be None, so we don't default to stdout
-        kwargs["stream"] = None
-        super().__init__(*args, **kwargs)
 
     def write_message(self, message):
         self.stream.write(message.message().as_bytes() + b"\n")

--- a/django/core/mail/backends/filebased.py
+++ b/django/core/mail/backends/filebased.py
@@ -10,12 +10,12 @@ from django.core.mail.backends.console import EmailBackend as ConsoleEmailBacken
 
 
 class EmailBackend(ConsoleEmailBackend):
-    def __init__(self, *args, file_path=None, **kwargs):
+    def __init__(self, fail_silently=False, file_path=None, **kwargs):
         self._fname = None
         # Since we're using the console-based backend as a base, force the
         # stream to be None, so we don't default to stdout.
         kwargs["stream"] = None
-        super().__init__(*args, **kwargs)
+        super().__init__(fail_silently=fail_silently, **kwargs)
 
         # RemovedInDjango70Warning.
         if self.alias is None:

--- a/django/core/mail/backends/locmem.py
+++ b/django/core/mail/backends/locmem.py
@@ -26,8 +26,10 @@ class EmailBackend(BaseEmailBackend):
     def send_messages(self, messages):
         """Redirect messages to the dummy outbox"""
         msg_count = 0
-        for message in messages:  # .message() triggers header validation
-            message.message()
-            mail.outbox.append(copy.deepcopy(message))
+        for message in messages:
+            message.message()  # Trigger header validation.
+            msg_copy = copy.deepcopy(message)
+            msg_copy.sent_using = self.alias
+            mail.outbox.append(msg_copy)
             msg_count += 1
         return msg_count

--- a/django/core/mail/backends/locmem.py
+++ b/django/core/mail/backends/locmem.py
@@ -18,6 +18,8 @@ class EmailBackend(BaseEmailBackend):
     The dummy outbox is accessible through the outbox instance attribute.
     """
 
+    # RemovedInDjango70Warning: *args. (The only supported posarg will be
+    # removed from BaseEmailBackend in Django 7.0.)
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if not hasattr(mail, "outbox"):

--- a/django/core/mail/backends/smtp.py
+++ b/django/core/mail/backends/smtp.py
@@ -7,6 +7,7 @@ import threading
 from email.headerregistry import Address, AddressHeader
 
 from django.conf import settings
+from django.core.mail import InvalidEmailProvider
 from django.core.mail.backends.base import BaseEmailBackend
 from django.core.mail.utils import DNS_NAME
 from django.utils.encoding import force_str, punycode
@@ -32,27 +33,59 @@ class EmailBackend(BaseEmailBackend):
         ssl_certfile=None,
         **kwargs,
     ):
-        super().__init__(fail_silently=fail_silently)
-        self.host = host or settings.EMAIL_HOST
-        self.port = port or settings.EMAIL_PORT
-        self.username = settings.EMAIL_HOST_USER if username is None else username
-        self.password = settings.EMAIL_HOST_PASSWORD if password is None else password
-        self.use_tls = settings.EMAIL_USE_TLS if use_tls is None else use_tls
-        self.use_ssl = settings.EMAIL_USE_SSL if use_ssl is None else use_ssl
-        self.timeout = settings.EMAIL_TIMEOUT if timeout is None else timeout
-        self.ssl_keyfile = (
-            settings.EMAIL_SSL_KEYFILE if ssl_keyfile is None else ssl_keyfile
-        )
-        self.ssl_certfile = (
-            settings.EMAIL_SSL_CERTFILE if ssl_certfile is None else ssl_certfile
-        )
-        if self.use_ssl and self.use_tls:
-            raise ValueError(
-                "EMAIL_USE_TLS/EMAIL_USE_SSL are mutually exclusive, so only set "
-                "one of those settings to True."
-            )
+        super().__init__(fail_silently=fail_silently, **kwargs)
         self.connection = None
         self._lock = threading.RLock()
+
+        # RemovedInDjango70Warning.
+        if self.alias is None:
+            # Use deprecated settings when EMAIL_PROVIDERS not enabled.
+            self.host = host or settings.EMAIL_HOST
+            self.port = port or settings.EMAIL_PORT
+            self.username = settings.EMAIL_HOST_USER if username is None else username
+            self.password = (
+                settings.EMAIL_HOST_PASSWORD if password is None else password
+            )
+            self.use_tls = settings.EMAIL_USE_TLS if use_tls is None else use_tls
+            self.use_ssl = settings.EMAIL_USE_SSL if use_ssl is None else use_ssl
+            self.timeout = settings.EMAIL_TIMEOUT if timeout is None else timeout
+            self.ssl_keyfile = (
+                settings.EMAIL_SSL_KEYFILE if ssl_keyfile is None else ssl_keyfile
+            )
+            self.ssl_certfile = (
+                settings.EMAIL_SSL_CERTFILE if ssl_certfile is None else ssl_certfile
+            )
+            if self.use_ssl and self.use_tls:
+                raise ValueError(
+                    "EMAIL_USE_TLS/EMAIL_USE_SSL are mutually exclusive, so "
+                    "only set one of those settings to True."
+                )
+            return
+
+        self.host = host
+        self.port = port
+        self.username = username
+        self.password = password
+        self.use_tls = use_tls if use_tls is not None else False
+        self.use_ssl = use_ssl if use_ssl is not None else False
+        self.timeout = timeout
+        self.ssl_keyfile = ssl_keyfile
+        self.ssl_certfile = ssl_certfile
+        if self.host is None:
+            raise InvalidEmailProvider("OPTIONS must define 'host'.", alias=self.alias)
+        if self.use_ssl and self.use_tls:
+            raise InvalidEmailProvider(
+                "The 'use_ssl' and 'use_tls' OPTIONS are incompatible. "
+                "Set at most one of them to True.",
+                alias=self.alias,
+            )
+        if self.port is None:
+            if self.use_ssl:
+                self.port = 465
+            elif self.use_tls:
+                self.port = 587
+            else:
+                self.port = 25
 
     @property
     def connection_class(self):

--- a/django/core/mail/backends/smtp.py
+++ b/django/core/mail/backends/smtp.py
@@ -33,7 +33,8 @@ class EmailBackend(BaseEmailBackend):
         ssl_certfile=None,
         **kwargs,
     ):
-        super().__init__(fail_silently=fail_silently, **kwargs)
+        super().__init__(**kwargs)
+        self.fail_silently = fail_silently
         self.connection = None
         self._lock = threading.RLock()
 

--- a/django/core/mail/backends/smtp.py
+++ b/django/core/mail/backends/smtp.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.core.mail import InvalidEmailProvider
 from django.core.mail.backends.base import BaseEmailBackend
 from django.core.mail.utils import DNS_NAME
+from django.utils.deprecation import RemovedInDjango70Warning, warn_about_external_use
 from django.utils.encoding import force_str, punycode
 from django.utils.functional import cached_property
 
@@ -33,6 +34,14 @@ class EmailBackend(BaseEmailBackend):
         ssl_certfile=None,
         **kwargs,
     ):
+        # RemovedInDjango70Warning.
+        if "alias" not in kwargs:
+            msg = (
+                "Directly creating EmailBackend instances is deprecated. "
+                "Use mail.providers instead."
+            )
+            warn_about_external_use(msg, RemovedInDjango70Warning)
+
         super().__init__(**kwargs)
         self.fail_silently = fail_silently
         self.connection = None

--- a/django/core/mail/deprecation.py
+++ b/django/core/mail/deprecation.py
@@ -1,0 +1,18 @@
+# RemovedInDjango70Warning: this entire file.
+# mail.providers-related deprecation warnings and helpers used in multiple
+# places. (In a separate file to avoid circular import problems.)
+
+
+def report_using_incompatibility(
+    connection=None, fail_silently=False, auth_user=None, auth_password=None
+):
+    """Report arguments incompatible with 'using'."""
+    if connection is not None:
+        raise TypeError("'connection' is not compatible with 'using'.")
+    if fail_silently:
+        raise TypeError("'fail_silently' is not compatible with 'using'.")
+    if auth_user is not None or auth_password is not None:
+        raise TypeError(
+            "'auth_user' and 'auth_password' are not compatible with 'using'. "
+            "Set 'username' and 'password' OPTIONS in EMAIL_PROVIDERS instead."
+        )

--- a/django/core/mail/deprecation.py
+++ b/django/core/mail/deprecation.py
@@ -1,6 +1,18 @@
 # RemovedInDjango70Warning: this entire file.
 # mail.providers-related deprecation warnings and helpers used in multiple
 # places. (In a separate file to avoid circular import problems.)
+import warnings
+
+from django.conf import DEPRECATED_EMAIL_SETTINGS, settings
+from django.utils.deprecation import (
+    RemovedInDjango70Warning,
+    django_file_prefixes,
+)
+
+NO_DEFAULT_EMAIL_PROVIDER_WARNING = (
+    "Django 7.0 will not have a default email provider. Configure "
+    "settings.EMAIL_PROVIDERS to avoid errors sending email."
+)
 
 
 def report_using_incompatibility(
@@ -15,4 +27,20 @@ def report_using_incompatibility(
         raise TypeError(
             "'auth_user' and 'auth_password' are not compatible with 'using'. "
             "Set 'username' and 'password' OPTIONS in EMAIL_PROVIDERS instead."
+        )
+
+
+def warn_about_default_email_providers_if_needed():
+    needs_warning = not (
+        hasattr(settings, "EMAIL_PROVIDERS")
+        or any(
+            hasattr(settings, name) and settings.is_overridden(name)
+            for name in DEPRECATED_EMAIL_SETTINGS
+        )
+    )
+    if needs_warning:
+        warnings.warn(
+            NO_DEFAULT_EMAIL_PROVIDER_WARNING,
+            RemovedInDjango70Warning,
+            skip_file_prefixes=django_file_prefixes(),
         )

--- a/django/core/mail/deprecation.py
+++ b/django/core/mail/deprecation.py
@@ -9,6 +9,18 @@ from django.utils.deprecation import (
     django_file_prefixes,
 )
 
+FAIL_SILENTLY_ARG_WARNING = (
+    "The 'fail_silently' argument is deprecated. See 'Migrating to "
+    "EMAIL_PROVIDERS' in Django's documentation for recommended replacements."
+)
+AUTH_ARGS_WARNING = (
+    "The 'auth_user' and 'auth_password' arguments are deprecated. Set "
+    "'username' and 'password' OPTIONS in EMAIL_PROVIDERS instead."
+)
+CONNECTION_ARG_WARNING = (
+    "The 'connection' argument is deprecated. Switch to the 'using' argument "
+    "with an EMAIL_PROVIDERS alias."
+)
 NO_DEFAULT_EMAIL_PROVIDER_WARNING = (
     "Django 7.0 will not have a default email provider. Configure "
     "settings.EMAIL_PROVIDERS to avoid errors sending email."

--- a/django/core/mail/exceptions.py
+++ b/django/core/mail/exceptions.py
@@ -1,0 +1,10 @@
+from django.core.exceptions import ImproperlyConfigured
+
+
+class InvalidEmailProvider(ImproperlyConfigured):
+    """There is a problem with OPTIONS in a settings.EMAIL_PROVIDERS entry."""
+
+    def __init__(self, msg, *, alias=None):
+        if alias is not None:
+            msg = f"EMAIL_PROVIDERS[{alias!r}]: {msg}"
+        super().__init__(msg)

--- a/django/core/mail/exceptions.py
+++ b/django/core/mail/exceptions.py
@@ -8,3 +8,11 @@ class InvalidEmailProvider(ImproperlyConfigured):
         if alias is not None:
             msg = f"EMAIL_PROVIDERS[{alias!r}]: {msg}"
         super().__init__(msg)
+
+
+class EmailProviderDoesNotExist(InvalidEmailProvider, KeyError):
+    """The requested alias is not defined in settings.EMAIL_PROVIDERS."""
+
+    def __init__(self, *, alias):
+        # This is the only permitted use for this exception.
+        super().__init__(f"The email provider '{alias}' is not configured.")

--- a/django/core/mail/handler.py
+++ b/django/core/mail/handler.py
@@ -1,0 +1,79 @@
+from django.conf import settings
+from django.core.mail import EmailProviderDoesNotExist, InvalidEmailProvider
+from django.utils.module_loading import import_string
+
+DEFAULT_EMAIL_PROVIDER_ALIAS = "default"
+
+# Default value for an EMAIL_PROVIDERS "BACKEND".
+# (Not related to the default email provider.)
+DEFAULT_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+
+
+class EmailProvidersHandler:
+    def __getitem__(self, /, alias):
+        return self.create_connection(alias)
+
+    def __contains__(self, /, alias):
+        return alias in self.settings
+
+    def __iter__(self):
+        return iter(self.settings)
+
+    def get(self, alias, /, default=None):
+        try:
+            return self[alias]
+        except EmailProviderDoesNotExist:
+            return default
+
+    @property
+    def default(self):
+        return self[DEFAULT_EMAIL_PROVIDER_ALIAS]
+
+    @property
+    def settings(self):
+        # RemovedInDjango70Warning: change to:
+        #   return settings.EMAIL_PROVIDERS
+        return getattr(settings, "EMAIL_PROVIDERS", {})
+
+    # RemovedInDjango70Warning.
+    @property
+    def _is_configured(self):
+        """True if settings.py has opted into EMAIL_PROVIDERS support."""
+        return hasattr(settings, "EMAIL_PROVIDERS")
+
+    # RemovedInDjango70Warning: _deprecated_kwargs.
+    def create_connection(self, alias, /, *, _deprecated_kwargs=None):
+        # RemovedInDjango70Warning.
+        if not self._is_configured and alias == DEFAULT_EMAIL_PROVIDER_ALIAS:
+            # Create providers.default from deprecated settings.
+            from django.core.mail import get_connection
+
+            assert _deprecated_kwargs is None
+            return get_connection()
+
+        try:
+            config = self.settings[alias]
+        except KeyError:
+            raise EmailProviderDoesNotExist(alias=alias) from None
+
+        options = config.get("OPTIONS", {})
+        if "alias" in options:
+            raise InvalidEmailProvider("OPTIONS must not define 'alias'.", alias=alias)
+
+        # RemovedInDjango70Warning.
+        if _deprecated_kwargs:
+            # get_connection() returning default provider with some overrides.
+            # _ignore_unknown_kwargs tells BaseEmailBackend not to report these
+            # keyword args as unknown OPTIONS.
+            assert alias == DEFAULT_EMAIL_PROVIDER_ALIAS
+            options = options | _deprecated_kwargs
+            options |= {"_ignore_unknown_kwargs": set(_deprecated_kwargs.keys())}
+
+        backend_path = config.get("BACKEND", DEFAULT_BACKEND)
+        try:
+            backend_class = import_string(backend_path)
+        except ImportError as error:
+            raise InvalidEmailProvider(
+                f"Could not find BACKEND {backend_path!r}: {error}", alias=alias
+            ) from error
+        return backend_class(alias=alias, **options)

--- a/django/core/mail/message.py
+++ b/django/core/mail/message.py
@@ -23,6 +23,8 @@ from django.utils.deprecation import RemovedInDjango70Warning, deprecate_posargs
 from django.utils.encoding import force_bytes, force_str, punycode
 from django.utils.timezone import get_current_timezone
 
+from .deprecation import report_using_incompatibility
+
 # RemovedInDjango70Warning.
 # Don't BASE64-encode UTF-8 messages so that we avoid unwanted attention from
 # some spam filters.
@@ -305,13 +307,6 @@ class EmailMessage:
         self.extra_headers = headers or {}
         self.connection = connection
 
-    def get_connection(self, fail_silently=False):
-        from django.core.mail import get_connection
-
-        if not self.connection:
-            self.connection = get_connection(fail_silently=fail_silently)
-        return self.connection
-
     def message(self, *, policy=email.policy.default):
         msg = email.message.EmailMessage(policy=policy)
         self._add_bodies(msg)
@@ -349,20 +344,40 @@ class EmailMessage:
         """
         return [email for email in (self.to + self.cc + self.bcc) if email]
 
-    def send(self, fail_silently=False):
+    def send(self, fail_silently=False, *, using=None):
         """Send the email message."""
         if not self.recipients():
             # Don't bother creating the network connection if there's nobody to
             # send to.
             return 0
 
-        if fail_silently and self.connection:
-            raise TypeError(
-                "fail_silently cannot be used with a connection. "
-                "Pass fail_silently to get_connection() instead."
+        # RemovedInDjango70Warning: replace the remainder of this method with:
+        #   from django.core.mail import providers
+        #   provider = providers.default if using is None else providers[using]
+        #   return provider.send_messages([self])
+
+        from django.core import mail
+
+        if hasattr(self, "get_connection"):
+            raise AttributeError(
+                "EmailMessage no longer supports the undocumented "
+                "get_connection() method."
             )
 
-        return self.get_connection(fail_silently).send_messages([self])
+        if using is not None:
+            report_using_incompatibility(self.connection, fail_silently)
+            connection = mail.providers[using]
+        elif self.connection:
+            connection = self.connection
+            if fail_silently:
+                raise TypeError(
+                    "fail_silently cannot be used with a connection. "
+                    "Pass fail_silently to get_connection() instead."
+                )
+        else:
+            connection = mail.get_connection(fail_silently=fail_silently)
+
+        return connection.send_messages([self])
 
     def attach(self, filename=None, content=None, mimetype=None):
         """

--- a/django/core/mail/message.py
+++ b/django/core/mail/message.py
@@ -19,11 +19,19 @@ from pathlib import Path
 
 from django.conf import settings
 from django.core.mail.utils import DNS_NAME
-from django.utils.deprecation import RemovedInDjango70Warning, deprecate_posargs
+from django.utils.deprecation import (
+    RemovedInDjango70Warning,
+    deprecate_posargs,
+    warn_about_external_use,
+)
 from django.utils.encoding import force_bytes, force_str, punycode
 from django.utils.timezone import get_current_timezone
 
-from .deprecation import report_using_incompatibility
+from .deprecation import (
+    CONNECTION_ARG_WARNING,
+    FAIL_SILENTLY_ARG_WARNING,
+    report_using_incompatibility,
+)
 
 # RemovedInDjango70Warning.
 # Don't BASE64-encode UTF-8 messages so that we avoid unwanted attention from
@@ -305,7 +313,28 @@ class EmailMessage:
                 else:
                     self.attach(*attachment)
         self.extra_headers = headers or {}
-        self.connection = connection
+        # RemovedInDjango70Warning.
+        if connection is not None:
+            warn_about_external_use(
+                CONNECTION_ARG_WARNING, RemovedInDjango70Warning, skip_frames=1
+            )
+        self._connection = connection
+
+    # RemovedInDjango70Warning: connection property.
+    @property
+    def connection(self):
+        msg = "The EmailMessage.connection attribute is deprecated."
+        warn_about_external_use(msg, RemovedInDjango70Warning)
+        return self._connection
+
+    @connection.setter
+    def connection(self, value):
+        msg = (
+            "The EmailMessage.connection attribute is deprecated. Switch to "
+            "EmailMessage.send(using=...) with an EMAIL_PROVIDERS alias."
+        )
+        warn_about_external_use(msg, RemovedInDjango70Warning)
+        self._connection = value
 
     def message(self, *, policy=email.policy.default):
         msg = email.message.EmailMessage(policy=policy)
@@ -358,6 +387,8 @@ class EmailMessage:
 
         from django.core import mail
 
+        if fail_silently:
+            warn_about_external_use(FAIL_SILENTLY_ARG_WARNING, RemovedInDjango70Warning)
         if hasattr(self, "get_connection"):
             raise AttributeError(
                 "EmailMessage no longer supports the undocumented "
@@ -365,10 +396,10 @@ class EmailMessage:
             )
 
         if using is not None:
-            report_using_incompatibility(self.connection, fail_silently)
+            report_using_incompatibility(self._connection, fail_silently)
             connection = mail.providers[using]
-        elif self.connection:
-            connection = self.connection
+        elif self._connection:
+            connection = self._connection
             if fail_silently:
                 raise TypeError(
                     "fail_silently cannot be used with a connection. "

--- a/django/middleware/common.py
+++ b/django/middleware/common.py
@@ -3,7 +3,7 @@ from urllib.parse import urlsplit
 
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
-from django.core.mail import mail_managers
+from django.core.mail import EmailProviderDoesNotExist, mail_managers, providers
 from django.http import HttpResponsePermanentRedirect
 from django.urls import is_valid_path
 from django.utils.deprecation import MiddlewareMixin
@@ -118,6 +118,9 @@ class CommonMiddleware(MiddlewareMixin):
 
 
 class BrokenLinkEmailsMiddleware(MiddlewareMixin):
+    # Set to override the mail.providers alias used for sending the email.
+    using = None
+
     def process_response(self, request, response):
         """Send broken link emails for relevant 404 NOT FOUND responses."""
         if response.status_code == 404 and not settings.DEBUG:
@@ -128,7 +131,7 @@ class BrokenLinkEmailsMiddleware(MiddlewareMixin):
             if not self.is_ignorable_request(request, path, domain, referer):
                 ua = request.META.get("HTTP_USER_AGENT", "<none>")
                 ip = request.META.get("REMOTE_ADDR", "<none>")
-                mail_managers(
+                self.send_mail(
                     "Broken %slink on %s"
                     % (
                         (
@@ -140,9 +143,19 @@ class BrokenLinkEmailsMiddleware(MiddlewareMixin):
                     ),
                     "Referrer: %s\nRequested URL: %s\nUser agent: %s\n"
                     "IP address: %s\n" % (referer, path, ua, ip),
-                    fail_silently=True,
                 )
         return response
+
+    def send_mail(self, subject, message, *args, **kwargs):
+        # RemovedInDjango70Warning.
+        if not providers._is_configured:
+            mail_managers(subject, message, *args, fail_silently=True, **kwargs)
+            return
+
+        try:
+            mail_managers(subject, message, *args, using=self.using, **kwargs)
+        except EmailProviderDoesNotExist:
+            pass
 
     def is_internal_request(self, domain, referer):
         """

--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -142,8 +142,17 @@ def setup_test_environment(debug=None):
     saved_data.debug = settings.DEBUG
     settings.DEBUG = debug
 
-    saved_data.email_backend = settings.EMAIL_BACKEND
-    settings.EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
+    # RemovedInDjango70Warning: Override EMAIL_PROVIDERS unconditionally;
+    # remove EMAIL_BACKEND override.
+    if hasattr(settings, "EMAIL_PROVIDERS"):
+        saved_data.email_providers = settings.EMAIL_PROVIDERS
+        settings.EMAIL_PROVIDERS = {
+            alias: {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"}
+            for alias in settings.EMAIL_PROVIDERS
+        }
+    else:
+        saved_data.email_backend = settings.EMAIL_BACKEND
+        settings.EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
 
     saved_data.template_render = Template._render
     saved_data.partial_template_render = PartialTemplate._render
@@ -164,7 +173,12 @@ def teardown_test_environment():
 
     settings.ALLOWED_HOSTS = saved_data.allowed_hosts
     settings.DEBUG = saved_data.debug
-    settings.EMAIL_BACKEND = saved_data.email_backend
+    # RemovedInDjango70Warning: Restore EMAIL_PROVIDERS unconditionally;
+    # remove EMAIL_BACKEND support.
+    if hasattr(saved_data, "email_providers"):
+        settings.EMAIL_PROVIDERS = saved_data.email_providers
+    if hasattr(saved_data, "email_backend"):
+        settings.EMAIL_BACKEND = saved_data.email_backend
     Template._render = saved_data.template_render
     PartialTemplate._render = saved_data.partial_template_render
 

--- a/django/utils/log.py
+++ b/django/utils/log.py
@@ -1,11 +1,13 @@
 import logging
 import logging.config  # needed when logging_config doesn't start with logging.config
+import warnings
 from copy import copy
 
 from django.conf import settings
 from django.core import mail
-from django.core.mail import get_connection
+from django.core.exceptions import ImproperlyConfigured
 from django.core.management.color import color_style
+from django.utils.deprecation import RemovedInDjango70Warning, django_file_prefixes
 from django.utils.module_loading import import_string
 
 request_logger = logging.getLogger("django.request")
@@ -83,10 +85,36 @@ class AdminEmailHandler(logging.Handler):
     request data will be provided in the email report.
     """
 
-    def __init__(self, include_html=False, email_backend=None, reporter_class=None):
+    def __init__(
+        self, include_html=False, email_backend=None, reporter_class=None, using=None
+    ):
         super().__init__()
+
+        # RemovedInDjango70Warning: email_backend arg.
+        if email_backend:
+            if using:
+                raise ImproperlyConfigured(
+                    "The 'email_backend' argument is not compatible with 'using'."
+                )
+            if mail.providers._is_configured:
+                raise ImproperlyConfigured(
+                    "The 'email_backend' argument is not valid when "
+                    "settings.EMAIL_PROVIDERS is defined."
+                )
+            warnings.warn(
+                "The 'email_backend' argument is deprecated. Use 'using' instead.",
+                RemovedInDjango70Warning,
+                skip_file_prefixes=django_file_prefixes(),
+            )
+        if hasattr(self, "connection"):
+            raise AttributeError(
+                "The undocumented AdminEmailHandler.connection() method is no longer "
+                "used."
+            )
+
         self.include_html = include_html
         self.email_backend = email_backend
+        self.using = using
         self.reporter_class = import_string(
             reporter_class or settings.DEFAULT_EXCEPTION_REPORTER
         )
@@ -135,12 +163,18 @@ class AdminEmailHandler(logging.Handler):
         self.send_mail(subject, message, html_message=html_message)
 
     def send_mail(self, subject, message, *args, **kwargs):
-        mail.mail_admins(
-            subject, message, *args, connection=self.connection(), **kwargs
-        )
+        # RemovedInDjango70Warning.
+        if not mail.providers._is_configured:
+            connection = mail.get_connection(
+                backend=self.email_backend, fail_silently=True
+            )
+            mail.mail_admins(subject, message, *args, connection=connection, **kwargs)
+            return
 
-    def connection(self):
-        return get_connection(backend=self.email_backend, fail_silently=True)
+        try:
+            mail.mail_admins(subject, message, *args, using=self.using, **kwargs)
+        except mail.EmailProviderDoesNotExist:
+            pass
 
     def format_subject(self, subject):
         """

--- a/docs/howto/deployment/checklist.txt
+++ b/docs/howto/deployment/checklist.txt
@@ -144,13 +144,18 @@ your application servers.
 
 If you haven't set up backups for your database, do it right now!
 
-:setting:`EMAIL_BACKEND` and related settings
----------------------------------------------
+:setting:`EMAIL_PROVIDERS` and related settings
+-----------------------------------------------
 
 If your site sends emails, these values need to be set correctly.
 
+In development, email is often configured to be printed to the console or
+stored in a local file. For production, you probably want to send real email
+messages. See :ref:`topic-email-configuration` for more information about
+setting :setting:`EMAIL_PROVIDERS` to use production email services.
+
 By default, Django sends email from ``webmaster@localhost`` and
-``root@localhost``. However, some mail providers reject email from these
+``root@localhost``. However, many email providers reject email from these
 addresses. To use different sender addresses, modify the
 :setting:`DEFAULT_FROM_EMAIL` and :setting:`SERVER_EMAIL` settings.
 

--- a/docs/howto/email-providers-migration.txt
+++ b/docs/howto/email-providers-migration.txt
@@ -1,0 +1,40 @@
+.. _migrating-to-email-providers:
+
+============================
+Migrating to email providers
+============================
+
+**TODO:** Migration guide. Rough outline follows:
+
+Most users:
+
+*   Verify readiness of any third-party email packages (some deprecation
+    warnings become hard errors when ``EMAIL_PROVIDERS`` is defined)
+*   Replace :setting:`EMAIL_BACKEND` and other deprecated ``EMAIL_*`` settings
+    with :setting:`EMAIL_PROVIDERS`
+
+Less common situations:
+
+*   Replace :func:`~django.core.mail.get_connection` and ``connection`` args
+    (options from DEP)
+*   Replace ``fail_silently`` (options from DEP)
+
+Even less common:
+
+*   Replace ``auth_user`` and ``auth_password`` args
+*   Change ``email_backend`` to ``using`` in ``AdminEmailHandler`` config
+*   Change custom ``BrokenLinksEmailMiddleware`` that overrides connection (?)
+
+If you have a custom email backend:
+
+*   Use keyword args for configuration; consume all ``**kwargs`` you use and
+    pass the remainder to superclass init (including ``alias``)
+*   Decide how to handle custom settings
+*   Decide how to handle ``fail_silently``
+
+"Backwards migration":
+
+* What to in a greenfield project using ``EMAIL_PROVIDERS`` if some third-party
+  package raises ``AttributeError: "The EMAIL_* setting is not available when
+  EMAIL_PROVIDERS is defined"``.
+  (See https://github.com/django/deps/pull/105#discussion_r3045843365.)

--- a/docs/howto/index.txt
+++ b/docs/howto/index.txt
@@ -62,6 +62,7 @@ Other guides
    custom-file-storage
    custom-management-commands
    custom-shell
+   email-providers-migration
 
 .. seealso::
 

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -73,6 +73,28 @@ details on these changes.
 
 * The ``SQLCompiler.quote_name_unless_alias()`` method will be removed.
 
+* The ``EMAIL_BACKEND``, ``EMAIL_FILE_PATH``, ``EMAIL_HOST``,
+  ``EMAIL_HOST_PASSWORD``, ``EMAIL_HOST_USER``, ``EMAIL_PORT``,
+  ``EMAIL_USE_TLS``, ``EMAIL_USE_SSL``, ``EMAIL_SSL_CERTFILE``,
+  ``EMAIL_SSL_KEYFILE``, and ``EMAIL_TIMEOUT`` settings will be removed.
+
+* The ``django.core.mail.get_connection()`` function will be removed.
+
+* The ``connection``, ``fail_silently``, ``auth_user``, and ``auth_password``
+  arguments will be removed from :func:`.send_mail`, :func:`.send_mass_mail`,
+  :func:`.mail_admins`, :func:`.mail_managers`, the :class:`.EmailMessage`
+  constructor, and :meth:`.EmailMessage.send`. Support for the
+  ``EmailMessage.connection`` attribute will also be removed.
+
+* Directly creating instances of the ``smtp.EmailBackend`` class will become
+  unsupported, and the class documentation for that backend will be removed.
+
+* The ``BaseEmailBackend.__init__()`` method will raise errors for unknown
+  keyword arguments and will remove support for ``fail_silently``.
+
+* The ``email_backend`` argument of :class:`.log.AdminEmailHandler` will be
+  removed.
+
 * The ``django.contrib.postgres.aggregates.BitAnd``,
   ``django.contrib.postgres.aggregates.BitOr``, and
   ``django.contrib.postgres.aggregates.BitXor`` classes will be removed.

--- a/docs/ref/logging.txt
+++ b/docs/ref/logging.txt
@@ -315,7 +315,7 @@ Handlers
 Django provides one log handler in addition to :mod:`those provided by the
 Python logging module <python:logging.handlers>`.
 
-.. class:: AdminEmailHandler(include_html=False, email_backend=None, reporter_class=None)
+.. class:: AdminEmailHandler(include_html=False, email_backend=None, reporter_class=None, using=None)
 
     This handler sends an email to the site :setting:`ADMINS` for each log
     message it receives.
@@ -346,20 +346,27 @@ Python logging module <python:logging.handlers>`.
     Be aware of the :ref:`security implications of logging
     <logging-security-implications>` when using the ``AdminEmailHandler``.
 
-    By setting the ``email_backend`` argument of ``AdminEmailHandler``, the
-    :ref:`email backend <topic-email-backends>` that is being used by the
-    handler can be overridden, like this::
+    Email is sent using the default :ref:`email provider
+    <topic-email-configuration>`. This can be overridden by setting the
+    ``using`` argument of ``AdminEmailHandler``, like this::
 
         "handlers": {
             "mail_admins": {
                 "level": "ERROR",
                 "class": "django.utils.log.AdminEmailHandler",
-                "email_backend": "django.core.mail.backends.filebased.EmailBackend",
+                "using": "internal",
             },
         }
 
-    By default, an instance of the email backend specified in
-    :setting:`EMAIL_BACKEND` will be used.
+    If the specified provider is not configured in the
+    :setting:`EMAIL_PROVIDERS` setting, no email will be sent and no additional
+    error will be raised.
+
+    By setting the deprecated ``email_backend`` argument of
+    ``AdminEmailHandler``, the :ref:`email backend <topic-email-backends>` that
+    is being used by the handler can be overridden. ``email_backend`` is not
+    supported when :setting:`EMAIL_PROVIDERS` is defined or when the ``using``
+    argument is provided.
 
     The ``reporter_class`` argument of ``AdminEmailHandler`` allows providing
     an ``django.views.debug.ExceptionReporter`` subclass to customize the
@@ -374,6 +381,14 @@ Python logging module <python:logging.handlers>`.
                 "reporter_class": "somepackage.error_reporter.CustomErrorReporter",
             },
         }
+
+    .. versionchanged:: 6.1
+
+        The ``using`` argument was added.
+
+    .. deprecated:: 6.1
+
+        ``email_backend``.
 
     .. method:: send_mail(subject, message, *args, **kwargs)
 

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -1392,15 +1392,93 @@ that are not allowed to visit any page, systemwide. Use this for bots/crawlers.
 This is only used if ``CommonMiddleware`` is installed (see
 :doc:`/topics/http/middleware`).
 
+.. setting:: EMAIL_PROVIDERS
+
+``EMAIL_PROVIDERS``
+-------------------
+
+Default: no default until Django 7.0, then ``{}``. (See deprecation note
+below.)
+
+A dictionary containing the settings for all email backends to be used with
+Django. It is a nested dictionary that maps backend aliases to dictionaries
+containing each provider's backend import path and configuration options.
+Example::
+
+    EMAIL_PROVIDERS = {
+        "default": {
+            "BACKEND": "django.core.mail.backends.smtp.EmailBackend",
+            "OPTIONS": {
+                "host": "smtp.example.net",
+            },
+        },
+        "newsletters": {
+            "BACKEND": "django.core.mail.backends.smtp.EmailBackend",
+            "OPTIONS": {
+                "host": "smtp.bulk-email-service.example.com",
+                "username": os.environ["BULK_EMAIL_SERVICE_ACCOUNT_ID"],
+                "password": os.environ["BULK_EMAIL_SERVICE_API_KEY"],
+                "use_tls": True,
+            },
+        },
+    }
+
+If you plan to send email through Django, configuring at least a ``"default"``
+provider is recommended. Any number of additional providers may also be
+specified. Depending on which backend is used, other options may be required.
+
+See :ref:`topic-email-configuration` for more information.
+
+.. versionadded:: 6.1
+
+.. deprecated:: 6.1
+
+    In Django 7.0, the default value will change to ``{}`` (no defined email
+    providers). Until then, if ``EMAIL_PROVIDERS`` is not defined in the
+    settings, Django will create a ``"default"`` email provider from the
+    deprecated :setting:`EMAIL_BACKEND` setting. Projects can opt into the
+    Django 7.0 behavior early by adding ``EMAIL_PROVIDERS`` and removing
+    ``EMAIL_BACKEND``  from their settings.
+
+.. setting:: EMAIL_PROVIDERS-BACKEND
+
+``BACKEND``
+~~~~~~~~~~~
+
+Default: ``"django.core.mail.backends.smtp.EmailBackend"``
+
+The Python import path to the email backend class. If ``"BACKEND"`` is omitted,
+Django's :ref:`topic-email-smtp-backend` is used.
+
+See :ref:`topic-email-backends` for a list of Django's built-in backends and
+pointers to community-maintained options.
+
+.. setting:: EMAIL_PROVIDERS-OPTIONS
+
+``OPTIONS``
+~~~~~~~~~~~
+
+Default: ``{}``
+
+Configuration parameters to pass to the email backend. The available and
+required options vary depending on the backend.
+
 .. setting:: EMAIL_BACKEND
 
 ``EMAIL_BACKEND``
 -----------------
 
-Default: ``'``:class:`django.core.mail.backends.smtp.EmailBackend`\ ``'``
+Default: ``'``:ref:`django.core.mail.backends.smtp.EmailBackend
+<topic-email-smtp-backend>`\ ``'``
 
 The backend to use for sending emails. For the list of available backends see
 :ref:`topic-email-backends`.
+
+.. deprecated:: 6.1
+
+    This setting is deprecated and will be removed in Django 7.0. Its
+    replacement is :setting:`BACKEND <EMAIL_PROVIDERS-BACKEND>` in the
+    :setting:`EMAIL_PROVIDERS` ``"default"`` configuration.
 
 .. setting:: EMAIL_FILE_PATH
 
@@ -1412,6 +1490,13 @@ Default: Not defined
 The directory used by the :ref:`file email backend <topic-email-file-backend>`
 to store output files.
 
+.. deprecated:: 6.1
+
+    This setting is deprecated and will be removed in Django 7.0. Its
+    replacement is ``"file_path"`` under
+    :setting:`OPTIONS <EMAIL_PROVIDERS-OPTIONS>` in an
+    :setting:`EMAIL_PROVIDERS` definition that uses the file email backend.
+
 .. setting:: EMAIL_HOST
 
 ``EMAIL_HOST``
@@ -1422,6 +1507,13 @@ Default: ``'localhost'``
 The host to use for sending email.
 
 See also :setting:`EMAIL_PORT`.
+
+.. deprecated:: 6.1
+
+    This setting is deprecated and will be removed in Django 7.0. Its
+    replacement is ``"host"`` under
+    :setting:`OPTIONS <EMAIL_PROVIDERS-OPTIONS>` in an
+    :setting:`EMAIL_PROVIDERS` definition that uses the SMTP email backend.
 
 .. setting:: EMAIL_HOST_PASSWORD
 
@@ -1437,6 +1529,13 @@ Django won't attempt authentication.
 
 See also :setting:`EMAIL_HOST_USER`.
 
+.. deprecated:: 6.1
+
+    This setting is deprecated and will be removed in Django 7.0. Its
+    replacement is ``"password"`` under
+    :setting:`OPTIONS <EMAIL_PROVIDERS-OPTIONS>` in an
+    :setting:`EMAIL_PROVIDERS` definition that uses the SMTP email backend.
+
 .. setting:: EMAIL_HOST_USER
 
 ``EMAIL_HOST_USER``
@@ -1449,6 +1548,13 @@ If empty, Django won't attempt authentication.
 
 See also :setting:`EMAIL_HOST_PASSWORD`.
 
+.. deprecated:: 6.1
+
+    This setting is deprecated and will be removed in Django 7.0. Its
+    replacement is ``"username"`` under
+    :setting:`OPTIONS <EMAIL_PROVIDERS-OPTIONS>` in an
+    :setting:`EMAIL_PROVIDERS` definition that uses the SMTP email backend.
+
 .. setting:: EMAIL_PORT
 
 ``EMAIL_PORT``
@@ -1457,6 +1563,13 @@ See also :setting:`EMAIL_HOST_PASSWORD`.
 Default: ``25``
 
 Port to use for the SMTP server defined in :setting:`EMAIL_HOST`.
+
+.. deprecated:: 6.1
+
+    This setting is deprecated and will be removed in Django 7.0. Its
+    replacement is ``"port"`` under
+    :setting:`OPTIONS <EMAIL_PROVIDERS-OPTIONS>` in an
+    :setting:`EMAIL_PROVIDERS` definition that uses the SMTP email backend.
 
 .. setting:: EMAIL_SUBJECT_PREFIX
 
@@ -1491,6 +1604,13 @@ This is used for explicit TLS connections, generally on port 587. If you are
 experiencing hanging connections, see the implicit TLS setting
 :setting:`EMAIL_USE_SSL`.
 
+.. deprecated:: 6.1
+
+    This setting is deprecated and will be removed in Django 7.0. Its
+    replacement is ``"use_tls"`` under
+    :setting:`OPTIONS <EMAIL_PROVIDERS-OPTIONS>` in an
+    :setting:`EMAIL_PROVIDERS` definition that uses the SMTP email backend.
+
 .. setting:: EMAIL_USE_SSL
 
 ``EMAIL_USE_SSL``
@@ -1505,6 +1625,13 @@ see the explicit TLS setting :setting:`EMAIL_USE_TLS`.
 
 Note that :setting:`EMAIL_USE_TLS`/:setting:`EMAIL_USE_SSL` are mutually
 exclusive, so only set one of those settings to ``True``.
+
+.. deprecated:: 6.1
+
+    This setting is deprecated and will be removed in Django 7.0. Its
+    replacement is ``"use_ssl"`` under
+    :setting:`OPTIONS <EMAIL_PROVIDERS-OPTIONS>` in an
+    :setting:`EMAIL_PROVIDERS` definition that uses the SMTP email backend.
 
 .. setting:: EMAIL_SSL_CERTFILE
 
@@ -1527,10 +1654,17 @@ or by using OpenSSL's ``SSL_CERT_FILE`` or ``SSL_CERT_DIR`` environment
 variables to specify a custom certificate bundle (if modifying the system
 bundle is not possible or desired).
 
-For more complex scenarios, the SMTP
-:class:`~django.core.mail.backends.smtp.EmailBackend` can be subclassed to add
-root certificates to its ``ssl_context`` using
+For more complex scenarios, the :ref:`SMTP EmailBackend
+<topic-email-smtp-backend>` can be subclassed to add root certificates to its
+``ssl_context`` using
 :meth:`python:ssl.SSLContext.load_verify_locations`.
+
+.. deprecated:: 6.1
+
+    This setting is deprecated and will be removed in Django 7.0. Its
+    replacement is ``"ssl_certfile"`` under
+    :setting:`OPTIONS <EMAIL_PROVIDERS-OPTIONS>` in an
+    :setting:`EMAIL_PROVIDERS` definition that uses the SMTP email backend.
 
 .. setting:: EMAIL_SSL_KEYFILE
 
@@ -1549,6 +1683,13 @@ They're passed to the underlying SSL connection. Please refer to the
 documentation of Python's :meth:`python:ssl.SSLContext.wrap_socket` function
 for details on how the certificate chain file and private key file are handled.
 
+.. deprecated:: 6.1
+
+    This setting is deprecated and will be removed in Django 7.0. Its
+    replacement is ``"ssl_keyfile"`` under
+    :setting:`OPTIONS <EMAIL_PROVIDERS-OPTIONS>` in an
+    :setting:`EMAIL_PROVIDERS` definition that uses the SMTP email backend.
+
 .. setting:: EMAIL_TIMEOUT
 
 ``EMAIL_TIMEOUT``
@@ -1558,6 +1699,13 @@ Default: ``None``
 
 Specifies a timeout in seconds for blocking operations like the connection
 attempt.
+
+.. deprecated:: 6.1
+
+    This setting is deprecated and will be removed in Django 7.0. Its
+    replacement is ``"timeout"`` under
+    :setting:`OPTIONS <EMAIL_PROVIDERS-OPTIONS>` in an
+    :setting:`EMAIL_PROVIDERS` definition that uses the SMTP email backend.
 
 .. setting:: FILE_UPLOAD_HANDLERS
 

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -571,7 +571,7 @@ Email
   parameter for sending a multipart :mimetype:`text/plain` and
   :mimetype:`text/html` email.
 
-* The SMTP :class:`~django.core.mail.backends.smtp.EmailBackend` now accepts a
+* The :ref:`SMTP EmailBackend <topic-email-smtp-backend>` now accepts a
   ``timeout`` parameter.
 
 File Storage

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -304,7 +304,7 @@ Email
   authentication with the :setting:`EMAIL_SSL_CERTFILE` and
   :setting:`EMAIL_SSL_KEYFILE` settings.
 
-* The SMTP :class:`~django.core.mail.backends.smtp.EmailBackend` now supports
+* The :ref:`SMTP EmailBackend <topic-email-smtp-backend>` now supports
   setting the ``timeout`` parameter with the :setting:`EMAIL_TIMEOUT` setting.
 
 * :class:`~django.core.mail.EmailMessage` and ``EmailMultiAlternatives`` now

--- a/docs/releases/4.2.txt
+++ b/docs/releases/4.2.txt
@@ -474,7 +474,7 @@ Miscellaneous
 
 * Support for ``PROJ`` < 5 is removed.
 
-* :class:`~django.core.mail.backends.smtp.EmailBackend` now verifies a
+* :ref:`SMTP EmailBackend <topic-email-smtp-backend>` now verifies a
   :attr:`hostname <ssl.SSLContext.check_hostname>` and
   :attr:`certificates <ssl.SSLContext.verify_mode>`. If you need the
   previous behavior that is less restrictive and not recommended, subclass

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -86,6 +86,33 @@ Python-level options, as Django does not need to load objects before deleting
 them. As a consequence, the :attr:`~django.db.models.DB_CASCADE` option does
 not trigger the ``pre_delete`` or ``post_delete`` signals.
 
+Email providers
+---------------
+
+The new :setting:`EMAIL_PROVIDERS` setting supports configuring multiple email
+provider backends with different options, similar to existing mechanisms for
+:setting:`CACHES`, :setting:`DATABASES`, :setting:`STORAGES`, and
+:setting:`TASKS`.
+
+You can select an email provider with the new ``using`` argument to :ref:`email
+sending <topic-email-sending>` functions, or obtain an email backend instance
+with :data:`mail.providers[alias] <django.core.mail.providers>`. See
+:doc:`/topics/email` for more details.
+
+:setting:`EMAIL_PROVIDERS` is not yet enabled by default in existing projects.
+It will replace :setting:`EMAIL_BACKEND` and several related ``EMAIL_*``
+settings in Django 7.0. Until then, the older settings will continue to work
+but will issue deprecation warnings: see the list of :ref:`email deprecations
+<email-providers-deprecations>` below.
+
+You can opt into the new features at any time before Django 7.0 using the
+migration guide that follows. To ease the transition,
+:data:`mail.providers["default"] <django.core.mail.providers.default>` works
+with either :setting:`!EMAIL_PROVIDERS` or the deprecated
+:setting:`EMAIL_BACKEND` setting defined, and the deprecated
+:func:`~django.core.mail.get_connection` function will return an instance of
+the default email provider when :setting:`EMAIL_PROVIDERS` is defined.
+
 Minor features
 --------------
 
@@ -237,7 +264,11 @@ Email
 Error Reporting
 ~~~~~~~~~~~~~~~
 
-* ...
+* The internal implementation of :class:`.BrokenLinkEmailsMiddleware` has been
+  updated for email providers. If you have a subclassed it (as suggested in
+  :doc:`/howto/error-reporting`) to customize email sending behavior, you may
+  want to review the updates in the base :class:`.BrokenLinkEmailsMiddleware`
+  class.
 
 File Storage
 ~~~~~~~~~~~~
@@ -515,12 +546,31 @@ Dropped support for MariaDB < 10.11
 Upstream support for MariaDB 10.6 ends in July 2026, and MariaDB 10.7-10.10 are
 short-term maintenance releases. Django 6.1 supports MariaDB 10.11 and higher.
 
-Miscellaneous
--------------
+Email
+-----
 
 * Providing ``fail_silently=True``, ``auth_user``, or ``auth_password`` to mail
   sending functions (such as :func:`~django.core.mail.send_mail`) while also
   providing a ``connection`` now raises a ``TypeError``.
+
+* Django's built-in ``EmailBackend`` classes now require keyword arguments in
+  their ``__init__()`` methods. Undocumented use of positional arguments will
+  raise a ``TypeError``. This does not affect calls to
+  :func:`mail.get_connection <django.core.mail.get_connection>` or other mail
+  APIs, but could require changes to code that constructs email backend
+  instances directly or to ``super().__init__(...)`` calls in custom email
+  backend subclasses.
+
+* The undocumented ``EmailMessage.get_connection()`` method is no longer used.
+  Defining it in a subclass or trying to call it now causes an error.
+
+* :meth:`EmailMessage.send() <django.core.mail.EmailMessage.send>` no longer
+  sets the ``connection`` property on the ``EmailMessage``. (This behavior was
+  never documented. The ``send()`` method will still *use* a ``connection``
+  that is set on the message before sending.)
+
+Miscellaneous
+-------------
 
 * :class:`~django.contrib.contenttypes.fields.GenericForeignKey` now uses a
   separate descriptor class: the private ``GenericForeignKeyDescriptor``.
@@ -546,10 +596,63 @@ Miscellaneous
   ``SimpleUploadedFile`` retain the previous behavior of evaluating based on
   the ``name`` attribute.
 
+* The undocumented ``connection()`` method of
+  :class:`.log.AdminEmailHandler` has been removed and is no longer called.
+  Subclasses overriding :meth:`.AdminEmailHandler.send_mail` should follow
+  the guidance for replacing ``mail.get_connection()`` described in
+  :ref:`migrating-to-email-providers`.
+
 .. _deprecated-features-6.1:
 
 Features deprecated in 6.1
 ==========================
+
+.. _email-providers-deprecations:
+
+Email
+-----
+
+* The :setting:`EMAIL_BACKEND`, :setting:`EMAIL_FILE_PATH`,
+  :setting:`EMAIL_HOST`, :setting:`EMAIL_HOST_PASSWORD`,
+  :setting:`EMAIL_HOST_USER`, :setting:`EMAIL_PORT`,
+  :setting:`EMAIL_USE_TLS`, :setting:`EMAIL_USE_SSL`,
+  :setting:`EMAIL_SSL_CERTFILE`, :setting:`EMAIL_SSL_KEYFILE`, and
+  :setting:`EMAIL_TIMEOUT` settings are deprecated. Replace them with an
+  :setting:`EMAIL_PROVIDERS` configuration dictionary as described in
+  :ref:`migrating-to-email-providers`.
+
+* :func:`.mail.get_connection` is deprecated. See
+  :ref:`migrating-to-email-providers` for replacement options.
+
+* The ``connection`` argument to :func:`.send_mail`, :func:`.send_mass_mail`,
+  :func:`.mail_admins`, :func:`.mail_managers`, and :class:`.EmailMessage` is
+  deprecated. The ``EmailMessage.connection`` attribute is also deprecated.
+  Switch to the ``using`` argument with an :setting:`EMAIL_PROVIDERS` alias.
+
+* The ``fail_silently`` argument to :func:`.send_mail`,
+  :func:`.send_mass_mail`, :func:`.mail_admins`, :func:`.mail_managers`, and
+  :meth:`.EmailMessage.send` is deprecated. See
+  :ref:`migrating-to-email-providers` for alternatives.
+
+* The ``auth_user`` and ``auth_password`` arguments to :func:`.send_mail` and
+  :func:`.send_mass_mail` are deprecated. Replace them with ``"username"`` and
+  ``"password"`` :setting:`OPTIONS <EMAIL_PROVIDERS-OPTIONS>` in
+  :setting:`EMAIL_PROVIDERS`.
+
+* Directly constructing and using instances of the
+  :ref:`smtp.EmailBackend <topic-email-smtp-backend>` class is deprecated. Use
+  :data:`.mail.providers` to obtain email backend instances.
+
+* The ``BaseEmailBackend.__init__()`` constructor no longer silently ignores
+  unknown keyword arguments. Custom email backend subclasses should ensure they
+  have consumed all supported ``**kwargs`` before forwarding the remainder to
+  superclass init. The base class now issues a deprecation warning for unknown
+  arguments, and it will treat them as errors starting in Django 7.0.
+
+* Support for ``fail_silently`` in the ``BaseEmailBackend`` is deprecated.
+  A custom email backend that wants to support ``fail_silently`` should manage
+  its own local attribute, not pass it to the base backend constructor.
+
 
 Miscellaneous
 -------------
@@ -582,6 +685,9 @@ Miscellaneous
   object passed as the ``compiler`` argument to the ``as_sql()`` method of
   :ref:`expressions <writing-your-own-query-expressions>`, is deprecated in
   favor of the newly introduced ``quote_name()`` method.
+
+* The ``email_backend`` argument of :class:`.log.AdminEmailHandler` is
+  deprecated in favor of the newly introduced ``using`` argument.
 
 * The ``BitAnd``, ``BitOr``, and ``BitXor`` classes in
   ``django.contrib.postgres.aggregates`` are deprecated in favor of the

--- a/docs/topics/email.txt
+++ b/docs/topics/email.txt
@@ -67,30 +67,134 @@ following approach::
 Configuring email
 =================
 
-By default, Django tries to send email by connecting to an `SMTP`_ server
-running on localhost, with no authentication. If that doesn't match your
-production environment, trying to send email will raise an error like
-``connection refused`` or ``authentication failed``, or cause a connection
-timeout. You will need to adjust Django's email settings to reflect your
-environment.
+New Django projects are not configured to send email by default. Instead, email
+is printed to ``stdout`` as a development aid (for projects created with
+:djadmin:`startproject`) or results in an ``EmailProviderDoesNotExist`` error
+(when the :setting:`EMAIL_PROVIDERS` setting isn't defined).
 
-Django abstracts the email sending process into an :ref:`email backend
-<topic-email-backends>` class. The :setting:`EMAIL_BACKEND` setting controls
-which backend Django uses.
+To enable sending real email, you will need to tell Django how to send it by
+creating or editing the :setting:`EMAIL_PROVIDERS` setting. For example, to
+send through an SMTP server running on the local machine::
 
-The default email backend is Django's :ref:`topic-email-smtp-backend`, which
-connects to an SMTP server using the host and port specified in the
-:setting:`EMAIL_HOST` and :setting:`EMAIL_PORT` settings. The
-:setting:`EMAIL_HOST_USER` and :setting:`EMAIL_HOST_PASSWORD` settings, if
-set, are used to authenticate to the SMTP server, and the
-:setting:`EMAIL_USE_TLS` and :setting:`EMAIL_USE_SSL` settings control whether
-a secure connection is used.
+    EMAIL_PROVIDERS = {
+        "default": {
+            "BACKEND": "django.core.mail.backends.smtp.EmailBackend",
+            "OPTIONS": {
+                "host": "localhost",
+            },
+        },
+    }
 
-SMTP is supported by nearly all email service providers (ESPs) and many hosting
-environments. But there are other options: many commercial ESPs offer HTTP APIs
+`SMTP`_ is supported by nearly all email service providers and many hosting
+environments. But there are other options: many commercial services offer APIs
 with additional sending features, and during development or testing you might
-not want to send email at all. :ref:`topic-email-backends` lists several
-possibilities.
+not want to send email at all.
+
+Django abstracts the email sending process into an "email backend" class.
+:ref:`topic-email-backends` lists the email backends that come with Django: the
+:ref:`SMTP backend <topic-email-smtp-backend>` for production use and several
+others meant for development and testing. It also covers :ref:`third-party
+packages <topic-third-party-email-backends>` and :ref:`custom backends
+<topic-custom-email-backend>` if Django's built-in backends don't meet your
+needs.
+
+Django's test runner automatically :ref:`overrides the email configuration
+<topics-testing-email>` during testing. It substitutes the :ref:`memory backend
+<topic-email-memory-backend>` for each defined provider, preventing email from
+being sent and giving test cases access to the messages.
+
+.. versionchanged:: 6.1
+
+    In earlier releases, Django defaulted to sending email through an SMTP
+    server running on localhost (using the now-deprecated
+    :setting:`EMAIL_BACKEND` and related settings).
+
+.. deprecated:: 6.1
+
+    Until Django 7.0, if the :setting:`EMAIL_PROVIDERS` setting is not defined
+    then the earlier behavior still applies: Django will default to using an
+    SMTP server on localhost (but will issue deprecation warnings). Starting in
+    Django 7.0, attempts to send email without :setting:`EMAIL_PROVIDERS`
+    defined will result in an ``EmailProviderDoesNotExist`` error.
+
+    Existing projects can opt into the new behavior early by adding
+    :setting:`EMAIL_PROVIDERS` to ``settings.py``. See
+    :ref:`migrating-to-email-providers` in the Django 6.1 release notes.
+
+Multiple email providers
+------------------------
+
+Sometimes different types of email need to be sent in different ways: internal
+vs. external email, different servers for users in different regions, different
+providers for transactional notifications and bulk marketing email, etc.
+
+The :setting:`EMAIL_PROVIDERS` setting can define multiple email providers with
+their own configurations. For example::
+
+    import os
+
+    EMAIL_PROVIDERS = {
+        "default": {
+            "BACKEND": "django.core.mail.backends.smtp.EmailBackend",
+            "OPTIONS": {
+                "host": "smtp.example.net",
+                "use_tls": True,
+                "username": os.environ["EMAIL_ACCOUNT_ID"],
+                "password": os.environ["EMAIL_API_KEY"],
+            },
+        },
+        "notifications": {
+            "BACKEND": "example.third.party.EmailBackend",
+            "OPTIONS": {
+                "api_key": os.environ["THIRD_PARTY_API_KEY"],
+                "region": "eu",
+            },
+        },
+        "admin": {
+            "BACKEND": "django.core.mail.backends.smtp.EmailBackend",
+            "OPTIONS": {
+                "host": "localhost",
+            },
+        },
+    }
+
+This defines three email providers:
+
+* ``"default"`` sends through an SMTP server at ``smtp.example.net`` with a TLS
+  secured connection. It reads an account id and API key from environment
+  variables and uses them as the SMTP authentication username and password.
+  (Many email services use some variation of this authentication scheme. Check
+  your provider's documentation for specific options to use.)
+
+* ``"notifications"`` sends through a hypothetical commercial email service,
+  using a third-party EmailBackend that connects directly to their API.
+  (See :ref:`topic-third-party-email-backends` for pointers on locating real,
+  community maintained email backend packages.)
+
+* ``"admin"`` sends through an SMTP server running on ``localhost``, with no
+  other options required.
+
+With this configuration, you can name a provider's alias in the ``using``
+argument to Django's :ref:`email sending functions <topic-email-sending>` to
+specify a particular provider::
+
+    from django.core.mail import send_mail
+
+    send_mail(
+        "Account activated",
+        "Congratulations, you're all ready to use our Django app!",
+        "from@example.com",
+        ["user@example.com"],
+        using="notifications",
+    )
+
+If ``using`` is not specified, Django uses the email provider defined for the
+``"default"`` alias.
+
+With reusable apps or Django features that send email for you, there may be an
+option to use a specific email provider. For example, Django's logging
+:class:`~django.utils.log.AdminEmailHandler` allows specifying the email
+provider alias in its ``using`` option.
 
 .. _SMTP: https://en.wikipedia.org/wiki/Simple_Mail_Transfer_Protocol
 
@@ -147,6 +251,11 @@ if used.
   be a :mimetype:`multipart/alternative` email with ``message`` as the
   :mimetype:`text/plain` content type and ``html_message`` as the
   :mimetype:`text/html` content type.
+* ``using``: An optional :setting:`EMAIL_PROVIDERS` alias to use to send the
+  mail. If unspecified, the default email provider will be used.
+
+``fail_silently``, ``auth_user``, ``auth_password``, and ``connection`` are not
+allowed with the ``using`` argument.
 
 The return value will be the number of successfully delivered messages (which
 can be ``0`` or ``1`` since it can only send one message).
@@ -156,7 +265,16 @@ can be ``0`` or ``1`` since it can only send one message).
     Passing ``fail_silently`` and later parameters as positional arguments is
     deprecated.
 
+.. deprecated:: 6.1
+
+    The ``fail_silently``, ``auth_user``, ``auth_password``, and ``connection``
+    arguments are deprecated. In most cases they can be replaced by ``using``
+    with an appropriate :setting:`EMAIL_PROVIDERS` configuration. See
+    :ref:`migrating-to-email-providers`.
+
 .. versionchanged:: 6.1
+
+    The ``using`` argument was added.
 
     Older versions ignored ``fail_silently=True``, ``auth_user``,
     and ``auth_password`` when a ``connection`` was also provided.
@@ -165,7 +283,7 @@ can be ``0`` or ``1`` since it can only send one message).
 ``send_mass_mail()``
 --------------------
 
-.. function:: send_mass_mail(datatuple, *, fail_silently=False, auth_user=None, auth_password=None, connection=None)
+.. function:: send_mass_mail(datatuple, *, fail_silently=False, auth_user=None, auth_password=None, connection=None, using=None)
 
 ``django.core.mail.send_mass_mail()`` is intended to handle mass emailing.
 
@@ -175,7 +293,11 @@ can be ``0`` or ``1`` since it can only send one message).
 
 ``fail_silently``, ``auth_user``, ``auth_password`` and ``connection`` have the
 same functions as in :func:`send_mail`. They must be given as keyword arguments
-if used.
+if used, and are not allowed with the ``using`` argument.
+
+The keyword argument ``using`` is an optional :setting:`EMAIL_PROVIDERS` alias
+to use to send the mail. If unspecified, the default email provider will be
+used.
 
 Each separate element of ``datatuple`` results in a separate email message.
 As in :func:`send_mail`, recipients in the same ``recipient_list`` will all see
@@ -206,8 +328,16 @@ The return value will be the number of successfully delivered messages.
     Passing ``fail_silently`` and later parameters as positional arguments is
     deprecated.
 
+.. deprecated:: 6.1
+
+    The ``fail_silently``, ``auth_user``, ``auth_password``, and ``connection``
+    arguments are deprecated. In most cases they can be replaced by ``using``
+    with an appropriate :setting:`EMAIL_PROVIDERS` configuration. See
+    :ref:`migrating-to-email-providers`.
 
 .. versionchanged:: 6.1
+
+    The ``using`` argument was added.
 
     Older versions ignored ``fail_silently=True``, ``auth_user``,
     and ``auth_password`` when a ``connection`` was also provided.
@@ -245,7 +375,7 @@ field::
 ``mail_admins()``
 -----------------
 
-.. function:: mail_admins(subject, message, *, fail_silently=False, connection=None, html_message=None)
+.. function:: mail_admins(subject, message, *, fail_silently=False, connection=None, html_message=None, using=None)
 
 ``django.core.mail.mail_admins()`` is a shortcut for sending an email to the
 site admins, as defined in the :setting:`ADMINS` setting.
@@ -263,12 +393,25 @@ If ``html_message`` is provided, the resulting email will be a
 :mimetype:`text/plain` content type and ``html_message`` as the
 :mimetype:`text/html` content type.
 
+The keyword argument ``using`` is an optional :setting:`EMAIL_PROVIDERS` alias
+to use to send the mail. If unspecified, the default email provider will be
+used.
+
 .. deprecated:: 6.0
 
     Passing ``fail_silently`` and later parameters as positional arguments is
     deprecated.
 
+.. deprecated:: 6.1
+
+    The ``fail_silently`` and ``connection`` arguments are deprecated. In most
+    cases they can be replaced by ``using`` with an appropriate
+    :setting:`EMAIL_PROVIDERS` configuration. See
+    :ref:`migrating-to-email-providers`.
+
 .. versionchanged:: 6.1
+
+    The ``using`` argument was added.
 
     Older versions ignored ``fail_silently=True`` when a ``connection``
     was also provided. This now raises a ``TypeError``.
@@ -276,7 +419,7 @@ If ``html_message`` is provided, the resulting email will be a
 ``mail_managers()``
 -------------------
 
-.. function:: mail_managers(subject, message, *, fail_silently=False, connection=None, html_message=None)
+.. function:: mail_managers(subject, message, *, fail_silently=False, connection=None, html_message=None, using=None)
 
 ``django.core.mail.mail_managers()`` is just like ``mail_admins()``, except it
 sends an email to the site managers, as defined in the :setting:`MANAGERS`
@@ -287,7 +430,16 @@ setting.
     Passing ``fail_silently`` and later parameters as positional arguments is
     deprecated.
 
+.. deprecated:: 6.1
+
+    The ``fail_silently`` and ``connection`` arguments are deprecated. In most
+    cases they can be replaced by ``using`` with an appropriate
+    :setting:`EMAIL_PROVIDERS` configuration. See
+    :ref:`migrating-to-email-providers`.
+
 .. versionchanged:: 6.1
+
+    The ``using`` argument was added.
 
     Older versions ignored ``fail_silently=True`` when a ``connection``
     was also provided. This now raises a ``TypeError``.
@@ -373,11 +525,15 @@ email backend API :ref:`provides an alternative
       an email message. The corresponding attribute is ``extra_headers``.
 
     * ``connection``: An :ref:`email backend <topic-email-backends>` instance.
-      Use this parameter if you are sending the :class:`!EmailMessage` via
-      :meth:`send` and you want to use the same connection for multiple
-      messages. If omitted, a new connection is created when :meth:`send` is
-      called. This parameter is ignored when using
+      This parameter is ignored when using
       :ref:`send_messages() <topics-sending-multiple-emails>`.
+
+      .. deprecated:: 6.1
+
+        The ``connection`` argument is deprecated. Instead, define an
+        :setting:`EMAIL_PROVIDERS` configuration with the desired connection
+        options, and then call :meth:`EmailMessage.send(using="...") <send>`
+        with that provider's alias. See :ref:`migrating-to-email-providers`.
 
     .. deprecated:: 6.0
 
@@ -400,20 +556,36 @@ email backend API :ref:`provides an alternative
 
     The class has the following methods:
 
-    .. method:: send(fail_silently=False)
+    .. method:: send(fail_silently=False, *, using=None)
 
-        Sends the message. If a connection was specified when the email was
-        constructed, that connection will be used. Otherwise, an instance of
-        the default backend will be instantiated and used. If the keyword
-        argument ``fail_silently`` is ``True``, exceptions raised while sending
-        the message will be quashed. An empty list of recipients will not raise
-        an exception. It will return ``1`` if the message was sent
-        successfully, otherwise ``0``.
+        Sends the message. Returns ``1`` if the message was sent successfully,
+        otherwise ``0``. (An empty list of recipients returns ``0`` -- it will
+        not raise an exception.)
+
+        The optional ``using`` keyword argument specifies an
+        :setting:`EMAIL_PROVIDERS` alias to use to send the mail. If not given,
+        the default email provider will be used.
+
+        If a deprecated connection was specified when the email was
+        constructed, that connection will be used. Providing both a connection
+        and ``using`` will raise an error.
+
+        If the deprecated keyword argument ``fail_silently`` is ``True``,
+        certain backend-dependent exceptions while sending the message will be
+        ignored. Providing both ``fail_silently`` and ``using`` will raise an
+        error.
 
         .. versionchanged:: 6.1
 
+            The ``using`` argument was added.
+
             Older versions ignored ``fail_silently=True`` when a ``connection``
             was also provided. This now raises a ``TypeError``.
+
+        .. deprecated:: 6.1
+
+            The ``fail_silently`` argument is deprecated. See
+            :ref:`migrating-to-email-providers` for alternatives.
 
     .. method:: message(*, policy=email.policy.default)
 
@@ -425,10 +597,9 @@ email backend API :ref:`provides an alternative
         an :mod:`email.policy.Policy <email.policy>` object. Defaults to
         :data:`email.policy.default`. In certain cases you may want to use
         :data:`~email.policy.SMTP`, :data:`~email.policy.SMTPUTF8` or a custom
-        policy. For example,
-        :class:`django.core.mail.backends.smtp.EmailBackend` uses the
-        :data:`~email.policy.SMTP` policy to ensure ``\r\n`` line endings as
-        required by the SMTP protocol.
+        policy. For example,the :ref:`SMTP email backend
+        <topic-email-smtp-backend>` uses the :data:`~email.policy.SMTP` policy
+        to ensure ``\r\n`` line endings as required by the SMTP protocol.
 
         If you ever need to extend Django's :class:`EmailMessage` class,
         you'll probably want to override this method to put the content you
@@ -691,10 +862,9 @@ require an email backend instance obtained via :func:`get_connection`, which is
 documented in :ref:`topic-email-backends`.
 
 The first approach is to obtain an email backend instance from
-:func:`get_connection` and use its ``send_messages()`` method. This takes a
+:data:`providers` and use its ``send_messages()`` method. This takes a
 list of :class:`EmailMessage` (or subclass) instances, and sends them all using
-that single connection. As a consequence, any :class:`connection
-<EmailMessage>` set on an individual message is ignored.
+that single connection.
 
 For example, if you have a function called ``get_notification_emails()`` that
 returns a list of :class:`EmailMessage` objects representing some periodic
@@ -703,12 +873,15 @@ email you wish to send out, you could send these emails using a single call to
 
     from django.core import mail
 
-    connection = mail.get_connection()  # Use default email connection
-    messages = get_notification_emails()
-    connection.send_messages(messages)
+    email_list = get_notification_emails()
+    # Use the default email provider. You could substitute
+    # mail.providers["alias"] for a specific provider.
+    backend = mail.providers.default
+    backend.send_messages(email_list)
 
 In this example, the call to ``send_messages()`` opens a connection on the
 backend, sends the list of messages, and then closes the connection again.
+(This is how :func:`send_mass_mail` is implemented.)
 
 The second approach is to use the ``open()`` and ``close()`` methods on the
 email backend to manually control the connection. ``send_messages()`` will not
@@ -717,32 +890,26 @@ manually open the connection, you can control when it is closed. For example::
 
     from django.core import mail
 
-    connection = mail.get_connection()
+    # Use the "notifications" email provider.
+    backend = mail.providers["notifications"]
 
     # Manually open the connection.
-    connection.open()
+    backend.open()
 
-    # Construct an email message that will use the connection.
-    email1 = mail.EmailMessage(
-        "Hello",
-        "Body goes here",
-        "from@example.com",
-        ["to1@example.com"],
-        connection=connection,
-    )
-    # Send the email through its connection. The connection was already open,
-    # so send() leaves it open after sending.
-    email1.send()
-
-    # Construct two more email messages. (Passing None as the third argument
+    # Construct an email message. (Passing None as the third argument
     # uses settings.DEFAULT_FROM_EMAIL as the "From:" address.)
+    email1 = mail.EmailMessage("Hi", "Message", None, ["to1@example.com"])
+    # Send the email. The connection was already open, so send_messages()
+    # leaves it open after sending.
+    backend.send_messages([email1])
+
+    # Construct and send two more messages. The connection is still open.
     email2 = mail.EmailMessage("Hi", "Message", None, ["to2@example.com"])
     email3 = mail.EmailMessage("Hi", "Message", None, ["to3@example.com"])
-    # Send the two messages. The connection is still open.
-    connection.send_messages([email2, email3])
+    backend.send_messages([email2, email3])
 
     # Because we opened it, we need to manually close the connection.
-    connection.close()
+    backend.close()
 
 When you manually open a backend's connection, you are responsible for ensuring
 it gets closed. The example above actually has a bug: if an exception occurs
@@ -757,21 +924,16 @@ on errors::
 
     from django.core import mail
 
-    with mail.get_connection() as connection:
+    # Use mail.providers[...] as a context manager.
+    with mail.providers["notifications"] as backend:
         # The backend connection is automatically opened inside the context.
-        email1 = mail.EmailMessage(
-            "Hello",
-            "Body goes here",
-            "from@example.com",
-            ["to1@example.com"],
-            connection=connection,
-        )
-        email1.send()
+        email1 = mail.EmailMessage("Hi", "Message", None, ["to1@example.com"])
+        backend.send_messages([email1])
 
         # The connection is still open, and is reused for the second send.
         email2 = mail.EmailMessage("Hi", "Message", None, ["to2@example.com"])
         email3 = mail.EmailMessage("Hi", "Message", None, ["to3@example.com"])
-        connection.send_messages([email2, email3])
+        backend.send_messages([email2, email3])
 
     # After exiting the context (either normally or because of an error),
     # the backend connection is automatically closed.
@@ -810,47 +972,160 @@ It can also be used as a context manager, which will automatically call
 SMTP backend
 ------------
 
-.. class:: backends.smtp.EmailBackend(host=None, port=None, username=None, password=None, use_tls=None, fail_silently=False, use_ssl=None, timeout=None, ssl_keyfile=None, ssl_certfile=None, **kwargs)
+The SMTP email backend connects to an SMTP server to send email. To use it, set
+:setting:`BACKEND <EMAIL_PROVIDERS-BACKEND>` to
+``"django.core.mail.backends.smtp.EmailBackend"``
 
-    This is the default backend. Email will be sent through a SMTP server.
+The SMTP backend supports these :setting:`OPTIONS <EMAIL_PROVIDERS-OPTIONS>`:
 
-    The value for each argument is retrieved from the matching setting if the
-    argument is ``None``:
+* ``"host"`` (required): the SMTP server hostname or IP address.
 
-    * ``host``: :setting:`EMAIL_HOST`
-    * ``port``: :setting:`EMAIL_PORT`
-    * ``username``: :setting:`EMAIL_HOST_USER`
-    * ``password``: :setting:`EMAIL_HOST_PASSWORD`
-    * ``use_tls``: :setting:`EMAIL_USE_TLS`
-    * ``use_ssl``: :setting:`EMAIL_USE_SSL`
-    * ``timeout``: :setting:`EMAIL_TIMEOUT`
-    * ``ssl_keyfile``: :setting:`EMAIL_SSL_KEYFILE`
-    * ``ssl_certfile``: :setting:`EMAIL_SSL_CERTFILE`
+* ``"port"``: the port number to connect to on the SMTP host. If omitted,
+  uses the standard port for the connection protocol depending on the
+  ``"use_tls"`` and ``"use_ssl"`` options: ``587`` for TLS, ``465`` for SSL,
+  or ``25`` for an unsecured connection.
 
-    The SMTP backend is the default configuration inherited by Django. If you
-    want to specify it explicitly, put the following in your settings::
+* ``"username"`` and ``"password"``: set these if your server requires SMTP
+  authentication ("SMTP AUTH" credentials, sometimes called SMTP login).
 
-        EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+  Although the username is often an email address, it should not be confused
+  with default "From:" addresses. Those are defined by the
+  :setting:`DEFAULT_FROM_EMAIL` and :setting:`SERVER_EMAIL` settings.
 
-    If unspecified, the default ``timeout`` will be the one provided by
-    :func:`socket.getdefaulttimeout`, which defaults to ``None`` (no timeout).
+* ``"use_tls"`` or ``"use_ssl"``: set one of these options to ``True`` to
+  connect to the SMTP server using a secure protocol -- ``"use_tls"`` for
+  explicit TLS or ``"use_ssl"`` for SSL (implicit TLS).
+
+* ``"ssl_certfile"`` and ``"ssl_keyfile"``: if the SMTP server's SSL/TLS
+  connection requires client certificate authentication, use these options to
+  specify the paths to a PEM-formatted certificate chain file and private key
+  file. (The key file can be omitted if the certificate file includes the
+  private key.)
+
+  These options are not intended for use with a private certificate authority
+  or self-signed SMTP server certificate. See
+  :ref:`topic-email-smtp-private-ca` below.
+
+  Note that these options don't result in checking certificate validity. They
+  are passed to the underlying SSL connection. Refer to the documentation of
+  Python's :meth:`ssl.SSLContext.wrap_socket` method for details on how the
+  certificate chain file and private key file are handled.
+
+* ``"timeout"``: the timeout (in seconds) for connecting to the SMTP server and
+  other blocking operations. If not specified, the value is obtained from
+  :func:`socket.getdefaulttimeout`, which defaults to no timeout (``None``)
+  meaning SMTP operations can block indefinitely.
+
+* ``"fail_silently"``: set to ``True`` to ignore certain errors while sending
+  a message. All :exc:`OSError`\s are ignored while opening the SMTP
+  connection, and :exc:`smtplib.SMTPException` errors are ignored while
+  communicating with the server. This will suppress both transient network
+  glitches and also serious configuration problems. However, it does not ignore
+  *all* errors, and problems with serializing the message will not fail
+  silently. (This option is available for backward compatibility but is not
+  recommended for typical use.)
+
+Example::
+
+    EMAIL_PROVIDERS = {
+        "default": {
+            "BACKEND": "django.core.mail.backends.smtp.EmailBackend",
+            "OPTIONS": {
+                "host": "smtp.example.net",
+                "use_tls": True,
+                "username": "my-app",
+                "password": os.environ["MY_APP_SMTP_PASSWORD"],
+                "timeout": 10,
+            },
+        },
+    }
+
+.. deprecated:: 6.1
+
+    When the :setting:`EMAIL_PROVIDERS` setting is not defined, Django uses
+    the SMTP backend as the default email provider (the default
+    :setting:`EMAIL_BACKEND`), connecting to localhost on port 25. This
+    behavior will be removed in Django 7.0, which will not have a default email
+    provider.
+
+    When the SMTP backend is used without :setting:`EMAIL_PROVIDERS` defined,
+    the options listed above are obtained from the deprecated
+    :setting:`EMAIL_HOST`, :setting:`EMAIL_PORT`, :setting:`EMAIL_HOST_USER`,
+    :setting:`EMAIL_HOST_PASSWORD`, :setting:`EMAIL_USE_TLS`,
+    :setting:`EMAIL_USE_SSL`, :setting:`EMAIL_SSL_KEYFILE`,
+    :setting:`EMAIL_SSL_CERTFILE`, and :setting:`EMAIL_TIMEOUT` settings,
+    respectively. (There is no setting equivalent to the ``"fail_silently"``
+    option.)
+
+
+.. class:: backends.smtp.EmailBackend
+
+    Directly instantiating an ``EmailBackend`` class is not recommended. Use
+    :data:`providers` to obtain a backend instance.
+
+    When constructed directly, the SMTP ``EmailBackend`` class accepts the
+    options listed above as keyword arguments. Default values come from the
+    corresponding, deprecated ``EMAIL_*`` settings. ``host`` is not required
+    and defaults to ``"localhost"``, and ``port`` defaults to ``25`` even if
+    ``use_tls`` or ``use_ssl`` is True.
+
+    When the :setting:`EMAIL_PROVIDERS` setting is defined, attempting to
+    directly create an SMTP ``EmailBackend`` will raise an ``AttributeError``.
+
+    .. deprecated:: 6.1
+
+        Directly constructing an instance of an ``EmailBackend`` class will be
+        unsupported in Django 7.0. Undocumented use will result in different
+        default argument handling compared to earlier releases.
+
+.. _topic-email-smtp-private-ca:
+
+Private and self-signed SMTP server certificates
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If the SMTP server uses an SSL certificate from a private certificate authority
+(CA), the CA's root certificate should be added to the system CA bundle on the
+client (where Django is running). Likewise, if the server uses a self-signed
+certificate, it should be added to the client's system CA bundle so it can be
+trusted. (The SMTP backend's ``"ssl_certfile"`` option cannot be used for CA
+roots or self-signed certificates.)
+
+Follow platform-specific instructions for adding to the system CA bundle. If
+modifying the system bundle is not possible or desired, an alternative is using
+OpenSSL's ``SSL_CERT_FILE`` or ``SSL_CERT_DIR`` environment variables to
+specify a custom certificate bundle.
+
+For more complex scenarios, the SMTP backend can be subclassed to add root
+certificates to its ``ssl_context`` using
+:meth:`ssl.SSLContext.load_verify_locations`.
 
 .. _topic-email-console-backend:
 
 Console backend
 ---------------
 
-Instead of sending out real emails the console backend just writes the
-emails that would be sent to the standard output. By default, the console
-backend writes to ``stdout``. You can use a different stream-like object by
-providing the ``stream`` keyword argument when constructing the connection.
+Instead of sending out real emails, the console backend writes the emails that
+would be sent to the standard output. To use it, set
+:setting:`BACKEND <EMAIL_PROVIDERS-BACKEND>` to
+``"django.core.mail.backends.console.EmailBackend"``.
 
-To specify this backend, put the following in your settings::
+The console backend supports these
+:setting:`OPTIONS <EMAIL_PROVIDERS-OPTIONS>`:
 
-    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+* ``"stream"``: a stream-like object to write to. Defaults to ``stdout``.
+
+* ``"fail_silently"``: set to ``True`` to ignore *all* errors while writing the
+  message to the stream, including errors serializing the message. (This option
+  is available for backward compatibility but is not recommended.)
 
 This backend is not intended for use in production -- it is provided as a
 convenience that can be used during development.
+
+.. versionchanged:: 6.1
+
+    The settings file created by :djadmin:`startproject` now sets up
+    :setting:`EMAIL_PROVIDERS` with the console backend as the default
+    email provider.
 
 .. _topic-email-file-backend:
 
@@ -858,17 +1133,29 @@ File backend
 ------------
 
 The file backend writes emails to a file. A new file is created for each new
-session that is opened on this backend. The directory to which the files are
-written is either taken from the :setting:`EMAIL_FILE_PATH` setting or from the
-``file_path`` keyword when creating a connection with :func:`get_connection`.
+session that is opened on this backend. To use it, set
+:setting:`BACKEND <EMAIL_PROVIDERS-BACKEND>` to
+``"django.core.mail.backends.filebased.EmailBackend"``.
 
-To specify this backend, put the following in your settings::
+The file backend supports these :setting:`OPTIONS <EMAIL_PROVIDERS-OPTIONS>`:
 
-    EMAIL_BACKEND = "django.core.mail.backends.filebased.EmailBackend"
-    EMAIL_FILE_PATH = "/tmp/app-messages"  # change this to a proper location
+* ``"file_path"`` (required): the directory to which the files are written. Can
+  be a string or a :class:`pathlib.Path` object. If the directory does not
+  exist, the file backend will attempt to create it.
+
+* ``"fail_silently"``: set to ``True`` to ignore *all* errors while writing the
+  message to the file -- including errors serializing the message -- but *not*
+  errors related to ensuring the file path directory exists. (This option is
+  available for backward compatibility but is not recommended.)
 
 This backend is not intended for use in production -- it is provided as a
 convenience that can be used during development.
+
+.. deprecated:: 6.1
+
+    When the file backend is used without the :setting:`EMAIL_PROVIDERS`
+    setting defined, it will get its ``file_path`` option from the
+    :setting:`EMAIL_FILE_PATH` setting.
 
 .. _topic-email-memory-backend:
 
@@ -878,27 +1165,33 @@ In-memory backend
 The ``'locmem'`` backend stores messages in a special attribute of the
 ``django.core.mail`` module. The ``outbox`` attribute is created when the first
 message is sent. It's a list with an :class:`EmailMessage` instance for each
-message that would be sent.
+message that would be sent. Messages in the outbox are annotated with a
+``sent_using`` attribute that identifies the :setting:`EMAIL_PROVIDERS` alias
+used to send the message.
 
-To specify this backend, put the following in your settings::
+To use the in-memory backend, set :setting:`BACKEND <EMAIL_PROVIDERS-BACKEND>`
+to ``"django.core.mail.backends.locmem.EmailBackend"``. It does not support any
+:setting:`OPTIONS <EMAIL_PROVIDERS-OPTIONS>`.
 
-    EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
+Django's test runner :ref:`automatically switches to this backend for testing
+<topics-testing-email>`.
 
 This backend is not intended for use in production -- it is provided as a
 convenience that can be used during development and testing.
 
-Django's test runner :ref:`automatically uses this backend for testing
-<topics-testing-email>`.
+.. versionchanged:: 6.1
+
+    The ``sent_using`` attribute was added to messages in the outbox.
 
 .. _topic-email-dummy-backend:
 
 Dummy backend
 -------------
 
-As the name suggests the dummy backend does nothing with your messages. To
-specify this backend, put the following in your settings::
-
-    EMAIL_BACKEND = "django.core.mail.backends.dummy.EmailBackend"
+As the name suggests the dummy backend does nothing with your messages. To use
+it, set :setting:`BACKEND <EMAIL_PROVIDERS-BACKEND>` to
+``"django.core.mail.backends.dummy.EmailBackend"``. It does not support any
+:setting:`OPTIONS <EMAIL_PROVIDERS-OPTIONS>`.
 
 This backend is not intended for use in production -- it is provided as a
 convenience that can be used during development.
@@ -932,9 +1225,11 @@ Third-party email backends are available that:
 Defining a custom email backend
 -------------------------------
 
-If you need to change how emails are sent you can write your own email
-backend. The :setting:`EMAIL_BACKEND` setting in your settings file is then
-the Python import path for your backend class.
+If you need to change how emails are sent you can write your own email backend.
+To use a custom backend, set :setting:`BACKEND <EMAIL_PROVIDERS-BACKEND>` to
+the Python import path for your backend class and
+:setting:`OPTIONS <EMAIL_PROVIDERS-OPTIONS>` to any ``__init__()`` arguments
+your backend supports.
 
 Custom email backends should subclass ``BaseEmailBackend`` that is located in
 the ``django.core.mail.backends.base`` module. A custom email backend must
@@ -944,28 +1239,92 @@ delivered messages. If your backend has any concept of a persistent session or
 connection, you should also implement the ``open()`` and ``close()`` methods.
 Refer to ``smtp.EmailBackend`` for a reference implementation.
 
+.. _topic-email-providers:
+
 Obtaining an instance of an email backend
 -----------------------------------------
 
-The :func:`get_connection` function in ``django.core.mail`` returns an
-instance of the email backend that you can use.
+The ``providers`` factory in :mod:`!django.core.email` returns instances of
+email backends.
+
+.. data:: providers
+
+    You can access the email providers configured in the
+    :setting:`EMAIL_PROVIDERS` setting through a dict-like object:
+    ``django.core.email.providers``:
+
+    .. code-block:: pycon
+
+        >>> from django.core.mail import providers
+        >>> providers["notifications"]
+
+    If the named key is not defined, an ``EmailProviderDoesNotExist`` error
+    will be raised. Other configuration problems will raise an
+    ``InvalidEmailProvider`` error.
+
+    .. versionadded:: 6.1
+
+.. data:: providers.default
+
+    As a shortcut, the default email provider can be accessed through
+    ``django.core.email.providers.default``:
+
+    .. code-block:: pycon
+
+        >>> from django.core.mail import providers
+        >>> providers.default
+
+    This is equivalent to ``providers["default"]``. If no default provider has
+    been defined, an ``EmailProviderDoesNotExist`` error will be raised.
+
+    .. deprecated:: 6.1
+
+        If the :setting:`EMAIL_PROVIDERS` setting is not defined,
+        ``providers.default`` will create an email backend instance from the
+        deprecated :setting:`EMAIL_BACKEND` and related settings. This allows
+        backwards compatibility with Django 6.0 and earlier.
+
+        This behavior (and those settings) will be removed in Django 7.0.
 
 .. function:: get_connection(backend=None, *, fail_silently=False, **kwargs)
 
-    By default, a call to ``get_connection()`` will return an instance of the
-    email backend specified in :setting:`EMAIL_BACKEND`. If you specify the
-    ``backend`` argument, an instance of that backend will be instantiated.
+    The deprecated :func:`!django.core.mail.get_connection` function creates
+    and returns an instance of an email backend. Its behavior depends on the
+    :setting:`EMAIL_PROVIDERS` setting and how the function is called.
 
-    The keyword-only ``fail_silently`` argument controls how the backend should
-    handle errors. If ``fail_silently`` is True, exceptions during the email
-    sending process will be silently ignored.
+    If the :setting:`EMAIL_PROVIDERS` setting is *not* defined:
 
-    All other keyword arguments are passed directly to the constructor of the
-    email backend.
+    * ``get_connection()`` with no arguments will return an instance of the
+      email backend specified in :setting:`EMAIL_BACKEND`.
+    * If you specify the ``backend`` argument, an instance of that backend will
+      be instantiated.
+    * If the keyword argument ``fail_silently`` is True, certain
+      backend-dependent exceptions during the email sending process will be
+      silently ignored.
+    * All other keyword arguments are passed directly to the constructor of the
+      email backend.
+
+    If the :setting:`EMAIL_PROVIDERS` setting *is* defined:
+
+    * ``get_connection()`` with no arguments will return
+      :data:`providers.default`.
+    * ``get_connection(...)`` called with only ``fail_silently`` or other
+      keyword arguments will create an instance of
+      ``EMAIL_PROVIDERS["default"]`` with any keywords added to the
+      default provider's :setting:`OPTIONS <EMAIL_PROVIDERS-OPTIONS>`.
+    * ``get_connection(backend, ...)`` with a backend import path will raise
+      an error.
 
     .. deprecated:: 6.0
 
         Passing ``fail_silently`` as positional argument is deprecated.
+
+    .. deprecated:: 6.1
+
+        :func:`!get_connection` is deprecated and will be removed in Django
+        7.0. Switch to :data:`providers[alias] <providers>`. See
+        :ref:`migrating-to-email-providers` for specific examples.
+
 
 Configuring email for development
 =================================
@@ -996,9 +1355,10 @@ anything. The :pypi:`aiosmtpd` package provides a way to accomplish this:
 
 This command will start a minimal SMTP server listening on port 8025 of
 localhost. This server prints to standard output all email headers and the
-email body. You then only need to set the :setting:`EMAIL_HOST` and
-:setting:`EMAIL_PORT` accordingly. For a more detailed discussion of SMTP
-server options, see the documentation of the `aiosmtpd`_ module.
+email body. You then only need to set an SMTP email provider's ``"host"`` and
+``"port"`` :setting:`OPTIONS <EMAIL_PROVIDERS-OPTIONS>` accordingly. For a more
+detailed discussion of SMTP server options, see the documentation of the
+`aiosmtpd`_ module.
 
 .. _aiosmtpd: https://aiosmtpd.readthedocs.io/en/latest/
 

--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -2034,17 +2034,19 @@ creates.
 Email services
 ==============
 
-If any of your Django views send email using :doc:`Django's email
-functionality </topics/email>`, you probably don't want to send email each time
-you run a test using that view. For this reason, Django's test runner
-automatically redirects all Django-sent email to a dummy outbox. This lets you
-test every aspect of sending email -- from the number of messages sent to the
-contents of each message -- without actually sending the messages.
+If any of your code sends email using :doc:`Django's email functionality
+</topics/email>`, you probably don't want to send email each time you run a
+test that exercises that code. For this reason, Django's test runner
+automatically redirects all Django-sent email to an in-memory outbox. This lets
+you test every aspect of sending email -- from the number of messages sent to
+the contents of each message -- without actually sending the messages.
 
-The test runner accomplishes this by transparently replacing the normal
-email backend with a testing backend.
-(Don't worry -- this has no effect on any other email senders outside of
-Django, such as your machine's mail server, if you're running one.)
+The test runner accomplishes this by transparently replacing the
+:setting:`BACKEND <EMAIL_PROVIDERS-BACKEND>` for each configured
+:setting:`EMAIL_PROVIDERS` alias with the ``'locmem'`` :ref:`memory email
+backend <topic-email-memory-backend>`. (Don't worry -- this has no effect on
+any other email senders outside of Django, such as your machine's mail server,
+if you're running one.)
 
 .. currentmodule:: django.core.mail
 
@@ -2081,6 +2083,9 @@ and contents::
 
             # Verify that the subject of the first message is correct.
             self.assertEqual(mail.outbox[0].subject, "Subject here")
+
+            # Verify the message was sent with the "default" email provider.
+            self.assertEqual(mail.outbox[0].sent_using, "default")
 
 As noted :ref:`previously <emptying-test-outbox>`, the test outbox is emptied
 at the start of every test in a Django ``*TestCase``. To empty the outbox

--- a/tests/admin_views/test_actions.py
+++ b/tests/admin_views/test_actions.py
@@ -24,7 +24,12 @@ from .models import (
 )
 
 
-@override_settings(ROOT_URLCONF="admin_views.urls")
+@override_settings(
+    ROOT_URLCONF="admin_views.urls",
+    EMAIL_PROVIDERS={
+        "default": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"}
+    },
+)
 class AdminActionsTest(TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -305,6 +305,11 @@ class AdminViewBasicTestCase(TestCase):
         )
 
 
+@override_settings(
+    EMAIL_PROVIDERS={
+        "default": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"}
+    }
+)
 class AdminViewBasicTest(AdminViewBasicTestCase):
     def test_trailing_slash_required(self):
         """
@@ -2346,6 +2351,9 @@ def get_perm(Model, codename):
             },
         }
     ],
+    EMAIL_PROVIDERS={
+        "default": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"}
+    },
 )
 class AdminViewPermissionsTest(TestCase):
     """Tests for Admin Views Permissions."""

--- a/tests/auth_tests/test_forms.py
+++ b/tests/auth_tests/test_forms.py
@@ -1157,7 +1157,12 @@ class UserChangeFormTest(TestDataMixin, TestCase):
         )
 
 
-@override_settings(TEMPLATES=AUTH_TEMPLATES)
+@override_settings(
+    TEMPLATES=AUTH_TEMPLATES,
+    EMAIL_PROVIDERS={
+        "default": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"}
+    },
+)
 class PasswordResetFormTest(TestDataMixin, TestCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/auth_tests/test_forms.py
+++ b/tests/auth_tests/test_forms.py
@@ -1380,7 +1380,11 @@ class PasswordResetFormTest(TestDataMixin, TestCase):
             )
         )
 
-    @override_settings(EMAIL_BACKEND="mail.custombackend.FailingEmailBackend")
+    @override_settings(
+        EMAIL_PROVIDERS={
+            "default": {"BACKEND": "mail.custombackend.FailingEmailBackend"}
+        }
+    )
     def test_save_send_email_exceptions_are_catched_and_logged(self):
         user, username, email = self.create_dummy_user()
         form = PasswordResetForm({"email": email})

--- a/tests/auth_tests/test_models.py
+++ b/tests/auth_tests/test_models.py
@@ -252,6 +252,11 @@ class AbstractBaseUserTests(SimpleTestCase):
 
 
 class AbstractUserTestCase(TestCase):
+    @override_settings(
+        EMAIL_PROVIDERS={
+            "default": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"}
+        }
+    )
     def test_email_user(self):
         # valid send_mail parameters
         kwargs = {

--- a/tests/auth_tests/test_views.py
+++ b/tests/auth_tests/test_views.py
@@ -61,6 +61,9 @@ class RedirectURLMixinTests(TestCase):
     LANGUAGE_CODE="en",
     TEMPLATES=AUTH_TEMPLATES,
     ROOT_URLCONF="auth_tests.urls",
+    EMAIL_PROVIDERS={
+        "default": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"}
+    },
 )
 class AuthViewsTestCase(TestCase):
     """

--- a/tests/logging_tests/logconfig.py
+++ b/tests/logging_tests/logconfig.py
@@ -12,8 +12,15 @@ class MyHandler(logging.Handler):
 
 
 class MyEmailBackend(BaseEmailBackend):
+    sent_messages = []
+
+    def __init__(self, fail_silently=False, **kwargs):
+        super().__init__(**kwargs)
+        self.fail_silently = fail_silently
+        self.__class__.sent_messages[:] = []
+
     def send_messages(self, email_messages):
-        pass
+        self.__class__.sent_messages.extend(email_messages)
 
 
 class CustomExceptionReporter(ExceptionReporter):

--- a/tests/logging_tests/logconfig.py
+++ b/tests/logging_tests/logconfig.py
@@ -11,6 +11,7 @@ class MyHandler(logging.Handler):
         self.config = settings.LOGGING
 
 
+# RemovedInDjango70Warning.
 class MyEmailBackend(BaseEmailBackend):
     sent_messages = []
 

--- a/tests/logging_tests/tests.py
+++ b/tests/logging_tests/tests.py
@@ -4,6 +4,7 @@ from io import StringIO
 from unittest import TestCase, mock
 
 from admin_scripts.tests import AdminScriptTestCase
+from mail import override_deprecated_email_settings
 from mail.custombackend import FailingEmailBackend
 
 from django.conf import settings
@@ -295,7 +296,7 @@ class AdminEmailHandlerTest(SimpleTestCase):
             record.request = self.request_factory.get(url_path, *args, **kwargs)
         return record
 
-    @override_settings(
+    @override_deprecated_email_settings(
         ADMINS=["admin@example.com"],
         EMAIL_BACKEND="mail.custombackend.FailingEmailBackend",
     )

--- a/tests/logging_tests/tests.py
+++ b/tests/logging_tests/tests.py
@@ -4,6 +4,7 @@ from io import StringIO
 from unittest import TestCase, mock
 
 from admin_scripts.tests import AdminScriptTestCase
+from mail.custombackend import FailingEmailBackend
 
 from django.conf import settings
 from django.core import mail
@@ -286,9 +287,22 @@ class AdminEmailHandlerTest(SimpleTestCase):
             h for h in logger.handlers if h.__class__.__name__ == "AdminEmailHandler"
         ][0]
 
-    def test_fail_silently(self):
-        admin_email_handler = self.get_admin_email_handler(self.logger)
-        self.assertTrue(admin_email_handler.connection().fail_silently)
+    def make_log_record(self, url_path=None, *args, **kwargs):
+        record = self.logger.makeRecord(
+            "name", logging.ERROR, "function", "lno", "message", None, None
+        )
+        if url_path is not None:
+            record.request = self.request_factory.get(url_path, *args, **kwargs)
+        return record
+
+    @override_settings(
+        ADMINS=["admin@example.com"],
+        EMAIL_BACKEND="mail.custombackend.FailingEmailBackend",
+    )
+    def test_sends_using_fail_silently(self):
+        FailingEmailBackend.did_fail_silently = False
+        self.logger.error("All work and no play makes Jack a dull boy")
+        self.assertTrue(FailingEmailBackend.did_fail_silently)
 
     @override_settings(
         ADMINS=["admin@example.com"],
@@ -383,36 +397,14 @@ class AdminEmailHandlerTest(SimpleTestCase):
         self.assertNotIn("\r", mail.outbox[0].subject)
         self.assertEqual(mail.outbox[0].subject, expected_subject)
 
-    @override_settings(
-        ADMINS=["admin@example.com"],
-        DEBUG=False,
-    )
+    @override_settings(ADMINS=["admin@example.com"])
     def test_uses_custom_email_backend(self):
-        """
-        Refs #19325
-        """
-        message = "All work and no play makes Jack a dull boy"
-        admin_email_handler = self.get_admin_email_handler(self.logger)
-        mail_admins_called = {"called": False}
-
-        def my_mail_admins(*args, **kwargs):
-            connection = kwargs["connection"]
-            self.assertIsInstance(connection, MyEmailBackend)
-            mail_admins_called["called"] = True
-
-        # Monkeypatches
-        orig_mail_admins = mail.mail_admins
-        orig_email_backend = admin_email_handler.email_backend
-        mail.mail_admins = my_mail_admins
-        admin_email_handler.email_backend = "logging_tests.logconfig.MyEmailBackend"
-
-        try:
-            self.logger.error(message)
-            self.assertTrue(mail_admins_called["called"])
-        finally:
-            # Revert Monkeypatches
-            mail.mail_admins = orig_mail_admins
-            admin_email_handler.email_backend = orig_email_backend
+        handler = AdminEmailHandler(
+            email_backend="logging_tests.logconfig.MyEmailBackend"
+        )
+        handler.emit(self.make_log_record("/"))
+        self.assertEqual(len(mail.outbox), 0)
+        self.assertEqual(len(MyEmailBackend.sent_messages), 1)
 
     @override_settings(
         ADMINS=["admin@example.com"],
@@ -423,12 +415,8 @@ class AdminEmailHandlerTest(SimpleTestCase):
         request.
         """
         handler = self.get_admin_email_handler(self.logger)
-        record = self.logger.makeRecord(
-            "name", logging.ERROR, "function", "lno", "message", None, None
-        )
         url_path = "/º"
-        record.request = self.request_factory.get(url_path)
-        handler.emit(record)
+        handler.emit(self.make_log_record(url_path))
         self.assertEqual(len(mail.outbox), 1)
         msg = mail.outbox[0]
         self.assertEqual(msg.to, ["admin@example.com"])
@@ -442,16 +430,10 @@ class AdminEmailHandlerTest(SimpleTestCase):
     def test_customize_send_mail_method(self):
         class ManagerEmailHandler(AdminEmailHandler):
             def send_mail(self, subject, message, *args, **kwargs):
-                mail.mail_managers(
-                    subject, message, *args, connection=self.connection(), **kwargs
-                )
+                mail.mail_managers(subject, message, *args, **kwargs)
 
         handler = ManagerEmailHandler()
-        record = self.logger.makeRecord(
-            "name", logging.ERROR, "function", "lno", "message", None, None
-        )
-        self.assertEqual(len(mail.outbox), 0)
-        handler.emit(record)
+        handler.emit(self.make_log_record())
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].to, ["manager@example.com"])
 
@@ -480,14 +462,10 @@ class AdminEmailHandlerTest(SimpleTestCase):
 
     @override_settings(ADMINS=["admin@example.com"])
     def test_custom_exception_reporter_is_used(self):
-        record = self.logger.makeRecord(
-            "name", logging.ERROR, "function", "lno", "message", None, None
-        )
-        record.request = self.request_factory.get("/")
         handler = AdminEmailHandler(
             reporter_class="logging_tests.logconfig.CustomExceptionReporter"
         )
-        handler.emit(record)
+        handler.emit(self.make_log_record("/"))
         self.assertEqual(len(mail.outbox), 1)
         msg = mail.outbox[0]
         self.assertEqual(msg.body, "message\n\ncustom traceback text")
@@ -496,16 +474,7 @@ class AdminEmailHandlerTest(SimpleTestCase):
     def test_emit_no_form_tag(self):
         """HTML email doesn't contain forms."""
         handler = AdminEmailHandler(include_html=True)
-        record = self.logger.makeRecord(
-            "name",
-            logging.ERROR,
-            "function",
-            "lno",
-            "message",
-            None,
-            None,
-        )
-        handler.emit(record)
+        handler.emit(self.make_log_record())
         self.assertEqual(len(mail.outbox), 1)
         msg = mail.outbox[0]
         self.assertEqual(msg.subject, "[Django] ERROR: message")
@@ -517,15 +486,7 @@ class AdminEmailHandlerTest(SimpleTestCase):
     @override_settings(ADMINS=[])
     def test_emit_no_admins(self):
         handler = AdminEmailHandler()
-        record = self.logger.makeRecord(
-            "name",
-            logging.ERROR,
-            "function",
-            "lno",
-            "message",
-            None,
-            None,
-        )
+        record = self.make_log_record()
         with mock.patch.object(
             handler,
             "format_subject",

--- a/tests/logging_tests/tests.py
+++ b/tests/logging_tests/tests.py
@@ -4,18 +4,27 @@ from io import StringIO
 from unittest import TestCase, mock
 
 from admin_scripts.tests import AdminScriptTestCase
-from mail import override_deprecated_email_settings
+from mail import (
+    ignore_no_default_email_provider_warning,
+    override_deprecated_email_settings,
+)
 from mail.custombackend import FailingEmailBackend
 
 from django.conf import settings
 from django.core import mail
-from django.core.exceptions import DisallowedHost, PermissionDenied, SuspiciousOperation
+from django.core.exceptions import (
+    DisallowedHost,
+    ImproperlyConfigured,
+    PermissionDenied,
+    SuspiciousOperation,
+)
 from django.core.files.temp import NamedTemporaryFile
 from django.core.management import color
 from django.http import HttpResponse
 from django.http.multipartparser import MultiPartParserError
 from django.test import RequestFactory, SimpleTestCase, override_settings
 from django.test.utils import LoggingCaptureMixin
+from django.utils.deprecation import RemovedInDjango70Warning
 from django.utils.log import (
     DEFAULT_LOGGING,
     AdminEmailHandler,
@@ -277,6 +286,11 @@ class CallbackFilterTest(SimpleTestCase):
         self.assertEqual(collector, ["a record"])
 
 
+@override_settings(
+    EMAIL_PROVIDERS={
+        "default": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"}
+    }
+)
 class AdminEmailHandlerTest(SimpleTestCase):
     logger = logging.getLogger("django")
     request_factory = RequestFactory()
@@ -296,11 +310,13 @@ class AdminEmailHandlerTest(SimpleTestCase):
             record.request = self.request_factory.get(url_path, *args, **kwargs)
         return record
 
+    # RemovedInDjango70Warning.
     @override_deprecated_email_settings(
         ADMINS=["admin@example.com"],
         EMAIL_BACKEND="mail.custombackend.FailingEmailBackend",
     )
     def test_sends_using_fail_silently(self):
+        del settings.EMAIL_PROVIDERS
         FailingEmailBackend.did_fail_silently = False
         self.logger.error("All work and no play makes Jack a dull boy")
         self.assertTrue(FailingEmailBackend.did_fail_silently)
@@ -398,14 +414,78 @@ class AdminEmailHandlerTest(SimpleTestCase):
         self.assertNotIn("\r", mail.outbox[0].subject)
         self.assertEqual(mail.outbox[0].subject, expected_subject)
 
+    # RemovedInDjango70Warning.
     @override_settings(ADMINS=["admin@example.com"])
+    @ignore_no_default_email_provider_warning()
     def test_uses_custom_email_backend(self):
-        handler = AdminEmailHandler(
-            email_backend="logging_tests.logconfig.MyEmailBackend"
-        )
+        del settings.EMAIL_PROVIDERS
+        msg = "The 'email_backend' argument is deprecated. Use 'using' instead."
+        with self.assertWarnsMessage(RemovedInDjango70Warning, msg):
+            handler = AdminEmailHandler(
+                email_backend="logging_tests.logconfig.MyEmailBackend"
+            )
         handler.emit(self.make_log_record("/"))
         self.assertEqual(len(mail.outbox), 0)
         self.assertEqual(len(MyEmailBackend.sent_messages), 1)
+
+    @override_settings(ADMINS=["admin@example.com"])
+    def test_sends_using_default_email_provider(self):
+        handler = AdminEmailHandler()
+        handler.emit(self.make_log_record())
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].sent_using, "default")
+
+    @override_settings(
+        ADMINS=["admin@example.com"],
+        EMAIL_PROVIDERS={},
+    )
+    def test_no_error_when_email_not_configured(self):
+        handler = AdminEmailHandler()
+        handler.emit(self.make_log_record())
+        self.assertEqual(len(mail.outbox), 0)
+
+    @override_settings(
+        ADMINS=["admin@example.com"],
+        EMAIL_PROVIDERS={
+            "custom": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"}
+        },
+    )
+    def test_using_arg(self):
+        handler = AdminEmailHandler(using="custom")
+        handler.emit(self.make_log_record())
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].sent_using, "custom")
+
+    # RemovedInDjango70Warning.
+    def test_using_conflicts_with_email_backend(self):
+        msg = "The 'email_backend' argument is not compatible with 'using'."
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+            AdminEmailHandler(
+                email_backend="logging_tests.logconfig.MyEmailBackend", using="custom"
+            )
+
+    # RemovedInDjango70Warning.
+    @override_settings(EMAIL_PROVIDERS={})
+    def test_email_backend_not_valid_when_email_providers_defined(self):
+        msg = (
+            "The 'email_backend' argument is not valid when "
+            "settings.EMAIL_PROVIDERS is defined."
+        )
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+            AdminEmailHandler(email_backend="logging_tests.logconfig.MyEmailBackend")
+
+    # RemovedInDjango70Warning.
+    def test_error_when_subclass_defines_undocumented_connection_method(self):
+
+        class CustomAdminEmailHandler(AdminEmailHandler):
+            def connection(self):
+                return mail.get_connection(some_important_option=True)
+
+        with self.assertRaisesMessage(
+            AttributeError,
+            "The undocumented AdminEmailHandler.connection() method is no longer used.",
+        ):
+            CustomAdminEmailHandler()
 
     @override_settings(
         ADMINS=["admin@example.com"],
@@ -616,6 +696,9 @@ class SecurityLoggerTest(LoggingAssertionMixin, SimpleTestCase):
     @override_settings(
         ADMINS=["admin@example.com"],
         DEBUG=False,
+        EMAIL_PROVIDERS={
+            "default": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"}
+        },
     )
     def test_suspicious_email_admins(self):
         self.client.get("/suspicious/")

--- a/tests/mail/__init__.py
+++ b/tests/mail/__init__.py
@@ -1,0 +1,54 @@
+import re
+from contextlib import nullcontext
+
+from django.conf import DEPRECATED_EMAIL_SETTINGS, EMAIL_SETTING_DEPRECATED_MSG
+from django.core.mail.deprecation import NO_DEFAULT_EMAIL_PROVIDER_WARNING
+from django.test import ignore_warnings, override_settings
+from django.utils.deprecation import RemovedInDjango70Warning
+
+
+# RemovedInDjango70Warning.
+class override_deprecated_email_settings(override_settings):
+    """Override settings, ignoring warnings for deprecated email settings.
+
+    Like override_settings(), but suppresses deprecation warnings related to
+    defining the overridden settings. Other settings can be included.
+
+    Warnings are ignored only while installing and restoring the settings
+    overrides, not for code within the context.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        deprecated_names = [
+            name for name in kwargs if name in DEPRECATED_EMAIL_SETTINGS
+        ]
+        if deprecated_names:
+            assert "{name}" in EMAIL_SETTING_DEPRECATED_MSG
+            deprecated_names_re = r"|".join(
+                re.escape(name) for name in deprecated_names
+            )
+            message_re = re.escape(EMAIL_SETTING_DEPRECATED_MSG).replace(
+                re.escape("{name}"), rf"(?:{deprecated_names_re})"
+            )
+            self.ignore_warnings = ignore_warnings(
+                category=RemovedInDjango70Warning, message=message_re
+            )
+        else:
+            self.ignore_warnings = nullcontext()
+
+    def enable(self):
+        with self.ignore_warnings:
+            super().enable()
+
+    def disable(self):
+        with self.ignore_warnings:
+            super().disable()
+
+
+# RemovedInDjango70Warning: Remove this helper and all uses of it.
+def ignore_no_default_email_provider_warning():
+    return ignore_warnings(
+        category=RemovedInDjango70Warning,
+        message=re.escape(NO_DEFAULT_EMAIL_PROVIDER_WARNING),
+    )

--- a/tests/mail/custombackend.py
+++ b/tests/mail/custombackend.py
@@ -33,6 +33,7 @@ class FailingEmailBackend(BaseEmailBackend):
         raise ValueError("FailingEmailBackend is doomed to fail.")
 
 
+# RemovedInDjango70Warning.
 class OptionsCapturingBackend(locmem.EmailBackend):
     """Capture the kwargs used to initialize the backend.
 

--- a/tests/mail/custombackend.py
+++ b/tests/mail/custombackend.py
@@ -3,6 +3,8 @@
 from django.core import mail
 from django.core.mail.backends import locmem
 from django.core.mail.backends.base import BaseEmailBackend
+from django.test import ignore_warnings
+from django.utils.deprecation import RemovedInDjango70Warning
 
 
 class EmailBackend(BaseEmailBackend):
@@ -40,7 +42,9 @@ class OptionsCapturingBackend(locmem.EmailBackend):
 
     def __init__(self, **kwargs):
         self.kwargs = kwargs.copy()
-        super().__init__(**kwargs)
+        msg = r".*BaseEmailBackend will raise a TypeError for unknown keyword arguments"
+        with ignore_warnings(category=RemovedInDjango70Warning, message=msg):
+            super().__init__(**kwargs)
 
     def send_messages(self, email_messages):
         previous_outbox_len = len(mail.outbox)

--- a/tests/mail/custombackend.py
+++ b/tests/mail/custombackend.py
@@ -1,5 +1,7 @@
 """A custom backend for testing."""
 
+from django.core import mail
+from django.core.mail.backends import locmem
 from django.core.mail.backends.base import BaseEmailBackend
 
 
@@ -15,6 +17,34 @@ class EmailBackend(BaseEmailBackend):
 
 
 class FailingEmailBackend(BaseEmailBackend):
+    did_fail_silently = False
+
+    def __init__(self, fail_silently=False, **kwargs):
+        super().__init__(**kwargs)
+        self.__class__.did_fail_silently = False
+        self.fail_silently = fail_silently
 
     def send_messages(self, email_messages):
+        if self.fail_silently:
+            self.__class__.did_fail_silently = True
+            return 0
         raise ValueError("FailingEmailBackend is doomed to fail.")
+
+
+class OptionsCapturingBackend(locmem.EmailBackend):
+    """Capture the kwargs used to initialize the backend.
+
+    Extend the testing backend to add a `backend_init_kwargs` property to each
+    mail.outbox entry, set to the kwargs used to initialize the backend.
+    """
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs.copy()
+        super().__init__(**kwargs)
+
+    def send_messages(self, email_messages):
+        previous_outbox_len = len(mail.outbox)
+        result = super().send_messages(email_messages)
+        for email in mail.outbox[previous_outbox_len:]:
+            email.backend_init_kwargs = self.kwargs
+        return result

--- a/tests/mail/custombackend.py
+++ b/tests/mail/custombackend.py
@@ -1,7 +1,7 @@
 """A custom backend for testing."""
 
 from django.core import mail
-from django.core.mail.backends import locmem
+from django.core.mail.backends import dummy, locmem
 from django.core.mail.backends.base import BaseEmailBackend
 from django.test import ignore_warnings
 from django.utils.deprecation import RemovedInDjango70Warning
@@ -52,3 +52,16 @@ class OptionsCapturingBackend(locmem.EmailBackend):
         for email in mail.outbox[previous_outbox_len:]:
             email.backend_init_kwargs = self.kwargs
         return result
+
+
+class InitCheckBackend(dummy.EmailBackend):
+
+    init_kwargs = None
+
+    def __init__(self, **kwargs):
+        # Pass only the 'alias' kwarg to super, and only if present in kwargs.
+        alias_kwargs = {
+            param: value for param, value in kwargs.items() if param == "alias"
+        }
+        super().__init__(**alias_kwargs)
+        self.__class__.init_kwargs = kwargs

--- a/tests/mail/test_backends.py
+++ b/tests/mail/test_backends.py
@@ -10,14 +10,12 @@ from smtplib import SMTPException
 from ssl import SSLError
 from unittest import mock, skipIf, skipUnless
 
-from django.conf import settings
 from django.core import mail
 from django.core.exceptions import ImproperlyConfigured
 from django.core.mail import EmailMessage
-from django.core.mail.backends import dummy, filebased, locmem, smtp
+from django.core.mail.backends import console, dummy, filebased, locmem, smtp
 from django.core.mail.backends.base import BaseEmailBackend
 from django.test import SimpleTestCase, override_settings
-from django.utils.module_loading import import_string
 
 from .tests import MailTestsMixin, message_from_bytes
 
@@ -45,12 +43,19 @@ class BaseEmailBackendTests(SimpleTestCase):
 class SharedEmailBackendTests(MailTestsMixin):
     """Common test cases run against each EmailBackend."""
 
-    email_backend = None
+    # Subclasses must set to the EmailBackend class being tested.
+    backend_class = None
 
-    @classmethod
-    def setUpClass(cls):
-        cls.enterClassContext(override_settings(EMAIL_BACKEND=cls.email_backend))
-        super().setUpClass()
+    # Create an instance of the backend_class for use in this test context
+    # (configured for use with get_mailbox_content() and flush_mailbox()).
+    # Subclasses should override to default kwargs for testing if needed.
+    def create_backend(self, **kwargs):
+        if self.backend_class is None:
+            raise NotImplementedError(
+                "Subclasses of SharedEmailBackendTests must provide a "
+                "backend_class attribute."
+            )
+        return self.backend_class(**kwargs)
 
     def get_mailbox_content(self):
         raise NotImplementedError(
@@ -78,7 +83,7 @@ class SharedEmailBackendTests(MailTestsMixin):
         email = EmailMessage(
             "Subject", "Content\n", "from@example.com", ["to@example.com"]
         )
-        num_sent = mail.get_connection().send_messages([email])
+        num_sent = self.create_backend().send_messages([email])
         self.assertEqual(num_sent, 1)
         message = self.get_the_message()
         self.assertEqual(message["subject"], "Subject")
@@ -93,7 +98,7 @@ class SharedEmailBackendTests(MailTestsMixin):
             "from@example.com",
             ["to@example.com"],
         )
-        num_sent = mail.get_connection().send_messages([email])
+        num_sent = self.create_backend().send_messages([email])
         self.assertEqual(num_sent, 1)
         message = self.get_the_message()
         self.assertEqual(message["subject"], "Chère maman")
@@ -106,7 +111,7 @@ class SharedEmailBackendTests(MailTestsMixin):
         emails_lists = ([email1, email2], iter((email1, email2)))
         for emails_list in emails_lists:
             with self.subTest(emails_list=repr(emails_list)):
-                num_sent = mail.get_connection().send_messages(emails_list)
+                num_sent = self.create_backend().send_messages(emails_list)
                 self.assertEqual(num_sent, 2)
                 messages = self.get_mailbox_content()
                 self.assertEqual(len(messages), 2)
@@ -115,11 +120,11 @@ class SharedEmailBackendTests(MailTestsMixin):
                 self.flush_mailbox()
 
     def test_connection_can_be_closed_even_if_not_opened(self):
-        backend = mail.get_connection()
+        backend = self.create_backend()
         backend.close()
 
     def test_connection_can_be_used_as_contextmanager(self):
-        backend = mail.get_connection()
+        backend = self.create_backend()
         backend.open = mock.Mock()
         backend.close = mock.Mock()
 
@@ -131,20 +136,18 @@ class SharedEmailBackendTests(MailTestsMixin):
         backend.close.assert_called_once()
 
     def test_fail_silently_arg_accepted(self):
-        backend_class = import_string(self.email_backend)
         for value in [True, False]:
             with self.subTest(fail_silently=value):
-                backend = backend_class(fail_silently=value)
+                backend = self.create_backend(fail_silently=value)
                 self.assertIs(backend.fail_silently, value)
 
     def test_unknown_kwargs_ignored(self):
-        backend_class = import_string(self.email_backend)
-        backend = backend_class(unknown_kwarg="foo")
+        backend = self.create_backend(unknown_kwarg="foo")
         self.assertFalse(hasattr(backend, "unknown_kwarg"))
 
 
 class DummyBackendTests(SharedEmailBackendTests, SimpleTestCase):
-    email_backend = "django.core.mail.backends.dummy.EmailBackend"
+    backend_class = dummy.EmailBackend
 
     def get_mailbox_content(self):
         # Shared tests that examine the content of sent messages are not
@@ -156,13 +159,13 @@ class DummyBackendTests(SharedEmailBackendTests, SimpleTestCase):
         pass
 
     def test_send_messages_returns_sent_count(self):
-        backend = dummy.EmailBackend()
+        backend = self.create_backend()
         email = EmailMessage(to=["to@example.com"])
         self.assertEqual(backend.send_messages([email, email, email]), 3)
 
 
 class LocmemBackendTests(SharedEmailBackendTests, SimpleTestCase):
-    email_backend = "django.core.mail.backends.locmem.EmailBackend"
+    backend_class = locmem.EmailBackend
 
     def get_mailbox_content(self):
         return [m.message() for m in mail.outbox]
@@ -178,8 +181,8 @@ class LocmemBackendTests(SharedEmailBackendTests, SimpleTestCase):
         """
         Make sure that the locmem backend populates the outbox.
         """
-        backend1 = locmem.EmailBackend()
-        backend2 = locmem.EmailBackend()
+        backend1 = self.create_backend()
+        backend2 = self.create_backend()
         email = EmailMessage(to=["to@example.com"])
         backend1.send_messages([email])
         backend2.send_messages([email])
@@ -189,7 +192,7 @@ class LocmemBackendTests(SharedEmailBackendTests, SimpleTestCase):
         # Headers are validated when using the locmem backend (#18861).
         # (See also EmailMessageTests.test_header_injection().)
         email = EmailMessage(subject="Subject\nMultiline", to=["to@example.com"])
-        backend = locmem.EmailBackend()
+        backend = self.create_backend()
         with self.assertRaises(ValueError):
             backend.send_messages([email])
 
@@ -198,7 +201,7 @@ class LocmemBackendTests(SharedEmailBackendTests, SimpleTestCase):
             subject="correct subject",
             to=["to@example.com"],
         )
-        backend = locmem.EmailBackend()
+        backend = self.create_backend()
         backend.send_messages([email])
         email.subject = "other subject"
         email.to.append("other@example.com")
@@ -207,14 +210,11 @@ class LocmemBackendTests(SharedEmailBackendTests, SimpleTestCase):
 
 
 class FileBackendTests(SharedEmailBackendTests, SimpleTestCase):
-    email_backend = "django.core.mail.backends.filebased.EmailBackend"
+    backend_class = filebased.EmailBackend
 
     def setUp(self):
         super().setUp()
         self.tmp_dir = self.mkdtemp()
-        _settings_override = override_settings(EMAIL_FILE_PATH=self.tmp_dir)
-        _settings_override.enable()
-        self.addCleanup(_settings_override.disable)
 
     def mkdtemp(self):
         tmp_dir = tempfile.mkdtemp()
@@ -228,6 +228,10 @@ class FileBackendTests(SharedEmailBackendTests, SimpleTestCase):
         with open(os.path.join(self.tmp_dir, filename), "rb") as fp:
             messages = fp.read().split(b"\n" + (b"-" * 79) + b"\n")
             return [message_from_bytes(m) for m in messages if m]
+
+    def create_backend(self, **kwargs):
+        kwargs.setdefault("file_path", self.tmp_dir)
+        return super().create_backend(**kwargs)
 
     def flush_mailbox(self):
         for filename in self.get_filenames():
@@ -258,10 +262,8 @@ class FileBackendTests(SharedEmailBackendTests, SimpleTestCase):
         msg = (
             "The EMAIL_FILE_PATH setting must be defined to use the file EmailBackend."
         )
-        with self.settings():
-            del settings.EMAIL_FILE_PATH
-            with self.assertRaisesMessage(ImproperlyConfigured, msg):
-                filebased.EmailBackend()
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+            filebased.EmailBackend()
 
     def test_error_if_file_path_is_not_directory(self):
         tmp_file = Path(self.tmp_dir) / "ordinary-file"
@@ -273,7 +275,7 @@ class FileBackendTests(SharedEmailBackendTests, SimpleTestCase):
             f"Path for saving email messages exists, but is not a directory: {tmp_file}"
         )
         with self.assertRaisesMessage(ImproperlyConfigured, msg):
-            filebased.EmailBackend(file_path=tmp_file)
+            self.create_backend(file_path=tmp_file)
 
     @skipIf(
         sys.platform == "win32",
@@ -282,7 +284,7 @@ class FileBackendTests(SharedEmailBackendTests, SimpleTestCase):
     def test_error_if_file_path_cannot_be_created(self):
         msg = "Could not create directory for saving email messages: /dev/null/foo"
         with self.assertRaisesMessage(ImproperlyConfigured, msg):
-            filebased.EmailBackend(file_path="/dev/null/foo")
+            self.create_backend(file_path="/dev/null/foo")
 
     @skipIf(
         sys.platform == "win32",
@@ -293,7 +295,7 @@ class FileBackendTests(SharedEmailBackendTests, SimpleTestCase):
         self.addCleanup(os.chmod, self.tmp_dir, 0o777)
         msg = f"Could not write to directory: {self.tmp_dir}"
         with self.assertRaisesMessage(ImproperlyConfigured, msg):
-            filebased.EmailBackend(file_path=self.tmp_dir)
+            self.create_backend(file_path=self.tmp_dir)
 
     def test_new_file_per_instance(self):
         # Documented behavior: "A new file is created for each new session that
@@ -301,17 +303,17 @@ class FileBackendTests(SharedEmailBackendTests, SimpleTestCase):
         email = EmailMessage(to=["to@example.com"])
         self.assertEqual(len(self.get_filenames()), 0)
 
-        backend1 = mail.get_connection()
+        backend1 = self.create_backend()
         backend1.send_messages([email])
         self.assertEqual(len(self.get_filenames()), 1)
 
-        backend2 = mail.get_connection()
+        backend2 = self.create_backend()
         backend2.send_messages([email])
         self.assertEqual(len(self.get_filenames()), 2)
 
     def test_multiple_messages_same_connection_single_file_reused(self):
         self.assertEqual(len(self.get_filenames()), 0)
-        backend = mail.get_connection()
+        backend = self.create_backend()
 
         self.assertIs(backend.open(), True)
         backend.send_messages([EmailMessage(to=["one@example.com"])])
@@ -333,7 +335,7 @@ class FileBackendTests(SharedEmailBackendTests, SimpleTestCase):
     def test_reopening_connection_uses_same_file(self):
         self.assertEqual(len(self.get_filenames()), 0)
 
-        backend = mail.get_connection()
+        backend = self.create_backend()
         self.assertIs(backend.open(), True)
         backend.send_messages([EmailMessage(to=["one@example.com"])])
         backend.close()
@@ -362,7 +364,7 @@ class FileBackendPathLibTests(FileBackendTests):
 
 
 class ConsoleBackendTests(SharedEmailBackendTests, SimpleTestCase):
-    email_backend = "django.core.mail.backends.console.EmailBackend"
+    backend_class = console.EmailBackend
 
     def setUp(self):
         super().setUp()
@@ -384,9 +386,7 @@ class ConsoleBackendTests(SharedEmailBackendTests, SimpleTestCase):
 
     def test_console_stream_kwarg(self):
         s = StringIO()
-        backend = mail.get_connection(
-            "django.core.mail.backends.console.EmailBackend", stream=s
-        )
+        backend = self.create_backend(stream=s)
         backend.send_messages([EmailMessage(to=["to@example.com"])])
         message = s.getvalue().split("\n" + ("-" * 79) + "\n")[0].encode()
         self.assertMessageHasHeaders(
@@ -444,12 +444,6 @@ class SMTPBackendTestsBase(SimpleTestCase):
             hostname="127.0.0.1",
             port=port,
         )
-        cls._settings_override = override_settings(
-            EMAIL_HOST=cls.smtp_controller.hostname,
-            EMAIL_PORT=cls.smtp_controller.port,
-        )
-        cls._settings_override.enable()
-        cls.addClassCleanup(cls._settings_override.disable)
         cls.smtp_controller.start()
         cls.addClassCleanup(cls.stop_smtp)
 
@@ -460,12 +454,17 @@ class SMTPBackendTestsBase(SimpleTestCase):
 
 @skipUnless(HAS_AIOSMTPD, "No aiosmtpd library detected.")
 class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
-    email_backend = "django.core.mail.backends.smtp.EmailBackend"
+    backend_class = smtp.EmailBackend
 
     def setUp(self):
         super().setUp()
         self.smtp_handler.flush_mailbox()
         self.addCleanup(self.smtp_handler.flush_mailbox)
+
+    def create_backend(self, **kwargs):
+        kwargs.setdefault("host", self.smtp_controller.hostname)
+        kwargs.setdefault("port", self.smtp_controller.port)
+        return super().create_backend(**kwargs)
 
     def flush_mailbox(self):
         self.smtp_handler.flush_mailbox()
@@ -495,7 +494,7 @@ class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
         self.assertEqual(backend.port, 5322)
 
     def test_smtp_connection_uses_host_and_port(self):
-        backend = smtp.EmailBackend(host="mail.example.com", port=5322)
+        backend = self.create_backend(host="mail.example.com", port=5322)
         self.assertEqual(backend.host, "mail.example.com")
         self.assertEqual(backend.port, 5322)
         with (
@@ -540,7 +539,7 @@ class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
         Opening the backend with non empty username/password tries
         to authenticate against the SMTP server.
         """
-        backend = smtp.EmailBackend(
+        backend = self.create_backend(
             username="not empty username", password="not empty password"
         )
         with mock.patch("smtplib.SMTP.login") as mock_smtp_login, backend:
@@ -555,14 +554,14 @@ class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
         """
         open() returns whether it opened a connection.
         """
-        backend = smtp.EmailBackend()
+        backend = self.create_backend()
         self.assertIsNone(backend.connection)
         opened = backend.open()
         backend.close()
         self.assertIs(opened, True)
 
     def test_reopen_connection(self):
-        backend = smtp.EmailBackend()
+        backend = self.create_backend()
         # Simulate an already open connection.
         backend.connection = mock.Mock(spec=object())
         self.assertIs(backend.open(), False)
@@ -578,7 +577,7 @@ class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
         self.assertIs(backend.use_tls, False)
 
     def test_email_tls_default_disabled(self):
-        backend = smtp.EmailBackend()
+        backend = self.create_backend()
         self.assertIs(backend.use_tls, False)
 
     def test_ssl_tls_mutually_exclusive(self):
@@ -587,7 +586,7 @@ class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
             "one of those settings to True."
         )
         with self.assertRaisesMessage(ValueError, msg):
-            smtp.EmailBackend(use_ssl=True, use_tls=True)
+            self.create_backend(use_ssl=True, use_tls=True)
 
     @override_settings(EMAIL_USE_SSL=True)
     def test_email_ssl_use_settings(self):
@@ -600,7 +599,7 @@ class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
         self.assertIs(backend.use_ssl, False)
 
     def test_email_ssl_default_disabled(self):
-        backend = smtp.EmailBackend()
+        backend = self.create_backend()
         self.assertIs(backend.use_ssl, False)
 
     @override_settings(EMAIL_SSL_CERTFILE="foo")
@@ -614,7 +613,7 @@ class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
         self.assertEqual(backend.ssl_certfile, "bar")
 
     def test_email_ssl_certfile_default_disabled(self):
-        backend = smtp.EmailBackend()
+        backend = self.create_backend()
         self.assertIsNone(backend.ssl_certfile)
 
     @override_settings(EMAIL_SSL_KEYFILE="foo")
@@ -628,11 +627,11 @@ class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
         self.assertEqual(backend.ssl_keyfile, "bar")
 
     def test_email_ssl_keyfile_default_disabled(self):
-        backend = smtp.EmailBackend()
+        backend = self.create_backend()
         self.assertIsNone(backend.ssl_keyfile)
 
     def test_ssl_context_uses_ssl_certfile_and_keyfile(self):
-        backend = smtp.EmailBackend(ssl_certfile="certfile", ssl_keyfile="keyfile")
+        backend = self.create_backend(ssl_certfile="certfile", ssl_keyfile="keyfile")
         with mock.patch(
             "django.core.mail.backends.smtp.ssl.SSLContext"
         ) as mock_ssl_context:
@@ -641,9 +640,8 @@ class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
         mock_ssl_context.assert_called_once_with(protocol=ssl.PROTOCOL_TLS_CLIENT)
         ssl_context.load_cert_chain.assert_called_once_with("certfile", "keyfile")
 
-    @override_settings(EMAIL_USE_TLS=True)
     def test_email_tls_attempts_starttls(self):
-        backend = smtp.EmailBackend()
+        backend = self.create_backend(use_tls=True)
         self.assertIs(backend.use_tls, True)
         with self.assertRaisesMessage(
             SMTPException, "STARTTLS extension not supported by server."
@@ -651,16 +649,15 @@ class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
             with backend:
                 pass
 
-    @override_settings(EMAIL_USE_SSL=True)
     def test_email_ssl_attempts_ssl_connection(self):
-        backend = smtp.EmailBackend()
+        backend = self.create_backend(use_ssl=True)
         self.assertIs(backend.use_ssl, True)
         with self.assertRaises(SSLError):
             with backend:
                 pass
 
     def test_connection_timeout_default(self):
-        backend = mail.get_connection("django.core.mail.backends.smtp.EmailBackend")
+        backend = self.create_backend()
         self.assertIsNone(backend.timeout)
 
     def test_connection_timeout_custom(self):
@@ -671,7 +668,9 @@ class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
                 kwargs.setdefault("timeout", 42)
                 super().__init__(*args, **kwargs)
 
-        myemailbackend = MyEmailBackend()
+        myemailbackend = MyEmailBackend(
+            host=self.smtp_controller.hostname, port=self.smtp_controller.port
+        )
         myemailbackend.open()
         self.assertEqual(myemailbackend.timeout, 42)
         self.assertEqual(myemailbackend.connection.timeout, 42)
@@ -688,12 +687,12 @@ class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
         self.assertEqual(backend.timeout, 15)
 
     def test_smtp_connection_uses_timeout(self):
-        backend = smtp.EmailBackend(timeout=10)
+        backend = self.create_backend(timeout=10)
         with backend:
             self.assertEqual(backend.connection.timeout, 10)
 
     def test_serialized_message_uses_crlf_line_ending(self):
-        backend = mail.get_connection()
+        backend = self.create_backend()
         with (
             backend,
             mock.patch.object(backend.connection, "sendmail") as mock_sendmail,
@@ -714,7 +713,7 @@ class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
         send_messages() shouldn't try to send messages if open() raises an
         exception after initializing the connection.
         """
-        backend = smtp.EmailBackend()
+        backend = self.create_backend()
         # Simulate connection initialization success and a subsequent
         # connection exception.
         backend.connection = mock.Mock()
@@ -723,14 +722,14 @@ class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
         self.assertEqual(backend.send_messages([email]), 0)
 
     def test_send_messages_with_empty_list_does_not_open_connection(self):
-        backend = smtp.EmailBackend()
+        backend = self.create_backend()
         backend.open = mock.Mock()
         self.assertEqual(backend.send_messages([]), 0)
         backend.open.assert_not_called()
 
     def test_send_messages_zero_sent(self):
         """A message isn't sent if it doesn't have any recipients."""
-        backend = smtp.EmailBackend()
+        backend = self.create_backend()
         backend.connection = mock.Mock()
         email = EmailMessage("Subject", "Content", "from@example.com", to=[])
         sent = backend.send_messages([email])
@@ -743,7 +742,7 @@ class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
         EmailMessage.all_recipients() (which is distinct from message header
         fields).
         """
-        backend = smtp.EmailBackend()
+        backend = self.create_backend()
         backend.connection = mock.Mock()
         for email_address in (
             # Invalid address with two @ signs.
@@ -782,7 +781,7 @@ class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
                 "To": "Discussão Django <django@discussão.example.org>",
             },
         )
-        backend = smtp.EmailBackend()
+        backend = self.create_backend()
         backend.send_messages([email])
         envelope = self.get_smtp_envelopes()[0]
         self.assertEqual(envelope["mail_from"], "lists@xn--discusso-xza.example.org")
@@ -807,7 +806,7 @@ class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
             cc=['"ශ්‍රී" <cc@xn--nxasmm1c.example.com>'],
             bcc=['"نامه‌ای." <bcc@xn--mgba3gch31f060k.example.com>'],
         )
-        backend = smtp.EmailBackend()
+        backend = self.create_backend()
         backend.send_messages([email])
         envelope = self.get_smtp_envelopes()[0]
         self.assertEqual(envelope["mail_from"], "from@xn--fa-hia.example.com")
@@ -825,7 +824,7 @@ class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
         The SMTP EmailBackend does not currently support non-ASCII local-parts.
         (That would require using the RFC 6532 SMTPUTF8 extension.) #35713.
         """
-        backend = smtp.EmailBackend()
+        backend = self.create_backend()
         backend.connection = mock.Mock(spec=object())
         email = EmailMessage(to=["nø@example.dk"])
         with self.assertRaisesMessage(
@@ -837,7 +836,7 @@ class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
     def test_prep_address_without_force_ascii(self):
         # A subclass implementing SMTPUTF8 could use
         # prep_address(force_ascii=False).
-        backend = smtp.EmailBackend()
+        backend = self.create_backend()
         for case in ["åh@example.dk", "oh@åh.example.dk", "åh@åh.example.dk"]:
             with self.subTest(case=case):
                 self.assertEqual(backend.prep_address(case, force_ascii=False), case)
@@ -848,7 +847,9 @@ class SMTPBackendStoppedServerTests(SMTPBackendTestsBase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.backend = smtp.EmailBackend()
+        cls.backend = smtp.EmailBackend(
+            host=cls.smtp_controller.hostname, port=cls.smtp_controller.port
+        )
         cls.smtp_controller.stop()
 
     @classmethod

--- a/tests/mail/test_backends.py
+++ b/tests/mail/test_backends.py
@@ -34,10 +34,14 @@ class BaseEmailBackendTests(SimpleTestCase):
         self.assertEqual(backend.alias, "test_alias")
 
     def test_fail_silently_arg_accepted(self):
+        msg_init = "BaseEmailBackend.__init__() does not support 'fail_silently'."
+        msg_use = "BaseEmailBackend.fail_silently is deprecated."
         for value in [True, False]:
             with self.subTest(fail_silently=value):
-                backend = BaseEmailBackend(fail_silently=value)
-                self.assertIs(backend.fail_silently, value)
+                with self.assertWarnsMessage(RemovedInDjango70Warning, msg_init):
+                    backend = BaseEmailBackend(fail_silently=value)
+                with self.assertWarnsMessage(RemovedInDjango70Warning, msg_use):
+                    self.assertIs(backend.fail_silently, value)
 
     def test_unknown_kwargs_error(self):
         msg = "EMAIL_PROVIDERS['test_alias']: Unknown options 'oops_typo', 'unknown'."
@@ -184,11 +188,30 @@ class SharedEmailBackendTests(MailTestsMixin):
 
         backend.close.assert_called_once()
 
+    # RemovedInDjango70Warning. (But keep overrides in subclasses.)
     def test_fail_silently_arg_accepted(self):
-        for value in [True, False]:
-            with self.subTest(fail_silently=value):
-                backend = self.create_backend(fail_silently=value)
-                self.assertIs(backend.fail_silently, value)
+        # In Django 7.0, the fail_silently arg will *not* be accepted by
+        # BaseEmailBackend. Backends that *do* support fail_silently must
+        # handle that argument themselves. Tests for those backends should
+        # override this test case to reflect continuing fail_silently support.
+        with self.subTest("Compatibility configuration"):
+            # Backend initialized in compatibility mode (without alias) warns
+            # but still sets attribute. (alias=None tells create_backend to
+            # _omit_ the `alias` arg.)
+            msg_init = "EmailBackend.__init__() does not support 'fail_silently'."
+            msg_use = "EmailBackend.fail_silently is deprecated."
+            for value in [True, False]:
+                with self.subTest(fail_silently=value):
+                    with self.assertWarnsMessage(RemovedInDjango70Warning, msg_init):
+                        backend = self.create_backend(alias=None, fail_silently=value)
+                    with self.assertWarnsMessage(RemovedInDjango70Warning, msg_use):
+                        self.assertIs(backend.fail_silently, value)
+
+        with self.subTest("Updated configuration"):
+            # Backend initialized with alias raises error.
+            msg_init = "EMAIL_PROVIDERS['test_alias']: Unknown options 'fail_silently'."
+            with self.assertRaisesMessage(InvalidEmailProvider, msg_init):
+                self.create_backend(fail_silently=True)
 
     def test_unknown_kwargs_error(self):
         msg = "EMAIL_PROVIDERS['test_alias']: Unknown options 'oops_typo', 'unknown'."
@@ -320,6 +343,15 @@ class FileBackendTests(SharedEmailBackendTests, SimpleTestCase):
         for filename in self.get_filenames():
             messages.extend(self.get_messages_from_filename(filename))
         return messages
+
+    def test_fail_silently_arg_accepted(self):
+        # RemovedInDjango70Warning: remove this comment (but keep the test).
+        # The file backend continues to support fail_silently. Override the
+        # SharedEmailBackendTests case that treats it as deprecated.
+        for value in [True, False]:
+            with self.subTest(fail_silently=value):
+                backend = self.create_backend(fail_silently=value)
+                self.assertIs(backend.fail_silently, value)
 
     def test_create_from_providers(self):
         # (Overrides SharedEmailBackendTests case.)
@@ -509,6 +541,15 @@ class ConsoleBackendTests(SharedEmailBackendTests, SimpleTestCase):
         messages = self.stream.getvalue().split("\n" + ("-" * 79) + "\n")
         return [message_from_bytes(m.encode()) for m in messages if m]
 
+    def test_fail_silently_arg_accepted(self):
+        # RemovedInDjango70Warning: remove this comment (but keep the test).
+        # The console backend continues to support fail_silently. Override the
+        # SharedEmailBackendTests case that treats it as deprecated.
+        for value in [True, False]:
+            with self.subTest(fail_silently=value):
+                backend = self.create_backend(fail_silently=value)
+                self.assertIs(backend.fail_silently, value)
+
     def test_console_stream_kwarg(self):
         s = StringIO()
         backend = self.create_backend(stream=s)
@@ -602,6 +643,15 @@ class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
 
     def get_smtp_envelopes(self):
         return self.smtp_handler.smtp_envelopes
+
+    def test_fail_silently_arg_accepted(self):
+        # RemovedInDjango70Warning: remove this comment (but keep the test).
+        # The SMTP backend continues to support fail_silently. Override the
+        # SharedEmailBackendTests case that treats it as deprecated.
+        for value in [True, False]:
+            with self.subTest(fail_silently=value):
+                backend = self.create_backend(fail_silently=value)
+                self.assertIs(backend.fail_silently, value)
 
     def test_create_from_providers(self):
         # (Overrides SharedEmailBackendTests case.)

--- a/tests/mail/test_backends.py
+++ b/tests/mail/test_backends.py
@@ -15,7 +15,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.mail import EmailMessage, InvalidEmailProvider
 from django.core.mail.backends import console, dummy, filebased, locmem, smtp
 from django.core.mail.backends.base import BaseEmailBackend
-from django.test import SimpleTestCase, override_settings
+from django.test import SimpleTestCase, ignore_warnings, override_settings
 from django.utils.deprecation import RemovedInDjango70Warning
 
 from .tests import MailTestsMixin, message_from_bytes
@@ -283,6 +283,10 @@ class LocmemBackendTests(SharedEmailBackendTests, SimpleTestCase):
         self.assertIsNone(mail.outbox[1].sent_using)
 
 
+@ignore_warnings(
+    category=RemovedInDjango70Warning,
+    message=r"The EMAIL_FILE_PATH setting is deprecated\.",
+)
 class FileBackendTests(SharedEmailBackendTests, SimpleTestCase):
     backend_class = filebased.EmailBackend
 
@@ -321,12 +325,14 @@ class FileBackendTests(SharedEmailBackendTests, SimpleTestCase):
         # (Overrides SharedEmailBackendTests case.)
         super().test_create_from_providers(required_options={"file_path": self.tmp_dir})
 
+    # RemovedInDjango70Warning.
     def test_email_file_path_use_settings(self):
         file_path_settings = self.mkdtemp()
         with self.settings(EMAIL_FILE_PATH=file_path_settings):
             backend = filebased.EmailBackend()
         self.assertEqual(backend.file_path, str(file_path_settings))
 
+    # RemovedInDjango70Warning.
     def test_email_file_path_override_settings(self):
         file_path_settings = self.mkdtemp()
         file_path_override = self.mkdtemp()
@@ -336,6 +342,7 @@ class FileBackendTests(SharedEmailBackendTests, SimpleTestCase):
             backend = filebased.EmailBackend(file_path=file_path_override)
         self.assertEqual(backend.file_path, str(file_path_override))
 
+    # RemovedInDjango70Warning.
     def test_error_if_email_file_path_setting_not_defined(self):
         msg = (
             "The EMAIL_FILE_PATH setting must be defined to use the file EmailBackend."
@@ -348,6 +355,7 @@ class FileBackendTests(SharedEmailBackendTests, SimpleTestCase):
         with self.assertRaisesMessage(InvalidEmailProvider, msg):
             filebased.EmailBackend(alias="test_alias")
 
+    # RemovedInDjango70Warning.
     @override_settings(EMAIL_FILE_PATH="/this/path/does/not/exist")
     def test_ignores_settings_when_initialized_with_alias(self):
         backend = self.create_backend()
@@ -547,6 +555,9 @@ class SMTPHandler:
 
 
 @skipUnless(HAS_AIOSMTPD, "No aiosmtpd library detected.")
+@ignore_warnings(
+    category=RemovedInDjango70Warning, message=r"The EMAIL_\w+ setting is deprecated\."
+)
 class SMTPBackendTestsBase(SimpleTestCase):
     @classmethod
     def setUpClass(cls):
@@ -596,6 +607,7 @@ class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
         # (Overrides SharedEmailBackendTests case.)
         super().test_create_from_providers(required_options={"host": "example.com"})
 
+    # RemovedInDjango70Warning.
     @override_settings(
         EMAIL_HOST="mail.example.com",
         EMAIL_PORT=822,
@@ -643,6 +655,7 @@ class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
                 backend = self.backend_class(host="mail.example.com", **kwargs)
                 self.assertEqual(backend.port, 25)
 
+    # RemovedInDjango70Warning.
     @override_settings(
         EMAIL_HOST="mail.example.com",
         EMAIL_PORT=822,
@@ -652,6 +665,7 @@ class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
         self.assertEqual(backend.host, "mail.example.com")
         self.assertEqual(backend.port, 822)
 
+    # RemovedInDjango70Warning.
     @override_settings(
         EMAIL_HOST="mail.example.com",
         EMAIL_PORT=822,
@@ -675,6 +689,7 @@ class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
             "mail.example.com", 5322, local_hostname=mock.ANY
         )
 
+    # RemovedInDjango70Warning.
     @override_settings(
         EMAIL_HOST_USER="not empty username",
         EMAIL_HOST_PASSWORD="not empty password",
@@ -684,6 +699,7 @@ class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
         self.assertEqual(backend.username, "not empty username")
         self.assertEqual(backend.password, "not empty password")
 
+    # RemovedInDjango70Warning.
     @override_settings(
         EMAIL_HOST_USER="not empty username",
         EMAIL_HOST_PASSWORD="not empty password",
@@ -693,6 +709,7 @@ class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
         self.assertEqual(backend.username, "username")
         self.assertEqual(backend.password, "password")
 
+    # RemovedInDjango70Warning.
     @override_settings(
         EMAIL_HOST_USER="not empty username",
         EMAIL_HOST_PASSWORD="not empty password",
@@ -734,11 +751,13 @@ class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
         backend.connection = mock.Mock(spec=object())
         self.assertIs(backend.open(), False)
 
+    # RemovedInDjango70Warning.
     @override_settings(EMAIL_USE_TLS=True)
     def test_email_tls_use_settings(self):
         backend = smtp.EmailBackend()
         self.assertIs(backend.use_tls, True)
 
+    # RemovedInDjango70Warning.
     @override_settings(EMAIL_USE_TLS=True)
     def test_email_tls_override_settings(self):
         backend = smtp.EmailBackend(use_tls=False)
@@ -756,6 +775,7 @@ class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
         with self.assertRaisesMessage(InvalidEmailProvider, msg):
             self.create_backend(use_ssl=True, use_tls=True)
 
+    # RemovedInDjango70Warning.
     def test_ssl_tls_settings_mutually_exclusive(self):
         msg = (
             "EMAIL_USE_TLS/EMAIL_USE_SSL are mutually exclusive, so only set "
@@ -767,11 +787,13 @@ class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
         ):
             smtp.EmailBackend()
 
+    # RemovedInDjango70Warning.
     @override_settings(EMAIL_USE_SSL=True)
     def test_email_ssl_use_settings(self):
         backend = smtp.EmailBackend()
         self.assertIs(backend.use_ssl, True)
 
+    # RemovedInDjango70Warning.
     @override_settings(EMAIL_USE_SSL=True)
     def test_email_ssl_override_settings(self):
         backend = smtp.EmailBackend(use_ssl=False)
@@ -781,11 +803,13 @@ class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
         backend = self.create_backend()
         self.assertIs(backend.use_ssl, False)
 
+    # RemovedInDjango70Warning.
     @override_settings(EMAIL_SSL_CERTFILE="foo")
     def test_email_ssl_certfile_use_settings(self):
         backend = smtp.EmailBackend()
         self.assertEqual(backend.ssl_certfile, "foo")
 
+    # RemovedInDjango70Warning.
     @override_settings(EMAIL_SSL_CERTFILE="foo")
     def test_email_ssl_certfile_override_settings(self):
         backend = smtp.EmailBackend(ssl_certfile="bar")
@@ -795,11 +819,13 @@ class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
         backend = self.create_backend()
         self.assertIsNone(backend.ssl_certfile)
 
+    # RemovedInDjango70Warning.
     @override_settings(EMAIL_SSL_KEYFILE="foo")
     def test_email_ssl_keyfile_use_settings(self):
         backend = smtp.EmailBackend()
         self.assertEqual(backend.ssl_keyfile, "foo")
 
+    # RemovedInDjango70Warning.
     @override_settings(EMAIL_SSL_KEYFILE="foo")
     def test_email_ssl_keyfile_override_settings(self):
         backend = smtp.EmailBackend(ssl_keyfile="bar")
@@ -855,11 +881,13 @@ class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
         self.assertEqual(myemailbackend.connection.timeout, 42)
         myemailbackend.close()
 
+    # RemovedInDjango70Warning.
     @override_settings(EMAIL_TIMEOUT=10)
     def test_email_timeout_use_settings(self):
         backend = smtp.EmailBackend()
         self.assertEqual(backend.timeout, 10)
 
+    # RemovedInDjango70Warning.
     @override_settings(EMAIL_TIMEOUT=10)
     def test_email_timeout_override_settings(self):
         backend = smtp.EmailBackend(timeout=15)

--- a/tests/mail/test_backends.py
+++ b/tests/mail/test_backends.py
@@ -12,10 +12,11 @@ from unittest import mock, skipIf, skipUnless
 
 from django.core import mail
 from django.core.exceptions import ImproperlyConfigured
-from django.core.mail import EmailMessage
+from django.core.mail import EmailMessage, InvalidEmailProvider
 from django.core.mail.backends import console, dummy, filebased, locmem, smtp
 from django.core.mail.backends.base import BaseEmailBackend
 from django.test import SimpleTestCase, override_settings
+from django.utils.deprecation import RemovedInDjango70Warning
 
 from .tests import MailTestsMixin, message_from_bytes
 
@@ -28,16 +29,35 @@ except ImportError:
 
 
 class BaseEmailBackendTests(SimpleTestCase):
+    def test_alias_arg_accepted(self):
+        backend = BaseEmailBackend(alias="test_alias")
+        self.assertEqual(backend.alias, "test_alias")
+
     def test_fail_silently_arg_accepted(self):
         for value in [True, False]:
             with self.subTest(fail_silently=value):
                 backend = BaseEmailBackend(fail_silently=value)
                 self.assertIs(backend.fail_silently, value)
 
+    def test_unknown_kwargs_error(self):
+        msg = "EMAIL_PROVIDERS['test_alias']: Unknown options 'oops_typo', 'unknown'."
+        with self.assertRaisesMessage(InvalidEmailProvider, msg):
+            BaseEmailBackend(alias="test_alias", oops_typo="foo", unknown="bar")
+
+    # RemovedInDjango70Warning.
     def test_unknown_kwargs_ignored(self):
-        backend = BaseEmailBackend(unknown_kwarg="foo")
-        self.assertIsInstance(backend, BaseEmailBackend)
-        self.assertFalse(hasattr(backend, "unknown_kwarg"))
+        # In compatibility mode (without alias), unknown keyword args are
+        # ignored with a deprecation warning.
+        msg = (
+            "BaseEmailBackend.__init__() does not support 'oops_typo', "
+            "'unknown'. In Django 7.0, BaseEmailBackend will raise a "
+            "TypeError for unknown keyword arguments."
+        )
+        with self.assertWarnsMessage(RemovedInDjango70Warning, msg):
+            backend = BaseEmailBackend(oops_typo="foo", unknown="foo")
+            self.assertIsInstance(backend, BaseEmailBackend)
+            self.assertFalse(hasattr(backend, "oops_typo"))
+            self.assertFalse(hasattr(backend, "unknown"))
 
 
 class SharedEmailBackendTests(MailTestsMixin):
@@ -49,12 +69,14 @@ class SharedEmailBackendTests(MailTestsMixin):
     # Create an instance of the backend_class for use in this test context
     # (configured for use with get_mailbox_content() and flush_mailbox()).
     # Subclasses should override to default kwargs for testing if needed.
-    def create_backend(self, **kwargs):
+    def create_backend(self, *, alias="test_alias", **kwargs):
         if self.backend_class is None:
             raise NotImplementedError(
                 "Subclasses of SharedEmailBackendTests must provide a "
                 "backend_class attribute."
             )
+        if alias is not None:
+            kwargs["alias"] = alias
         return self.backend_class(**kwargs)
 
     def get_mailbox_content(self):
@@ -78,6 +100,16 @@ class SharedEmailBackendTests(MailTestsMixin):
             % (len(mailbox), [m.as_string() for m in mailbox]),
         )
         return mailbox[0]
+
+    def test_accepts_alias(self):
+        backend = self.create_backend(alias="this-alias")
+        self.assertEqual(backend.alias, "this-alias")
+
+    # RemovedInDjango70Warning.
+    def test_alias_is_optional_during_transition_to_email_providers(self):
+        # alias=None tells create_backend() to _omit_ the `alias` arg.
+        backend = self.create_backend(alias=None)
+        self.assertIsNone(backend.alias)
 
     def test_send(self):
         email = EmailMessage(
@@ -141,9 +173,25 @@ class SharedEmailBackendTests(MailTestsMixin):
                 backend = self.create_backend(fail_silently=value)
                 self.assertIs(backend.fail_silently, value)
 
+    def test_unknown_kwargs_error(self):
+        msg = "EMAIL_PROVIDERS['test_alias']: Unknown options 'oops_typo', 'unknown'."
+        with self.assertRaisesMessage(InvalidEmailProvider, msg):
+            self.create_backend(oops_typo=True, unknown="foo")
+
+    # RemovedInDjango70Warning.
     def test_unknown_kwargs_ignored(self):
-        backend = self.create_backend(unknown_kwarg="foo")
-        self.assertFalse(hasattr(backend, "unknown_kwarg"))
+        # In compatibility mode (without alias), unknown keyword args are
+        # ignored with a deprecation warning.
+        backend_module = self.backend_class.__module__
+        msg = (
+            f"{backend_module}.EmailBackend.__init__() does not support "
+            "'unknown_kwarg'. In Django 7.0, BaseEmailBackend will raise a "
+            "TypeError for unknown keyword arguments."
+        )
+        with self.assertWarnsMessage(RemovedInDjango70Warning, msg):
+            # alias=None tells create_backend() to _omit_ the `alias` arg.
+            backend = self.create_backend(alias=None, unknown_kwarg="foo")
+            self.assertFalse(hasattr(backend, "unknown_kwarg"))
 
 
 class DummyBackendTests(SharedEmailBackendTests, SimpleTestCase):
@@ -208,6 +256,15 @@ class LocmemBackendTests(SharedEmailBackendTests, SimpleTestCase):
         self.assertEqual(mail.outbox[0].subject, "correct subject")
         self.assertEqual(mail.outbox[0].to, ["to@example.com"])
 
+    def test_adds_sent_using_attribute(self):
+        email = EmailMessage("to@example.com")
+        locmem.EmailBackend(alias="custom").send_messages([email])
+        locmem.EmailBackend().send_messages([email])
+
+        self.assertEqual(len(mail.outbox), 2)
+        self.assertEqual(mail.outbox[0].sent_using, "custom")
+        self.assertIsNone(mail.outbox[1].sent_using)
+
 
 class FileBackendTests(SharedEmailBackendTests, SimpleTestCase):
     backend_class = filebased.EmailBackend
@@ -265,6 +322,16 @@ class FileBackendTests(SharedEmailBackendTests, SimpleTestCase):
         with self.assertRaisesMessage(ImproperlyConfigured, msg):
             filebased.EmailBackend()
 
+    def test_file_path_option_required(self):
+        msg = "EMAIL_PROVIDERS['test_alias']: OPTIONS must define 'file_path'."
+        with self.assertRaisesMessage(InvalidEmailProvider, msg):
+            filebased.EmailBackend(alias="test_alias")
+
+    @override_settings(EMAIL_FILE_PATH="/this/path/does/not/exist")
+    def test_ignores_settings_when_initialized_with_alias(self):
+        backend = self.create_backend()
+        self.assertEqual(backend.file_path, str(self.tmp_dir))
+
     def test_error_if_file_path_is_not_directory(self):
         tmp_file = Path(self.tmp_dir) / "ordinary-file"
         tmp_file.touch()
@@ -272,19 +339,38 @@ class FileBackendTests(SharedEmailBackendTests, SimpleTestCase):
             # Running the non-"PathLib" version of FileBackendTests.
             tmp_file = str(tmp_file)
         msg = (
-            f"Path for saving email messages exists, but is not a directory: {tmp_file}"
+            f"EMAIL_PROVIDERS['test_alias']: 'file_path' is not a directory: {tmp_file}"
         )
-        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+        with self.assertRaisesMessage(InvalidEmailProvider, msg):
             self.create_backend(file_path=tmp_file)
+
+        # RemovedInDjango70Warning.
+        with self.subTest("Compatibility"):
+            msg = (
+                "Path for saving email messages exists, but is not a "
+                f"directory: {tmp_file}"
+            )
+            with self.assertRaisesMessage(ImproperlyConfigured, msg):
+                # alias=None tells create_backend() to _omit_ the `alias` arg.
+                self.create_backend(alias=None, file_path=tmp_file)
 
     @skipIf(
         sys.platform == "win32",
         "No cross-platform means to force an OSError from os.makedirs().",
     )
     def test_error_if_file_path_cannot_be_created(self):
-        msg = "Could not create directory for saving email messages: /dev/null/foo"
-        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+        msg = (
+            "EMAIL_PROVIDERS['test_alias']: Could not create 'file_path': /dev/null/foo"
+        )
+        with self.assertRaisesMessage(InvalidEmailProvider, msg):
             self.create_backend(file_path="/dev/null/foo")
+
+        # RemovedInDjango70Warning.
+        with self.subTest("Compatibility"):
+            msg = "Could not create directory for saving email messages: /dev/null/foo"
+            with self.assertRaisesMessage(ImproperlyConfigured, msg):
+                # alias=None tells create_backend() to _omit_ the `alias` arg.
+                self.create_backend(alias=None, file_path="/dev/null/foo")
 
     @skipIf(
         sys.platform == "win32",
@@ -293,9 +379,19 @@ class FileBackendTests(SharedEmailBackendTests, SimpleTestCase):
     def test_error_if_file_path_is_not_writeable(self):
         os.chmod(self.tmp_dir, 0o444)
         self.addCleanup(os.chmod, self.tmp_dir, 0o777)
-        msg = f"Could not write to directory: {self.tmp_dir}"
-        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+        msg = (
+            "EMAIL_PROVIDERS['test_alias']: 'file_path' is not writeable: "
+            f"{self.tmp_dir}"
+        )
+        with self.assertRaisesMessage(InvalidEmailProvider, msg):
             self.create_backend(file_path=self.tmp_dir)
+
+        # RemovedInDjango70Warning.
+        with self.subTest("Compatibility"):
+            msg = f"Could not write to directory: {self.tmp_dir}"
+            with self.assertRaisesMessage(ImproperlyConfigured, msg):
+                # alias=None tells create_backend() to _omit_ the `alias` arg.
+                self.create_backend(alias=None, file_path=self.tmp_dir)
 
     def test_new_file_per_instance(self):
         # Documented behavior: "A new file is created for each new session that
@@ -478,6 +574,53 @@ class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
     @override_settings(
         EMAIL_HOST="mail.example.com",
         EMAIL_PORT=822,
+        EMAIL_HOST_USER="username",
+        EMAIL_HOST_PASSWORD="password",
+        EMAIL_USE_TLS=True,
+        EMAIL_USE_SSL=None,
+        EMAIL_SSL_CERTFILE="foo",
+        EMAIL_SSL_KEYFILE="bar",
+    )
+    def test_ignores_settings_when_initialized_with_alias(self):
+        backend = self.backend_class(alias="test_alias", host="local.mail")
+        # All properties (except host) should be defaults.
+        self.assertEqual(backend.host, "local.mail")
+        self.assertEqual(backend.port, 25)
+        self.assertIsNone(backend.username)
+        self.assertIsNone(backend.password)
+        self.assertIs(backend.use_tls, False)
+        self.assertIs(backend.use_ssl, False)
+        self.assertIsNone(backend.ssl_certfile)
+        self.assertIsNone(backend.ssl_keyfile)
+
+    def test_host_option_required(self):
+        msg = "EMAIL_PROVIDERS['test_alias']: OPTIONS must define 'host'."
+        with self.assertRaisesMessage(InvalidEmailProvider, msg):
+            self.backend_class(alias="test_alias")
+
+    def test_port_default_adapts_to_security(self):
+        cases = [
+            ("default", {}, 25),
+            ("SSL", {"use_ssl": True}, 465),
+            ("TLS", {"use_tls": True}, 587),
+        ]
+        for case, kwargs, expected_port in cases:
+            with self.subTest(case):
+                backend = self.backend_class(
+                    alias="test_alias", host="mail.example.com", **kwargs
+                )
+                self.assertEqual(backend.port, expected_port)
+
+        # RemovedInDjango70Warning: Until Django 7.0, the dynamic port default
+        # applies only when initialized through mail.providers.
+        for case, kwargs, _ in cases:
+            with self.subTest(f"compatibility {case}"):
+                backend = self.backend_class(host="mail.example.com", **kwargs)
+                self.assertEqual(backend.port, 25)
+
+    @override_settings(
+        EMAIL_HOST="mail.example.com",
+        EMAIL_PORT=822,
     )
     def test_email_host_use_settings(self):
         backend = smtp.EmailBackend()
@@ -582,11 +725,22 @@ class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
 
     def test_ssl_tls_mutually_exclusive(self):
         msg = (
+            "EMAIL_PROVIDERS['test_alias']: The 'use_ssl' and 'use_tls' "
+            "OPTIONS are incompatible. Set at most one of them to True."
+        )
+        with self.assertRaisesMessage(InvalidEmailProvider, msg):
+            self.create_backend(use_ssl=True, use_tls=True)
+
+    def test_ssl_tls_settings_mutually_exclusive(self):
+        msg = (
             "EMAIL_USE_TLS/EMAIL_USE_SSL are mutually exclusive, so only set "
             "one of those settings to True."
         )
-        with self.assertRaisesMessage(ValueError, msg):
-            self.create_backend(use_ssl=True, use_tls=True)
+        with (
+            self.settings(EMAIL_USE_SSL=True, EMAIL_USE_TLS=True),
+            self.assertRaisesMessage(ValueError, msg),
+        ):
+            smtp.EmailBackend()
 
     @override_settings(EMAIL_USE_SSL=True)
     def test_email_ssl_use_settings(self):
@@ -847,8 +1001,12 @@ class SMTPBackendStoppedServerTests(SMTPBackendTestsBase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        # RemovedInDjango70Warning: alias argument can be removed (needed
+        # during mail.providers transition to prevent compatibility mode).
         cls.backend = smtp.EmailBackend(
-            host=cls.smtp_controller.hostname, port=cls.smtp_controller.port
+            alias="test_alias",
+            host=cls.smtp_controller.hostname,
+            port=cls.smtp_controller.port,
         )
         cls.smtp_controller.stop()
 

--- a/tests/mail/test_backends.py
+++ b/tests/mail/test_backends.py
@@ -1,4 +1,5 @@
 import os
+import re
 import shutil
 import socket
 import ssl
@@ -228,7 +229,15 @@ class SharedEmailBackendTests(MailTestsMixin):
             "'unknown_kwarg'. In Django 7.0, BaseEmailBackend will raise a "
             "TypeError for unknown keyword arguments."
         )
-        with self.assertWarnsMessage(RemovedInDjango70Warning, msg):
+        with (
+            self.assertWarnsMessage(RemovedInDjango70Warning, msg),
+            ignore_warnings(
+                category=RemovedInDjango70Warning,
+                message=re.escape(
+                    "Directly creating EmailBackend instances is deprecated."
+                ),
+            ),
+        ):
             # alias=None tells create_backend() to _omit_ the `alias` arg.
             backend = self.create_backend(alias=None, unknown_kwarg="foo")
             self.assertFalse(hasattr(backend, "unknown_kwarg"))
@@ -622,6 +631,10 @@ class SMTPBackendTestsBase(SimpleTestCase):
 
 
 @skipUnless(HAS_AIOSMTPD, "No aiosmtpd library detected.")
+@ignore_warnings(
+    category=RemovedInDjango70Warning,
+    message=re.escape("Directly creating EmailBackend instances is deprecated."),
+)
 class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
     backend_class = smtp.EmailBackend
 
@@ -679,6 +692,19 @@ class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
         self.assertIs(backend.use_ssl, False)
         self.assertIsNone(backend.ssl_certfile)
         self.assertIsNone(backend.ssl_keyfile)
+
+    # RemovedInDjango70Warning.
+    def test_direct_construction_deprecated(self):
+        msg = (
+            "Directly creating EmailBackend instances is deprecated. Use "
+            "mail.providers instead."
+        )
+        with self.assertWarnsMessage(RemovedInDjango70Warning, msg):
+            backend = self.backend_class(use_tls=True)
+        # Default values come from deprecated settings without special handling
+        # for port.
+        self.assertEqual(backend.host, "localhost")
+        self.assertEqual(backend.port, 25)
 
     def test_host_option_required(self):
         msg = "EMAIL_PROVIDERS['test_alias']: OPTIONS must define 'host'."

--- a/tests/mail/test_backends.py
+++ b/tests/mail/test_backends.py
@@ -1,19 +1,23 @@
 import os
 import shutil
 import socket
+import ssl
 import sys
 import tempfile
-from email import message_from_binary_file, policy
 from io import StringIO
 from pathlib import Path
-from smtplib import SMTP, SMTPException
+from smtplib import SMTPException
 from ssl import SSLError
-from unittest import mock, skipUnless
+from unittest import mock, skipIf, skipUnless
 
+from django.conf import settings
 from django.core import mail
-from django.core.mail import EmailMessage, send_mail
-from django.core.mail.backends import dummy, locmem, smtp
+from django.core.exceptions import ImproperlyConfigured
+from django.core.mail import EmailMessage
+from django.core.mail.backends import dummy, filebased, locmem, smtp
+from django.core.mail.backends.base import BaseEmailBackend
 from django.test import SimpleTestCase, override_settings
+from django.utils.module_loading import import_string
 
 from .tests import MailTestsMixin, message_from_bytes
 
@@ -25,10 +29,21 @@ except ImportError:
     HAS_AIOSMTPD = False
 
 
-class BaseEmailBackendTests(MailTestsMixin):
-    """
-    Shared test cases repeated for each EmailBackend.
-    """
+class BaseEmailBackendTests(SimpleTestCase):
+    def test_fail_silently_arg_accepted(self):
+        for value in [True, False]:
+            with self.subTest(fail_silently=value):
+                backend = BaseEmailBackend(fail_silently=value)
+                self.assertIs(backend.fail_silently, value)
+
+    def test_unknown_kwargs_ignored(self):
+        backend = BaseEmailBackend(unknown_kwarg="foo")
+        self.assertIsInstance(backend, BaseEmailBackend)
+        self.assertFalse(hasattr(backend, "unknown_kwarg"))
+
+
+class SharedEmailBackendTests(MailTestsMixin):
+    """Common test cases run against each EmailBackend."""
 
     email_backend = None
 
@@ -39,13 +54,14 @@ class BaseEmailBackendTests(MailTestsMixin):
 
     def get_mailbox_content(self):
         raise NotImplementedError(
-            "subclasses of BaseEmailBackendTests must provide a get_mailbox_content() "
-            "method"
+            "Subclasses of SharedEmailBackendTests must provide a "
+            "get_mailbox_content() method."
         )
 
     def flush_mailbox(self):
         raise NotImplementedError(
-            "subclasses of BaseEmailBackendTests may require a flush_mailbox() method"
+            "Subclasses of SharedEmailBackendTests may require a "
+            "flush_mailbox() method."
         )
 
     def get_the_message(self):
@@ -98,38 +114,36 @@ class BaseEmailBackendTests(MailTestsMixin):
                 self.assertEqual(messages[1]["To"], "to-2@example.com")
                 self.flush_mailbox()
 
-    def test_close_connection(self):
-        """
-        Connection can be closed (even when not explicitly opened)
-        """
-        conn = mail.get_connection(username="", password="")
-        conn.close()
+    def test_connection_can_be_closed_even_if_not_opened(self):
+        backend = mail.get_connection()
+        backend.close()
 
-    def test_use_as_contextmanager(self):
-        """
-        The connection can be used as a contextmanager.
-        """
-        opened = [False]
-        closed = [False]
-        conn = mail.get_connection(username="", password="")
+    def test_connection_can_be_used_as_contextmanager(self):
+        backend = mail.get_connection()
+        backend.open = mock.Mock()
+        backend.close = mock.Mock()
 
-        def open():
-            opened[0] = True
+        with backend as backend_cm:
+            backend.open.assert_called_once()
+            self.assertIs(backend_cm, backend)
+            backend.close.assert_not_called()
 
-        conn.open = open
+        backend.close.assert_called_once()
 
-        def close():
-            closed[0] = True
+    def test_fail_silently_arg_accepted(self):
+        backend_class = import_string(self.email_backend)
+        for value in [True, False]:
+            with self.subTest(fail_silently=value):
+                backend = backend_class(fail_silently=value)
+                self.assertIs(backend.fail_silently, value)
 
-        conn.close = close
-        with conn as same_conn:
-            self.assertTrue(opened[0])
-            self.assertIs(same_conn, conn)
-            self.assertFalse(closed[0])
-        self.assertTrue(closed[0])
+    def test_unknown_kwargs_ignored(self):
+        backend_class = import_string(self.email_backend)
+        backend = backend_class(unknown_kwarg="foo")
+        self.assertFalse(hasattr(backend, "unknown_kwarg"))
 
 
-class DummyBackendTests(BaseEmailBackendTests, SimpleTestCase):
+class DummyBackendTests(SharedEmailBackendTests, SimpleTestCase):
     email_backend = "django.core.mail.backends.dummy.EmailBackend"
 
     def get_mailbox_content(self):
@@ -142,12 +156,12 @@ class DummyBackendTests(BaseEmailBackendTests, SimpleTestCase):
         pass
 
     def test_send_messages_returns_sent_count(self):
-        connection = dummy.EmailBackend()
+        backend = dummy.EmailBackend()
         email = EmailMessage(to=["to@example.com"])
-        self.assertEqual(connection.send_messages([email, email, email]), 3)
+        self.assertEqual(backend.send_messages([email, email, email]), 3)
 
 
-class LocmemBackendTests(BaseEmailBackendTests, SimpleTestCase):
+class LocmemBackendTests(SharedEmailBackendTests, SimpleTestCase):
     email_backend = "django.core.mail.backends.locmem.EmailBackend"
 
     def get_mailbox_content(self):
@@ -162,109 +176,192 @@ class LocmemBackendTests(BaseEmailBackendTests, SimpleTestCase):
 
     def test_locmem_shared_messages(self):
         """
-        Make sure that the locmen backend populates the outbox.
+        Make sure that the locmem backend populates the outbox.
         """
-        connection = locmem.EmailBackend()
-        connection2 = locmem.EmailBackend()
+        backend1 = locmem.EmailBackend()
+        backend2 = locmem.EmailBackend()
         email = EmailMessage(to=["to@example.com"])
-        connection.send_messages([email])
-        connection2.send_messages([email])
+        backend1.send_messages([email])
+        backend2.send_messages([email])
         self.assertEqual(len(mail.outbox), 2)
 
     def test_validate_multiline_headers(self):
         # Headers are validated when using the locmem backend (#18861).
         # (See also EmailMessageTests.test_header_injection().)
+        email = EmailMessage(subject="Subject\nMultiline", to=["to@example.com"])
+        backend = locmem.EmailBackend()
         with self.assertRaises(ValueError):
-            send_mail(
-                "Subject\nMultiline", "Content", "from@example.com", ["to@example.com"]
-            )
+            backend.send_messages([email])
 
     def test_outbox_not_mutated_after_send(self):
         email = EmailMessage(
             subject="correct subject",
             to=["to@example.com"],
         )
-        email.send()
+        backend = locmem.EmailBackend()
+        backend.send_messages([email])
         email.subject = "other subject"
         email.to.append("other@example.com")
         self.assertEqual(mail.outbox[0].subject, "correct subject")
         self.assertEqual(mail.outbox[0].to, ["to@example.com"])
 
 
-class FileBackendTests(BaseEmailBackendTests, SimpleTestCase):
+class FileBackendTests(SharedEmailBackendTests, SimpleTestCase):
     email_backend = "django.core.mail.backends.filebased.EmailBackend"
 
     def setUp(self):
         super().setUp()
         self.tmp_dir = self.mkdtemp()
-        self.addCleanup(shutil.rmtree, self.tmp_dir)
         _settings_override = override_settings(EMAIL_FILE_PATH=self.tmp_dir)
         _settings_override.enable()
         self.addCleanup(_settings_override.disable)
 
     def mkdtemp(self):
-        return tempfile.mkdtemp()
+        tmp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmp_dir)
+        return tmp_dir
+
+    def get_filenames(self):
+        return os.listdir(self.tmp_dir)
+
+    def get_messages_from_filename(self, filename):
+        with open(os.path.join(self.tmp_dir, filename), "rb") as fp:
+            messages = fp.read().split(b"\n" + (b"-" * 79) + b"\n")
+            return [message_from_bytes(m) for m in messages if m]
 
     def flush_mailbox(self):
-        for filename in os.listdir(self.tmp_dir):
+        for filename in self.get_filenames():
             os.unlink(os.path.join(self.tmp_dir, filename))
 
     def get_mailbox_content(self):
         messages = []
-        for filename in os.listdir(self.tmp_dir):
-            with open(os.path.join(self.tmp_dir, filename), "rb") as fp:
-                session = fp.read().split(b"\n" + (b"-" * 79) + b"\n")
-            messages.extend(message_from_bytes(m) for m in session if m)
+        for filename in self.get_filenames():
+            messages.extend(self.get_messages_from_filename(filename))
         return messages
 
-    def test_file_sessions(self):
-        """Make sure opening a connection creates a new file"""
-        msg = EmailMessage(
-            "Subject",
-            "Content",
-            "bounce@example.com",
-            ["to@example.com"],
-            headers={"From": "from@example.com"},
+    def test_email_file_path_use_settings(self):
+        file_path_settings = self.mkdtemp()
+        with self.settings(EMAIL_FILE_PATH=file_path_settings):
+            backend = filebased.EmailBackend()
+        self.assertEqual(backend.file_path, str(file_path_settings))
+
+    def test_email_file_path_override_settings(self):
+        file_path_settings = self.mkdtemp()
+        file_path_override = self.mkdtemp()
+        self.assertNotEqual(file_path_settings, file_path_override)
+
+        with self.settings(EMAIL_FILE_PATH=file_path_settings):
+            backend = filebased.EmailBackend(file_path=file_path_override)
+        self.assertEqual(backend.file_path, str(file_path_override))
+
+    def test_error_if_email_file_path_setting_not_defined(self):
+        msg = (
+            "The EMAIL_FILE_PATH setting must be defined to use the file EmailBackend."
         )
-        connection = mail.get_connection()
-        connection.send_messages([msg])
+        with self.settings():
+            del settings.EMAIL_FILE_PATH
+            with self.assertRaisesMessage(ImproperlyConfigured, msg):
+                filebased.EmailBackend()
 
-        self.assertEqual(len(os.listdir(self.tmp_dir)), 1)
-        with open(os.path.join(self.tmp_dir, os.listdir(self.tmp_dir)[0]), "rb") as fp:
-            message = message_from_binary_file(fp, policy=policy.default)
-        self.assertEqual(message.get_content_type(), "text/plain")
-        self.assertEqual(message.get("subject"), "Subject")
-        self.assertEqual(message.get("from"), "from@example.com")
-        self.assertEqual(message.get("to"), "to@example.com")
+    def test_error_if_file_path_is_not_directory(self):
+        tmp_file = Path(self.tmp_dir) / "ordinary-file"
+        tmp_file.touch()
+        if isinstance(self.tmp_dir, str):
+            # Running the non-"PathLib" version of FileBackendTests.
+            tmp_file = str(tmp_file)
+        msg = (
+            f"Path for saving email messages exists, but is not a directory: {tmp_file}"
+        )
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+            filebased.EmailBackend(file_path=tmp_file)
 
-        connection2 = mail.get_connection()
-        connection2.send_messages([msg])
-        self.assertEqual(len(os.listdir(self.tmp_dir)), 2)
+    @skipIf(
+        sys.platform == "win32",
+        "No cross-platform means to force an OSError from os.makedirs().",
+    )
+    def test_error_if_file_path_cannot_be_created(self):
+        msg = "Could not create directory for saving email messages: /dev/null/foo"
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+            filebased.EmailBackend(file_path="/dev/null/foo")
 
-        connection.send_messages([msg])
-        self.assertEqual(len(os.listdir(self.tmp_dir)), 2)
+    @skipIf(
+        sys.platform == "win32",
+        "chmod does not reliably make directories read-only on Windows.",
+    )
+    def test_error_if_file_path_is_not_writeable(self):
+        os.chmod(self.tmp_dir, 0o444)
+        self.addCleanup(os.chmod, self.tmp_dir, 0o777)
+        msg = f"Could not write to directory: {self.tmp_dir}"
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+            filebased.EmailBackend(file_path=self.tmp_dir)
 
-        msg.connection = mail.get_connection()
-        self.assertTrue(connection.open())
-        msg.send()
-        self.assertEqual(len(os.listdir(self.tmp_dir)), 3)
-        msg.send()
-        self.assertEqual(len(os.listdir(self.tmp_dir)), 3)
+    def test_new_file_per_instance(self):
+        # Documented behavior: "A new file is created for each new session that
+        # is opened on this backend."
+        email = EmailMessage(to=["to@example.com"])
+        self.assertEqual(len(self.get_filenames()), 0)
 
-        connection.close()
+        backend1 = mail.get_connection()
+        backend1.send_messages([email])
+        self.assertEqual(len(self.get_filenames()), 1)
+
+        backend2 = mail.get_connection()
+        backend2.send_messages([email])
+        self.assertEqual(len(self.get_filenames()), 2)
+
+    def test_multiple_messages_same_connection_single_file_reused(self):
+        self.assertEqual(len(self.get_filenames()), 0)
+        backend = mail.get_connection()
+
+        self.assertIs(backend.open(), True)
+        backend.send_messages([EmailMessage(to=["one@example.com"])])
+        filenames = self.get_filenames()
+        self.assertEqual(len(filenames), 1)
+
+        # Send a second message while connection is still open.
+        backend.send_messages([EmailMessage(to=["two@example.com"])])
+        self.assertEqual(self.get_filenames(), filenames)
+
+        backend.close()
+        self.assertEqual(self.get_filenames(), filenames)
+
+        messages = self.get_messages_from_filename(filenames[0])
+        self.assertEqual(len(messages), 2)
+        self.assertEqual(messages[0]["to"], "one@example.com")
+        self.assertEqual(messages[1]["to"], "two@example.com")
+
+    def test_reopening_connection_uses_same_file(self):
+        self.assertEqual(len(self.get_filenames()), 0)
+
+        backend = mail.get_connection()
+        self.assertIs(backend.open(), True)
+        backend.send_messages([EmailMessage(to=["one@example.com"])])
+        backend.close()
+        filenames = self.get_filenames()
+        self.assertEqual(len(filenames), 1)
+
+        # Reopen the connection.
+        self.assertIs(backend.open(), True)
+        backend.send_messages([EmailMessage(to=["two@example.com"])])
+        self.assertEqual(self.get_filenames(), filenames)
+        backend.close()
+        self.assertEqual(self.get_filenames(), filenames)
+
+        messages = self.get_messages_from_filename(filenames[0])
+        self.assertEqual(len(messages), 2)
+        self.assertEqual(messages[0]["to"], "one@example.com")
+        self.assertEqual(messages[1]["to"], "two@example.com")
 
 
 class FileBackendPathLibTests(FileBackendTests):
-    """
-    Repeat FileBackendTests cases using a Path object as file_path.
-    """
+    """Repeat FileBackendTests cases using a Path object as file_path."""
 
     def mkdtemp(self):
         tmp_dir = super().mkdtemp()
         return Path(tmp_dir)
 
 
-class ConsoleBackendTests(BaseEmailBackendTests, SimpleTestCase):
+class ConsoleBackendTests(SharedEmailBackendTests, SimpleTestCase):
     email_backend = "django.core.mail.backends.console.EmailBackend"
 
     def setUp(self):
@@ -286,31 +383,15 @@ class ConsoleBackendTests(BaseEmailBackendTests, SimpleTestCase):
         return [message_from_bytes(m.encode()) for m in messages if m]
 
     def test_console_stream_kwarg(self):
-        """
-        The console backend can be pointed at an arbitrary stream.
-        """
         s = StringIO()
-        connection = mail.get_connection(
+        backend = mail.get_connection(
             "django.core.mail.backends.console.EmailBackend", stream=s
         )
-        send_mail(
-            "Subject",
-            "Content",
-            "from@example.com",
-            ["to@example.com"],
-            connection=connection,
-        )
+        backend.send_messages([EmailMessage(to=["to@example.com"])])
         message = s.getvalue().split("\n" + ("-" * 79) + "\n")[0].encode()
         self.assertMessageHasHeaders(
             message,
-            {
-                ("MIME-Version", "1.0"),
-                ("Content-Type", 'text/plain; charset="utf-8"'),
-                ("Content-Transfer-Encoding", "7bit"),
-                ("Subject", "Subject"),
-                ("From", "from@example.com"),
-                ("To", "to@example.com"),
-            },
+            {("To", "to@example.com")},
         )
         self.assertIn(b"\nDate: ", message)
 
@@ -378,7 +459,7 @@ class SMTPBackendTestsBase(SimpleTestCase):
 
 
 @skipUnless(HAS_AIOSMTPD, "No aiosmtpd library detected.")
-class SMTPBackendTests(BaseEmailBackendTests, SMTPBackendTestsBase):
+class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
     email_backend = "django.core.mail.backends.smtp.EmailBackend"
 
     def setUp(self):
@@ -394,6 +475,38 @@ class SMTPBackendTests(BaseEmailBackendTests, SMTPBackendTestsBase):
 
     def get_smtp_envelopes(self):
         return self.smtp_handler.smtp_envelopes
+
+    @override_settings(
+        EMAIL_HOST="mail.example.com",
+        EMAIL_PORT=822,
+    )
+    def test_email_host_use_settings(self):
+        backend = smtp.EmailBackend()
+        self.assertEqual(backend.host, "mail.example.com")
+        self.assertEqual(backend.port, 822)
+
+    @override_settings(
+        EMAIL_HOST="mail.example.com",
+        EMAIL_PORT=822,
+    )
+    def test_email_host_override_settings(self):
+        backend = smtp.EmailBackend(host="other.example.net", port=5322)
+        self.assertEqual(backend.host, "other.example.net")
+        self.assertEqual(backend.port, 5322)
+
+    def test_smtp_connection_uses_host_and_port(self):
+        backend = smtp.EmailBackend(host="mail.example.com", port=5322)
+        self.assertEqual(backend.host, "mail.example.com")
+        self.assertEqual(backend.port, 5322)
+        with (
+            mock.patch("django.core.mail.backends.smtp.smtplib.SMTP") as mock_smtp,
+            backend,
+        ):
+            # Using backend as context manager opens the connection.
+            pass
+        mock_smtp.assert_called_once_with(
+            "mail.example.com", 5322, local_hostname=mock.ANY
+        )
 
     @override_settings(
         EMAIL_HOST_USER="not empty username",
@@ -430,17 +543,19 @@ class SMTPBackendTests(BaseEmailBackendTests, SMTPBackendTestsBase):
         backend = smtp.EmailBackend(
             username="not empty username", password="not empty password"
         )
-        with self.assertRaisesMessage(
-            SMTPException, "SMTP AUTH extension not supported by server."
-        ):
-            with backend:
-                pass
+        with mock.patch("smtplib.SMTP.login") as mock_smtp_login, backend:
+            # Using backend as context manager opens the connection and
+            # attempts login.
+            pass
+        mock_smtp_login.assert_called_once_with(
+            "not empty username", "not empty password"
+        )
 
     def test_server_open(self):
         """
         open() returns whether it opened a connection.
         """
-        backend = smtp.EmailBackend(username="", password="")
+        backend = smtp.EmailBackend()
         self.assertIsNone(backend.connection)
         opened = backend.open()
         backend.close()
@@ -455,16 +570,16 @@ class SMTPBackendTests(BaseEmailBackendTests, SMTPBackendTestsBase):
     @override_settings(EMAIL_USE_TLS=True)
     def test_email_tls_use_settings(self):
         backend = smtp.EmailBackend()
-        self.assertTrue(backend.use_tls)
+        self.assertIs(backend.use_tls, True)
 
     @override_settings(EMAIL_USE_TLS=True)
     def test_email_tls_override_settings(self):
         backend = smtp.EmailBackend(use_tls=False)
-        self.assertFalse(backend.use_tls)
+        self.assertIs(backend.use_tls, False)
 
     def test_email_tls_default_disabled(self):
         backend = smtp.EmailBackend()
-        self.assertFalse(backend.use_tls)
+        self.assertIs(backend.use_tls, False)
 
     def test_ssl_tls_mutually_exclusive(self):
         msg = (
@@ -477,16 +592,16 @@ class SMTPBackendTests(BaseEmailBackendTests, SMTPBackendTestsBase):
     @override_settings(EMAIL_USE_SSL=True)
     def test_email_ssl_use_settings(self):
         backend = smtp.EmailBackend()
-        self.assertTrue(backend.use_ssl)
+        self.assertIs(backend.use_ssl, True)
 
     @override_settings(EMAIL_USE_SSL=True)
     def test_email_ssl_override_settings(self):
         backend = smtp.EmailBackend(use_ssl=False)
-        self.assertFalse(backend.use_ssl)
+        self.assertIs(backend.use_ssl, False)
 
     def test_email_ssl_default_disabled(self):
         backend = smtp.EmailBackend()
-        self.assertFalse(backend.use_ssl)
+        self.assertIs(backend.use_ssl, False)
 
     @override_settings(EMAIL_SSL_CERTFILE="foo")
     def test_email_ssl_certfile_use_settings(self):
@@ -516,10 +631,20 @@ class SMTPBackendTests(BaseEmailBackendTests, SMTPBackendTestsBase):
         backend = smtp.EmailBackend()
         self.assertIsNone(backend.ssl_keyfile)
 
+    def test_ssl_context_uses_ssl_certfile_and_keyfile(self):
+        backend = smtp.EmailBackend(ssl_certfile="certfile", ssl_keyfile="keyfile")
+        with mock.patch(
+            "django.core.mail.backends.smtp.ssl.SSLContext"
+        ) as mock_ssl_context:
+            ssl_context = backend.ssl_context
+        self.assertIs(ssl_context, mock_ssl_context.return_value)
+        mock_ssl_context.assert_called_once_with(protocol=ssl.PROTOCOL_TLS_CLIENT)
+        ssl_context.load_cert_chain.assert_called_once_with("certfile", "keyfile")
+
     @override_settings(EMAIL_USE_TLS=True)
     def test_email_tls_attempts_starttls(self):
         backend = smtp.EmailBackend()
-        self.assertTrue(backend.use_tls)
+        self.assertIs(backend.use_tls, True)
         with self.assertRaisesMessage(
             SMTPException, "STARTTLS extension not supported by server."
         ):
@@ -529,15 +654,14 @@ class SMTPBackendTests(BaseEmailBackendTests, SMTPBackendTestsBase):
     @override_settings(EMAIL_USE_SSL=True)
     def test_email_ssl_attempts_ssl_connection(self):
         backend = smtp.EmailBackend()
-        self.assertTrue(backend.use_ssl)
+        self.assertIs(backend.use_ssl, True)
         with self.assertRaises(SSLError):
             with backend:
                 pass
 
     def test_connection_timeout_default(self):
-        """The connection's timeout value is None by default."""
-        connection = mail.get_connection("django.core.mail.backends.smtp.EmailBackend")
-        self.assertIsNone(connection.timeout)
+        backend = mail.get_connection("django.core.mail.backends.smtp.EmailBackend")
+        self.assertIsNone(backend.timeout)
 
     def test_connection_timeout_custom(self):
         """The timeout parameter can be customized."""
@@ -554,45 +678,36 @@ class SMTPBackendTests(BaseEmailBackendTests, SMTPBackendTestsBase):
         myemailbackend.close()
 
     @override_settings(EMAIL_TIMEOUT=10)
-    def test_email_timeout_override_settings(self):
+    def test_email_timeout_use_settings(self):
         backend = smtp.EmailBackend()
         self.assertEqual(backend.timeout, 10)
 
-    def test_email_msg_uses_crlf(self):
-        """#23063 -- RFC-compliant messages are sent over SMTP."""
-        send = SMTP.send
-        try:
-            smtp_messages = []
+    @override_settings(EMAIL_TIMEOUT=10)
+    def test_email_timeout_override_settings(self):
+        backend = smtp.EmailBackend(timeout=15)
+        self.assertEqual(backend.timeout, 15)
 
-            def mock_send(self, s):
-                smtp_messages.append(s)
-                return send(self, s)
+    def test_smtp_connection_uses_timeout(self):
+        backend = smtp.EmailBackend(timeout=10)
+        with backend:
+            self.assertEqual(backend.connection.timeout, 10)
 
-            SMTP.send = mock_send
+    def test_serialized_message_uses_crlf_line_ending(self):
+        backend = mail.get_connection()
+        with (
+            backend,
+            mock.patch.object(backend.connection, "sendmail") as mock_sendmail,
+        ):
+            backend.send_messages([EmailMessage(to=["to@example.com"])])
 
-            email = EmailMessage(
-                "Subject", "Content", "from@example.com", ["to@example.com"]
-            )
-            mail.get_connection().send_messages([email])
-
-            # Find the actual message
-            msg = None
-            for i, m in enumerate(smtp_messages):
-                if m[:4] == "data":
-                    msg = smtp_messages[i + 1]
-                    break
-
-            self.assertTrue(msg)
-
-            msg = msg.decode()
-            # The message only contains CRLF and not combinations of CRLF, LF,
-            # and CR.
-            msg = msg.replace("\r\n", "")
-            self.assertNotIn("\r", msg)
-            self.assertNotIn("\n", msg)
-
-        finally:
-            SMTP.send = send
+        # The third argument to SMTP.sendmail() is the serialized message.
+        mock_sendmail.assert_called_once()
+        msg = mock_sendmail.call_args.args[2].decode()
+        # The message only contains CRLF and not combinations of CRLF, LF, and
+        # CR (#23063).
+        msg = msg.replace("\r\n", "")
+        self.assertNotIn("\r", msg)
+        self.assertNotIn("\n", msg)
 
     def test_send_messages_after_open_failed(self):
         """
@@ -602,23 +717,25 @@ class SMTPBackendTests(BaseEmailBackendTests, SMTPBackendTestsBase):
         backend = smtp.EmailBackend()
         # Simulate connection initialization success and a subsequent
         # connection exception.
-        backend.connection = mock.Mock(spec=object())
+        backend.connection = mock.Mock()
         backend.open = lambda: None
         email = EmailMessage(to=["to@example.com"])
         self.assertEqual(backend.send_messages([email]), 0)
 
-    def test_send_messages_empty_list(self):
+    def test_send_messages_with_empty_list_does_not_open_connection(self):
         backend = smtp.EmailBackend()
-        backend.connection = mock.Mock(spec=object())
+        backend.open = mock.Mock()
         self.assertEqual(backend.send_messages([]), 0)
+        backend.open.assert_not_called()
 
     def test_send_messages_zero_sent(self):
         """A message isn't sent if it doesn't have any recipients."""
         backend = smtp.EmailBackend()
-        backend.connection = mock.Mock(spec=object())
+        backend.connection = mock.Mock()
         email = EmailMessage("Subject", "Content", "from@example.com", to=[])
         sent = backend.send_messages([email])
         self.assertEqual(sent, 0)
+        backend.connection.sendmail.assert_not_called()
 
     def test_avoids_sending_to_invalid_addresses(self):
         """
@@ -731,7 +848,7 @@ class SMTPBackendStoppedServerTests(SMTPBackendTestsBase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.backend = smtp.EmailBackend(username="", password="")
+        cls.backend = smtp.EmailBackend()
         cls.smtp_controller.stop()
 
     @classmethod

--- a/tests/mail/test_backends.py
+++ b/tests/mail/test_backends.py
@@ -111,6 +111,23 @@ class SharedEmailBackendTests(MailTestsMixin):
         backend = self.create_backend(alias=None)
         self.assertIsNone(backend.alias)
 
+    def test_create_from_providers(self, required_options=None):
+        # Subclasses must override this test case if any options are required.
+        backend_import_path = (
+            f"{self.backend_class.__module__}.{self.backend_class.__name__}"
+        )
+        with self.settings(
+            EMAIL_PROVIDERS={
+                "custom": {
+                    "BACKEND": backend_import_path,
+                    "OPTIONS": required_options or {},
+                }
+            }
+        ):
+            backend = mail.providers["custom"]
+            self.assertIsInstance(backend, self.backend_class)
+            self.assertEqual(backend.alias, "custom")
+
     def test_send(self):
         email = EmailMessage(
             "Subject", "Content\n", "from@example.com", ["to@example.com"]
@@ -299,6 +316,10 @@ class FileBackendTests(SharedEmailBackendTests, SimpleTestCase):
         for filename in self.get_filenames():
             messages.extend(self.get_messages_from_filename(filename))
         return messages
+
+    def test_create_from_providers(self):
+        # (Overrides SharedEmailBackendTests case.)
+        super().test_create_from_providers(required_options={"file_path": self.tmp_dir})
 
     def test_email_file_path_use_settings(self):
         file_path_settings = self.mkdtemp()
@@ -570,6 +591,10 @@ class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
 
     def get_smtp_envelopes(self):
         return self.smtp_handler.smtp_envelopes
+
+    def test_create_from_providers(self):
+        # (Overrides SharedEmailBackendTests case.)
+        super().test_create_from_providers(required_options={"host": "example.com"})
 
     @override_settings(
         EMAIL_HOST="mail.example.com",

--- a/tests/mail/test_deprecated.py
+++ b/tests/mail/test_deprecated.py
@@ -102,6 +102,21 @@ class UndocumentedFeatureErrorTests(SimpleTestCase):
         with self.assertRaisesMessage(AttributeError, msg):
             email.message()
 
+    def test_undocumented_get_connection_override_no_longer_supported(self):
+
+        class CustomEmailMessage(EmailMessage):
+            def get_connection(self, fail_silently=False):
+                return None
+
+        email = CustomEmailMessage(to=["to@example.com"])
+
+        msg = (
+            "EmailMessage no longer supports the undocumented "
+            "get_connection() method."
+        )
+        with self.assertRaisesMessage(AttributeError, msg):
+            email.send()
+
 
 @ignore_warnings(category=RemovedInDjango70Warning)
 class DeprecatedCompatibilityTests(SimpleTestCase):

--- a/tests/mail/test_deprecated.py
+++ b/tests/mail/test_deprecated.py
@@ -1,16 +1,28 @@
 # RemovedInDjango70Warning: This entire file.
+import re
+import types
+import warnings
+from contextlib import contextmanager
 from email.mime.text import MIMEText
+from unittest import mock
 
+import django.conf
+from django.conf import LazySettings
+from django.core.exceptions import ImproperlyConfigured
 from django.core.mail import (
     EmailAlternative,
     EmailAttachment,
     EmailMessage,
     EmailMultiAlternatives,
+    get_connection,
+    providers,
 )
+from django.core.mail.deprecation import NO_DEFAULT_EMAIL_PROVIDER_WARNING
 from django.core.mail.message import forbid_multi_line_headers, sanitize_address
-from django.test import SimpleTestCase, ignore_warnings
+from django.test import SimpleTestCase, ignore_warnings, override_settings
 from django.utils.deprecation import RemovedInDjango70Warning
 
+from . import override_deprecated_email_settings
 from .tests import MailTestsMixin
 
 
@@ -135,3 +147,320 @@ class DeprecatedCompatibilityTests(SimpleTestCase):
         msg = EmailMessage(attachments=[txt])
         payload = msg.message().get_payload()
         self.assertEqual(payload[0], txt)
+
+
+class DeprecatedEmailSettingsTests(SimpleTestCase):
+    """Deprecations and compatibility errors related to EMAIL_PROVIDERS."""
+
+    deprecated_setting_defaults = {
+        "EMAIL_BACKEND": "django.core.mail.backends.smtp.EmailBackend",
+        "EMAIL_HOST": "localhost",
+        "EMAIL_PORT": 25,
+        "EMAIL_HOST_USER": "",
+        "EMAIL_HOST_PASSWORD": "",
+        "EMAIL_USE_TLS": False,
+        "EMAIL_USE_SSL": False,
+        "EMAIL_SSL_CERTFILE": None,
+        "EMAIL_SSL_KEYFILE": None,
+        "EMAIL_TIMEOUT": None,
+        # EMAIL_FILE_PATH does not have a default.
+    }
+
+    deprecated_settings = deprecated_setting_defaults.keys() | {"EMAIL_FILE_PATH"}
+
+    # Tests for defining settings must cover three separate cases, which go
+    # through different code paths in django.conf:
+    # - settings module (settings.py; LazySettings wraps Settings)
+    # - settings.configure() (LazySettings wraps UserSettingsHolder)
+    # - override_settings() (a.k.a. SimpleTestCase.settings(); temporarily
+    #   inserts a UserSettingsHolder into the current LazySettings)
+    #
+    # A settings module must be simulated in these tests. (The real settings
+    # module can't be modified, and override_settings() isn't the same as using
+    # a settings module.) To do that:
+    # - Optionally use a self.mock_settings_module() context to populate a
+    #   simulated settings.py.
+    # - Call self.init_simulated_settings() to initialize settings from a
+    #   module (the mock_settings_module() if active, else the real one) and
+    #   return a settings object equivalent to django.conf.settings.
+
+    def mock_settings_module(self, **settings):
+        settings_module = types.ModuleType("mocked_settings")
+        for name, value in settings.items():
+            setattr(settings_module, name, value)
+        # Patch the settings module import in Settings.__init__() to
+        # substitute the mocked settings.
+        return mock.patch(
+            "django.conf.importlib.import_module",
+            autospec=True,
+            return_value=settings_module,
+        )
+
+    def init_simulated_settings(self):
+        settings = LazySettings()
+        getattr(settings, "FOO", None)  # Trigger _setup().
+        return settings
+
+    @contextmanager
+    def assertNotWarnsMessage(self, category, message):
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            warnings.filterwarnings(
+                "always", category=category, message=rf".*{re.escape(message)}"
+            )
+            yield caught_warnings
+        self.assertEqual([str(warning) for warning in caught_warnings], [])
+
+    def assertHasOnlyDefaultEmailSettings(self, settings, msg=None):
+        non_default_settings = [
+            name for name in self.deprecated_settings if settings.is_overridden(name)
+        ]
+        if hasattr(settings, "EMAIL_PROVIDERS"):
+            non_default_settings.append("EMAIL_PROVIDERS")
+        self.assertEqual(non_default_settings, [], msg=msg)
+
+    def test_warn_when_defining_deprecated_settings(self):
+        for name in self.deprecated_settings:
+            msg = (
+                f"The {name} setting is deprecated. Migrate to "
+                "EMAIL_PROVIDERS before Django 7.0."
+            )
+            settings = {name: "foo"}
+            with self.subTest(name=name):
+                with (
+                    self.subTest("settings module"),
+                    self.mock_settings_module(**settings),
+                    self.assertWarnsMessage(RemovedInDjango70Warning, msg),
+                ):
+                    self.init_simulated_settings()
+                with (
+                    self.subTest("settings.configure()"),
+                    self.assertWarnsMessage(RemovedInDjango70Warning, msg),
+                ):
+                    LazySettings().configure(**settings)
+                with (
+                    self.subTest("override_settings()"),
+                    self.assertWarnsMessage(RemovedInDjango70Warning, msg),
+                ):
+                    with override_settings(**settings):
+                        pass
+
+    def test_multiple_deprecated_settings_are_all_reported(self):
+        msg_re = r"The EMAIL_(BACKEND|HOST|PORT) setting is deprecated."
+        settings = {"EMAIL_BACKEND": "foo", "EMAIL_HOST": "bar", "EMAIL_PORT": 2525}
+        expected_warning_count = len(settings)
+
+        with self.subTest("settings module"), self.mock_settings_module(**settings):
+            with self.assertWarnsRegex(RemovedInDjango70Warning, msg_re) as cm:
+                self.init_simulated_settings()
+            self.assertEqual(len(cm.warnings), expected_warning_count)
+
+        with self.subTest("settings.configure()"):
+            with self.assertWarnsRegex(RemovedInDjango70Warning, msg_re) as cm:
+                LazySettings().configure(**settings)
+            self.assertEqual(len(cm.warnings), expected_warning_count)
+
+        with self.subTest("override_settings()"):
+            with (
+                self.assertWarnsRegex(RemovedInDjango70Warning, msg_re) as cm,
+                override_settings(**settings),
+            ):
+                pass
+            # override_settings() accesses each setting twice: setattr while
+            # enabling and getattr while disabling (for change notification).
+            self.assertEqual(len(cm.warnings), 2 * expected_warning_count)
+
+    def test_warn_about_no_default_email_provider(self):
+        # Test precondition: the real settings object must be default.
+        self.assertHasOnlyDefaultEmailSettings(django.conf.settings)
+
+        # The warning is issued if no email-backend-related settings are
+        # defined, but only when email is sent. Any attempt to send email
+        # should invoke get_connection() or providers.create_connection().
+        # TODO: Is that true? What about CustomBackend().send_messages(...)?
+        msg = NO_DEFAULT_EMAIL_PROVIDER_WARNING
+        with (
+            self.subTest("get_connection()"),
+            self.assertWarnsMessage(RemovedInDjango70Warning, msg),
+            ignore_warnings(
+                category=RemovedInDjango70Warning,
+                message=re.escape("get_connection() is deprecated."),
+            ),
+        ):
+            get_connection()
+        with (
+            self.subTest("providers.default"),
+            self.assertWarnsMessage(RemovedInDjango70Warning, msg),
+        ):
+            _ = providers.default
+
+        # The warning is not issued on startup, to avoid creating noise for
+        # projects that don't send email at all.
+        with self.assertNotWarnsMessage(RemovedInDjango70Warning, msg):
+            settings = self.init_simulated_settings()
+        self.assertHasOnlyDefaultEmailSettings(settings, msg="invalid test")
+
+    def test_no_default_email_provider_warning_if_any_email_setting_defined(self):
+        # Test precondition: the real settings object must be default.
+        self.assertHasOnlyDefaultEmailSettings(django.conf.settings)
+
+        # The warning from the previous test is not issued if any deprecated
+        # email setting is defined (which would result in a startup-time
+        # warning about EMAIL_PROVIDERS) or if EMAIL_PROVIDERS is defined.
+        msg = NO_DEFAULT_EMAIL_PROVIDER_WARNING
+        for name in self.deprecated_settings:
+            value = self.deprecated_setting_defaults.get(name, "foo")
+            with (
+                self.subTest(name=name),
+                override_deprecated_email_settings(**{name: value}),
+                self.assertNotWarnsMessage(RemovedInDjango70Warning, msg),
+            ):
+                _ = providers.default
+        with (
+            self.subTest(name="EMAIL_PROVIDERS"),
+            self.settings(
+                EMAIL_PROVIDERS={
+                    "default": {
+                        "BACKEND": "django.core.mail.backends.locmem.EmailBackend"
+                    }
+                }
+            ),
+            self.assertNotWarnsMessage(RemovedInDjango70Warning, msg),
+        ):
+            _ = providers.default
+
+    def test_deprecated_settings_not_allowed_with_email_providers(self):
+        for name in self.deprecated_settings:
+            msg = (
+                "Deprecated email settings are not allowed when "
+                f"EMAIL_PROVIDERS is defined: {name}."
+            )
+            settings = {name: "foo", "EMAIL_PROVIDERS": {}}
+            with self.subTest(name=name):
+                with (
+                    self.subTest("settings module"),
+                    self.mock_settings_module(**settings),
+                    self.assertRaisesMessage(ImproperlyConfigured, msg),
+                ):
+                    self.init_simulated_settings()
+                with (
+                    self.subTest("settings.configure()"),
+                    self.assertRaisesMessage(ImproperlyConfigured, msg),
+                ):
+                    LazySettings().configure(**settings)
+                # There is intentionally no override_settings() subtest here.
+                # override_settings() does not check for settings conflicts.
+
+    def test_warn_when_using_deprecated_settings(self):
+        for name in self.deprecated_settings:
+            msg = (
+                f"The {name} setting is deprecated. Migrate to "
+                "EMAIL_PROVIDERS before Django 7.0."
+            )
+            with (
+                self.subTest(name=name),
+                override_deprecated_email_settings(**{name: "foo"}),
+                self.assertWarnsMessage(RemovedInDjango70Warning, msg),
+            ):
+                getattr(django.conf.settings, name)
+
+    @override_settings(EMAIL_PROVIDERS={})
+    def test_deprecated_settings_do_not_exist_when_email_providers_defined(self):
+        # The global_settings defaults for the deprecated settings are hidden
+        # when EMAIL_PROVIDERS is defined.
+        for name in self.deprecated_settings:
+            with self.subTest(name=name):
+                self.assertFalse(hasattr(django.conf.settings, name))
+
+    @override_settings(EMAIL_PROVIDERS={})
+    def test_deprecated_settings_not_in_dir_when_email_providers_defined(self):
+        known_settings = dir(django.conf.settings)
+        actual_overlap = set(self.deprecated_settings) & set(known_settings)
+        self.assertEqual(actual_overlap, set())
+
+    def test_deprecated_settings_are_in_dir_without_email_providers(self):
+        expected_settings = self.deprecated_setting_defaults.keys()
+        known_settings = dir(django.conf.settings)
+        actual_overlap = set(expected_settings) & set(known_settings)
+        self.assertEqual(actual_overlap, expected_settings)
+
+    @override_settings(EMAIL_PROVIDERS={})
+    def test_error_when_using_deprecated_settings_with_email_providers_defined(self):
+        for name in self.deprecated_settings:
+            msg = (
+                f"The {name} setting is not available when EMAIL_PROVIDERS "
+                "is defined"
+            )
+            with (
+                self.subTest(name=name),
+                override_deprecated_email_settings(**{name: "foo"}),
+            ):
+                with self.assertRaisesMessage(AttributeError, msg):
+                    getattr(django.conf.settings, name)
+
+    @ignore_warnings(category=RemovedInDjango70Warning)
+    def test_direct_settings_manipulation(self):
+        settings = self.init_simulated_settings()
+
+        # Accessing deprecated setting (from global defaults) caches its value
+        # in LazySettings.__dir__.
+        self.assertEqual(settings.EMAIL_PORT, 25)
+
+        # Defining EMAIL_PROVIDERS invalidates the cache but is not an error.
+        settings.EMAIL_PROVIDERS = {}
+
+        # Accessing the conflicting setting _is_ an error.
+        msg = "not available when EMAIL_PROVIDERS is defined"
+        with self.assertRaisesMessage(AttributeError, msg):
+            _ = settings.EMAIL_PORT  # Not `25` from the cache.
+
+        # Adding a conflicting setting is not an error, but accessing it is.
+        settings.EMAIL_HOST = "example.com"
+        with self.assertRaisesMessage(AttributeError, msg):
+            _ = settings.EMAIL_HOST
+
+        # Deleting EMAIL_PROVIDERS removes the conflict and allows access to
+        # the deprecated settings again.
+        del settings.EMAIL_PROVIDERS
+        self.assertEqual(settings.EMAIL_PORT, 25)
+        self.assertEqual(settings.EMAIL_HOST, "example.com")
+
+    @override_settings(EMAIL_PROVIDERS={})
+    def test_error_when_using_conflicting_setting_via_override_settings(self):
+        # Overriding EMAIL_HOST when EMAIL_PROVIDERS is defined creates a
+        # conflict but does not cause an immediate error.
+        with override_deprecated_email_settings(EMAIL_HOST="example.com"):
+            self.assertEqual(django.conf.settings.EMAIL_PROVIDERS, {})
+            # Trying to access the conflicting setting causes an error.
+            with self.assertRaisesMessage(AttributeError, "not available"):
+                _ = django.conf.settings.EMAIL_HOST
+
+            # Both conflicting settings are defined (neither is inherited from
+            # default global_settings), so LazySettings.__dir__() does not hide
+            # them.
+            self.assertIn("EMAIL_HOST", dir(django.conf.settings))
+            self.assertIn("EMAIL_PROVIDERS", dir(django.conf.settings))
+
+            del django.conf.settings.EMAIL_HOST
+            self.assertNotIn("EMAIL_HOST", dir(django.conf.settings))
+
+    @ignore_warnings(category=RemovedInDjango70Warning)
+    def test_deprecated_settings_defaults_unchanged(self):
+        # Django's test runner overrides EMAIL_BACKEND in django.conf.settings,
+        # so construct a fresh settings object for this test.
+        settings = self.init_simulated_settings()
+        for name, expected in self.deprecated_setting_defaults.items():
+            with self.subTest(name=name):
+                actual = getattr(settings, name)
+                if expected is None:
+                    self.assertIsNone(actual)
+                elif expected is True or expected is False:
+                    self.assertIs(actual, expected)
+                else:
+                    self.assertEqual(actual, expected)
+
+    @ignore_warnings(category=RemovedInDjango70Warning)
+    def test_email_backend_override_during_tests(self):
+        self.assertEqual(
+            django.conf.settings.EMAIL_BACKEND,
+            "django.core.mail.backends.locmem.EmailBackend",
+        )

--- a/tests/mail/test_handler.py
+++ b/tests/mail/test_handler.py
@@ -1,0 +1,228 @@
+from django.core.mail import EmailProviderDoesNotExist, InvalidEmailProvider, providers
+from django.core.mail.backends import locmem, smtp
+from django.test import SimpleTestCase, override_settings
+
+from .custombackend import InitCheckBackend
+
+
+class EmailProvidersTests(SimpleTestCase):
+    def setUp(self):
+        InitCheckBackend.init_kwargs = None
+
+    @override_settings(
+        EMAIL_PROVIDERS={
+            "default": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"},
+            "custom": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"},
+        }
+    )
+    def test_getitem(self):
+        with self.subTest("defined providers"):
+            self.assertEqual(providers["default"].alias, "default")
+            self.assertEqual(providers["custom"].alias, "custom")
+
+        with self.subTest("missing provider"):
+            msg = "The email provider 'unknown' is not configured."
+            with self.assertRaisesMessage(EmailProviderDoesNotExist, msg) as cm:
+                _ = providers["unknown"]
+            # `except KeyError` would catch EmailProviderDoesNotExist.
+            self.assertIsInstance(cm.exception, KeyError)
+
+    @override_settings(
+        EMAIL_PROVIDERS={
+            "one": {"BACKEND": "mail.custombackend.InitCheckBackend"},
+            "two": {"BACKEND": "mail.custombackend.InitCheckBackend"},
+            "three": {"BACKEND": "mail.custombackend.InitCheckBackend"},
+        }
+    )
+    def test_contains(self):
+        self.assertIn("two", providers)
+        self.assertNotIn("zero", providers)
+        self.assertNotIn(None, providers)
+        # __contains__() does not construct any backend instance.
+        self.assertIsNone(InitCheckBackend.init_kwargs)
+
+    @override_settings(
+        EMAIL_PROVIDERS={
+            "one": {"BACKEND": "mail.custombackend.InitCheckBackend"},
+            "two": {"BACKEND": "mail.custombackend.InitCheckBackend"},
+            "three": {"BACKEND": "mail.custombackend.InitCheckBackend"},
+        }
+    )
+    def test_iter(self):
+        self.assertEqual(list(providers), ["one", "two", "three"])
+        # __iter__() does not construct any backend instance.
+        self.assertIsNone(InitCheckBackend.init_kwargs)
+
+    @override_settings(
+        EMAIL_PROVIDERS={
+            "default": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"},
+            "custom": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"},
+        }
+    )
+    def test_get(self):
+        with self.subTest("defined providers"):
+            self.assertEqual(providers.get("default").alias, "default")
+            self.assertEqual(providers.get("custom").alias, "custom")
+
+        with self.subTest("missing provider"):
+            with self.subTest("no default arg"):
+                self.assertIsNone(providers.get("unknown"))
+            with self.subTest("positional default arg"):
+                self.assertEqual(providers.get("unknown", "foo"), "foo")
+            with self.subTest("keyword default arg"):
+                self.assertEqual(providers.get("unknown", default="foo"), "foo")
+
+    @override_settings(
+        EMAIL_PROVIDERS={
+            "default": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"}
+        }
+    )
+    def test_default_provider_property(self):
+        backend = providers.default
+        self.assertEqual(backend.alias, "default")
+
+    # RemovedInDjango70Warning: remove override_settings (but keep the test).
+    # (EMAIL_PROVIDERS={} becomes the default in Django 7.0.)
+    @override_settings(EMAIL_PROVIDERS={})
+    def test_default_email_providers(self):
+        msg = "The email provider 'default' is not configured."
+        with (
+            self.subTest('providers["default"]'),
+            self.assertRaisesMessage(EmailProviderDoesNotExist, msg),
+        ):
+            _ = providers["default"]
+        with (
+            self.subTest("providers.default"),
+            self.assertRaisesMessage(EmailProviderDoesNotExist, msg),
+        ):
+            _ = providers.default
+
+        with self.subTest("providers.get()"):
+            self.assertIsNone(providers.get("default"))
+        with self.subTest("providers.__contains__()"):
+            self.assertIs("default" in providers, False)
+        with self.subTest("providers.__iter__()"):
+            self.assertEqual(list(providers), [])
+
+    @override_settings(
+        EMAIL_PROVIDERS={
+            "custom": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"}
+        }
+    )
+    def test_default_provider_not_required(self):
+        self.assertEqual(providers["custom"].alias, "custom")
+        msg = "The email provider 'default' is not configured."
+        with self.assertRaisesMessage(EmailProviderDoesNotExist, msg):
+            _ = providers.default
+
+    @override_settings(
+        EMAIL_PROVIDERS={
+            "custom": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"}
+        }
+    )
+    def test_instances_not_cached(self):
+        self.assertIsNot(providers["custom"], providers["custom"])
+
+    @override_settings(EMAIL_PROVIDERS={"custom": {"OPTIONS": {"host": "localhost"}}})
+    def test_default_backend_is_smtp(self):
+        # Omitting "BACKEND" gives the SMTP EmailBackend.
+        backend = providers["custom"]
+        self.assertIsInstance(backend, smtp.EmailBackend)
+
+    @override_settings(
+        EMAIL_PROVIDERS={"default": {"BACKEND": "mail.custombackend.EmailBackend"}}
+    )
+    def test_custom_backend(self):
+        backend = providers.default
+        self.assertTrue(hasattr(backend, "test_outbox"))
+
+    @override_settings(EMAIL_PROVIDERS={"custom": {"BACKEND": "foo.bar"}})
+    def test_invalid_backend(self):
+        msg = (
+            "EMAIL_PROVIDERS['custom']: Could not find BACKEND 'foo.bar': No "
+            "module named 'foo'"
+        )
+        with self.assertRaisesMessage(InvalidEmailProvider, msg):
+            _ = providers["custom"]
+
+    @override_settings(
+        EMAIL_PROVIDERS={
+            "custom": {
+                "BACKEND": "mail.custombackend.InitCheckBackend",
+                "OPTIONS": {"one": 1, "false": False, "foo": "bar"},
+            }
+        }
+    )
+    def test_options_are_provided_to_backend_init(self):
+        _ = providers["custom"]
+        self.assertEqual(
+            InitCheckBackend.init_kwargs,
+            {"alias": "custom", "one": 1, "false": False, "foo": "bar"},
+        )
+
+    @override_settings(
+        EMAIL_PROVIDERS={
+            "custom": {
+                "BACKEND": "django.core.mail.backends.smtp.EmailBackend",
+                "OPTIONS": {"alias": "imposter", "host": "localhost"},
+            }
+        }
+    )
+    def test_alias_is_invalid_option(self):
+        msg = "EMAIL_PROVIDERS['custom']: OPTIONS must not define 'alias'."
+        with self.assertRaisesMessage(InvalidEmailProvider, msg):
+            _ = providers["custom"]
+        with self.assertRaises(EmailProviderDoesNotExist):
+            _ = providers["imposter"]
+
+    @override_settings(
+        EMAIL_PROVIDERS={
+            "custom": {
+                "BACKEND": "django.core.mail.backends.locmem.EmailBackend",
+                "OPTIONS": {"unknown": "foo"},
+            }
+        }
+    )
+    def test_unknown_options(self):
+        # This error message actually comes from BaseEmailBackend.
+        msg = "EMAIL_PROVIDERS['custom']: Unknown options 'unknown'."
+        with self.assertRaisesMessage(InvalidEmailProvider, msg):
+            _ = providers["custom"]
+
+    def test_does_not_exist_is_limited_purpose(self):
+        # Code that wants to send email only when it has been configured will
+        # trap and ignore EmailProviderDoesNotExist. If that error is used to
+        # report anything other than a missing alias key in EMAIL_PROVIDERS,
+        # unrelated configuration errors may be incorrectly silenced. The
+        # error's constructor is designed to discourage other uses.
+        msg = "EmailProviderDoesNotExist.__init__() takes 1 positional argument"
+        with self.assertRaisesMessage(TypeError, msg):
+            EmailProviderDoesNotExist("Some other configuration problem")
+
+
+# RemovedInDjango70Warning.
+class EmailProvidersCompatibilityTests(SimpleTestCase):
+    """providers.default is usable even when EMAIL_PROVIDERS is not defined."""
+
+    @override_settings(
+        EMAIL_BACKEND="mail.custombackend.InitCheckBackend"
+    )
+    def test_default_provider_with_deprecated_settings(self):
+        InitCheckBackend.init_kwargs = None
+        backend = providers.default
+        self.assertIsNone(backend.alias)
+        self.assertIsInstance(backend, InitCheckBackend)
+        self.assertNotIn("alias", InitCheckBackend.init_kwargs)
+
+    def test_default_provider_with_no_settings(self):
+        backend = providers.default
+        # Django's test runner changes the default EMAIL_BACKEND to locmem.
+        self.assertIsInstance(backend, locmem.EmailBackend)
+        # In compatibility mode, backends are constructed with no 'alias' arg.
+        self.assertIsNone(backend.alias)
+
+    def test_unknown_provider_with_no_settings(self):
+        # Compatibility only applies to the default provider.
+        msg = "The email provider 'unknown' is not configured."
+        with self.assertRaisesMessage(EmailProviderDoesNotExist, msg):
+            _ = providers["unknown"]

--- a/tests/mail/test_handler.py
+++ b/tests/mail/test_handler.py
@@ -2,6 +2,10 @@ from django.core.mail import EmailProviderDoesNotExist, InvalidEmailProvider, pr
 from django.core.mail.backends import locmem, smtp
 from django.test import SimpleTestCase, override_settings
 
+from . import (
+    ignore_no_default_email_provider_warning,
+    override_deprecated_email_settings,
+)
 from .custombackend import InitCheckBackend
 
 
@@ -204,7 +208,7 @@ class EmailProvidersTests(SimpleTestCase):
 class EmailProvidersCompatibilityTests(SimpleTestCase):
     """providers.default is usable even when EMAIL_PROVIDERS is not defined."""
 
-    @override_settings(
+    @override_deprecated_email_settings(
         EMAIL_BACKEND="mail.custombackend.InitCheckBackend"
     )
     def test_default_provider_with_deprecated_settings(self):
@@ -214,6 +218,7 @@ class EmailProvidersCompatibilityTests(SimpleTestCase):
         self.assertIsInstance(backend, InitCheckBackend)
         self.assertNotIn("alias", InitCheckBackend.init_kwargs)
 
+    @ignore_no_default_email_provider_warning()
     def test_default_provider_with_no_settings(self):
         backend = providers.default
         # Django's test runner changes the default EMAIL_BACKEND to locmem.

--- a/tests/mail/test_sendtestemail.py
+++ b/tests/mail/test_sendtestemail.py
@@ -6,6 +6,9 @@ from django.test import SimpleTestCase, override_settings
 @override_settings(
     ADMINS=["admin@example.com", "admin_and_manager@example.com"],
     MANAGERS=["manager@example.com", "admin_and_manager@example.com"],
+    EMAIL_PROVIDERS={
+        "default": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"}
+    },
 )
 class SendTestEmailManagementCommand(SimpleTestCase):
     """

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -38,7 +38,11 @@ from django.test.utils import ignore_warnings, requires_tz_support
 from django.utils.deprecation import RemovedInDjango70Warning
 from django.utils.translation import gettext_lazy
 
-from . import custombackend
+from . import (
+    custombackend,
+    ignore_no_default_email_provider_warning,
+    override_deprecated_email_settings,
+)
 
 # Check whether python/cpython#128110 has been fixed by seeing if space between
 # encoded-words is ignored (as required by RFC 2047 section 6.2).
@@ -242,7 +246,7 @@ class MailTestsMixin:
         if hasattr(settings, "EMAIL_PROVIDERS"):
             return self.settings(EMAIL_PROVIDERS={"default": {"BACKEND": backend}})
         else:
-            return self.settings(EMAIL_BACKEND=backend)
+            return override_deprecated_email_settings(EMAIL_BACKEND=backend)
 
 
 class EmailMessageTests(MailTestsMixin, SimpleTestCase):
@@ -2475,6 +2479,7 @@ class MailAdminsAndManagersTestsWithEmailProviders(MailAdminsAndManagersTests):
                 self.assertEqual(mail.outbox[0].sent_using, "custom")
 
 
+@ignore_warnings(category=RemovedInDjango70Warning)
 class GetConnectionTests(SimpleTestCase):
     """Tests for django.core.mail.get_connection()."""
 
@@ -2789,6 +2794,10 @@ class DeprecatedInternalsTests(SimpleTestCase):
 # RemovedInDjango70Warning.
 class MailDeprecatedPositionalArgsTests(SimpleTestCase):
 
+    def get_connection(self, *args, **kwargs):
+        with ignore_no_default_email_provider_warning():
+            return mail.get_connection(*args, **kwargs)
+
     def assertDeprecatedIn70(self, params, name):
         return self.assertWarnsMessage(
             RemovedInDjango70Warning,
@@ -2797,7 +2806,7 @@ class MailDeprecatedPositionalArgsTests(SimpleTestCase):
 
     def test_get_connection(self):
         with self.assertDeprecatedIn70("'fail_silently'", "get_connection"):
-            mail.get_connection(
+            self.get_connection(
                 "django.core.mail.backends.dummy.EmailBackend",
                 # Deprecated positional arg:
                 True,
@@ -2818,7 +2827,7 @@ class MailDeprecatedPositionalArgsTests(SimpleTestCase):
                 None,
                 None,
                 None,
-                mail.get_connection(),
+                self.get_connection(),
                 "html message",
             )
 
@@ -2833,7 +2842,7 @@ class MailDeprecatedPositionalArgsTests(SimpleTestCase):
                 None,
                 None,
                 None,
-                mail.get_connection(),
+                self.get_connection(),
             )
 
     def test_mail_admins(self):
@@ -2845,7 +2854,7 @@ class MailDeprecatedPositionalArgsTests(SimpleTestCase):
                 "message",
                 # Deprecated positional args:
                 None,
-                mail.get_connection(),
+                self.get_connection(),
                 "html message",
             )
 
@@ -2858,7 +2867,7 @@ class MailDeprecatedPositionalArgsTests(SimpleTestCase):
                 "message",
                 # Deprecated positional args:
                 None,
-                mail.get_connection(),
+                self.get_connection(),
                 "html message",
             )
 
@@ -2874,7 +2883,7 @@ class MailDeprecatedPositionalArgsTests(SimpleTestCase):
                 ["to@example.com"],
                 # Deprecated positional args:
                 ["bcc@example.com"],
-                mail.get_connection(),
+                self.get_connection(),
                 [EmailAttachment("file.txt", "attachment\n", "text/plain")],
                 {"X-Header": "custom header"},
                 ["cc@example.com"],
@@ -2894,7 +2903,7 @@ class MailDeprecatedPositionalArgsTests(SimpleTestCase):
                 ["to@example.com"],
                 # Deprecated positional args:
                 ["bcc@example.com"],
-                mail.get_connection(),
+                self.get_connection(),
                 [EmailAttachment("file.txt", "attachment\n", "text/plain")],
                 {"X-Header": "custom header"},
                 [EmailAlternative("html body", "text/html")],

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -35,6 +35,8 @@ from django.test.utils import ignore_warnings, requires_tz_support
 from django.utils.deprecation import RemovedInDjango70Warning
 from django.utils.translation import gettext_lazy
 
+from . import custombackend
+
 # Check whether python/cpython#128110 has been fixed by seeing if space between
 # encoded-words is ignored (as required by RFC 2047 section 6.2).
 NEEDS_CPYTHON_128110_WORKAROUND = (
@@ -234,9 +236,7 @@ class MailTestsMixin:
 
 
 class EmailMessageTests(MailTestsMixin, SimpleTestCase):
-    """
-    Tests for django.core.mail.EmailMessage and EmailMultiAlternative.
-    """
+    """Tests for django.core.mail.EmailMessage and EmailMultiAlternative."""
 
     def test_ascii(self):
         email = EmailMessage(
@@ -802,12 +802,13 @@ class EmailMessageTests(MailTestsMixin, SimpleTestCase):
         # even an empty body.
         self.assertEqual(msg.message().get_payload(), "\n")
 
-    @mock.patch("socket.getfqdn", return_value="漢字")
-    def test_non_ascii_dns_non_unicode_email(self, mocked_getfqdn):
+    def test_non_ascii_dns_non_unicode_email(self):
         delattr(DNS_NAME, "_fqdn")
         email = EmailMessage()
         email.encoding = "iso-8859-1"
-        self.assertIn("@xn--p8s937b>", email.message()["Message-ID"])
+        with mock.patch("socket.getfqdn", return_value="漢字"):
+            message = email.message()
+        self.assertIn("@xn--p8s937b>", message["Message-ID"])
 
     def test_encoding(self):
         """
@@ -1685,8 +1686,8 @@ class EmailMessageTests(MailTestsMixin, SimpleTestCase):
         """
         # This is meant to verify EmailMessage.__init__() doesn't apply any
         # special processing that would be missing for properties set later.
-        original_connection = mail.get_connection(username="original")
-        new_connection = mail.get_connection(username="new")
+        original_connection = mail.get_connection()
+        new_connection = mail.get_connection()
         email = EmailMessage(
             "original subject",
             "original body\n",
@@ -1809,7 +1810,7 @@ class EmailMessageTests(MailTestsMixin, SimpleTestCase):
         )
 
     def test_send_fail_silently_conflict(self):
-        email = mail.EmailMessage(
+        email = EmailMessage(
             "Subject",
             "Body",
             "from@example.com",
@@ -1825,9 +1826,7 @@ class EmailMessageTests(MailTestsMixin, SimpleTestCase):
 
 
 class SendMailTests(SimpleTestCase, MailTestsMixin):
-    """
-    Tests for django.core.mail.send_mail().
-    """
+    """Tests for django.core.mail.send_mail()."""
 
     def test_plaintext_send_mail(self):
         """
@@ -1863,12 +1862,25 @@ class SendMailTests(SimpleTestCase, MailTestsMixin):
         self.assertEqual(message.get_payload(1).get_content(), "HTML Content\n")
         self.assertEqual(message.get_payload(1).get_content_type(), "text/html")
 
+    def test_returns_count_of_messages_sent(self):
+        cases = [
+            (["to@example.com"], 1),
+            (["one@example.com", "two@example.com"], 1),
+            ([], 0),
+        ]
+        for recipient_list, expected_count in cases:
+            with self.subTest(recipient_list=recipient_list):
+                count = send_mail(
+                    "Subject", "Content", "from@example.com", recipient_list
+                )
+                self.assertEqual(count, expected_count)
+
     def test_idn_addresses(self):
         """
         IDNA encoding is applied to non-ASCII domains in address headers
         (#14301).
         """
-        self.assertTrue(send_mail("Subject", "Content", "from@öäü.com", ["to@öäü.com"]))
+        send_mail("Subject", "Content", "from@öäü.com", ["to@öäü.com"])
         message = self.get_outbox_message()
         self.assertEqual(message.get("from"), "from@xn--4ca9at.com")
         self.assertEqual(message.get("to"), "to@xn--4ca9at.com")
@@ -1878,14 +1890,14 @@ class SendMailTests(SimpleTestCase, MailTestsMixin):
         Email sending should support lazy email addresses (#24416).
         """
         _ = gettext_lazy
-        self.assertTrue(send_mail("Subject", "Content", _("tester"), [_("django")]))
+        send_mail("Subject", "Content", _("tester"), [_("django")])
         message = self.get_outbox_message()
         self.assertEqual(message.get("from"), "tester")
         self.assertEqual(message.get("to"), "django")
 
     def test_connection_arg(self):
         # Send using non-default connection.
-        connection = mail.get_connection("mail.custombackend.EmailBackend")
+        connection = custombackend.EmailBackend()
         send_mail(
             "Subject",
             "Content",
@@ -1897,13 +1909,40 @@ class SendMailTests(SimpleTestCase, MailTestsMixin):
         self.assertEqual(len(connection.test_outbox), 1)
         self.assertEqual(connection.test_outbox[0].subject, "Subject")
 
+    def test_auth_passed_to_backend_init(self):
+        with self.settings(EMAIL_BACKEND="mail.custombackend.OptionsCapturingBackend"):
+            send_mail(
+                "Subject",
+                "Content",
+                "from@example.com",
+                ["to@example.com"],
+                auth_user="user",
+                auth_password="password",
+            )
+        # "auth_user" and "auth_password" become "username" and "password".
+        init_kwargs = mail.outbox[0].backend_init_kwargs
+        self.assertEqual(init_kwargs["username"], "user")
+        self.assertEqual(init_kwargs["password"], "password")
+
+    def test_fail_silently_passed_to_backend_init(self):
+        with self.settings(EMAIL_BACKEND="mail.custombackend.OptionsCapturingBackend"):
+            send_mail(
+                "Subject",
+                "Content",
+                "from@example.com",
+                ["to@example.com"],
+                fail_silently=True,
+            )
+        init_kwargs = mail.outbox[0].backend_init_kwargs
+        self.assertIs(init_kwargs["fail_silently"], True)
+
     def test_fail_silently_conflict(self):
         msg = (
             "fail_silently cannot be used with a connection. "
             "Pass fail_silently to get_connection() instead."
         )
         with self.assertRaisesMessage(TypeError, msg):
-            mail.send_mail(
+            send_mail(
                 "Subject",
                 "Body",
                 "from@example.com",
@@ -1922,7 +1961,7 @@ class SendMailTests(SimpleTestCase, MailTestsMixin):
                 self.subTest(param=param),
                 self.assertRaisesMessage(TypeError, msg),
             ):
-                mail.send_mail(
+                send_mail(
                     "subject",
                     "body",
                     "from@example.com",
@@ -1933,13 +1972,34 @@ class SendMailTests(SimpleTestCase, MailTestsMixin):
 
 
 class SendMassMailTests(SimpleTestCase):
-    """
-    Tests for django.core.mail.send_mass_mail().
-    """
+    """Tests for django.core.mail.send_mass_mail()."""
+
+    def test_send_mass_mail(self):
+        count = send_mass_mail(
+            [
+                ("Subject1", "Content1", "from1@example.com", ["to1@example.com"]),
+                (
+                    "Subject2",
+                    "Content2",
+                    "from2@example.com",
+                    ["to2a@example.com", "to2b@example.com"],
+                ),
+            ],
+        )
+        self.assertEqual(count, 2)
+        self.assertEqual(len(mail.outbox), 2)
+        self.assertEqual(mail.outbox[0].subject, "Subject1")
+        self.assertEqual(mail.outbox[0].body, "Content1")
+        self.assertEqual(mail.outbox[0].from_email, "from1@example.com")
+        self.assertEqual(mail.outbox[0].to, ["to1@example.com"])
+        self.assertEqual(mail.outbox[1].subject, "Subject2")
+        self.assertEqual(mail.outbox[1].body, "Content2")
+        self.assertEqual(mail.outbox[1].from_email, "from2@example.com")
+        self.assertEqual(mail.outbox[1].to, ["to2a@example.com", "to2b@example.com"])
 
     def test_connection_arg(self):
         # Send using non-default connection.
-        connection = mail.get_connection("mail.custombackend.EmailBackend")
+        connection = custombackend.EmailBackend()
         send_mass_mail(
             [
                 ("Subject1", "Content1", "from1@example.com", ["to1@example.com"]),
@@ -1951,6 +2011,30 @@ class SendMassMailTests(SimpleTestCase):
         self.assertEqual(len(connection.test_outbox), 2)
         self.assertEqual(connection.test_outbox[0].subject, "Subject1")
         self.assertEqual(connection.test_outbox[1].subject, "Subject2")
+        # Connection is provided to EmailMessage objects (#17811).
+        self.assertIs(connection.test_outbox[0].connection, connection)
+        self.assertIs(connection.test_outbox[1].connection, connection)
+
+    def test_auth_passed_to_backend_init(self):
+        with self.settings(EMAIL_BACKEND="mail.custombackend.OptionsCapturingBackend"):
+            send_mass_mail(
+                [("Subject1", "Content1", "from1@example.com", ["to1@example.com"])],
+                auth_user="user",
+                auth_password="password",
+            )
+        # "auth_user" and "auth_password" become "username" and "password".
+        init_kwargs = mail.outbox[0].backend_init_kwargs
+        self.assertEqual(init_kwargs["username"], "user")
+        self.assertEqual(init_kwargs["password"], "password")
+
+    def test_fail_silently_passed_to_backend_init(self):
+        with self.settings(EMAIL_BACKEND="mail.custombackend.OptionsCapturingBackend"):
+            send_mass_mail(
+                [("Subject1", "Content1", "from1@example.com", ["to1@example.com"])],
+                fail_silently=True,
+            )
+        init_kwargs = mail.outbox[0].backend_init_kwargs
+        self.assertIs(init_kwargs["fail_silently"], True)
 
     def test_send_fail_silently_conflict(self):
         datatuple = (("Subject", "Message", "from@example.com", ["to@example.com"]),)
@@ -1959,7 +2043,7 @@ class SendMassMailTests(SimpleTestCase):
             "Pass fail_silently to get_connection() instead."
         )
         with self.assertRaisesMessage(TypeError, msg):
-            mail.send_mass_mail(
+            send_mass_mail(
                 datatuple, fail_silently=True, connection=mail.get_connection()
             )
 
@@ -1974,15 +2058,13 @@ class SendMassMailTests(SimpleTestCase):
                 self.subTest(param=param),
                 self.assertRaisesMessage(TypeError, msg),
             ):
-                mail.send_mass_mail(
+                send_mass_mail(
                     datatuple, **{param: "value"}, connection=mail.get_connection()
                 )
 
 
 class MailAdminsAndManagersTests(SimpleTestCase, MailTestsMixin):
-    """
-    Tests for django.core.mail.mail_admins() and mail_managers().
-    """
+    """Tests for django.core.mail.mail_admins() and mail_managers()."""
 
     def test_mail_admins_and_managers(self):
         tests = (
@@ -2128,7 +2210,7 @@ class MailAdminsAndManagersTests(SimpleTestCase, MailTestsMixin):
     @override_settings(ADMINS=["nobody@example.com"])
     def test_connection_arg_mail_admins(self):
         # Send using non-default connection.
-        connection = mail.get_connection("mail.custombackend.EmailBackend")
+        connection = custombackend.EmailBackend()
         mail_admins("Admin message", "Content", connection=connection)
         self.assertEqual(mail.outbox, [])
         self.assertEqual(len(connection.test_outbox), 1)
@@ -2137,7 +2219,7 @@ class MailAdminsAndManagersTests(SimpleTestCase, MailTestsMixin):
     @override_settings(MANAGERS=["nobody@example.com"])
     def test_connection_arg_mail_managers(self):
         # Send using non-default connection.
-        connection = mail.get_connection("mail.custombackend.EmailBackend")
+        connection = custombackend.EmailBackend()
         mail_managers("Manager message", "Content", connection=connection)
         self.assertEqual(mail.outbox, [])
         self.assertEqual(len(connection.test_outbox), 1)
@@ -2149,7 +2231,7 @@ class MailAdminsAndManagersTests(SimpleTestCase, MailTestsMixin):
             "Pass fail_silently to get_connection() instead."
         )
         with self.assertRaisesMessage(TypeError, msg):
-            mail.mail_admins(
+            mail_admins(
                 "Subject",
                 "Message",
                 fail_silently=True,
@@ -2162,7 +2244,7 @@ class MailAdminsAndManagersTests(SimpleTestCase, MailTestsMixin):
             "Pass fail_silently to get_connection() instead."
         )
         with self.assertRaisesMessage(TypeError, msg):
-            mail.mail_managers(
+            mail_managers(
                 "Subject",
                 "Message",
                 fail_silently=True,
@@ -2171,9 +2253,18 @@ class MailAdminsAndManagersTests(SimpleTestCase, MailTestsMixin):
 
 
 class GetConnectionTests(SimpleTestCase):
-    """
-    Tests for django.core.mail.get_connection().
-    """
+    """Tests for django.core.mail.get_connection()."""
+
+    @override_settings(EMAIL_BACKEND="django.core.mail.backends.console.EmailBackend")
+    def test_uses_email_backend_setting(self):
+        connection = mail.get_connection()
+        self.assertIsInstance(connection, console.EmailBackend)
+
+    @override_settings(EMAIL_BACKEND="django.core.mail.backends.smtp.EmailBackend")
+    def test_backend_specific_kwargs(self):
+        connection = mail.get_connection(host="mail.example.com")
+        self.assertIsInstance(connection, smtp.EmailBackend)
+        self.assertEqual(connection.host, "mail.example.com")
 
     def test_backend_arg(self):
         """Test backend argument of mail.get_connection()"""
@@ -2226,7 +2317,7 @@ class GetConnectionTests(SimpleTestCase):
         used with custom backends.
         """
         c = mail.get_connection(fail_silently=True, foo="bar")
-        self.assertTrue(c.fail_silently)
+        self.assertIs(c.fail_silently, True)
 
 
 # RemovedInDjango70Warning.

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -33,6 +33,11 @@ from django.core.mail import (
     send_mass_mail,
 )
 from django.core.mail.backends import console, dummy, filebased, locmem, smtp
+from django.core.mail.deprecation import (
+    AUTH_ARGS_WARNING,
+    CONNECTION_ARG_WARNING,
+    FAIL_SILENTLY_ARG_WARNING,
+)
 from django.test import SimpleTestCase, override_settings
 from django.test.utils import ignore_warnings, requires_tz_support
 from django.utils.deprecation import RemovedInDjango70Warning
@@ -1654,6 +1659,8 @@ class EmailMessageTests(MailTestsMixin, SimpleTestCase):
         email = EmailMultiAlternatives()
         self.assertIsInstance(email.message(), PyMessage)  # force serialization.
 
+    # RemovedInDjango70Warning: connection argument.
+    @ignore_warnings(category=RemovedInDjango70Warning)
     def test_positional_arguments_order(self):
         """
         EmailMessage class docs: "… is initialized with the following
@@ -1693,6 +1700,8 @@ class EmailMessageTests(MailTestsMixin, SimpleTestCase):
         )
         self.assertIs(email.connection, connection)
 
+    # RemovedInDjango70Warning: connection argument and attribute.
+    @ignore_warnings(category=RemovedInDjango70Warning)
     def test_all_params_can_be_set_before_send(self):
         """
         EmailMessage class docs: "All parameters … can be set at any time
@@ -1823,6 +1832,8 @@ class EmailMessageTests(MailTestsMixin, SimpleTestCase):
             message.as_string(policy=policy.compat32),
         )
 
+    # RemovedInDjango70Warning.
+    @ignore_warnings(category=RemovedInDjango70Warning)
     def test_send_fail_silently_conflict(self):
         email = EmailMessage(
             "Subject",
@@ -1850,6 +1861,36 @@ class EmailMessageTests(MailTestsMixin, SimpleTestCase):
         else:
             self.assertIsNone(mail.outbox[0].sent_using)
 
+    # RemovedInDjango70Warning.
+    def test_connection_arg_deprecated(self):
+        connection = object()
+        with self.assertWarnsMessage(RemovedInDjango70Warning, CONNECTION_ARG_WARNING):
+            email = EmailMessage(connection=connection)
+        with ignore_warnings(category=RemovedInDjango70Warning):
+            self.assertIs(email.connection, connection)
+
+    # RemovedInDjango70Warning.
+    def test_connection_attr_deprecated(self):
+        email = EmailMessage()
+        connection = object()
+        msg_set = (
+            "The EmailMessage.connection attribute is deprecated. Switch to "
+            "EmailMessage.send(using=...) with an EMAIL_PROVIDERS alias."
+        )
+        msg_get = "The EmailMessage.connection attribute is deprecated."
+        with self.assertWarnsMessage(RemovedInDjango70Warning, msg_set):
+            email.connection = connection
+        with self.assertWarnsMessage(RemovedInDjango70Warning, msg_get):
+            self.assertIs(email.connection, connection)
+
+    # RemovedInDjango70Warning.
+    def test_fail_silently_deprecated(self):
+        email = EmailMessage(to=["to@example.com"])
+        with self.assertWarnsMessage(
+            RemovedInDjango70Warning, FAIL_SILENTLY_ARG_WARNING
+        ):
+            email.send(fail_silently=True)
+
 
 # RemovedInDjango70Warning: Move override_settings and additional test cases to
 # EmailMessageTests and remove this class.
@@ -1872,6 +1913,7 @@ class EmailMessageTestsWithEmailProviders(EmailMessageTests):
         self.assertEqual(mail.outbox[2].sent_using, "default")
 
     # RemovedInDjango70Warning.
+    @ignore_warnings(category=RemovedInDjango70Warning)
     def test_send_using_conflicts_with_connection(self):
         msg = "'connection' is not compatible with 'using'."
         with self.subTest("in constructor"):
@@ -1886,6 +1928,7 @@ class EmailMessageTestsWithEmailProviders(EmailMessageTests):
                 email.send(using="test")
 
     # RemovedInDjango70Warning.
+    @ignore_warnings(category=RemovedInDjango70Warning)
     def test_send_using_conflicts_with_fail_silently(self):
         msg = "'fail_silently' is not compatible with 'using'"
         email = EmailMessage(to=["to@example.com"])
@@ -1972,22 +2015,28 @@ class SendMailTests(SimpleTestCase, MailTestsMixin):
         self.assertEqual(message.get("from"), "tester")
         self.assertEqual(message.get("to"), "django")
 
+    # RemovedInDjango70Warning.
     def test_connection_arg(self):
         # Send using non-default connection.
         connection = custombackend.EmailBackend()
-        send_mail(
-            "Subject",
-            "Content",
-            "from@example.com",
-            ["to@example.com"],
-            connection=connection,
-        )
+        with self.assertWarnsMessage(RemovedInDjango70Warning, CONNECTION_ARG_WARNING):
+            send_mail(
+                "Subject",
+                "Content",
+                "from@example.com",
+                ["to@example.com"],
+                connection=connection,
+            )
         self.assertEqual(mail.outbox, [])
         self.assertEqual(len(connection.test_outbox), 1)
         self.assertEqual(connection.test_outbox[0].subject, "Subject")
 
+    # RemovedInDjango70Warning.
     def test_auth_passed_to_backend_init(self):
-        with self.use_email_backend("mail.custombackend.OptionsCapturingBackend"):
+        with (
+            self.use_email_backend("mail.custombackend.OptionsCapturingBackend"),
+            self.assertWarnsMessage(RemovedInDjango70Warning, AUTH_ARGS_WARNING),
+        ):
             send_mail(
                 "Subject",
                 "Content",
@@ -2001,8 +2050,14 @@ class SendMailTests(SimpleTestCase, MailTestsMixin):
         self.assertEqual(init_kwargs["username"], "user")
         self.assertEqual(init_kwargs["password"], "password")
 
+    # RemovedInDjango70Warning.
     def test_fail_silently_passed_to_backend_init(self):
-        with self.use_email_backend("mail.custombackend.OptionsCapturingBackend"):
+        with (
+            self.use_email_backend("mail.custombackend.OptionsCapturingBackend"),
+            self.assertWarnsMessage(
+                RemovedInDjango70Warning, FAIL_SILENTLY_ARG_WARNING
+            ),
+        ):
             send_mail(
                 "Subject",
                 "Content",
@@ -2013,6 +2068,8 @@ class SendMailTests(SimpleTestCase, MailTestsMixin):
         init_kwargs = mail.outbox[0].backend_init_kwargs
         self.assertIs(init_kwargs["fail_silently"], True)
 
+    # RemovedInDjango70Warning.
+    @ignore_warnings(category=RemovedInDjango70Warning)
     def test_fail_silently_conflict(self):
         msg = (
             "fail_silently cannot be used with a connection. "
@@ -2028,6 +2085,8 @@ class SendMailTests(SimpleTestCase, MailTestsMixin):
                 connection=mail.get_connection(),
             )
 
+    # RemovedInDjango70Warning.
+    @ignore_warnings(category=RemovedInDjango70Warning)
     def test_auth_conflict(self):
         msg = (
             "auth_user and auth_password cannot be used with a connection. "
@@ -2048,6 +2107,7 @@ class SendMailTests(SimpleTestCase, MailTestsMixin):
                 )
 
     # RemovedInDjango70Warning.
+    @ignore_warnings(category=RemovedInDjango70Warning)
     def test_using_connection_conflict(self):
         msg = "'connection' is not compatible with 'using'."
         with self.assertRaisesMessage(TypeError, msg):
@@ -2061,6 +2121,7 @@ class SendMailTests(SimpleTestCase, MailTestsMixin):
             )
 
     # RemovedInDjango70Warning.
+    @ignore_warnings(category=RemovedInDjango70Warning)
     def test_using_fail_silently_conflict(self):
         msg = "'fail_silently' is not compatible with 'using'"
         with self.assertRaisesMessage(TypeError, msg):
@@ -2074,6 +2135,7 @@ class SendMailTests(SimpleTestCase, MailTestsMixin):
             )
 
     # RemovedInDjango70Warning.
+    @ignore_warnings(category=RemovedInDjango70Warning)
     def test_using_auth_conflict(self):
         msg = (
             "'auth_user' and 'auth_password' are not compatible with 'using'. "
@@ -2154,26 +2216,36 @@ class SendMassMailTests(MailTestsMixin, SimpleTestCase):
         else:
             self.assertIsNone(mail.outbox[0].sent_using)
 
+    # RemovedInDjango70Warning.
     def test_connection_arg(self):
         # Send using non-default connection.
         connection = custombackend.EmailBackend()
-        send_mass_mail(
-            [
-                ("Subject1", "Content1", "from1@example.com", ["to1@example.com"]),
-                ("Subject2", "Content2", "from2@example.com", ["to2@example.com"]),
-            ],
-            connection=connection,
-        )
+        with self.assertWarnsMessage(RemovedInDjango70Warning, CONNECTION_ARG_WARNING):
+            send_mass_mail(
+                [
+                    ("Subject1", "Content1", "from1@example.com", ["to1@example.com"]),
+                    ("Subject2", "Content2", "from2@example.com", ["to2@example.com"]),
+                ],
+                connection=connection,
+            )
         self.assertEqual(mail.outbox, [])
         self.assertEqual(len(connection.test_outbox), 2)
         self.assertEqual(connection.test_outbox[0].subject, "Subject1")
         self.assertEqual(connection.test_outbox[1].subject, "Subject2")
         # Connection is provided to EmailMessage objects (#17811).
-        self.assertIs(connection.test_outbox[0].connection, connection)
-        self.assertIs(connection.test_outbox[1].connection, connection)
+        with ignore_warnings(
+            category=RemovedInDjango70Warning,
+            message="The EmailMessage.connection attribute is deprecated.",
+        ):
+            self.assertIs(connection.test_outbox[0].connection, connection)
+            self.assertIs(connection.test_outbox[1].connection, connection)
 
+    # RemovedInDjango70Warning.
     def test_auth_passed_to_backend_init(self):
-        with self.use_email_backend("mail.custombackend.OptionsCapturingBackend"):
+        with (
+            self.use_email_backend("mail.custombackend.OptionsCapturingBackend"),
+            self.assertWarnsMessage(RemovedInDjango70Warning, AUTH_ARGS_WARNING),
+        ):
             send_mass_mail(
                 [("Subject1", "Content1", "from1@example.com", ["to1@example.com"])],
                 auth_user="user",
@@ -2184,8 +2256,14 @@ class SendMassMailTests(MailTestsMixin, SimpleTestCase):
         self.assertEqual(init_kwargs["username"], "user")
         self.assertEqual(init_kwargs["password"], "password")
 
+    # RemovedInDjango70Warning.
     def test_fail_silently_passed_to_backend_init(self):
-        with self.use_email_backend("mail.custombackend.OptionsCapturingBackend"):
+        with (
+            self.use_email_backend("mail.custombackend.OptionsCapturingBackend"),
+            self.assertWarnsMessage(
+                RemovedInDjango70Warning, FAIL_SILENTLY_ARG_WARNING
+            ),
+        ):
             send_mass_mail(
                 [("Subject1", "Content1", "from1@example.com", ["to1@example.com"])],
                 fail_silently=True,
@@ -2193,6 +2271,8 @@ class SendMassMailTests(MailTestsMixin, SimpleTestCase):
         init_kwargs = mail.outbox[0].backend_init_kwargs
         self.assertIs(init_kwargs["fail_silently"], True)
 
+    # RemovedInDjango70Warning.
+    @ignore_warnings(category=RemovedInDjango70Warning)
     def test_send_fail_silently_conflict(self):
         datatuple = (("Subject", "Message", "from@example.com", ["to@example.com"]),)
         msg = (
@@ -2204,6 +2284,8 @@ class SendMassMailTests(MailTestsMixin, SimpleTestCase):
                 datatuple, fail_silently=True, connection=mail.get_connection()
             )
 
+    # RemovedInDjango70Warning.
+    @ignore_warnings(category=RemovedInDjango70Warning)
     def test_send_auth_conflict(self):
         datatuple = (("Subject", "Message", "from@example.com", ["to@example.com"]),)
         msg = (
@@ -2220,6 +2302,7 @@ class SendMassMailTests(MailTestsMixin, SimpleTestCase):
                 )
 
     # RemovedInDjango70Warning.
+    @ignore_warnings(category=RemovedInDjango70Warning)
     def test_using_connection_conflict(self):
         msg = "'connection' is not compatible with 'using'."
         with self.assertRaisesMessage(TypeError, msg):
@@ -2230,6 +2313,7 @@ class SendMassMailTests(MailTestsMixin, SimpleTestCase):
             )
 
     # RemovedInDjango70Warning.
+    @ignore_warnings(category=RemovedInDjango70Warning)
     def test_using_fail_silently_conflict(self):
         msg = "'fail_silently' is not compatible with 'using'"
         with self.assertRaisesMessage(TypeError, msg):
@@ -2415,24 +2499,43 @@ class MailAdminsAndManagersTests(SimpleTestCase, MailTestsMixin):
                     with self.assertRaisesMessage(ImproperlyConfigured, msg):
                         mail_func("subject", "content")
 
+    # RemovedInDjango70Warning.
     @override_settings(ADMINS=["nobody@example.com"])
     def test_connection_arg_mail_admins(self):
         # Send using non-default connection.
         connection = custombackend.EmailBackend()
-        mail_admins("Admin message", "Content", connection=connection)
+        with self.assertWarnsMessage(RemovedInDjango70Warning, CONNECTION_ARG_WARNING):
+            mail_admins("Admin message", "Content", connection=connection)
         self.assertEqual(mail.outbox, [])
         self.assertEqual(len(connection.test_outbox), 1)
         self.assertEqual(connection.test_outbox[0].subject, "[Django] Admin message")
 
+    # RemovedInDjango70Warning.
     @override_settings(MANAGERS=["nobody@example.com"])
+    @ignore_warnings(category=RemovedInDjango70Warning)
     def test_connection_arg_mail_managers(self):
         # Send using non-default connection.
         connection = custombackend.EmailBackend()
-        mail_managers("Manager message", "Content", connection=connection)
+        with self.assertWarnsMessage(RemovedInDjango70Warning, CONNECTION_ARG_WARNING):
+            mail_managers("Manager message", "Content", connection=connection)
         self.assertEqual(mail.outbox, [])
         self.assertEqual(len(connection.test_outbox), 1)
         self.assertEqual(connection.test_outbox[0].subject, "[Django] Manager message")
 
+    # RemovedInDjango70Warning.
+    @override_settings(ADMINS=["admin@example.com"], MANAGERS=["manager@example.com"])
+    def test_fail_silently_deprecated(self):
+        for mail_func in [mail_managers, mail_admins]:
+            with (
+                self.subTest(mail_func=mail_func),
+                self.assertWarnsMessage(
+                    RemovedInDjango70Warning, FAIL_SILENTLY_ARG_WARNING
+                ),
+            ):
+                mail_func("Subject", "Content", fail_silently=True)
+
+    # RemovedInDjango70Warning.
+    @ignore_warnings(category=RemovedInDjango70Warning)
     def test_mail_admins_fail_silently_conflict(self):
         msg = (
             "fail_silently cannot be used with a connection. "
@@ -2446,6 +2549,8 @@ class MailAdminsAndManagersTests(SimpleTestCase, MailTestsMixin):
                 connection=mail.get_connection(),
             )
 
+    # RemovedInDjango70Warning.
+    @ignore_warnings(category=RemovedInDjango70Warning)
     def test_mail_managers_fail_silently_conflict(self):
         msg = (
             "fail_silently cannot be used with a connection. "
@@ -2479,9 +2584,18 @@ class MailAdminsAndManagersTestsWithEmailProviders(MailAdminsAndManagersTests):
                 self.assertEqual(mail.outbox[0].sent_using, "custom")
 
 
+# RemovedInDjango70Warning.
 @ignore_warnings(category=RemovedInDjango70Warning)
 class GetConnectionTests(SimpleTestCase):
     """Tests for django.core.mail.get_connection()."""
+
+    def test_deprecated(self):
+        msg = (
+            "get_connection() is deprecated. See 'Migrating to EMAIL_PROVIDERS' in "
+            "Django's documentation for recommended replacements."
+        )
+        with self.assertWarnsMessage(RemovedInDjango70Warning, msg):
+            mail.get_connection()
 
     @override_settings(EMAIL_BACKEND="django.core.mail.backends.console.EmailBackend")
     def test_uses_email_backend_setting(self):
@@ -2795,7 +2909,13 @@ class DeprecatedInternalsTests(SimpleTestCase):
 class MailDeprecatedPositionalArgsTests(SimpleTestCase):
 
     def get_connection(self, *args, **kwargs):
-        with ignore_no_default_email_provider_warning():
+        with (
+            ignore_no_default_email_provider_warning(),
+            ignore_warnings(
+                category=RemovedInDjango70Warning,
+                message=re.escape("get_connection() is deprecated."),
+            ),
+        ):
             return mail.get_connection(*args, **kwargs)
 
     def assertDeprecatedIn70(self, params, name):

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from textwrap import dedent
 from unittest import mock
 
+from django.conf import settings
 from django.core import mail
 from django.core.exceptions import ImproperlyConfigured
 from django.core.mail import (
@@ -24,8 +25,10 @@ from django.core.mail import (
     EmailAttachment,
     EmailMessage,
     EmailMultiAlternatives,
+    EmailProviderDoesNotExist,
     mail_admins,
     mail_managers,
+    providers,
     send_mail,
     send_mass_mail,
 )
@@ -233,6 +236,13 @@ class MailTestsMixin:
             for subpart in message.get_payload():
                 structure.append(self.get_message_structure(subpart, level + 1))
         return "".join(structure)
+
+    # RemovedInDjango70Warning.
+    def use_email_backend(self, backend):
+        if hasattr(settings, "EMAIL_PROVIDERS"):
+            return self.settings(EMAIL_PROVIDERS={"default": {"BACKEND": backend}})
+        else:
+            return self.settings(EMAIL_BACKEND=backend)
 
 
 class EmailMessageTests(MailTestsMixin, SimpleTestCase):
@@ -1677,7 +1687,7 @@ class EmailMessageTests(MailTestsMixin, SimpleTestCase):
         self.assertEqual(
             email.recipients(), ["to@example.com", "cc@example.com", "bcc@example.com"]
         )
-        self.assertIs(email.get_connection(), connection)
+        self.assertIs(email.connection, connection)
 
     def test_all_params_can_be_set_before_send(self):
         """
@@ -1739,7 +1749,7 @@ class EmailMessageTests(MailTestsMixin, SimpleTestCase):
             email.recipients(),
             ["new-to@example.com", "new-cc@example.com", "new-bcc@example.com"],
         )
-        self.assertIs(email.get_connection(), new_connection)
+        self.assertIs(email.connection, new_connection)
         self.assertNotIn("original", message.as_string())
 
     def test_message_is_python_email_message(self):
@@ -1824,9 +1834,72 @@ class EmailMessageTests(MailTestsMixin, SimpleTestCase):
         with self.assertRaisesMessage(TypeError, msg):
             email.send(fail_silently=True)
 
+    def test_send(self):
+        email = EmailMessage(to=["to@example.com"])
+        email.send()
+        self.assertEqual(mail.outbox[0].to, ["to@example.com"])
+
+        # RemovedInDjango70Warning: Change to (removing the `if`):
+        #   self.assertEqual(mail.outbox[0].sent_using, "default")
+        if providers._is_configured:
+            self.assertEqual(mail.outbox[0].sent_using, "default")
+        else:
+            self.assertIsNone(mail.outbox[0].sent_using)
+
+
+# RemovedInDjango70Warning: Move override_settings and additional test cases to
+# EmailMessageTests and remove this class.
+@override_settings(
+    EMAIL_PROVIDERS={
+        "default": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"},
+        "custom": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"},
+    }
+)
+class EmailMessageTestsWithEmailProviders(EmailMessageTests):
+    # Repeat all EmailMessageTests with EMAIL_PROVIDERS defined.
+
+    def test_send_using(self):
+        email = EmailMessage(to=["to@example.com"])
+        email.send()
+        email.send(using="custom")
+        email.send()
+        self.assertEqual(mail.outbox[0].sent_using, "default")
+        self.assertEqual(mail.outbox[1].sent_using, "custom")
+        self.assertEqual(mail.outbox[2].sent_using, "default")
+
+    # RemovedInDjango70Warning.
+    def test_send_using_conflicts_with_connection(self):
+        msg = "'connection' is not compatible with 'using'."
+        with self.subTest("in constructor"):
+            email = EmailMessage(to=["to@example.com"], connection=object())
+            with self.assertRaisesMessage(TypeError, msg):
+                email.send(using="test")
+
+        with self.subTest("as attribute"):
+            email = EmailMessage(to=["to@example.com"])
+            email.connection = object()
+            with self.assertRaisesMessage(TypeError, msg):
+                email.send(using="test")
+
+    # RemovedInDjango70Warning.
+    def test_send_using_conflicts_with_fail_silently(self):
+        msg = "'fail_silently' is not compatible with 'using'"
+        email = EmailMessage(to=["to@example.com"])
+        with self.assertRaisesMessage(TypeError, msg):
+            email.send(using="test", fail_silently=True)
+
 
 class SendMailTests(SimpleTestCase, MailTestsMixin):
     """Tests for django.core.mail.send_mail()."""
+
+    def test_sends_using_default_provider(self):
+        send_mail("subject", "body", "from@example.com", ["to@example.com"])
+        # RemovedInDjango70Warning: Change to (removing the `if`):
+        #   self.assertEqual(mail.outbox[0].sent_using, "default")
+        if providers._is_configured:
+            self.assertEqual(mail.outbox[0].sent_using, "default")
+        else:
+            self.assertIsNone(mail.outbox[0].sent_using)
 
     def test_plaintext_send_mail(self):
         """
@@ -1910,7 +1983,7 @@ class SendMailTests(SimpleTestCase, MailTestsMixin):
         self.assertEqual(connection.test_outbox[0].subject, "Subject")
 
     def test_auth_passed_to_backend_init(self):
-        with self.settings(EMAIL_BACKEND="mail.custombackend.OptionsCapturingBackend"):
+        with self.use_email_backend("mail.custombackend.OptionsCapturingBackend"):
             send_mail(
                 "Subject",
                 "Content",
@@ -1925,7 +1998,7 @@ class SendMailTests(SimpleTestCase, MailTestsMixin):
         self.assertEqual(init_kwargs["password"], "password")
 
     def test_fail_silently_passed_to_backend_init(self):
-        with self.settings(EMAIL_BACKEND="mail.custombackend.OptionsCapturingBackend"):
+        with self.use_email_backend("mail.custombackend.OptionsCapturingBackend"):
             send_mail(
                 "Subject",
                 "Content",
@@ -1970,8 +2043,77 @@ class SendMailTests(SimpleTestCase, MailTestsMixin):
                     connection=mail.get_connection(),
                 )
 
+    # RemovedInDjango70Warning.
+    def test_using_connection_conflict(self):
+        msg = "'connection' is not compatible with 'using'."
+        with self.assertRaisesMessage(TypeError, msg):
+            send_mail(
+                "subject",
+                "body",
+                "from@example.com",
+                ["to@example.com"],
+                connection=object(),
+                using="default",
+            )
 
-class SendMassMailTests(SimpleTestCase):
+    # RemovedInDjango70Warning.
+    def test_using_fail_silently_conflict(self):
+        msg = "'fail_silently' is not compatible with 'using'"
+        with self.assertRaisesMessage(TypeError, msg):
+            send_mail(
+                "subject",
+                "body",
+                "from@example.com",
+                ["to@example.com"],
+                fail_silently=True,
+                using="default",
+            )
+
+    # RemovedInDjango70Warning.
+    def test_using_auth_conflict(self):
+        msg = (
+            "'auth_user' and 'auth_password' are not compatible with 'using'. "
+            "Set 'username' and 'password' OPTIONS in EMAIL_PROVIDERS instead."
+        )
+        for param in ["auth_user", "auth_password"]:
+            with (
+                self.subTest(param=param),
+                self.assertRaisesMessage(TypeError, msg),
+            ):
+                send_mail(
+                    "subject",
+                    "body",
+                    "from@example.com",
+                    ["to@example.com"],
+                    using="default",
+                    **{param: "value"},
+                )
+
+
+# RemovedInDjango70Warning: Move override_settings and additional test cases to
+# SendMailTests and remove this class.
+@override_settings(
+    EMAIL_PROVIDERS={
+        "default": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"},
+        "custom": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"},
+    }
+)
+class SendMailTestsWithEmailProviders(SendMailTests):
+    # Repeat all SendMailTests with EMAIL_PROVIDERS defined.
+
+    def test_using_arg(self):
+        # Send using non-default provider.
+        send_mail(
+            "Subject",
+            "Content",
+            "from@example.com",
+            ["to@example.com"],
+            using="custom",
+        )
+        self.assertEqual(mail.outbox[0].sent_using, "custom")
+
+
+class SendMassMailTests(MailTestsMixin, SimpleTestCase):
     """Tests for django.core.mail.send_mass_mail()."""
 
     def test_send_mass_mail(self):
@@ -1997,6 +2139,17 @@ class SendMassMailTests(SimpleTestCase):
         self.assertEqual(mail.outbox[1].from_email, "from2@example.com")
         self.assertEqual(mail.outbox[1].to, ["to2a@example.com", "to2b@example.com"])
 
+    def test_sends_using_default_provider(self):
+        send_mass_mail(
+            [("Subject1", "Content1", "from1@example.com", ["to1@example.com"])]
+        )
+        # RemovedInDjango70Warning: Change to (removing the `if`):
+        #   self.assertEqual(mail.outbox[0].sent_using, "default")
+        if providers._is_configured:
+            self.assertEqual(mail.outbox[0].sent_using, "default")
+        else:
+            self.assertIsNone(mail.outbox[0].sent_using)
+
     def test_connection_arg(self):
         # Send using non-default connection.
         connection = custombackend.EmailBackend()
@@ -2016,7 +2169,7 @@ class SendMassMailTests(SimpleTestCase):
         self.assertIs(connection.test_outbox[1].connection, connection)
 
     def test_auth_passed_to_backend_init(self):
-        with self.settings(EMAIL_BACKEND="mail.custombackend.OptionsCapturingBackend"):
+        with self.use_email_backend("mail.custombackend.OptionsCapturingBackend"):
             send_mass_mail(
                 [("Subject1", "Content1", "from1@example.com", ["to1@example.com"])],
                 auth_user="user",
@@ -2028,7 +2181,7 @@ class SendMassMailTests(SimpleTestCase):
         self.assertEqual(init_kwargs["password"], "password")
 
     def test_fail_silently_passed_to_backend_init(self):
-        with self.settings(EMAIL_BACKEND="mail.custombackend.OptionsCapturingBackend"):
+        with self.use_email_backend("mail.custombackend.OptionsCapturingBackend"):
             send_mass_mail(
                 [("Subject1", "Content1", "from1@example.com", ["to1@example.com"])],
                 fail_silently=True,
@@ -2061,6 +2214,45 @@ class SendMassMailTests(SimpleTestCase):
                 send_mass_mail(
                     datatuple, **{param: "value"}, connection=mail.get_connection()
                 )
+
+    # RemovedInDjango70Warning.
+    def test_using_connection_conflict(self):
+        msg = "'connection' is not compatible with 'using'."
+        with self.assertRaisesMessage(TypeError, msg):
+            send_mass_mail(
+                [("Subject1", "Content1", "from1@example.com", ["to1@example.com"])],
+                connection=object(),
+                using="default",
+            )
+
+    # RemovedInDjango70Warning.
+    def test_using_fail_silently_conflict(self):
+        msg = "'fail_silently' is not compatible with 'using'"
+        with self.assertRaisesMessage(TypeError, msg):
+            send_mass_mail(
+                [("Subject1", "Content1", "from1@example.com", ["to1@example.com"])],
+                fail_silently=True,
+                using="default",
+            )
+
+
+# RemovedInDjango70Warning: Move override_settings and additional test cases to
+# SendMassMailTests and remove this class.
+@override_settings(
+    EMAIL_PROVIDERS={
+        "default": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"},
+        "custom": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"},
+    }
+)
+class SendMassMailTestsWithEmailProviders(SendMassMailTests):
+    # Repeat all SendMassMailTests with EMAIL_PROVIDERS defined.
+
+    def test_using_arg(self):
+        send_mass_mail(
+            [("Subject1", "Content1", "from1@example.com", ["to1@example.com"])],
+            using="custom",
+        )
+        self.assertEqual(mail.outbox[0].sent_using, "custom")
 
 
 class MailAdminsAndManagersTests(SimpleTestCase, MailTestsMixin):
@@ -2148,6 +2340,18 @@ class MailAdminsAndManagersTests(SimpleTestCase, MailTestsMixin):
             with self.subTest(mail_func=mail_func):
                 mail_func("hi", "there")
                 self.assertEqual(mail.outbox, [])
+
+    @override_settings(ADMINS=["admin@example.com"], MANAGERS=["manager@example.com"])
+    def test_sends_using_default_provider(self):
+        for mail_func in [mail_admins, mail_managers]:
+            with self.subTest(mail_func.__name__):
+                mail_func("Subject", "Content")
+                # RemovedInDjango70Warning: Change to (removing the `if`):
+                #   self.assertEqual(mail.outbox[0].sent_using, "default")
+                if providers._is_configured:
+                    self.assertEqual(mail.outbox[0].sent_using, "default")
+                else:
+                    self.assertIsNone(mail.outbox[0].sent_using)
 
     # RemovedInDjango70Warning.
     def test_deprecated_admins_managers_tuples(self):
@@ -2252,6 +2456,25 @@ class MailAdminsAndManagersTests(SimpleTestCase, MailTestsMixin):
             )
 
 
+# RemovedInDjango70Warning: Move override_settings and additional test cases to
+# MailAdminsAndManagersTests and remove this class.
+@override_settings(
+    EMAIL_PROVIDERS={
+        "default": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"},
+        "custom": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"},
+    }
+)
+class MailAdminsAndManagersTestsWithEmailProviders(MailAdminsAndManagersTests):
+    # Repeat all MailAdminsAndManagersTests with EMAIL_PROVIDERS defined.
+
+    @override_settings(ADMINS=["admin@example.com"], MANAGERS=["manager@example.com"])
+    def test_using_arg(self):
+        for mail_func in [mail_admins, mail_managers]:
+            with self.subTest(mail_func.__name__):
+                mail_func("Subject", "Content", using="custom")
+                self.assertEqual(mail.outbox[0].sent_using, "custom")
+
+
 class GetConnectionTests(SimpleTestCase):
     """Tests for django.core.mail.get_connection()."""
 
@@ -2318,6 +2541,70 @@ class GetConnectionTests(SimpleTestCase):
         """
         c = mail.get_connection(fail_silently=True, foo="bar")
         self.assertIs(c.fail_silently, True)
+
+    @override_settings(
+        EMAIL_PROVIDERS={
+            "default": {
+                "BACKEND": "django.core.mail.backends.smtp.EmailBackend",
+                "OPTIONS": {"host": "mail.example.com"},
+            },
+            "custom": {
+                "BACKEND": "django.core.mail.backends.locmem.EmailBackend",
+            },
+        }
+    )
+    def test_email_providers_compatibility(self):
+        # Returns default provider when EMAIL_PROVIDERS defined.
+        with self.subTest("no args"):
+            backend = mail.get_connection()
+            self.assertIsInstance(backend, smtp.EmailBackend)
+            self.assertEqual(backend.host, "mail.example.com")
+            self.assertFalse(backend.fail_silently)
+
+        with self.subTest("with fail_silently"):
+            backend = mail.get_connection(fail_silently=True)
+            self.assertIsInstance(backend, smtp.EmailBackend)
+            self.assertEqual(backend.host, "mail.example.com")
+            self.assertTrue(backend.fail_silently)
+            # Original OPTIONS are intact.
+            self.assertEqual(
+                settings.EMAIL_PROVIDERS["default"]["OPTIONS"],
+                {"host": "mail.example.com"},
+            )
+
+        with self.subTest("with other keyword args"):
+            backend = mail.get_connection(host="example.net")
+            self.assertIsInstance(backend, smtp.EmailBackend)
+            self.assertEqual(backend.host, "example.net")
+            self.assertFalse(backend.fail_silently)
+            self.assertEqual(
+                settings.EMAIL_PROVIDERS["default"]["OPTIONS"],
+                {"host": "mail.example.com"},
+            )
+
+        with self.subTest("with fail_silently and other keyword args"):
+            backend = mail.get_connection(host="example.net", fail_silently=True)
+            self.assertIsInstance(backend, smtp.EmailBackend)
+            self.assertEqual(backend.host, "example.net")
+            self.assertTrue(backend.fail_silently)
+            self.assertEqual(
+                settings.EMAIL_PROVIDERS["default"]["OPTIONS"],
+                {"host": "mail.example.com"},
+            )
+
+        msg = "get_connection(backend, ...) is not supported with EMAIL_PROVIDERS."
+        with self.subTest("with backend"), self.assertRaisesMessage(RuntimeError, msg):
+            mail.get_connection(backend="django.core.mail.backends.dummy.EmailBackend")
+
+    @override_settings(
+        EMAIL_PROVIDERS={
+            "custom": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"}
+        }
+    )
+    def test_email_providers_compatibility_no_default_provider(self):
+        msg = "The email provider 'default' is not configured."
+        with self.assertRaisesMessage(EmailProviderDoesNotExist, msg):
+            mail.get_connection()
 
 
 # RemovedInDjango70Warning.

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -254,6 +254,7 @@ class MailTestsMixin:
             return override_deprecated_email_settings(EMAIL_BACKEND=backend)
 
 
+@ignore_no_default_email_provider_warning()
 class EmailMessageTests(MailTestsMixin, SimpleTestCase):
     """Tests for django.core.mail.EmailMessage and EmailMultiAlternative."""
 
@@ -1936,6 +1937,7 @@ class EmailMessageTestsWithEmailProviders(EmailMessageTests):
             email.send(using="test", fail_silently=True)
 
 
+@ignore_no_default_email_provider_warning()
 class SendMailTests(SimpleTestCase, MailTestsMixin):
     """Tests for django.core.mail.send_mail()."""
 
@@ -2179,6 +2181,7 @@ class SendMailTestsWithEmailProviders(SendMailTests):
         self.assertEqual(mail.outbox[0].sent_using, "custom")
 
 
+@ignore_no_default_email_provider_warning()
 class SendMassMailTests(MailTestsMixin, SimpleTestCase):
     """Tests for django.core.mail.send_mass_mail()."""
 
@@ -2343,6 +2346,7 @@ class SendMassMailTestsWithEmailProviders(SendMassMailTests):
         self.assertEqual(mail.outbox[0].sent_using, "custom")
 
 
+@ignore_no_default_email_provider_warning()
 class MailAdminsAndManagersTests(SimpleTestCase, MailTestsMixin):
     """Tests for django.core.mail.mail_admins() and mail_managers()."""
 

--- a/tests/middleware/tests.py
+++ b/tests/middleware/tests.py
@@ -7,6 +7,7 @@ from io import BytesIO
 from unittest import mock
 from urllib.parse import quote
 
+from mail import override_deprecated_email_settings
 from mail.custombackend import FailingEmailBackend
 
 from django.conf import settings
@@ -501,7 +502,9 @@ class BrokenLinkEmailsMiddlewareTest(SimpleTestCase):
         BrokenLinkEmailsMiddleware(self.get_response)(self.req)
         self.assertEqual(len(mail.outbox), 1)
 
-    @override_settings(EMAIL_BACKEND="mail.custombackend.FailingEmailBackend")
+    @override_deprecated_email_settings(
+        EMAIL_BACKEND="mail.custombackend.FailingEmailBackend"
+    )
     def test_sends_using_fail_silently(self):
         FailingEmailBackend.did_fail_silently = False
         self.req.META["HTTP_REFERER"] = "/another/url/"

--- a/tests/middleware/tests.py
+++ b/tests/middleware/tests.py
@@ -407,6 +407,9 @@ class CommonMiddlewareTest(SimpleTestCase):
 @override_settings(
     IGNORABLE_404_URLS=[re.compile(r"foo")],
     MANAGERS=["manager@example.com"],
+    EMAIL_PROVIDERS={
+        "default": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"}
+    },
 )
 class BrokenLinkEmailsMiddlewareTest(SimpleTestCase):
     rf = RequestFactory()
@@ -502,14 +505,47 @@ class BrokenLinkEmailsMiddlewareTest(SimpleTestCase):
         BrokenLinkEmailsMiddleware(self.get_response)(self.req)
         self.assertEqual(len(mail.outbox), 1)
 
+    # RemovedInDjango70Warning.
     @override_deprecated_email_settings(
         EMAIL_BACKEND="mail.custombackend.FailingEmailBackend"
     )
     def test_sends_using_fail_silently(self):
+        del settings.EMAIL_PROVIDERS
         FailingEmailBackend.did_fail_silently = False
         self.req.META["HTTP_REFERER"] = "/another/url/"
         BrokenLinkEmailsMiddleware(self.get_response)(self.req)
         self.assertTrue(FailingEmailBackend.did_fail_silently)
+
+    def test_sends_using_default_provider(self):
+        self.req.META["HTTP_REFERER"] = "/another/url/"
+        BrokenLinkEmailsMiddleware(self.get_response)(self.req)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].sent_using, "default")
+
+    @override_settings(EMAIL_PROVIDERS={})
+    def test_no_error_when_email_not_configured(self):
+        self.req.META["HTTP_REFERER"] = "/another/url/"
+        BrokenLinkEmailsMiddleware(self.get_response)(self.req)
+        self.assertEqual(len(mail.outbox), 0)
+
+    @override_settings(
+        EMAIL_PROVIDERS={
+            "custom": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"}
+        },
+    )
+    def test_custom_send_mail(self):
+        class SubclassedMiddleware(BrokenLinkEmailsMiddleware):
+            using = "custom"
+
+            def send_mail(self, subject, message, *args, **kwargs):
+                super().send_mail("custom subject", "custom message", *args, **kwargs)
+
+        self.req.META["HTTP_REFERER"] = "/another/url/"
+        SubclassedMiddleware(self.get_response)(self.req)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].sent_using, "custom")
+        self.assertEqual(mail.outbox[0].subject, "[Django] custom subject")
+        self.assertEqual(mail.outbox[0].body, "custom message")
 
 
 @override_settings(ROOT_URLCONF="middleware.cond_get_urls")

--- a/tests/middleware/tests.py
+++ b/tests/middleware/tests.py
@@ -7,6 +7,8 @@ from io import BytesIO
 from unittest import mock
 from urllib.parse import quote
 
+from mail.custombackend import FailingEmailBackend
+
 from django.conf import settings
 from django.core import mail
 from django.core.exceptions import PermissionDenied
@@ -498,6 +500,13 @@ class BrokenLinkEmailsMiddlewareTest(SimpleTestCase):
         self.req.META["HTTP_REFERER"] = self.req.path_info[:-1]
         BrokenLinkEmailsMiddleware(self.get_response)(self.req)
         self.assertEqual(len(mail.outbox), 1)
+
+    @override_settings(EMAIL_BACKEND="mail.custombackend.FailingEmailBackend")
+    def test_sends_using_fail_silently(self):
+        FailingEmailBackend.did_fail_silently = False
+        self.req.META["HTTP_REFERER"] = "/another/url/"
+        BrokenLinkEmailsMiddleware(self.get_response)(self.req)
+        self.assertTrue(FailingEmailBackend.did_fail_silently)
 
 
 @override_settings(ROOT_URLCONF="middleware.cond_get_urls")

--- a/tests/project_template/test_settings.py
+++ b/tests/project_template/test_settings.py
@@ -3,6 +3,8 @@ import shutil
 import tempfile
 
 from django import conf
+from django.core import mail
+from django.core.mail.backends import console
 from django.test import SimpleTestCase
 from django.test.utils import extend_sys_path
 
@@ -46,3 +48,11 @@ class TestStartProjectSettings(SimpleTestCase):
                     b"X-Frame-Options: DENY",
                 ],
             )
+
+    def test_email_providers(self):
+        with extend_sys_path(self.temp_dir.name):
+            from test_settings import EMAIL_PROVIDERS
+
+        with self.settings(EMAIL_PROVIDERS=EMAIL_PROVIDERS):
+            backend = mail.providers.default
+            self.assertIsInstance(backend, console.EmailBackend)

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -30,6 +30,7 @@ else:
     from django.test.utils import NullTimeKeeper, TimeKeeper, get_runner
     from django.utils.deprecation import (
         RemovedAfterNextVersionWarning,
+        RemovedInDjango70Warning,
         RemovedInNextVersionWarning,
     )
     from django.utils.functional import classproperty
@@ -52,6 +53,14 @@ warnings.simplefilter("error", RemovedAfterNextVersionWarning)
 # patterns.
 warnings.simplefilter("error", ResourceWarning)
 warnings.simplefilter("error", RuntimeWarning)
+
+# Temporarily ignore this warning. A later commit will update tests that send
+# mail and remove this filter.
+warnings.filterwarnings(
+    "ignore",
+    r"Django 7\.0 will not have a default email provider\.",
+    category=RemovedInDjango70Warning,
+)
 
 # Reduce garbage collection frequency to improve performance. Since CPython
 # uses refcounting, garbage collection only collects objects with cyclic

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -30,7 +30,6 @@ else:
     from django.test.utils import NullTimeKeeper, TimeKeeper, get_runner
     from django.utils.deprecation import (
         RemovedAfterNextVersionWarning,
-        RemovedInDjango70Warning,
         RemovedInNextVersionWarning,
     )
     from django.utils.functional import classproperty
@@ -53,14 +52,6 @@ warnings.simplefilter("error", RemovedAfterNextVersionWarning)
 # patterns.
 warnings.simplefilter("error", ResourceWarning)
 warnings.simplefilter("error", RuntimeWarning)
-
-# Temporarily ignore this warning. A later commit will update tests that send
-# mail and remove this filter.
-warnings.filterwarnings(
-    "ignore",
-    r"Django 7\.0 will not have a default email provider\.",
-    category=RemovedInDjango70Warning,
-)
 
 # Reduce garbage collection frequency to improve performance. Since CPython
 # uses refcounting, garbage collection only collects objects with cyclic

--- a/tests/test_client/tests.py
+++ b/tests/test_client/tests.py
@@ -61,7 +61,12 @@ def async_middleware_urlconf(get_response):
     return middleware
 
 
-@override_settings(ROOT_URLCONF="test_client.urls")
+@override_settings(
+    ROOT_URLCONF="test_client.urls",
+    EMAIL_PROVIDERS={
+        "default": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"}
+    },
+)
 class ClientTest(TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/tests/test_client/views.py
+++ b/tests/test_client/views.py
@@ -381,7 +381,7 @@ def mass_mail_sending_view(request):
         ["second@example.com", "third@example.com"],
     )
 
-    c = mail.get_connection()
+    c = mail.providers.default
     c.send_messages([m1, m2])
 
     return HttpResponse("Mail sent")

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -4,6 +4,7 @@ import threading
 import traceback
 import unittest
 import warnings
+from contextlib import contextmanager
 from functools import partial
 from io import StringIO
 from unittest import mock
@@ -47,6 +48,7 @@ from django.test.utils import (
     isolate_apps,
     override_settings,
     setup_test_environment,
+    teardown_test_environment,
 )
 from django.urls import NoReverseMatch, path, reverse, reverse_lazy
 from django.utils.html import VOID_ELEMENTS
@@ -1813,15 +1815,49 @@ class SetupTestEnvironmentTests(SimpleTestCase):
         ):
             setup_test_environment()
 
+    @contextmanager
+    def mock_test_state(self):
+        """Mock Django's test state within a context.
+
+        This allows testing setup/teardown_test_environment() without impacting
+        the real test state or breaking Django's test runner.
+
+        Within the context, the state is initially reset so that calling
+        setup_test_environment() won't raise an "already called" error. The
+        original (real) state is restored at the end of the context.
+        """
+        with mock.patch("django.test.utils._TestState") as test_state:
+            del test_state.saved_data
+            yield test_state
+
     def test_allowed_hosts(self):
         for type_ in (list, tuple):
             with self.subTest(type_=type_):
                 allowed_hosts = type_("*")
-                with mock.patch("django.test.utils._TestState") as x:
-                    del x.saved_data
-                    with self.settings(ALLOWED_HOSTS=allowed_hosts):
-                        setup_test_environment()
-                        self.assertEqual(settings.ALLOWED_HOSTS, ["*", "testserver"])
+                with (
+                    self.mock_test_state(),
+                    self.settings(ALLOWED_HOSTS=allowed_hosts),
+                ):
+                    setup_test_environment()
+                    self.assertEqual(settings.ALLOWED_HOSTS, ["*", "testserver"])
+
+    def test_email_backend_override(self):
+        with (
+            self.mock_test_state(),
+            self.settings(
+                EMAIL_BACKEND="django.core.mail.backends.console.EmailBackend"
+            ),
+        ):
+            setup_test_environment()
+            self.assertEqual(
+                settings.EMAIL_BACKEND,
+                "django.core.mail.backends.locmem.EmailBackend",
+            )
+            teardown_test_environment()
+            self.assertEqual(
+                settings.EMAIL_BACKEND,
+                "django.core.mail.backends.console.EmailBackend",
+            )
 
 
 class OverrideSettingsTests(SimpleTestCase):

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -37,6 +37,7 @@ from django.test import (
     SimpleTestCase,
     TestCase,
     TransactionTestCase,
+    ignore_warnings,
     skipIfDBFeature,
     skipUnlessDBFeature,
 )
@@ -51,6 +52,7 @@ from django.test.utils import (
     teardown_test_environment,
 )
 from django.urls import NoReverseMatch, path, reverse, reverse_lazy
+from django.utils.deprecation import RemovedInDjango70Warning
 from django.utils.html import VOID_ELEMENTS
 
 from .models import Car, Person, PossessedCar
@@ -1841,6 +1843,7 @@ class SetupTestEnvironmentTests(SimpleTestCase):
                     setup_test_environment()
                     self.assertEqual(settings.ALLOWED_HOSTS, ["*", "testserver"])
 
+    @ignore_warnings(category=RemovedInDjango70Warning)
     def test_email_backend_override(self):
         with (
             self.mock_test_state(),

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import sys
 import threading
@@ -1843,6 +1844,7 @@ class SetupTestEnvironmentTests(SimpleTestCase):
                     setup_test_environment()
                     self.assertEqual(settings.ALLOWED_HOSTS, ["*", "testserver"])
 
+    # RemovedInDjango70Warning.
     @ignore_warnings(category=RemovedInDjango70Warning)
     def test_email_backend_override(self):
         with (
@@ -1856,11 +1858,46 @@ class SetupTestEnvironmentTests(SimpleTestCase):
                 settings.EMAIL_BACKEND,
                 "django.core.mail.backends.locmem.EmailBackend",
             )
+            self.assertFalse(hasattr(settings, "EMAIL_PROVIDERS"))
             teardown_test_environment()
             self.assertEqual(
                 settings.EMAIL_BACKEND,
                 "django.core.mail.backends.console.EmailBackend",
             )
+            self.assertFalse(hasattr(settings, "EMAIL_PROVIDERS"))
+
+    def test_email_providers_override(self):
+        expected_value = {
+            "default": {
+                "OPTIONS": {"host": "localhost"},
+            },
+            "custom": {
+                "BACKEND": "path.to.custom.EmailBackend",
+                "OPTIONS": {"custom": "option"},
+            },
+        }
+        settings_value = copy.deepcopy(expected_value)
+        with self.mock_test_state(), self.settings(EMAIL_PROVIDERS=settings_value):
+            setup_test_environment()
+            self.assertEqual(
+                settings.EMAIL_PROVIDERS,
+                {
+                    "default": {
+                        "BACKEND": "django.core.mail.backends.locmem.EmailBackend"
+                    },
+                    "custom": {
+                        "BACKEND": "django.core.mail.backends.locmem.EmailBackend"
+                    },
+                },
+            )
+            # setup_test_environment() shouldn't mutate original setting value.
+            self.assertEqual(settings_value, expected_value)
+            # RemovedInDjango70Warning: Remove both EMAIL_BACKEND assertions.
+            self.assertFalse(hasattr(settings, "EMAIL_BACKEND"))
+
+            teardown_test_environment()
+            self.assertEqual(settings.EMAIL_PROVIDERS, expected_value)
+            self.assertFalse(hasattr(settings, "EMAIL_BACKEND"))
 
 
 class OverrideSettingsTests(SimpleTestCase):

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -496,6 +496,14 @@ class DebugViewTests(SimpleTestCase):
             response = self.client.get("/raises500/", headers={"accept": "text/plain"})
         self.assertContains(response, "Oh dear, an error occurred!", status_code=500)
 
+    # RemovedInDjango70Warning.
+    @override_settings(EMAIL_PROVIDERS={})
+    def test_works_with_email_providers_defined(self):
+        with self.assertLogs("django.request", "ERROR"):
+            response = self.client.get("/raises500/")
+        self.assertContains(response, "EMAIL_PROVIDERS", status_code=500)
+        self.assertNotContains(response, "EMAIL_BACKEND", status_code=500)
+
 
 class DebugViewQueriesAllowedTests(SimpleTestCase):
     # May need a query to initialize MySQL connection

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -1594,7 +1594,12 @@ class ExceptionReportTestMixin:
                 self.assertNotIn(v, body)
 
 
-@override_settings(ROOT_URLCONF="view_tests.urls")
+@override_settings(
+    ROOT_URLCONF="view_tests.urls",
+    EMAIL_PROVIDERS={
+        "default": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"}
+    },
+)
 class ExceptionReporterFilterTests(
     ExceptionReportTestMixin, LoggingCaptureMixin, SimpleTestCase
 ):


### PR DESCRIPTION
### ➡️ ➡️ ➡️  This PR has moved to https://github.com/django/django/pull/21231.

-----

<img width="360" height="216" alt="This PR has hidden comments! GitHub has hidden some comments on this page, which may include unresolved review feedback and other open discussions. Be sure to search the page for “Load more…” and click all the links found." src="https://github.com/user-attachments/assets/9096e077-1b73-447d-b5be-4c8d48cfa795" />

Upvote [*Please stop hiding PR comments*](https://github.com/orgs/community/discussions/112603) to request a fix.

-----

#### Trac ticket number

ticket-35514

#### Branch description
Implements `mail.providers` factory and dictionary-based `EMAIL_PROVIDERS` setting, aligning Django's email backend configuration with similar capabilities
in caches, databases, storages, and tasks.

See [DEP 0018](https://github.com/django/deps/pull/105)

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

* PyCharm AI Assistant "next edit suggestions": general coding
* GPT-5.4 Mini: reworking tests with mock, technical questions
* Claude 4.6 Sonnet: analysis of some test cases, some code review
* GPT-5.5: some code review and technical questions

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- n/a I have attached screenshots in both light and dark modes for any UI changes.
