### PR TITLE
Removed checkout step from labels.yml.

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -21,10 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-
       - name: "Check title and manage labels"
         uses: actions/github-script@v8
         with:

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,5 +1,7 @@
 rules:
   dangerous-triggers:
+    # Before ignoring a file, assume all inputs are malicious, assign explicit
+    # minimal permissions, and do not use actions/checkout.
     ignore:
       - coverage_comment.yml
       - labels.yml


### PR DESCRIPTION
#### Branch description
While discussing #21077, we noted the need for an ignore in `zizmor.yml`. That prompted me to clarify when an ignore is justified, and doing that prompted one tightening in `labels.yml`.

Raising a public PR because I believe there is no exploit possible right now, as this action does not execute any user code. Still, removing the checkout step is a good tightening because it should never be done in an action with a `pull_request_target` trigger. (What if there is a script executed or an `npm ci` step later in the workflow?)

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
