### PR TITLE
Fix django__django-13512

### DIFF
--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -1258,7 +1258,7 @@ class JSONField(CharField):
     def prepare_value(self, value):
         if isinstance(value, InvalidJSONInput):
             return value
-        return json.dumps(value, cls=self.encoder)
+        return json.dumps(value, ensure_ascii=False, cls=self.encoder)
 
     def has_changed(self, initial, data):
         if super().has_changed(initial, data):


### PR DESCRIPTION
Fix: Admin doesn't display properly unicode chars in JSONFields.

Added `ensure_ascii=False` to `json.dumps()` in `JSONField.prepare_value()` so that unicode characters (e.g. Chinese characters like 中国) are displayed properly in the admin instead of being escaped to ASCII sequences like `\\u4e2d\\u56fd`.

## Changes
- `django/forms/fields.py`: Added `ensure_ascii=False` parameter to `json.dumps` call in `JSONField.prepare_value()` method.