### PR TITLE
Fixed #37006 -- Improved autodetector logic for renaming and altering primary keys

### DIFF
--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -1090,7 +1090,7 @@ class MigrationAutodetector:
                         )
                         or is_pk_rename
                     ):
-                        if is_pk_rename or self.questioner.ask_rename(
+                        if self.questioner.ask_rename(
                             model_name, rem_field_name, field_name, field
                         ):
                             self.renamed_operations.append(

--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -1076,14 +1076,21 @@ class MigrationAutodetector:
                             old_field_dec[2]["to"] = self.renamed_models_rel[old_rel_to]
                     old_field.set_attributes_from_name(rem_field_name)
                     old_db_column = old_field.get_attname_column()[1]
-                    if old_field_dec == field_dec or (
-                        # Was the field renamed and db_column equal to the
-                        # old field's column added?
-                        old_field_dec[0:2] == field_dec[0:2]
-                        and dict(old_field_dec[2], db_column=old_db_column)
-                        == field_dec[2]
+                    is_pk_rename = old_field_dec[2].get("primary_key") and field_dec[
+                        2
+                    ].get("primary_key")
+                    if (
+                        old_field_dec == field_dec
+                        or (
+                            # Was the field renamed and db_column equal to the
+                            # old field's column added?
+                            old_field_dec[0:2] == field_dec[0:2]
+                            and dict(old_field_dec[2], db_column=old_db_column)
+                            == field_dec[2]
+                        )
+                        or is_pk_rename
                     ):
-                        if self.questioner.ask_rename(
+                        if is_pk_rename or self.questioner.ask_rename(
                             model_name, rem_field_name, field_name, field
                         ):
                             self.renamed_operations.append(
@@ -1336,7 +1343,12 @@ class MigrationAutodetector:
             # If the field was confirmed to be renamed it means that only
             # db_column was allowed to change which generate_renamed_fields()
             # already accounts for by adding an AlterField operation.
-            if old_field_dec != new_field_dec and old_field_name == field_name:
+            is_pk_rename = old_field_dec[2].get("primary_key") and new_field_dec[2].get(
+                "primary_key"
+            )
+            if old_field_dec != new_field_dec and (
+                old_field_name == field_name or is_pk_rename
+            ):
                 both_m2m = old_field.many_to_many and new_field.many_to_many
                 neither_m2m = not old_field.many_to_many and not new_field.many_to_many
                 target_changed = (

--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -1340,14 +1340,18 @@ class MigrationAutodetector:
                     new_field.remote_field.through = old_field.remote_field.through
             old_field_dec = self.deep_deconstruct(old_field)
             new_field_dec = self.deep_deconstruct(new_field)
-            # If the field was confirmed to be renamed it means that only
-            # db_column was allowed to change which generate_renamed_fields()
-            # already accounts for by adding an AlterField operation.
-            is_pk_rename = old_field_dec[2].get("primary_key") and new_field_dec[2].get(
-                "primary_key"
-            )
+            is_pk_renamed = old_field_dec[2].get("primary_key") and new_field_dec[
+                2
+            ].get("primary_key")
+            # If the field was confirmed to be renamed and it was not the PK it
+            # means that only db_column was allowed to change which
+            # generate_renamed_fields() already accounts for by adding
+            # an AlterField operation.
+            #
+            # However, if the renamed column was the primary key,
+            # the AlterField operation needs to be considered here.
             if old_field_dec != new_field_dec and (
-                old_field_name == field_name or is_pk_rename
+                old_field_name == field_name or is_pk_renamed
             ):
                 both_m2m = old_field.many_to_many and new_field.many_to_many
                 neither_m2m = not old_field.many_to_many and not new_field.many_to_many

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -5635,6 +5635,48 @@ class AutodetectorTests(BaseAutodetectorTests):
             unique_together={("first_renamed", "second")},
         )
 
+    def test_alter_rename_pk(self):
+        """
+        Altering a model's primary key field and renaming it is detected
+        without recreating the column
+        """
+        changes = self.get_changes(
+            [self.author_empty],
+            [self.author_custom_pk],
+            MigrationQuestioner({"ask_rename": True}),
+        )
+
+        # Right number/type of migrations?
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertEqual(len(changes["testapp"][0].operations), 2)
+        self.assertOperationTypes(changes, "testapp", 0, ["RenameField", "AlterField"])
+        self.assertOperationAttributes(
+            changes,
+            "testapp",
+            0,
+            0,
+            model_name="author",
+            old_name="id",
+            new_name="pk_field",
+        )
+        self.assertOperationAttributes(
+            changes,
+            "testapp",
+            0,
+            1,
+            model_name="author",
+            name="pk_field",
+        )
+        self.assertEqual(
+            changes["testapp"][0].operations[1].field.deconstruct(),
+            (
+                "pk_field",
+                "django.db.models.IntegerField",
+                [],
+                {"primary_key": True},
+            ),
+        )
+
 
 class MigrationSuggestNameTests(SimpleTestCase):
     def test_no_operations(self):

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -5637,7 +5637,7 @@ class AutodetectorTests(BaseAutodetectorTests):
 
     def test_alter_rename_pk(self):
         """
-        Altering a model's primary key field and renaming it is detected
+        Changing a primary key name and type detects renaming and altering
         without recreating the column
         """
         changes = self.get_changes(
@@ -5674,6 +5674,47 @@ class AutodetectorTests(BaseAutodetectorTests):
                 "django.db.models.IntegerField",
                 [],
                 {"primary_key": True},
+            ),
+        )
+
+    def test_recreate_pk(self):
+        """
+        Changing a primary key name and type triggers and respects questioner
+        if recreating it is preferred over renaming and altering
+        """
+        changes = self.get_changes(
+            [self.author_empty],
+            [self.author_custom_pk],
+            MigrationQuestioner({"ask_rename": False}),
+        )
+
+        # Right number/type of migrations?
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertEqual(len(changes["testapp"][0].operations), 2)
+        self.assertOperationTypes(changes, "testapp", 0, ["RemoveField", "AddField"])
+        self.assertOperationAttributes(
+            changes,
+            "testapp",
+            0,
+            0,
+            model_name="author",
+            name="id",
+        )
+        self.assertOperationAttributes(
+            changes,
+            "testapp",
+            0,
+            1,
+            model_name="author",
+            name="pk_field",
+        )
+        self.assertEqual(
+            changes["testapp"][0].operations[1].field.deconstruct(),
+            (
+                None,
+                "django.db.models.IntegerField",
+                [],
+                {"default": None, "primary_key": True},
             ),
         )
 


### PR DESCRIPTION
#### Trac ticket number

ticket-37006

#### Branch description
The migration autodetector now considers that tables always have a single primary key. This allows a simultaneous rename and type change to be detected as a rename and alter operation instead of dropping and recreating the column

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
