### PR TITLE
Fix django__django-11728

### DIFF
--- a/django/contrib/admindocs/utils.py
+++ b/django/contrib/admindocs/utils.py
@@ -180,6 +180,11 @@ def replace_named_groups(pattern):
             elif val == ')' and prev_char != '\\':
                 unmatched_open_brackets -= 1
             prev_char = val
+        else:
+            # If the loop completes without a break (i.e. the group is at the
+            # end of the pattern), check if brackets are balanced.
+            if unmatched_open_brackets == 0:
+                group_pattern_and_name.append((pattern[start:end + idx + 1], group_name))
 
     # Replace the string for named capture groups with their group names.
     for group_pattern, group_name in group_pattern_and_name:
@@ -212,6 +217,9 @@ def replace_unnamed_groups(pattern):
             elif val == ')' and prev_char != '\\':
                 unmatched_open_brackets -= 1
             prev_char = val
+        else:
+            if unmatched_open_brackets == 0:
+                group_indices.append((start, start + 1 + idx + 1))
 
     # Remove unnamed group matches inside other unnamed capture groups.
     group_start_end_indices = []


### PR DESCRIPTION
Fix replace_named_groups() and replace_unnamed_groups() not replacing trailing groups.

When a named or unnamed group is at the end of the pattern (no trailing characters after the closing parenthesis), the for loop that tracks bracket balance completes without triggering the break condition, causing the group to never be appended to the results list.

Added for/else clauses to handle the case where the loop completes normally (group at end of pattern) by checking if brackets are balanced and appending the group.

Example from the issue:
- Input: r'entries/(?P<pk>[^/.]+)/relationships/(?P<related_field>\w+)'
- Before fix: related_field group was NOT replaced
- After fix: correctly outputs entries/<pk>/relationships/<related_field>