### PR TITLE
Fixed #20151 -- Added permission check for proxy models in get_deleted_objects.

### DIFF
--- a/django/contrib/admin/utils.py
+++ b/django/contrib/admin/utils.py
@@ -175,25 +175,11 @@ def get_deleted_objects(objs, request, admin_site):
                 obj_display,
             )
         else:
-            opts = obj._meta
-
-            # Check if the concrete model is registered in the admin,
-            # and if so, whether the user has delete permissions for it.
-            concrete_model = opts.concrete_model
-            obj_admin = admin_site._registry.get(concrete_model)
-
-            # If the concrete model is registered, \
-            # check delete permissions for it.
-            if obj_admin and not obj_admin.has_delete_permission(request, obj):
+            # If the model is not registered,
+            # check if the user has delete permissions for the model.
+            p = "%s.delete_%s" % (opts.app_label, opts.model_name)
+            if not request.user.has_perm(p):
                 perms_needed.add(opts.verbose_name)
-            else:
-                # Fallback to checking permissions
-                # for the model of the object itself,
-                # If the concrete model isn't registered,
-                # check delete permissions for the model of the object itself.
-                p = "%s.delete_%s" % (opts.app_label, opts.model_name)
-                if not request.user.has_perm(p):
-                    perms_needed.add(opts.verbose_name)
 
             return no_edit_link
 

--- a/django/contrib/admin/utils.py
+++ b/django/contrib/admin/utils.py
@@ -175,8 +175,26 @@ def get_deleted_objects(objs, request, admin_site):
                 obj_display,
             )
         else:
-            # Don't display link to edit, because it either has no
-            # admin or is edited inline.
+            opts = obj._meta
+
+            # Check if the concrete model is registered in the admin,
+            # and if so, whether the user has delete permissions for it.
+            concrete_model = opts.concrete_model
+            obj_admin = admin_site._registry.get(concrete_model)
+
+            # If the concrete model is registered, \
+            # check delete permissions for it.
+            if obj_admin and not obj_admin.has_delete_permission(request, obj):
+                perms_needed.add(opts.verbose_name)
+            else:
+                # Fallback to checking permissions
+                # for the model of the object itself,
+                # If the concrete model isn't registered,
+                # check delete permissions for the model of the object itself.
+                p = "%s.delete_%s" % (opts.app_label, opts.model_name)
+                if not request.user.has_perm(p):
+                    perms_needed.add(opts.verbose_name)
+
             return no_edit_link
 
     to_delete = collector.nested(format_callback)

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -2078,6 +2078,11 @@ default templates used by the :class:`ModelAdmin` views:
     :attr:`~django.db.models.Options.verbose_name`\s of the models that the
     user doesn't have permission to delete.
 
+    .. versionchanged:: 6.1
+
+        Added a fallback to check the model's global delete permission if it
+        is not registered in the admin.
+
     ``protected`` is a list of strings representing of all the protected
     related objects that can't be deleted. The list is displayed in the
     template.

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -92,6 +92,9 @@ Minor features
 :mod:`django.contrib.admin`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* ``ModelAdmin.get_deleted_objects()`` now falls back to checking a user's
+  model delete permissions if the model is not registered in the admin.
+
 * The admin site login view now redirects authenticated users to the next URL,
   if available, instead of always redirecting to the admin index page.
 

--- a/tests/admin_utils/models.py
+++ b/tests/admin_utils/models.py
@@ -40,6 +40,12 @@ class ArticleProxy(Article):
         proxy = True
 
 
+class ArticleProxy2(ArticleProxy):
+    class Meta:
+        proxy = True
+        verbose_name = "article proxy level 2"
+
+
 class Cascade(models.Model):
     num = models.PositiveSmallIntegerField()
     parent = models.ForeignKey("self", models.CASCADE, null=True)

--- a/tests/admin_utils/tests.py
+++ b/tests/admin_utils/tests.py
@@ -37,6 +37,7 @@ from django.utils.safestring import mark_safe
 from .models import (
     Article,
     ArticleProxy,
+    ArticleProxy2,
     Car,
     Cascade,
     DBCascade,
@@ -533,35 +534,48 @@ class UtilsTests(SimpleTestCase):
 
 
 class ProxyModelTests(TestCase):
-    def test_get_deleted_objects_proxy_permissions(self):
+    def test_get_deleted_objects_proxy_permissions_and_proxy_of_proxy(self):
         """
         Regression test for #20151: get_deleted_objects should check
-        permissions for proxy models even if they aren't in the admin.
+        global permissions for proxy models not registered in the admin.
         """
         site = Site.objects.create(domain="example.com")
         article = Article.objects.create(site=site, title="Test", hist="Test hist")
+
+        # First-level proxy
         article_proxy = ArticleProxy.objects.get(pk=article.pk)
+
+        # Second-level proxy
+        article_proxy2 = ArticleProxy2.objects.get(pk=article.pk)
 
         user = User.objects.create_user(
             username="testuser", password="testpass", is_staff=True
         )
-        article_ct = ContentType.objects.get_for_model(Article)
 
-        # Give permission for Article, but NOT for ArticleProxy
+        # We ONLY give permission to the concrete Article model.
+        # Per modern Django, this DOES NOT grant permission to
+        # ArticleProxy or ArticleProxy2.
+        article_ct = ContentType.objects.get_for_model(Article)
         delete_perm = Permission.objects.get(
             content_type=article_ct, codename="delete_article"
         )
         user.user_permissions.add(delete_perm)
 
-        # Create a request with the user
         request = RequestFactory().get("/")
         request.user = user
 
-        # The function should now identify that the user doesn't have
-        # permission to delete the ArticleProxy instance
-        _, _, perms_needed, _ = get_deleted_objects(
+        # Check first-level proxy (not registered in admin)
+        _, _, perms_needed1, _ = get_deleted_objects(
             [article_proxy], request, AdminSite()
         )
-        # Verify that the permission needed for ArticleProxy is included in
-        # the perms_needed list.
-        self.assertIn("article proxy", perms_needed)
+        # It should be in perms_needed
+        # because the user lacks 'delete_articleproxy'
+        self.assertIn("article proxy", perms_needed1)
+
+        # Check second-level proxy (not registered in admin)
+        _, _, perms_needed2, _ = get_deleted_objects(
+            [article_proxy2], request, AdminSite()
+        )
+        # It should be in perms_needed
+        # because the user lacks 'delete_articleproxy2'
+        self.assertIn("article proxy level 2", perms_needed2)

--- a/tests/admin_utils/tests.py
+++ b/tests/admin_utils/tests.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 from django import forms
 from django.conf import settings
 from django.contrib import admin
-from django.contrib.admin import helpers
+from django.contrib.admin import AdminSite, helpers
 from django.contrib.admin.utils import (
     NestedObjects,
     build_q_object_from_lookup_parameters,
@@ -12,22 +12,31 @@ from django.contrib.admin.utils import (
     display_for_value,
     flatten,
     flatten_fieldsets,
+    get_deleted_objects,
     help_text_for_field,
     label_for_field,
     lookup_field,
     quote,
 )
-from django.contrib.auth.models import User
+from django.contrib.auth.models import Permission, User
 from django.contrib.auth.templatetags.auth import render_password_as_hash
+from django.contrib.contenttypes.models import ContentType
 from django.core.validators import EMPTY_VALUES
 from django.db import DEFAULT_DB_ALIAS, models
-from django.test import SimpleTestCase, TestCase, override_settings, skipUnlessDBFeature
+from django.test import (
+    RequestFactory,
+    SimpleTestCase,
+    TestCase,
+    override_settings,
+    skipUnlessDBFeature,
+)
 from django.test.utils import isolate_apps
 from django.utils.formats import localize
 from django.utils.safestring import mark_safe
 
 from .models import (
     Article,
+    ArticleProxy,
     Car,
     Cascade,
     DBCascade,
@@ -521,3 +530,38 @@ class UtilsTests(SimpleTestCase):
             & models.Q(hist__iexact="history")
             & (models.Q(site__pk=1) | models.Q(site__pk=2)),
         )
+
+
+class ProxyModelTests(TestCase):
+    def test_get_deleted_objects_proxy_permissions(self):
+        """
+        Regression test for #20151: get_deleted_objects should check
+        permissions for proxy models even if they aren't in the admin.
+        """
+        site = Site.objects.create(domain="example.com")
+        article = Article.objects.create(site=site, title="Test", hist="Test hist")
+        article_proxy = ArticleProxy.objects.get(pk=article.pk)
+
+        user = User.objects.create_user(
+            username="testuser", password="testpass", is_staff=True
+        )
+        article_ct = ContentType.objects.get_for_model(Article)
+
+        # Give permission for Article, but NOT for ArticleProxy
+        delete_perm = Permission.objects.get(
+            content_type=article_ct, codename="delete_article"
+        )
+        user.user_permissions.add(delete_perm)
+
+        # Create a request with the user
+        request = RequestFactory().get("/")
+        request.user = user
+
+        # The function should now identify that the user doesn't have
+        # permission to delete the ArticleProxy instance
+        _, _, perms_needed, _ = get_deleted_objects(
+            [article_proxy], request, AdminSite()
+        )
+        # Verify that the permission needed for ArticleProxy is included in
+        # the perms_needed list.
+        self.assertIn("article proxy", perms_needed)


### PR DESCRIPTION
**Trac ticket number**
ticket-20151

#### Branch description
This PR resolves a long-standing issue where `django.contrib.admin.utils.get_deleted_objects` failed to verify permissions for proxy models not explicitly registered in the `AdminSite`. By implementing a fallback to `user.has_perm`, this change ensures that all objects in the deletion summary—including those in inlines or proxy levels—are properly authorized before being displayed or deleted. This aligns with modern Django's handling of independent proxy permissions.

I have updated the logic in `utils.py`, added comprehensive regression tests for multi-level proxies in `tests/admin_utils/tests.py`, and updated the 6.1 release notes and admin reference documentation.

#### AI Assistance Disclosure (REQUIRED)
- [ ] No AI tools were used in preparing this PR.
- [x] If AI tools were used, I have disclosed which ones, and fully reviewed and verified their output.

AI tool used: I utilized Gemini to research the historical context of ticket #20151, verify reStructuredText syntax for the documentation, and structure the logic for testing multi-level proxy permissions. I have manually reviewed, edited, and verified all code and documentation.

#### Checklist
- [x] This PR follows the contribution guidelines.
- [x] This PR does not disclose a security vulnerability.
- [x] This PR targets the main branch.<!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.