### PR TITLE
Fix django__django-12039

### DIFF
--- a/django/db/backends/ddl_references.py
+++ b/django/db/backends/ddl_references.py
@@ -83,10 +83,14 @@ class Columns(TableColumns):
 
     def __str__(self):
         def col_str(column, idx):
+            col = self.quote_name(column)
             try:
-                return self.quote_name(column) + self.col_suffixes[idx]
+                suffix = self.col_suffixes[idx]
             except IndexError:
-                return self.quote_name(column)
+                return col
+            if suffix:
+                col = '{} {}'.format(col, suffix)
+            return col
 
         return ', '.join(col_str(column, idx) for idx, column in enumerate(self.columns))
 
@@ -112,9 +116,13 @@ class IndexColumns(Columns):
         def col_str(column, idx):
             # Index.__init__() guarantees that self.opclasses is the same
             # length as self.columns.
-            col = '{} {}'.format(self.quote_name(column), self.opclasses[idx])
+            col = self.quote_name(column)
+            if self.opclasses[idx]:
+                col = '{} {}'.format(col, self.opclasses[idx])
             try:
-                col = '{} {}'.format(col, self.col_suffixes[idx])
+                suffix = self.col_suffixes[idx]
+                if suffix:
+                    col = '{} {}'.format(col, suffix)
             except IndexError:
                 pass
             return col


### PR DESCRIPTION
Fix whitespace in CREATE INDEX statements.

## Problem

Two whitespace issues in `django/db/backends/ddl_references.py`:

1. `Columns.__str__()` concatenated `col_suffixes` directly without a space, producing `"name"DESC` instead of `"name" DESC`.

2. `IndexColumns.__str__()` unconditionally formatted opclasses and col_suffixes with `'{} {}'.format(...)` even when they were empty strings, producing trailing whitespace like `"name" text_pattern_ops ` when opclasses was used without explicit ordering.

## Fix

- `Columns.__str__()`: Check if the suffix is non-empty before adding it, and use `'{} {}'.format()` to ensure proper spacing.
- `IndexColumns.__str__()`: Skip empty opclasses and empty col_suffixes instead of unconditionally formatting them.

## Testing

- Ran `backends.test_ddl_references` test suite: all 28 tests pass.
- Ran `schema` test suite: all 129 tests pass (22 skipped).
- Manual verification with all combinations of empty/non-empty opclasses and col_suffixes confirms correct output.