### PR TITLE
Fixed OSMWidget map tiles not loading due to stale OpenLayers CDN version

### DIFF
--- a/django/contrib/gis/forms/widgets.py
+++ b/django/contrib/gis/forms/widgets.py
@@ -78,12 +78,12 @@ class OpenLayersWidget(BaseGeometryWidget):
     class Media:
         css = {
             "all": (
-                "https://cdn.jsdelivr.net/npm/ol@v7.2.2/ol.css",
+                "https://cdn.jsdelivr.net/npm/ol@v10.8.0/ol.css",
                 "gis/css/ol3.css",
             )
         }
         js = (
-            "https://cdn.jsdelivr.net/npm/ol@v7.2.2/dist/ol.js",
+            "https://cdn.jsdelivr.net/npm/ol@v10.8.0/dist/ol.js",
             "gis/js/OLMapWidget.js",
         )
 

--- a/js_tests/tests.html
+++ b/js_tests/tests.html
@@ -156,7 +156,7 @@
         <textarea id="id_multipolygon" name="multipolygon" class="vSerializedField required"
                   style="display:none;" rows="10" cols="150"></textarea>
     </div>
-    <script src='https://cdn.jsdelivr.net/npm/ol@v7.2.2/dist/ol.js'></script>
+    <script src='https://cdn.jsdelivr.net/npm/ol@v10.8.0/dist/ol.js'></script>
     <script src='../django/contrib/gis/static/gis/js/OLMapWidget.js' data-cover></script>
     <script src='./gis/mapwidget.test.js'></script>
 


### PR DESCRIPTION
#### Trac ticket number

ticket-36990

#### Branch description

OSMWidget was silently failing to load map tiles because the bundled OpenLayers CDN URL still pointed to v7.2.2. The OpenStreetMap tile servers enforce a referrer policy that older OpenLayers builds do not satisfy, causing 403s from tile.openstreetmap.org with no obvious console error — the result is a blank map for anyone using OSMWidget.

This patch bumps the CDN URL to v10.8.0 in `OpenLayersWidget.Media` (the `css` and `js` tuples) and in `js_tests/tests.html`. The OpenLayers public API used by `OLMapWidget.js` (`ol.Map`, `ol.layer.Tile/Vector`, `ol.source.OSM/XYZ/Vector`, `ol.interaction.Draw/Modify`, etc.) has not changed between v7 and v10, so no JS changes are needed.

Tested locally on macOS (Apple Silicon) with Python 3.13, GDAL 3.12.4, GEOS 3.14.1, SpatiaLite. Both CDN endpoints return HTTP 200. OSM tiles load correctly with no 403s. `gis_tests.test_geoforms` + `gis_tests.geos_tests` (158 tests) pass.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

I also used an LLM to help set up the test environment; all results were verified manually.
#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.