### PR TITLE
Replaced yaml serializer workaround to preserve dict order with PyYAML's sort_keys=False.

### DIFF
--- a/django/core/serializers/pyyaml.py
+++ b/django/core/serializers/pyyaml.py
@@ -34,9 +34,6 @@ DjangoSafeDumper.add_representer(decimal.Decimal, DjangoSafeDumper.represent_dec
 DjangoSafeDumper.add_representer(
     collections.OrderedDict, DjangoSafeDumper.represent_ordered_dict
 )
-# Workaround to represent dictionaries in insertion order.
-# See https://github.com/yaml/pyyaml/pull/143.
-DjangoSafeDumper.add_representer(dict, DjangoSafeDumper.represent_ordered_dict)
 
 
 class Serializer(PythonSerializer):
@@ -59,7 +56,13 @@ class Serializer(PythonSerializer):
 
     def end_serialization(self):
         self.options.setdefault("allow_unicode", True)
-        yaml.dump(self.objects, self.stream, Dumper=DjangoSafeDumper, **self.options)
+        yaml.dump(
+            self.objects,
+            self.stream,
+            Dumper=DjangoSafeDumper,
+            sort_keys=False,
+            **self.options,
+        )
 
     def getvalue(self):
         # Grandparent super


### PR DESCRIPTION
The sort_keys parameter was [added in PyYAML 5.1](https://github.com/yaml/pyyaml/commit/07c88c6c1bee51439a00bc07827980fbb161a1ad) (released March 2019). [According to the Django 6.0 release notes, PyYAML 6.0.2 is the first to confirm compatibility with Python 3.12.]

The workaround in Django was added in 24b82cd201e21060fbc02117dc16d1702877a1f3 (refs ticket-30159).

There's already a regression test that fails if `sort_keys=False` is removed:
```
======================================================================
FAIL: test_deterministic_mapping_ordering (serializers.test_yaml.YamlSerializerTestCase.test_deterministic_mapping_ordering)
Mapping such as fields should be deterministically ordered. (#24558)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.12/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/usr/lib/python3.12/unittest/case.py", line 634, in run
    self._callTestMethod(testMethod)
    ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/unittest/case.py", line 589, in _callTestMethod
    if method() is not None:
    ^^^^^^^^^^^^^^^^^
  File "/home/tim/code/django/tests/serializers/tests.py", line 399, in test_deterministic_mapping_ordering
    self.assertEqual(
  File "/usr/lib/python3.12/unittest/case.py", line 885, in assertEqual
    assertion_func(first, second, msg=msg)
    ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/unittest/case.py", line 1251, in assertMultiLineEqual
    self.fail(self._formatMessage(msg, standardMsg))
    ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/unittest/case.py", line 715, in fail
    raise self.failureException(msg)
    ^^^^^^^^^^^^^^^^^
AssertionError: '- fields:\n    author: 2\n    categories:\n[165 chars] 1\n' != '- model: serializers.article\n  pk: 1\n  fi[165 chars][]\n'
+ - model: serializers.article
+   pk: 1
- - fields:
? ^
+   fields:
? ^
      author: 2
+     headline: Poker has no place on ESPN
+     pub_date: 2006-06-16 11:00:00
      categories:
      - 3
      - 1
-     headline: Poker has no place on ESPN
      meta_data: []
-     pub_date: 2006-06-16 11:00:00
      topics: []
-   model: serializers.article
-   pk: 1
```