### PR TITLE
Fixed #36837 -- Skipped backends not implementing (a)get_user() in (a)force_login().

### DIFF
--- a/django/test/client.py
+++ b/django/test/client.py
@@ -865,10 +865,15 @@ class ClientMixin:
 
     def _get_backend(self):
         from django.contrib.auth import load_backend
+        from django.contrib.auth.backends import BaseBackend
+
+        def overrides(backend, name):
+            base = getattr(BaseBackend, name)
+            return getattr(type(backend), name, base) is not base
 
         for backend_path in settings.AUTHENTICATION_BACKENDS:
             backend = load_backend(backend_path)
-            if hasattr(backend, "get_user"):
+            if overrides(backend, "get_user") or overrides(backend, "aget_user"):
                 return backend_path
 
     def _login(self, user, backend=None):

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -222,7 +222,9 @@ Templates
 Tests
 ~~~~~
 
-* ...
+* :meth:`~django.test.Client.force_login` now skips members of
+  :setting:`AUTHENTICATION_BACKENDS` not implementing ``(a)get_user()``, e.g.
+  permission-only backends.
 
 URLs
 ~~~~

--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -479,14 +479,20 @@ Use the ``django.test.Client`` class to make requests.
 
         The user will have its ``backend`` attribute set to the value of the
         ``backend`` argument (which should be a dotted Python path string), or
-        to ``settings.AUTHENTICATION_BACKENDS[0]`` if a value isn't provided.
-        The :func:`~django.contrib.auth.authenticate` function called by
-        :meth:`login` normally annotates the user like this.
+        if a value isn't provided, the first backend from
+        :setting:`AUTHENTICATION_BACKENDS` implementing ``get_user()`` or
+        ``aget_user()``. The :func:`~django.contrib.auth.authenticate` function
+        called by :meth:`login` normally annotates the user like this.
 
         This method is faster than ``login()`` since the expensive
         password hashing algorithms are bypassed. Also, you can speed up
         ``login()`` by :ref:`using a weaker hasher while testing
         <speeding-up-tests-auth-hashers>`.
+
+        .. versionchanged:: 6.2
+
+            On older versions, backends not implementing ``(a)get_user()`` were
+            eligible to be selected.
 
     .. method:: Client.logout()
     .. method:: Client.alogout()

--- a/tests/test_client/auth_backends.py
+++ b/tests/test_client/auth_backends.py
@@ -1,4 +1,4 @@
-from django.contrib.auth.backends import ModelBackend
+from django.contrib.auth.backends import BaseBackend, ModelBackend
 
 
 class TestClientBackend(ModelBackend):
@@ -6,4 +6,10 @@ class TestClientBackend(ModelBackend):
 
 
 class BackendWithoutGetUserMethod:
+    pass
+
+
+class PermissionOnlyBackend(BaseBackend):
+    """This class inherits from BaseBackend but does not implement get_user."""
+
     pass

--- a/tests/test_client/tests.py
+++ b/tests/test_client/tests.py
@@ -794,6 +794,25 @@ class ClientTest(TestCase):
         self.client.force_login(self.u1)
         self.assertEqual(self.u1.backend, "django.contrib.auth.backends.ModelBackend")
 
+    @override_settings(
+        AUTHENTICATION_BACKENDS=[
+            "test_client.auth_backends.PermissionOnlyBackend",
+            "django.contrib.auth.backends.ModelBackend",
+        ]
+    )
+    def test_force_login_skips_noop_get_user_backend(self):
+        """force_login() skips auth backends without concrete get_user()."""
+        self.client.force_login(self.u1)
+        self.assertEqual(self.u1.backend, "django.contrib.auth.backends.ModelBackend")
+
+    @override_settings(
+        AUTHENTICATION_BACKENDS=[
+            "test_client.auth_backends.PermissionOnlyBackend",
+        ]
+    )
+    def test_force_login_all_backends_noop(self):
+        self.assertIsNone(self.client._get_backend())
+
     @override_settings(SESSION_ENGINE="django.contrib.sessions.backends.signed_cookies")
     def test_logout_cookie_sessions(self):
         self.test_logout()


### PR DESCRIPTION
#### Trac ticket number

ticket-36837

#### Branch description

Permission-only authentication backends (e.g., django-rules, django-guardian) that inherit from `BaseBackend` without overriding `get_user()` were incorrectly selected by `Client.force_login()`. This happened because `_get_backend()` only checked `hasattr(backend, "get_user")`, which was always `True` for any `BaseBackend` subclass — even those that never intended to support authentication.

[EDIT:] See https://github.com/django/django/pull/21065#discussion_r3244564031 for the eventual implementation. What follows was the initial proposal.

***

This PR adds a `noop = True` attribute to `BaseBackend.get_user()` and `BaseBackend.aget_user()` to statically declare that these are placeholder implementations. `Client._get_backend()` now also checks `not getattr(backend.get_user, "noop", False)`, skipping backends that haven't explicitly overridden `get_user()`.

This follows the precedent set by `natural_key.dependencies` in Django's serialization framework, where a function attribute is used to declaratively convey metadata about a method.

With this change, third-party packages can safely inherit from `BaseBackend` for permission-only backends without interfering with `force_login()` backend selection, and without having to avoid `BaseBackend` inheritance (which would also mean losing the built-in async support).

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

GitHub Copilot was used for code generation and test writing. All output was reviewed and verified.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
