### PR TITLE
Fixed #37029 -- Moved endblock tag outside changelist-footer div.

### DIFF
--- a/django/contrib/admin/templates/admin/change_list.html
+++ b/django/contrib/admin/templates/admin/change_list.html
@@ -91,8 +91,8 @@
           <div class="changelist-footer">
           {% pagination cl %}
           {% if cl.formset and cl.result_count %}<input type="submit" name="_save" class="default" value="{% translate 'Save' %}">{% endif %}
-          {% endblock %}
           </div>
+        {% endblock %}
           </form>
         </div>
       </div>


### PR DESCRIPTION
#### Trac ticket number
ticket-37029

#### Branch description
The `{% endblock %}` tag in `change_list.html` was incorrectly placed inside the `changelist-footer` div, resulting in improper template structure.

This fix moves the `{% endblock %}` tag outside the `div` to ensure correct block boundaries and cleaner HTML structure. The change does not affect functionality but improves template correctness and maintainability.

#### AI Assistance Disclosure (REQUIRED)
If AI tools were used, I have disclosed which ones, and fully reviewed and verified their output.

I used Cloud AI tools as an assistant to help understand the issue and validate the fix. All changes were carefully reviewed and verified by me.

#### Checklist
- [x] This PR follows the contribution guidelines
- [x] This PR targets the main branch
- [x] The commit message is written in past tense
- [x] I have checked the "Has patch" ticket flag in Trac