### PR TITLE
Fixed #37013 -- Omitted tzinfo argument to Trunc & Extract with USE_TZ = True and TIME_ZONE != UTC creates ambiguity for migrations

### DIFF
--- a/django/db/models/functions/datetime.py
+++ b/django/db/models/functions/datetime.py
@@ -1,3 +1,5 @@
+import warnings
+
 from django.conf import settings
 from django.db.models.expressions import Func
 from django.db.models.fields import (
@@ -17,6 +19,7 @@ from django.db.models.lookups import (
     YearLte,
 )
 from django.utils import timezone
+from django.utils.deprecation import RemovedInDjango71Warning, django_file_prefixes
 
 
 class TimezoneMixin:
@@ -34,6 +37,25 @@ class TimezoneMixin:
             else:
                 tzname = timezone._get_timezone_name(self.tzinfo)
         return tzname
+
+    def deconstruct(self):
+        path, args, kwargs = super().deconstruct()
+        if self.tzinfo is None and settings.USE_TZ:
+            warnings.warn(
+                f"The {self.__class__.__name__}() database function's tzinfo "
+                "argument is not provided. This is deprecated because the "
+                "timezone information is not captured in migrations, which "
+                "can lead to inconsistent behavior if TIME_ZONE changes. "
+                "Pass the tzinfo argument to suppress this warning.",
+                category=RemovedInDjango71Warning,
+                skip_file_prefixes=django_file_prefixes(),
+            )
+            # RemovedInDjango71Warning: when the deprecation ends, replace the
+            # warning above with the following, so that the current timezone is
+            # captured in migrations instead of being silently resolved at run
+            # time (get_tzname() is left unchanged for query-time usage):
+            # kwargs["tzinfo"] = timezone.get_current_timezone()
+        return path, args, kwargs
 
 
 class Extract(TimezoneMixin, Transform):

--- a/django/db/models/functions/datetime.py
+++ b/django/db/models/functions/datetime.py
@@ -1,3 +1,5 @@
+import warnings
+
 from django.conf import settings
 from django.db.models.expressions import Func
 from django.db.models.fields import (
@@ -17,6 +19,7 @@ from django.db.models.lookups import (
     YearLte,
 )
 from django.utils import timezone
+from django.utils.deprecation import RemovedInDjango2029Warning, django_file_prefixes
 
 
 class TimezoneMixin:
@@ -34,6 +37,25 @@ class TimezoneMixin:
             else:
                 tzname = timezone._get_timezone_name(self.tzinfo)
         return tzname
+
+    def deconstruct(self):
+        path, args, kwargs = super().deconstruct()
+        if self.tzinfo is None and settings.USE_TZ:
+            warnings.warn(
+                f"The {self.__class__.__name__}() database function's tzinfo "
+                "argument is not provided, which can lead to inconsistent "
+                "behavior if TIME_ZONE changes. In Django 2029, the current "
+                "time zone will be captured in migrations when tzinfo is "
+                "omitted. Pass an explicit tzinfo to suppress this warning.",
+                category=RemovedInDjango2029Warning,
+                skip_file_prefixes=django_file_prefixes(),
+            )
+            # RemovedInDjango2029Warning: when the deprecation ends, replace
+            # the warning with the following, so that the current timezone is
+            # captured in migrations instead of being silently resolved at run
+            # time (get_tzname() is left unchanged for query-time usage):
+            # kwargs["tzinfo"] = timezone.get_current_timezone()
+        return path, args, kwargs
 
 
 class Extract(TimezoneMixin, Transform):

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -20,6 +20,11 @@ details on these changes.
 * Calling ``QuerySet.aiterator()`` after ``prefetch_related()`` without
   providing a ``chunk_size`` will raise :exc:`ValueError`.
 
+* The :class:`~django.db.models.functions.Extract` and
+  :class:`~django.db.models.functions.Trunc` database functions will capture
+  the current timezone in ``deconstruct()`` when the ``tzinfo`` argument is
+  omitted and :setting:`USE_TZ` is ``True``.
+
 .. _deprecation-removed-in-7.0:
 
 7.0

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -23,6 +23,11 @@ details on these changes.
 * Calling ``QuerySet.aiterator()`` after ``prefetch_related()`` without
   providing a ``chunk_size`` will raise :exc:`ValueError`.
 
+* The :class:`~django.db.models.functions.Extract` and
+  :class:`~django.db.models.functions.Trunc` database functions will capture
+  the current timezone in migrations when the ``tzinfo`` argument is omitted
+  and :setting:`USE_TZ` is ``True``.
+
 .. _deprecation-removed-in-2028:
 
 2028

--- a/docs/ref/models/database-functions.txt
+++ b/docs/ref/models/database-functions.txt
@@ -233,6 +233,16 @@ Django usually uses the databases' extract function, so you may use any
 provided by :mod:`zoneinfo`, can be passed to extract a value in a specific
 timezone.
 
+.. deprecated:: 6.2
+
+    Omitting the ``tzinfo`` argument when these functions are used in
+    migrations (for example as a
+    :attr:`db_default <django.db.models.Field.db_default>`) and
+    :setting:`USE_TZ` is ``True`` is deprecated. The timezone information
+    is not captured during migration serialization, which can lead to
+    inconsistent behavior if :setting:`TIME_ZONE` changes. Pass the
+    ``tzinfo`` argument explicitly to suppress this warning.
+
 Given the datetime ``2015-06-15 23:30:01.000321+00:00``, the built-in
 ``lookup_name``\s return:
 
@@ -593,6 +603,16 @@ depending on ``output_field``, with fields up to ``kind`` set to their minimum
 value. If ``output_field`` is omitted, it will default to the ``output_field``
 of ``expression``. A ``tzinfo`` subclass, usually provided by :mod:`zoneinfo`,
 can be passed to truncate a value in a specific timezone.
+
+.. deprecated:: 6.2
+
+    Omitting the ``tzinfo`` argument when these functions are used in
+    migrations (for example as a
+    :attr:`db_default <django.db.models.Field.db_default>`) and
+    :setting:`USE_TZ` is ``True`` is deprecated. The timezone information
+    is not captured during migration serialization, which can lead to
+    inconsistent behavior if :setting:`TIME_ZONE` changes. Pass the
+    ``tzinfo`` argument explicitly to suppress this warning.
 
 Given the datetime ``2015-06-15 14:30:50.000321+00:00``, the built-in
 ``kind``\s return:

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -282,3 +282,14 @@ Miscellaneous
   providing a ``chunk_size`` is deprecated. It currently falls back to a
   ``chunk_size`` of 2000, but a ``ValueError`` will be raised in
   Django 7.1.
+
+* Omitting the ``tzinfo`` argument of
+  :class:`~django.db.models.functions.Extract` and
+  :class:`~django.db.models.functions.Trunc` database functions when used in
+  migrations (for example as a
+  :attr:`db_default <django.db.models.Field.db_default>`) and :setting:`USE_TZ`
+  is ``True`` is deprecated. The timezone information is not captured during
+  migration serialization, which can lead to inconsistent behavior if
+  :setting:`TIME_ZONE` changes. Pass the ``tzinfo`` argument explicitly to
+  suppress this warning. In Django 7.1, the current timezone will be captured
+  automatically when ``tzinfo`` is omitted.

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -369,3 +369,14 @@ Miscellaneous
   providing a ``chunk_size`` is deprecated. It currently falls back to a
   ``chunk_size`` of 2000, but a ``ValueError`` will be raised in
   Django 2029.
+
+* Omitting the ``tzinfo`` argument of
+  :class:`~django.db.models.functions.Extract` and
+  :class:`~django.db.models.functions.Trunc` database functions when used in
+  migrations (for example as a
+  :attr:`db_default <django.db.models.Field.db_default>`) and :setting:`USE_TZ`
+  is ``True`` is deprecated. The timezone information is not captured during
+  migration serialization, which can lead to inconsistent behavior if
+  :setting:`TIME_ZONE` changes. Pass the ``tzinfo`` argument explicitly to
+  suppress this warning. In Django 2029, the current timezone will be captured
+  automatically when ``tzinfo`` is omitted.

--- a/tests/db_functions/datetime/test_extract_trunc.py
+++ b/tests/db_functions/datetime/test_extract_trunc.py
@@ -45,6 +45,7 @@ from django.test import (
     skipUnlessDBFeature,
 )
 from django.utils import timezone
+from django.utils.deprecation import RemovedInDjango71Warning
 
 from ..models import Author, DTModel, Fan
 
@@ -1974,3 +1975,56 @@ class DateFunctionWithTimeZoneTests(DateFunctionTests):
             .count(),
             1,
         )
+
+    def test_extract_deconstruct_tzinfo_none_deprecation(self):
+        """
+        Deconstructing Extract without an explicit tzinfo raises a deprecation
+        warning when USE_TZ is True.
+        """
+        extract = Extract("start_datetime", "hour")
+        with self.assertWarnsMessage(
+            RemovedInDjango71Warning,
+            "Extract() database function's tzinfo argument is not provided",
+        ):
+            extract.deconstruct()
+
+    def test_trunc_deconstruct_tzinfo_none_deprecation(self):
+        """
+        Deconstructing Trunc without an explicit tzinfo raises a deprecation
+        warning when USE_TZ is True.
+        """
+        trunc = Trunc("start_datetime", "day", output_field=DateTimeField())
+        with self.assertWarnsMessage(
+            RemovedInDjango71Warning,
+            "Trunc() database function's tzinfo argument is not provided",
+        ):
+            trunc.deconstruct()
+
+    @override_settings(USE_TZ=False)
+    def test_extract_deconstruct_tzinfo_none_no_warning_without_tz(self):
+        """
+        Deconstructing Extract without an explicit tzinfo does not warn when
+        USE_TZ is False.
+        """
+        # runtests.py turns the deprecation warning into an error.
+        Extract("start_datetime", "hour").deconstruct()
+
+    @override_settings(USE_TZ=False)
+    def test_trunc_deconstruct_tzinfo_none_no_warning_without_tz(self):
+        """
+        Deconstructing Trunc without an explicit tzinfo does not warn when
+        USE_TZ is False.
+        """
+        Trunc("start_datetime", "day", output_field=DateTimeField()).deconstruct()
+
+    def test_extract_deconstruct_with_tzinfo_no_deprecation(self):
+        """Deconstructing Extract with an explicit tzinfo does not warn."""
+        melb = zoneinfo.ZoneInfo("Australia/Melbourne")
+        Extract("start_datetime", "hour", tzinfo=melb).deconstruct()
+
+    def test_trunc_deconstruct_with_tzinfo_no_deprecation(self):
+        """Deconstructing Trunc with an explicit tzinfo does not warn."""
+        melb = zoneinfo.ZoneInfo("Australia/Melbourne")
+        Trunc(
+            "start_datetime", "day", output_field=DateTimeField(), tzinfo=melb
+        ).deconstruct()

--- a/tests/db_functions/datetime/test_extract_trunc.py
+++ b/tests/db_functions/datetime/test_extract_trunc.py
@@ -45,6 +45,7 @@ from django.test import (
     skipUnlessDBFeature,
 )
 from django.utils import timezone
+from django.utils.deprecation import RemovedInDjango2029Warning
 
 from ..models import Author, DTModel, Fan
 
@@ -1974,3 +1975,39 @@ class DateFunctionWithTimeZoneTests(DateFunctionTests):
             .count(),
             1,
         )
+
+    def test_extract_deconstruct_tzinfo_none(self):
+        msg = "Extract() database function's tzinfo argument is not provided"
+        # RemovedInDjango2029Warning: When the deprecation ends, replace with:
+        # _, _, kwargs = Extract("start_datetime", "hour").deconstruct()
+        # self.assertEqual(kwargs["tzinfo"].key, settings.TIME_ZONE)
+        with self.assertWarnsMessage(RemovedInDjango2029Warning, msg):
+            Extract("start_datetime", "hour").deconstruct()
+
+    def test_trunc_deconstruct_tzinfo_none(self):
+        msg = "Trunc() database function's tzinfo argument is not provided"
+        # RemovedInDjango2029Warning: When the deprecation ends, replace with:
+        # _, _, kwargs = Trunc("start_datetime", "day").deconstruct()
+        # self.assertEqual(kwargs["tzinfo"].key, settings.TIME_ZONE)
+        with self.assertWarnsMessage(RemovedInDjango2029Warning, msg):
+            Trunc("start_datetime", "day").deconstruct()
+
+    @override_settings(USE_TZ=False)
+    def test_extract_deconstruct_use_tz_false(self):
+        _, _, kwargs = Extract("start_datetime", "hour").deconstruct()
+        self.assertNotIn("tzinfo", kwargs)
+
+    @override_settings(USE_TZ=False)
+    def test_trunc_deconstruct_use_tz_false(self):
+        _, _, kwargs = Trunc("start_datetime", "day").deconstruct()
+        self.assertNotIn("tzinfo", kwargs)
+
+    def test_extract_deconstruct_with_tzinfo(self):
+        melb = zoneinfo.ZoneInfo("Australia/Melbourne")
+        _, _, kwargs = Extract("start_datetime", "hour", tzinfo=melb).deconstruct()
+        self.assertEqual(kwargs["tzinfo"], melb)
+
+    def test_trunc_deconstruct_with_tzinfo(self):
+        melb = zoneinfo.ZoneInfo("Australia/Melbourne")
+        _, _, kwargs = Trunc("start_datetime", "day", tzinfo=melb).deconstruct()
+        self.assertEqual(kwargs["tzinfo"], melb)


### PR DESCRIPTION
#### Trac ticket number

ticket-37013

#### Branch description

When `Extract` and `Trunc` database functions are used in migrations (for
example as a `db_default`) with `USE_TZ = True` and the `tzinfo` argument is
omitted, the timezone is resolved from `settings.TIME_ZONE` at run time but is
not captured during migration serialization. If `TIME_ZONE` later changes, the
database-side value can silently diverge from what the migration recorded,
creating ambiguity.

This PR deprecates omitting `tzinfo` in that migration/serialization path. A
`RemovedInDjango71Warning` is raised from `deconstruct()` (the migration
serialization hook, and the only place the omission is ambiguous) when
`tzinfo` is `None` and `USE_TZ` is `True`. Normal queryset usage
(`annotate()`/`filter()`) is unaffected. At the end of the deprecation period,
`deconstruct()` will capture the current timezone into `kwargs` so it is
recorded in the migration; `get_tzname()` is left unchanged for query-time
usage.

Changes:
- `django/db/models/functions/datetime.py`: added `TimezoneMixin.deconstruct()`
  raising the deprecation warning, with a breadcrumb for the future end state.
- `docs/ref/models/database-functions.txt`, `docs/releases/6.2.txt`,
  `docs/internals/deprecation.txt`: documented the deprecation and its removal.
- `tests/db_functions/datetime/test_extract_trunc.py`: added tests for the
  warning being raised (and not raised when `tzinfo` is provided or
  `USE_TZ = False`).

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Used Claude (claude.ai/claude-code) for code generation, writing tests, and
drafting docs. All output was manually reviewed, run against the `db_functions`
test suite, and verified for correctness.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
