### PR TITLE
adding de-ch to LANG_INFO

### DIFF
--- a/django/conf/locale/__init__.py
+++ b/django/conf/locale/__init__.py
@@ -105,6 +105,12 @@ LANG_INFO = {
         "name": "German",
         "name_local": "Deutsch",
     },
+    "de-ch": {
+        "bidi": False,
+        "code": "de-ch",
+        "name": "German (Switzerland)",
+        "name_local": "Deutsch (Schweiz)",
+    },
     "dsb": {
         "bidi": False,
         "code": "dsb",


### PR DESCRIPTION
#### Trac ticket number
N/A - typo

#### Branch description
get_language_info returned the same for de and de-ch if de-ch was not in LANG_INFO. Thus, the default langauge selction did not work properly, i.e. it contained two identical elements and de-ch could actually not be chosen, sicne both referred to de. By adding de-ch in LANG_INFO, this was solved.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x ] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [ x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x ] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [ x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x ] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [ x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [ N/A] I have checked the "Has patch" ticket flag in the Trac system.
- [ N/A] I have added or updated relevant tests.
- [ N/A] I have added or updated relevant docs, including release notes if applicable.
- [ N/A] I have attached screenshots in both light and dark modes for any UI changes.
