### PR TITLE
Refs #36494 -- Added support for JSONField __range, __has_keys lookups with expressions.

### DIFF
--- a/django/db/models/fields/json.py
+++ b/django/db/models/fields/json.py
@@ -277,6 +277,8 @@ class HasKeys(HasKeyLookup):
     logical_operator = " AND "
 
     def get_prep_lookup(self):
+        if hasattr(self.rhs, "resolve_expression"):
+            return self.rhs
         return [str(item) for item in self.rhs]
 
 
@@ -719,6 +721,29 @@ class KeyTransformGte(KeyTransformNumericLookupMixin, lookups.GreaterThanOrEqual
     pass
 
 
+class KeyTransformRange(KeyTransformNumericLookupMixin, lookups.Range):
+    def process_rhs(self, compiler, connection):
+        if self.rhs_is_direct_value():
+            return super().process_rhs(compiler, connection)
+        rhs_start = KeyTransform(0, self.rhs)
+        rhs_end = KeyTransform(1, self.rhs)
+        start_sql, start_params = compiler.compile(rhs_start)
+        end_sql, end_params = compiler.compile(rhs_end)
+        return [start_sql, end_sql], tuple(start_params) + tuple(end_params)
+
+    def as_mysql(self, compiler, connection):
+        if self.rhs_is_direct_value():
+            return self.as_sql(compiler, connection)
+        lhs, lhs_params = self.process_lhs(compiler, connection)
+        rhs_start = KeyTransform(0, self.rhs)
+        rhs_end = KeyTransform(1, self.rhs)
+        start_sql, start_params = compiler.compile(rhs_start)
+        end_sql, end_params = compiler.compile(rhs_end)
+        sql = "(%s >= %s AND %s <= %s)" % (lhs, start_sql, lhs, end_sql)
+        params = (*lhs_params, *start_params, *lhs_params, *end_params)
+        return sql, params
+
+
 KeyTransform.register_lookup(KeyTransformIn)
 KeyTransform.register_lookup(KeyTransformExact)
 KeyTransform.register_lookup(KeyTransformIExact)
@@ -735,6 +760,7 @@ KeyTransform.register_lookup(KeyTransformLt)
 KeyTransform.register_lookup(KeyTransformLte)
 KeyTransform.register_lookup(KeyTransformGt)
 KeyTransform.register_lookup(KeyTransformGte)
+KeyTransform.register_lookup(KeyTransformRange)
 
 
 class KeyTransformFactory:

--- a/django/db/models/fields/json.py
+++ b/django/db/models/fields/json.py
@@ -184,6 +184,11 @@ class HasKeyLookup(PostgresOperatorLookup):
     logical_operator = None
 
     def compile_json_path_final_key(self, connection, key_transform):
+        if hasattr(key_transform, "resolve_expression"):
+            raise NotSupportedError(
+                f"{self.lookup_name} lookup with expressions is not supported on "
+                f"{connection.display_name}."
+            )
         # Compile the final key without interpreting ints as array elements.
         return ".%s" % json.dumps(key_transform)
 
@@ -277,6 +282,8 @@ class HasKeys(HasKeyLookup):
     logical_operator = " AND "
 
     def get_prep_lookup(self):
+        if hasattr(self.rhs, "resolve_expression"):
+            return self.rhs
         return [str(item) for item in self.rhs]
 
 
@@ -719,6 +726,29 @@ class KeyTransformGte(KeyTransformNumericLookupMixin, lookups.GreaterThanOrEqual
     pass
 
 
+class KeyTransformRange(KeyTransformNumericLookupMixin, lookups.Range):
+    def process_rhs(self, compiler, connection):
+        if self.rhs_is_direct_value():
+            return super().process_rhs(compiler, connection)
+        rhs_start = KeyTransform(0, self.rhs)
+        rhs_end = KeyTransform(1, self.rhs)
+        start_sql, start_params = compiler.compile(rhs_start)
+        end_sql, end_params = compiler.compile(rhs_end)
+        return [start_sql, end_sql], tuple(start_params) + tuple(end_params)
+
+    def as_mysql(self, compiler, connection):
+        if self.rhs_is_direct_value():
+            return self.as_sql(compiler, connection)
+        lhs, lhs_params = self.process_lhs(compiler, connection)
+        rhs_start = KeyTransform(0, self.rhs)
+        rhs_end = KeyTransform(1, self.rhs)
+        start_sql, start_params = compiler.compile(rhs_start)
+        end_sql, end_params = compiler.compile(rhs_end)
+        sql = "(%s >= %s AND %s <= %s)" % (lhs, start_sql, lhs, end_sql)
+        params = (*lhs_params, *start_params, *lhs_params, *end_params)
+        return sql, params
+
+
 KeyTransform.register_lookup(KeyTransformIn)
 KeyTransform.register_lookup(KeyTransformExact)
 KeyTransform.register_lookup(KeyTransformIExact)
@@ -735,6 +765,7 @@ KeyTransform.register_lookup(KeyTransformLt)
 KeyTransform.register_lookup(KeyTransformLte)
 KeyTransform.register_lookup(KeyTransformGt)
 KeyTransform.register_lookup(KeyTransformGte)
+KeyTransform.register_lookup(KeyTransformRange)
 
 
 class KeyTransformFactory:

--- a/tests/model_fields/test_jsonfield.py
+++ b/tests/model_fields/test_jsonfield.py
@@ -652,6 +652,38 @@ class TestQuerying(TestCase):
             [self.objs[3], self.objs[4], self.objs[6]],
         )
 
+    def test_has_key_expression_not_supported(self):
+        if connection.vendor == "postgresql":
+            self.skipTest("PostgreSQL natively supports has_key with expressions.")
+
+        msg = (
+            "has_key lookup with expressions is not supported on %s."
+            % connection.display_name
+        )
+        with self.assertRaisesMessage(NotSupportedError, msg):
+            list(NullableJSONModel.objects.filter(value__has_key=F("id")))
+
+        msg = (
+            "has_keys lookup with expressions is not supported on %s."
+            % connection.display_name
+        )
+        with self.assertRaisesMessage(NotSupportedError, msg):
+            list(NullableJSONModel.objects.filter(value__has_keys=F("id")))
+
+        msg = (
+            "has_any_keys lookup with expressions is not supported on %s."
+            % connection.display_name
+        )
+        with self.assertRaisesMessage(NotSupportedError, msg):
+            list(NullableJSONModel.objects.filter(value__has_any_keys=F("id")))
+
+    def test_range_with_expression(self):
+        obj = NullableJSONModel.objects.create(value={"target": 5, "bounds": [2, 6]})
+        self.assertSequenceEqual(
+            NullableJSONModel.objects.filter(value__target__range=F("value__bounds")),
+            [obj],
+        )
+
     def test_has_key_number(self):
         obj = NullableJSONModel.objects.create(
             value={


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-36494

#### Branch description
This PR fixes crashes in ``JSONField`` expressions in PostgreSQL, SQLite, and MySQL. It uses KeyTransform to unpack array bounds for ``__range`` to fix parameter mismatches, and it maps MySQL queries to ``>= AND <=`` to get around its ``BETWEEN`` bug. For ``__has_keys``, it uses ``hasattr`` to safely skip list comprehensions on SQL expressions, which fixes TypeErrors. It also stops ``JSONDecodeErrors`` from happening when you look up numbers by checking ``rhs_is_direct_value()``. Used Gemini to generate a boilerplate and to analyze the approach.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [X] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [X] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [X] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [X] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
