### PR TITLE
Fixed #37025 -- Doc'd that RemoteUserMiddleware.header does not correspond to request.META under ASGI.

### DIFF
--- a/django/contrib/auth/middleware.py
+++ b/django/contrib/auth/middleware.py
@@ -8,6 +8,7 @@ from django.contrib.auth import REDIRECT_FIELD_NAME, load_backend
 from django.contrib.auth.backends import RemoteUserBackend
 from django.contrib.auth.views import redirect_to_login
 from django.core.exceptions import ImproperlyConfigured
+from django.core.handlers.asgi import ASGIRequest
 from django.shortcuts import resolve_url
 from django.utils.deprecation import MiddlewareMixin
 from django.utils.functional import SimpleLazyObject
@@ -141,7 +142,7 @@ class RemoteUserMiddleware:
                 " before the RemoteUserMiddleware class."
             )
         try:
-            username = request.META[self.header]
+            username = self._get_username(request)
         except KeyError:
             # If specified header doesn't exist then remove any existing
             # authenticated remote-user, or return (leaving request.user set to
@@ -184,7 +185,7 @@ class RemoteUserMiddleware:
                 " before the RemoteUserMiddleware class."
             )
         try:
-            username = request.META["HTTP_" + self.header]
+            username = self._get_username(request)
         except KeyError:
             # If specified header doesn't exist then remove any existing
             # authenticated remote-user, or return (leaving request.user set to
@@ -227,6 +228,11 @@ class RemoteUserMiddleware:
         except AttributeError:  # Backend has no clean_username method.
             pass
         return username
+
+    def _get_username(self, request):
+        if isinstance(request, ASGIRequest):
+            return request.META["HTTP_" + self.header]
+        return request.META[self.header]
 
     def _remove_invalid_user(self, request):
         """

--- a/docs/howto/auth-remote-user.txt
+++ b/docs/howto/auth-remote-user.txt
@@ -76,7 +76,11 @@ regardless of ``AUTHENTICATION_BACKENDS``.
 
 If your authentication mechanism uses a custom HTTP header and not
 ``REMOTE_USER``, you can subclass ``RemoteUserMiddleware`` and set the
-``header`` attribute to the desired ``request.META`` key. For example:
+``header`` attribute. Under WSGI, this is looked up in ``request.META``, so it
+should be prefixed with ``HTTP_``. Under ASGI, this value is prefixed with
+``HTTP_`` when looked up, so it should not be prefixed -- it should
+correspond to the header your authentication mechanism will set. For example,
+to use the ``AUTHUSER`` header instead:
 
 .. code-block:: python
    :caption: ``mysite/middleware.py``
@@ -85,7 +89,8 @@ If your authentication mechanism uses a custom HTTP header and not
 
 
     class CustomHeaderRemoteUserMiddleware(RemoteUserMiddleware):
-        header = "HTTP_AUTHUSER"
+        header = "HTTP_AUTHUSER"  # for WSGI deployments
+        header = "AUTHUSER"  # for ASGI deployments
 
 This custom middleware is then used in the :setting:`MIDDLEWARE` setting
 instead of :class:`django.contrib.auth.middleware.RemoteUserMiddleware`::
@@ -103,9 +108,7 @@ instead of :class:`django.contrib.auth.middleware.RemoteUserMiddleware`::
     client can supply the header. You must be sure that your web server or
     reverse proxy always sets or strips that header based on the appropriate
     authentication checks, never permitting an end user to submit a fake (or
-    "spoofed") header value. In particular, ASGI deployments cannot be exposed
-    directly to the internet (that is, without a reverse proxy) when using this
-    middleware.
+    "spoofed") header value.
 
     Since the HTTP headers ``X-Auth-User`` and ``X-Auth_User`` (for example)
     both normalize to the ``HTTP_X_AUTH_USER`` key in ``request.META``, you
@@ -115,10 +118,12 @@ instead of :class:`django.contrib.auth.middleware.RemoteUserMiddleware`::
     Under WSGI, this warning doesn't apply to ``RemoteUserMiddleware`` in its
     default configuration with ``header = "REMOTE_USER"``, since a key that
     doesn't start with ``HTTP_`` in ``request.META`` can only be set by your
-    WSGI server, not directly from an HTTP request header. This warning *does*
-    apply by default on ASGI, because in the async path, the middleware
-    prepends ``HTTP_`` to the defined header name before looking it up in
-    ``request.META``.
+    WSGI server, not directly from an HTTP request header.
+
+    This warning applies under ASGI in all configurations, because there is
+    no equivalent for a WSGI server's ability to place a trusted value in the
+    environ. ASGI deployments *must* use a reverse proxy as described above
+    when using this middleware.
 
 If you need more control, you can create your own authentication backend
 that inherits from :class:`~django.contrib.auth.backends.RemoteUserBackend` and

--- a/tests/auth_tests/test_remote_user.py
+++ b/tests/auth_tests/test_remote_user.py
@@ -1,10 +1,14 @@
+import unittest
 from datetime import UTC, datetime
+
+import asgiref.sync
 
 from django.conf import settings
 from django.contrib.auth import aauthenticate, authenticate
 from django.contrib.auth.backends import RemoteUserBackend
 from django.contrib.auth.middleware import RemoteUserMiddleware
 from django.contrib.auth.models import User
+from django.middleware.common import CommonMiddleware
 from django.middleware.csrf import _get_new_csrf_string, _mask_cipher_secret
 from django.test import (
     AsyncClient,
@@ -436,6 +440,29 @@ class RemoteUserCustomTest(RemoteUserTest):
         self.assertEqual(newuser.email, "user@example.com")
 
 
+class ASGISyncPathRemoteUserTest(RemoteUserTest):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # Patch CommonMiddleware to be sync-only, and order it last. This will
+        # force process_request() to run even on an async request.
+        common = settings.MIDDLEWARE[:].pop(1)
+        # If this mock is removed, then methods in this class will fail without
+        # making cls.header begin with HTTP_, like CustomHeaderRemoteUserTest.
+        cls.enterClassContext(
+            unittest.mock.patch.object(CommonMiddleware, "async_capable", False)
+        )
+        cls.enterClassContext(
+            override_settings(MIDDLEWARE=[*settings.MIDDLEWARE, cls.middleware, common])
+        )
+
+    def setUp(self):
+        method = getattr(self, self._testMethodName)
+        if not isinstance(method, asgiref.sync.AsyncToSync):
+            self.skipTest("This test covers async-only functionality")
+
+
 class CustomHeaderMiddleware(RemoteUserMiddleware):
     """
     Middleware that overrides custom HTTP auth user header.
@@ -450,6 +477,11 @@ class CustomHeaderRemoteUserTest(RemoteUserTest):
     header.
     """
 
+    middleware = "auth_tests.test_remote_user.CustomHeaderMiddleware"
+    header = "HTTP_AUTHUSER"
+
+
+class CustomHeaderASGISyncPathRemoteUserTest(ASGISyncPathRemoteUserTest):
     middleware = "auth_tests.test_remote_user.CustomHeaderMiddleware"
     header = "HTTP_AUTHUSER"
 

--- a/tests/auth_tests/test_remote_user.py
+++ b/tests/auth_tests/test_remote_user.py
@@ -545,7 +545,7 @@ class PersistentRemoteUserTest(RemoteUserTest):
         await User.objects.acreate(username="knownuser")
         # Known user authenticates
         response = await self.async_client.get(
-            "/remote_user/", headers={self.header: self.known_user}
+            "/remote_user/", **{self.header: self.known_user}
         )
         self.assertEqual(response.context["user"].username, "knownuser")
         # Should stay logged in if the REMOTE_USER header disappears.

--- a/tests/auth_tests/test_remote_user.py
+++ b/tests/auth_tests/test_remote_user.py
@@ -478,12 +478,43 @@ class CustomHeaderRemoteUserTest(RemoteUserTest):
     """
 
     middleware = "auth_tests.test_remote_user.CustomHeaderMiddleware"
+    # Note: under WSGI, your request should send the "AUTHUSER" header, but
+    # under ASGI, your request should send "HTTP_AUTHUSER". The test client
+    # hides this difference, because it does not pass this value via the
+    # `headers` kwarg. By passing it via `**extra`, it gets passed to the
+    # underlying request, which, for ASGI, will apply prefixing, turning
+    # HTTP_AUTHUSER -> HTTP_HTTP_AUTHUSER. A more sensible header for ASGI
+    # is tested separately, see CustomHeaderASGISyncPathRemoteUserTest.
     header = "HTTP_AUTHUSER"
 
 
 class CustomHeaderASGISyncPathRemoteUserTest(ASGISyncPathRemoteUserTest):
-    middleware = "auth_tests.test_remote_user.CustomHeaderMiddleware"
-    header = "HTTP_AUTHUSER"
+    """
+    Tests a custom RemoteUserMiddleware subclass with custom HTTP auth user
+    header, with other sync middleware forcing sync execution under ASGI.
+
+    These tests are only run under ASGI, see super().setUpClass().
+    """
+
+    # Use a header that's more sensible for ASGI. (On the superclass,
+    # the header value HTTP_AUTHUSER will become, after prefixing,
+    # HTTP_HTTP_AUTHUSER under ASGI.)
+    header = "AUTHUSER"
+
+    async def test_header_value(self):
+        """
+        Header values do not correspond to request.META under ASGI. Thus,
+        a single subclass with a custom header cannot be reused on both WSGI
+        and ASGI deployments.
+        """
+        response = await self.async_client.get("/remote_user/", **{self.header: ""})
+        request = response.asgi_request
+        # The prefixed form is in request.META.
+        self.assertIn("HTTP_" + self.header, request.META)
+        self.assertNotIn(self.header, request.META)
+        # The unprefixed form is in request.headers.
+        self.assertIn(self.header, request.headers)
+        self.assertNotIn("HTTP_" + self.header, request.headers)
 
 
 class PersistentRemoteUserTest(RemoteUserTest):
@@ -514,7 +545,7 @@ class PersistentRemoteUserTest(RemoteUserTest):
         await User.objects.acreate(username="knownuser")
         # Known user authenticates
         response = await self.async_client.get(
-            "/remote_user/", **{self.header: self.known_user}
+            "/remote_user/", headers={self.header: self.known_user}
         )
         self.assertEqual(response.context["user"].username, "knownuser")
         # Should stay logged in if the REMOTE_USER header disappears.


### PR DESCRIPTION
#### Trac ticket number
ticket-37025

#### Branch description
Building on the effort from #21043 to bring the documentation for `RemoteUserMiddleware` up to date in case anyone is using it with ASGI (?), we noticed that our existing test case for a custom header (e.g. `header = "HTTP_AUTHUSER"`), meant that a double-prefixed key `HTTP_HTTP_AUTHUSER` was set in `request.META`:

https://github.com/django/django/blob/09f27cc373eb1e6e5e8b286204809a79b61d55c3/tests/auth_tests/test_remote_user.py#L439-L444

This PR doesn't break that usage, but it documents the usage you probably want under ASGI, which is just `header = "AUTH_USER"`, if you don't care about reusing the same subclass under WSGI.

~While here, replace the hard-coded prefixing of "HTTP_" with a more flexible lookup against `request.headers`. This makes the security caveat easier to document, instead of describing an implementation detail.~

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

I asked ChatGPT (GPT-5.3) to try to disprove my claim that the included code change is backward compatible, and to suggest the `getattr()` trick in the test case subclass. EDIT: that was all pertaining to a prior iteration.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
