### PR TITLE
Fixed #37029 -- Corrected placement of </div> in change_list.html's pagination block.

### DIFF
--- a/django/contrib/admin/templates/admin/change_list.html
+++ b/django/contrib/admin/templates/admin/change_list.html
@@ -89,11 +89,11 @@
             {% if action_form and actions_on_bottom and cl.show_admin_actions %}{% admin_actions %}{% endif %}
           {% endblock %}
           {% block pagination %}
-          <div class="changelist-footer">
-          {% pagination cl %}
-          {% if cl.formset and cl.result_count %}<input type="submit" name="_save" class="default" value="{% translate 'Save' %}">{% endif %}
+            <div class="changelist-footer">
+            {% pagination cl %}
+            {% if cl.formset and cl.result_count %}<input type="submit" name="_save" class="default" value="{% translate 'Save' %}">{% endif %}
+            </div>
           {% endblock %}
-          </div>
           </form>
         </div>
       </div>

--- a/docs/releases/6.0.5.txt
+++ b/docs/releases/6.0.5.txt
@@ -9,4 +9,7 @@ Django 6.0.5 fixes several bugs in 6.0.4.
 Bugfixes
 ========
 
-* ...
+* Fixed a misplaced ``</div>`` in the
+  ``django/contrib/admin/templates/admin/change_list.html`` template added in
+  Django 6.0 that could be problematic when overriding the ``pagination`` block
+  (:ticket:`37029`).


### PR DESCRIPTION
Bug in 3f59711581bd22ebd0f13fb040b15b69c0eee21f.

ticket-37029

I don't think a test is required. If we added a test for the placement of every HTML tag in every template, that would be very onerous.