### PR TITLE
Keep traceback in converter

### DIFF
--- a/django/contrib/staticfiles/storage.py
+++ b/django/contrib/staticfiles/storage.py
@@ -297,7 +297,7 @@ class HashedFilesMixin:
                 line = _line_at_position(matchobj.string, matchobj.start())
                 note = f"{name!r} contains this reference {matched!r} on line {line}"
                 exc.add_note(note)
-                raise exc
+                raise
 
             transformed_url = "/".join(
                 url_path.split("/")[:-1] + hashed_url.split("/")[-1:]


### PR DESCRIPTION
While exploring the codebase I noticed that the converter function in staticfiles/storage.py re-raises a ValueError by name after adding a note to it, which resets the traceback to line 300 instead of keeping it at the original raise site inside _stored_name.

The note added by exc.add_note(note) is attached to the exception object itself, not to the traceback, so a bare raise preserves it just fine — the note still shows up when the exception is printed. The only thing that changes is that the traceback now points back to the _url() call that originally raised, rather than to the re-raise line, which is where it should be.

The surrounding code at lines 289–294 already handles the try/except correctly — the raise exc on line 300 is the odd one out.
Happy to close this if the traceback reset is intentional for some reason I am missing.
Thanks.