### PR TITLE
Fixed #37024 -- Made SITE_ID system check validation use Site._meta.pk.

### DIFF
--- a/django/contrib/sites/checks.py
+++ b/django/contrib/sites/checks.py
@@ -1,14 +1,30 @@
-from types import NoneType
-
 from django.conf import settings
 from django.core.checks import Error
+from django.core.exceptions import ValidationError
 
 
 def check_site_id(app_configs, **kwargs):
-    if hasattr(settings, "SITE_ID") and not isinstance(
-        settings.SITE_ID, (NoneType, int)
-    ):
-        return [
-            Error("The SITE_ID setting must be an integer", id="sites.E101"),
-        ]
+    # Inner import avoids AppRegistryNotReady
+    from django.contrib.sites.models import Site
+
+    if hasattr(settings, "SITE_ID"):
+        try:
+            site_id = Site._meta.pk.to_python(settings.SITE_ID)
+        except ValidationError as exc:
+            return [
+                Error(
+                    f"The SITE_ID setting failed to validate: {exc}.", id="sites.E101"
+                ),
+            ]
+        else:
+            # to_python() might coerce a SITE_ID of the wrong type to the valid
+            # type, e.g. "1" to 1 for AutoField.
+            if site_id != settings.SITE_ID:
+                expected_type = type(site_id).__name__
+                return [
+                    Error(
+                        f"The SITE_ID setting must be of type {expected_type}.",
+                        id="sites.E101",
+                    ),
+                ]
     return []

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -967,7 +967,8 @@ The following checks are performed on any model using a
 The following checks verify that :mod:`django.contrib.sites` is correctly
 configured:
 
-* **sites.E101**: The :setting:`SITE_ID` setting must be an integer.
+* **sites.E101**: The :setting:`SITE_ID` setting must be of type ``<type>``.
+  *or* The :setting:`SITE_ID` setting failed to validate: ``<error>``.
 
 ``staticfiles``
 ---------------

--- a/tests/sites_tests/tests.py
+++ b/tests/sites_tests/tests.py
@@ -204,12 +204,25 @@ class SitesFrameworkTests(TestCase):
         self.assertEqual(self.site.natural_key(), (self.site.domain,))
 
     @override_settings(SITE_ID="1")
-    def test_check_site_id(self):
+    def test_check_site_id_incorrect_type(self):
         self.assertEqual(
             check_site_id(None),
             [
                 checks.Error(
-                    msg="The SITE_ID setting must be an integer",
+                    msg="The SITE_ID setting must be of type int.",
+                    id="sites.E101",
+                ),
+            ],
+        )
+
+    @override_settings(SITE_ID="x")
+    def test_check_site_id_failed_to_validate(self):
+        self.assertEqual(
+            check_site_id(None),
+            [
+                checks.Error(
+                    msg="The SITE_ID setting failed to validate: ['“x” value "
+                    "must be an integer.'].",
                     id="sites.E101",
                 ),
             ],


### PR DESCRIPTION
ticket-37024

The patch was validated on MongoDB with these modifications:
```diff
diff --git a/tests/sites_tests/tests.py b/tests/sites_tests/tests.py
index d46c955a87..bc725a58f7 100644
--- a/tests/sites_tests/tests.py
+++ b/tests/sites_tests/tests.py
@@ -205,13 +205,13 @@ class SitesFrameworkTests(TestCase):
         self.assertEqual(Site.objects.get_by_natural_key(self.site.domain), self.site)
         self.assertEqual(self.site.natural_key(), (self.site.domain,))
 
-    @override_settings(SITE_ID="1")
+    @override_settings(SITE_ID="111111111111111111111111")
     def test_check_site_id_incorrect_type(self):
         self.assertEqual(
             check_site_id(None),
             [
                 checks.Error(
-                    msg="The SITE_ID setting must be of type int.",
+                    msg="The SITE_ID setting must be of type ObjectId.",
                     id="sites.E101",
                 ),
             ],
@@ -223,15 +223,17 @@ class SitesFrameworkTests(TestCase):
             check_site_id(None),
             [
                 checks.Error(
-                    msg="The SITE_ID setting failed to validate: ['“x” value "
-                    "must be an integer.'].",
+                    msg="The SITE_ID setting failed to validate: ['“x” is not "
+                    "a valid Object Id.'].",
                     id="sites.E101",
                 ),
             ],
         )
 
     def test_valid_site_id(self):
-        for site_id in [1, None]:
+        from bson import ObjectId
+
+        for site_id in [ObjectId("111111111111111111111111"), None]:
             with self.subTest(site_id=site_id), self.settings(SITE_ID=site_id):
                 self.assertEqual(check_site_id(None), []
```

