### PR TITLE
Fixed #37026 -- Added edit_only support to GenericInlineModelAdmin.

### DIFF
--- a/django/contrib/contenttypes/admin.py
+++ b/django/contrib/contenttypes/admin.py
@@ -95,7 +95,7 @@ class GenericInlineModelAdmin(InlineModelAdmin):
 
     checks_class = GenericInlineModelAdminChecks
 
-    def get_formset(self, request, obj=None, **kwargs):
+    def get_formset(self, request, obj=None, edit_only=False, **kwargs):
         if "fields" in kwargs:
             fields = kwargs.pop("fields")
         else:
@@ -124,6 +124,7 @@ class GenericInlineModelAdmin(InlineModelAdmin):
             "min_num": self.get_min_num(request, obj),
             "max_num": self.get_max_num(request, obj),
             "exclude": exclude,
+            "edit_only": edit_only,
             **kwargs,
         }
 

--- a/django/contrib/contenttypes/forms.py
+++ b/django/contrib/contenttypes/forms.py
@@ -93,6 +93,7 @@ def generic_inlineformset_factory(
     validate_min=False,
     absolute_max=None,
     can_delete_extra=True,
+    edit_only=False,
 ):
     """
     Return a ``GenericInlineFormSet`` for the given kwargs.
@@ -126,6 +127,7 @@ def generic_inlineformset_factory(
         validate_min=validate_min,
         absolute_max=absolute_max,
         can_delete_extra=can_delete_extra,
+        edit_only=edit_only,
     )
     FormSet.ct_field = ct_field
     FormSet.ct_fk_field = fk_field

--- a/tests/generic_inline_admin/tests.py
+++ b/tests/generic_inline_admin/tests.py
@@ -479,3 +479,17 @@ class GenericInlineModelAdminTest(SimpleTestCase):
             request.name = name
             self.assertEqual(ma.get_inlines(request, None), (inline_class,))
             self.assertEqual(type(ma.get_inline_instances(request)[0]), inline_class)
+
+    def test_edit_only_is_respected(self):
+        """
+        GenericInlineModelAdmin.get_formset() respects edit_only.
+        """
+
+        class EditOnlyInline(GenericTabularInline):
+            model = Media
+
+        ma = EditOnlyInline(Media, self.site)
+        formset = ma.get_formset(request, edit_only=True)
+        self.assertTrue(formset.edit_only)
+        formset = ma.get_formset(request, edit_only=False)
+        self.assertFalse(formset.edit_only)

--- a/tests/generic_inline_admin/tests.py
+++ b/tests/generic_inline_admin/tests.py
@@ -484,12 +484,10 @@ class GenericInlineModelAdminTest(SimpleTestCase):
         """
         GenericInlineModelAdmin.get_formset() respects edit_only.
         """
-
         class EditOnlyInline(GenericTabularInline):
             model = Media
-
         ma = EditOnlyInline(Media, self.site)
         formset = ma.get_formset(request, edit_only=True)
-        self.assertTrue(formset.edit_only)
+        self.assertIs(formset.edit_only, True)
         formset = ma.get_formset(request, edit_only=False)
-        self.assertFalse(formset.edit_only)
+        self.assertIs(formset.edit_only, False)

--- a/tests/generic_inline_admin/tests.py
+++ b/tests/generic_inline_admin/tests.py
@@ -484,8 +484,10 @@ class GenericInlineModelAdminTest(SimpleTestCase):
         """
         GenericInlineModelAdmin.get_formset() respects edit_only.
         """
+
         class EditOnlyInline(GenericTabularInline):
             model = Media
+
         ma = EditOnlyInline(Media, self.site)
         formset = ma.get_formset(request, edit_only=True)
         self.assertIs(formset.edit_only, True)


### PR DESCRIPTION
#### Trac ticket number
ticket-37026

#### Branch description
BaseModelFormSet received an edit_only parameter
in #26142 and #33822, but it was never implemented
for GenericInlineModelAdmin.

This fix adds edit_only support to:
- generic_inlineformset_factory() in forms.py
- GenericInlineModelAdmin.get_formset() in admin.py

A regression test has been added.

#### AI Assistance Disclosure (REQUIRED)
- [x] If AI tools were used, I have disclosed
which ones, and fully reviewed and verified
their output.

I used Claude (claude.ai) as an AI assistant
to help understand the codebase. All code
changes were reviewed, understood, and tested
by me personally. The full test suite was run
locally with 21 tests passing.

#### Checklist
- [x] This PR follows the contribution guidelines
- [x] This PR targets the main branch
- [x] The commit message is written in past tense
- [x] I have checked the "Has patch" ticket flag
      in Trac