### PR TITLE
Fix django__django-12262

### DIFF
--- a/django/template/library.py
+++ b/django/template/library.py
@@ -261,7 +261,7 @@ def parse_bits(parser, bits, params, varargs, varkw, defaults,
         if kwarg:
             # The kwarg was successfully extracted
             param, value = kwarg.popitem()
-            if param not in params and param not in unhandled_kwargs and varkw is None:
+            if param not in params and param not in kwonly and varkw is None:
                 # An unexpected keyword argument was supplied
                 raise TemplateSyntaxError(
                     "'%s' received unexpected keyword argument '%s'" %

--- a/tests/template_tests/test_custom.py
+++ b/tests/template_tests/test_custom.py
@@ -62,6 +62,8 @@ class SimpleTagTests(TagTestCase):
                 'simple_keyword_only_param - Expected result: 37'),
             ('{% load custom %}{% simple_keyword_only_default %}',
                 'simple_keyword_only_default - Expected result: 42'),
+            ('{% load custom %}{% simple_keyword_only_default kwarg=37 %}',
+                'simple_keyword_only_default - Expected result: 37'),
             ('{% load custom %}{% simple_one_default 37 %}', 'simple_one_default - Expected result: 37, hi'),
             ('{% load custom %}{% simple_one_default 37 two="hello" %}',
                 'simple_one_default - Expected result: 37, hello'),


### PR DESCRIPTION
Fix TemplateSyntaxError for keyword-only arguments with defaults in template tags.

Changed `parse_bits()` in `django/template/library.py` to check `param not in kwonly` instead of `param not in unhandled_kwargs` so that keyword-only arguments with defaults are recognized as valid keyword arguments.

This fixes:
- `simple_tag`/`inclusion_tag` raising 'unexpected keyword argument' when a keyword-only arg with a default value is provided
- Duplicate keyword args for keyword-only params now correctly raise 'received multiple values' instead of 'unexpected keyword argument'

## Testing
- Ran `python tests/runtests.py template_tests.test_custom --parallel=1` - all 22 tests pass
- Added test case for `simple_keyword_only_default` with an explicit kwarg value to cover the bug scenario