### PR TITLE
Fix django__django-13512

### DIFF
--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -1258,7 +1258,7 @@ class JSONField(CharField):
     def prepare_value(self, value):
         if isinstance(value, InvalidJSONInput):
             return value
-        return json.dumps(value, cls=self.encoder)
+        return json.dumps(value, ensure_ascii=False, cls=self.encoder)
 
     def has_changed(self, initial, data):
         if super().has_changed(initial, data):

--- a/tests/forms_tests/field_tests/test_jsonfield.py
+++ b/tests/forms_tests/field_tests/test_jsonfield.py
@@ -29,6 +29,8 @@ class JSONFieldTest(SimpleTestCase):
         self.assertEqual(field.prepare_value({'a': 'b'}), '{"a": "b"}')
         self.assertEqual(field.prepare_value(None), 'null')
         self.assertEqual(field.prepare_value('foo'), '"foo"')
+        # Unicode characters should be displayed as-is, not escaped to ASCII.
+        self.assertEqual(field.prepare_value({'key': '中国'}), '{"key": "中国"}')
 
     def test_widget(self):
         field = JSONField()


### PR DESCRIPTION
Fix: Admin doesn't display properly unicode chars in JSONFields

## Problem
`json.dumps` uses ASCII encoding by default, so when editing a JSONField containing unicode characters (e.g. Chinese characters like 中国) in Django admin, they appear as ASCII escape sequences (e.g. `\u4e2d\u56fd`).

## Fix
Added `ensure_ascii=False` to the `json.dumps` call in `JSONField.prepare_value()` in `django/forms/fields.py`, so unicode characters are displayed as-is in the admin form.

## Changes
- `django/forms/fields.py`: Added `ensure_ascii=False` parameter to `json.dumps` in `prepare_value()` method.