### PR TITLE
Fixed #36986 -- Added Field.serialize_to_python/xml() and deserialize_from_python/xml() hooks.

### DIFF
--- a/django/core/serializers/python.py
+++ b/django/core/serializers/python.py
@@ -7,8 +7,6 @@ basis for other serializers.
 from django.apps import apps
 from django.core.serializers import base
 from django.db import DEFAULT_DB_ALIAS, models
-from django.db.models import CompositePrimaryKey
-from django.utils.encoding import is_protected_type
 
 
 class Serializer(base.Serializer):
@@ -35,21 +33,12 @@ class Serializer(base.Serializer):
     def get_dump_object(self, obj):
         data = {"model": str(obj._meta)}
         if not self.use_natural_primary_keys or not self._resolve_natural_key(obj):
-            data["pk"] = self._value_from_field(obj, obj._meta.pk)
+            data["pk"] = obj._meta.pk.serialize_to_python(obj, self)
         data["fields"] = self._current
         return data
 
-    def _value_from_field(self, obj, field):
-        if isinstance(field, CompositePrimaryKey):
-            return [self._value_from_field(obj, f) for f in field]
-        value = field.value_from_object(obj)
-        # Protected types (i.e., primitives like None, numbers, dates,
-        # and Decimals) are passed through as is. All other values are
-        # converted to string first.
-        return value if is_protected_type(value) else field.value_to_string(obj)
-
     def handle_field(self, obj, field):
-        self._current[field.name] = self._value_from_field(obj, field)
+        self._current[field.name] = field.serialize_to_python(obj, self)
 
     def handle_fk_field(self, obj, field):
         if self.use_natural_foreign_keys and (
@@ -57,7 +46,7 @@ class Serializer(base.Serializer):
         ):
             value = natural_key_value
         else:
-            value = self._value_from_field(obj, field)
+            value = field.serialize_to_python(obj, self)
         self._current[field.name] = value
 
     def handle_m2m_field(self, obj, field):
@@ -70,7 +59,7 @@ class Serializer(base.Serializer):
                     if natural := value.natural_key():
                         return natural
                     else:
-                        return self._value_from_field(value, value._meta.pk)
+                        return value._meta.pk.serialize_to_python(value, self)
 
                 def queryset_iterator(obj, field):
                     attr = getattr(obj, field.name)
@@ -90,7 +79,7 @@ class Serializer(base.Serializer):
             else:
 
                 def m2m_value(value):
-                    return self._value_from_field(value, value._meta.pk)
+                    return value._meta.pk.serialize_to_python(value, self)
 
                 def queryset_iterator(obj, field):
                     query_set = getattr(obj, field.name).select_related(None).only("pk")
@@ -206,7 +195,7 @@ class Deserializer(base.Deserializer):
             # Handle all other fields
             else:
                 try:
-                    data[field.name] = field.to_python(field_value)
+                    data[field.name] = field.deserialize_from_python(field_value)
                 except Exception as e:
                     raise base.DeserializationError.WithData(
                         e, obj["model"], obj.get("pk"), field_value

--- a/django/core/serializers/xml_serializer.py
+++ b/django/core/serializers/xml_serializer.py
@@ -2,7 +2,6 @@
 XML serializer.
 """
 
-import json
 from contextlib import contextmanager
 from xml.dom import minidom, pulldom
 from xml.sax import handler
@@ -110,11 +109,7 @@ class Serializer(base.Serializer):
 
         # Get a "string version" of the object's data.
         if getattr(obj, field.name) is not None:
-            value = field.value_to_string(obj)
-            if field.get_internal_type() == "JSONField":
-                # Dump value since JSONField.value_to_string() doesn't output
-                # strings.
-                value = json.dumps(value, cls=field.encoder)
+            value = field.serialize_to_xml(obj, self)
             try:
                 self.xml.characters(value)
             except UnserializableContentError:
@@ -347,10 +342,7 @@ class Deserializer(base.Deserializer):
                 if field_node.getElementsByTagName("None"):
                     value = None
                 else:
-                    value = field.to_python(getInnerText(field_node).strip())
-                    # Load value since JSONField.to_python() outputs strings.
-                    if field.get_internal_type() == "JSONField":
-                        value = json.loads(value, cls=field.decoder)
+                    value = field.deserialize_from_xml(field_node)
                 data[field.name] = value
 
         obj = base.build_instance(Model, data, self.db)

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -32,6 +32,7 @@ from django.utils.dateparse import (
 )
 from django.utils.deprecation import RemovedInDjango70Warning, django_file_prefixes
 from django.utils.duration import duration_string
+from django.utils.encoding import is_protected_type
 from django.utils.functional import Promise, cached_property
 from django.utils.ipv6 import MAX_IPV6_ADDRESS_LENGTH, clean_ipv6_address
 from django.utils.text import capfirst
@@ -1120,6 +1121,35 @@ class Field(RegisterLookupMixin):
         This is used by the serialization framework.
         """
         return str(self.value_from_object(obj))
+
+    def serialize_to_python(self, obj, serializer):
+        """
+        Return the serialized value for the serializers that inherit the Python
+        serializer (json, jsonl, yaml).
+        """
+        value = self.value_from_object(obj)
+        # Protected types (i.e., primitives like None, numbers, dates, and
+        # Decimals) are passed through as is. All other values are converted to
+        # string.
+        return value if is_protected_type(value) else self.value_to_string(obj)
+
+    def deserialize_from_python(self, value):
+        """
+        Return the deserialized value for the serializers that inherit the
+        Python serializer (json, jsonl, yaml).
+        """
+        return self.to_python(value)
+
+    def serialize_to_xml(self, obj, serializer):
+        """Return the serialized value for the XML serializer."""
+        return self.value_to_string(obj)
+
+    def deserialize_from_xml(self, field_node):
+        """Return the deserialized value for the XML serializer."""
+        from django.core.serializers.xml_serializer import getInnerText
+
+        value = getInnerText(field_node).strip()
+        return self.to_python(value)
 
     @property
     def flatchoices(self):

--- a/django/db/models/fields/composite.py
+++ b/django/db/models/fields/composite.py
@@ -155,6 +155,9 @@ class CompositePrimaryKey(Field):
             ]
         return value
 
+    def serialize_to_python(self, obj, serializer):
+        return [f.serialize_to_python(obj, serializer) for f in self]
+
 
 CompositePrimaryKey.register_lookup(TupleExact)
 CompositePrimaryKey.register_lookup(TupleGreaterThan)

--- a/django/db/models/fields/json.py
+++ b/django/db/models/fields/json.py
@@ -139,6 +139,17 @@ class JSONField(CheckFieldDefaultMixin, Field):
     def value_to_string(self, obj):
         return self.value_from_object(obj)
 
+    def deserialize_from_xml(self, value):
+        value = super().deserialize_from_xml(value)
+        # Load value since JSONField.to_python() isn't defined to convert
+        # strings to Python values.
+        return json.loads(value, cls=self.decoder)
+
+    def serialize_to_xml(self, obj, serializer):
+        value = super().serialize_to_xml(obj, serializer)
+        # Dump value since value_to_string() doesn't output strings.
+        return json.dumps(value, cls=self.encoder)
+
     def formfield(self, **kwargs):
         return super().formfield(
             **{

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -2640,6 +2640,47 @@ Field API reference
 
         See :ref:`converting-model-field-to-serialization` for usage.
 
+    Some additional hooks for serialization and deserialization should only be
+    used if :meth:`value_to_string` and :meth:`to_python` aren't sufficient.
+    For example, :class:`CompositePrimaryKey` overrides
+    ``serialize_to_python()`` to call it for each of its fields. To allow this
+    sort of use case, each serialize method provides the ``serializer`` as an
+    argument.
+
+    Hooks for serializers that inherit the Python serializer (``json``,
+    ``jsonl``, and ``yaml``):
+
+    .. method:: serialize_to_python(obj, serializer)
+
+        .. versionadded:: 6.1
+
+        The base implementation passes through JSON-serializable types
+        (``None``, ``int``, ``float``, :class:`~decimal.Decimal`,
+        :class:`~datetime.datetime`, :class:`~datetime.date`, and
+        :class:`~datetime.time`) unchanged. Other values are passed to
+        :meth:`value_to_string`.
+
+    .. method:: deserialize_from_python(value)
+
+        .. versionadded:: 6.1
+
+        The base implementation calls :meth:`to_python`.
+
+    Hooks for the ``xml`` serializer:
+
+    .. method:: serialize_to_xml(obj, serializer)
+
+        .. versionadded:: 6.1
+
+        The base implementation calls :meth:`value_to_string`.
+
+    .. method:: deserialize_from_xml(field_node)
+
+        .. versionadded:: 6.1
+
+        The base implementation extracts the text from ``field_node``, strips
+        whitespace, and passes the value to :meth:`to_python`.
+
     When using :doc:`model forms </topics/forms/modelforms>`, the ``Field``
     needs to know which form field it should be represented by:
 

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -348,6 +348,17 @@ Serialization
   :exc:`~django.core.exceptions.SuspiciousOperation` when it encounters
   unexpected nested tags.
 
+* New model field methods allow more advanced customization of serialization
+  and deserialization.
+
+  For serializers that inherit from the Python serializer (``json``, ``jsonl``,
+  and ``yaml``): :meth:`~.Field.serialize_to_python`,
+  :meth:`~.Field.deserialize_from_python`
+
+  For the XML serializer: :meth:`~.Field.serialize_to_xml`,
+  :meth:`~.Field.deserialize_from_xml`
+
+
 Signals
 ~~~~~~~
 


### PR DESCRIPTION
ticket-36986

Removes the special casing of `JSONField` in XML serializer (https://github.com/django/django/pull/12613) and `CompositePrimaryKey` in Python serializer (https://github.com/django/django/pull/18056).

Depends on https://github.com/django/django/pull/21054 (now merged).