### PR TITLE
Fixed #22226 -- Clarified quoting when reversing admin URLs.

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -3455,7 +3455,9 @@ if you specifically wanted the admin view from the admin instance named
 
 .. code-block:: pycon
 
-    >>> change_url = reverse("admin:polls_choice_change", args=(quote(c.pk),), current_app="custom")
+    >>> change_url = reverse(
+    ...     "admin:polls_choice_change", args=(quote(c.pk),), current_app="custom"
+    ... )
 
 For more details, see the documentation on :ref:`reversing namespaced URLs
 <topics-http-reversing-url-namespaces>`.

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -3440,8 +3440,9 @@ call:
 .. code-block:: pycon
 
     >>> from django.urls import reverse
+    >>> from django.contrib.admin.utils import quote
     >>> c = Choice.objects.get(...)
-    >>> change_url = reverse("admin:polls_choice_change", args=(c.id,))
+    >>> change_url = reverse("admin:polls_choice_change", args=(quote(c.pk),))
 
 This will find the first registered instance of the admin application
 (whatever the instance name), and resolve to the view for changing
@@ -3454,10 +3455,14 @@ if you specifically wanted the admin view from the admin instance named
 
 .. code-block:: pycon
 
-    >>> change_url = reverse("admin:polls_choice_change", args=(c.id,), current_app="custom")
+    >>> change_url = reverse("admin:polls_choice_change", args=(quote(c.pk),), current_app="custom")
 
 For more details, see the documentation on :ref:`reversing namespaced URLs
 <topics-http-reversing-url-namespaces>`.
+
+For URLs that take an ``object_id`` argument, use
+:func:`django.contrib.admin.utils.quote` to escape the primary key before
+passing it to :func:`django.urls.reverse`.
 
 To allow easier reversing of the admin urls in templates, Django provides an
 ``admin_urlname`` filter which takes an action as argument:
@@ -3466,12 +3471,14 @@ To allow easier reversing of the admin urls in templates, Django provides an
 
     {% load admin_urls %}
     <a href="{% url opts|admin_urlname:'add' %}">Add user</a>
-    <a href="{% url opts|admin_urlname:'delete' user.pk %}">Delete this user</a>
+    <a href="{% url opts|admin_urlname:'delete' user.pk|admin_urlquote %}">Delete this user</a>
 
 The action in the examples above match the last part of the URL names for
 :class:`ModelAdmin` instances described above. The ``opts`` variable can be any
 object which has an ``app_label`` and ``model_name`` attributes and is usually
-supplied by the admin views for the current model.
+supplied by the admin views for the current model. For URLs that take an
+``object_id`` argument, use the ``admin_urlquote`` filter to escape primary key
+values before passing them to the :ttag:`url` template tag.
 
 The ``display`` decorator
 =========================

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -3463,8 +3463,8 @@ For more details, see the documentation on :ref:`reversing namespaced URLs
 <topics-http-reversing-url-namespaces>`.
 
 For URLs that take an ``object_id`` argument, use
-:func:`django.contrib.admin.utils.quote` to escape the primary key before
-passing it to :func:`django.urls.reverse`.
+``django.contrib.admin.utils.quote()`` to escape the primary key before
+passing it to :func:`~django.urls.reverse`.
 
 To allow easier reversing of the admin urls in templates, Django provides an
 ``admin_urlname`` filter which takes an action as argument:

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -3440,8 +3440,14 @@ call:
 .. code-block:: pycon
 
     >>> from django.urls import reverse
+    >>> from django.contrib.admin.utils import quote
     >>> c = Choice.objects.get(...)
-    >>> change_url = reverse("admin:polls_choice_change", args=(c.id,))
+    >>> change_url = reverse("admin:polls_choice_change", args=(quote(c.pk),))
+
+The ``change``, ``delete``, and ``history`` views expect their primary key
+argument to be escaped with ``django.contrib.admin.utils.quote()``. Otherwise
+reversing can produce URLs that the admin fails to resolve correctly when the
+key contains characters such as ``_``, ``/``, or ``:``.
 
 This will find the first registered instance of the admin application
 (whatever the instance name), and resolve to the view for changing
@@ -3454,7 +3460,9 @@ if you specifically wanted the admin view from the admin instance named
 
 .. code-block:: pycon
 
-    >>> change_url = reverse("admin:polls_choice_change", args=(c.id,), current_app="custom")
+    >>> change_url = reverse(
+    ...     "admin:polls_choice_change", args=(quote(c.pk),), current_app="custom"
+    ... )
 
 For more details, see the documentation on :ref:`reversing namespaced URLs
 <topics-http-reversing-url-namespaces>`.
@@ -3466,12 +3474,13 @@ To allow easier reversing of the admin urls in templates, Django provides an
 
     {% load admin_urls %}
     <a href="{% url opts|admin_urlname:'add' %}">Add user</a>
-    <a href="{% url opts|admin_urlname:'delete' user.pk %}">Delete this user</a>
+    <a href="{% url opts|admin_urlname:'delete' user.pk|admin_urlquote %}">Delete this user</a>
 
 The action in the examples above match the last part of the URL names for
 :class:`ModelAdmin` instances described above. The ``opts`` variable can be any
 object which has an ``app_label`` and ``model_name`` attributes and is usually
-supplied by the admin views for the current model.
+supplied by the admin views for the current model. The ``admin_urlquote``
+filter is the template equivalent of ``quote()`` above.
 
 The ``display`` decorator
 =========================


### PR DESCRIPTION
#### Trac ticket number

ticket-22226

#### Branch description

Clarified the admin docs to show that URLs taking an `object_id` must use Django's admin-specific quoting.

- Updated the Python `reverse()` examples to use `django.contrib.admin.utils.quote()`.
- Updated the template example to use the `admin_urlquote` filter.
- Added short explanatory notes for both Python and template usage.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Used OpenAI Codex assistance and manually reviewed the final patch before submission.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.

Not applicable for this PR:

- Tests: documentation-only clarification.
- UI screenshots: no UI changes.

