### PR TITLE
Fixed #36938 -- Removed unnecessary ordering from compound queries.

### DIFF
--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -86,9 +86,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         "annotations.tests.NonAggregateAnnotationTestCase.test_custom_functions",
         "annotations.tests.NonAggregateAnnotationTestCase."
         "test_custom_functions_can_ref_other_functions",
-        # A bug in Django with respect to unioning ordered querysets (#36938).
-        "queries.test_qs_combinators.QuerySetSetOperationTests."
-        "test_count_union_with_select_related_in_values",
     }
     insert_test_table_with_defaults = (
         "INSERT INTO {} VALUES (DEFAULT, DEFAULT, DEFAULT)"

--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -85,9 +85,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         "annotations.tests.NonAggregateAnnotationTestCase.test_custom_functions",
         "annotations.tests.NonAggregateAnnotationTestCase."
         "test_custom_functions_can_ref_other_functions",
-        # A bug in Django with respect to unioning ordered querysets (#36938).
-        "queries.test_qs_combinators.QuerySetSetOperationTests."
-        "test_count_union_with_select_related_in_values",
     }
     insert_test_table_with_defaults = (
         "INSERT INTO {} VALUES (DEFAULT, DEFAULT, DEFAULT)"

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -640,6 +640,15 @@ class SQLCompiler:
         if selected is not None and compiler.query.selected is None:
             compiler.query = compiler.query.clone()
             compiler.query.set_values(selected)
+        if (
+            (
+                features.requires_compound_order_by_subquery
+                and not features.ignores_unnecessary_order_by_in_subqueries
+            )
+            or not features.supports_parentheses_in_compound
+        ) and compiler.get_order_by():
+            compiler.query = compiler.query.clone()
+            compiler.query.clear_ordering(force=False)
         part_sql, part_args = compiler.as_sql(with_col_aliases=True)
         if compiler.query.combinator:
             # Wrap in a subquery if wrapping in parentheses isn't

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -590,10 +590,6 @@ class SQLCompiler:
                     raise DatabaseError(
                         "LIMIT/OFFSET not allowed in subqueries of compound statements."
                     )
-                if compiler.get_order_by():
-                    raise DatabaseError(
-                        "ORDER BY not allowed in subqueries of compound statements."
-                    )
         parts = []
         empty_compiler = None
         for compiler in compilers:

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -773,6 +773,13 @@ class SQLCompiler:
             combinator = self.query.combinator
             features = self.connection.features
             if combinator:
+                if not features.ignores_unnecessary_order_by_in_subqueries and (
+                    self.query.subquery
+                    or (order_by and features.requires_compound_order_by_subquery)
+                ):
+                    self.query = self.query.clone()
+                    self.query.clear_ordering(force=False)
+                    self.query.clear_ordering_in_combined_queries()
                 if not getattr(features, "supports_select_{}".format(combinator)):
                     raise NotSupportedError(
                         "{} is not supported on this database backend.".format(

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1312,8 +1312,7 @@ class Query(BaseExpression):
             and not connection.features.ignores_unnecessary_order_by_in_subqueries
         ):
             self.clear_ordering(force=False)
-            for query in self.combined_queries:
-                query.clear_ordering(force=False)
+            self.clear_ordering_in_combined_queries()
         sql, params = self.get_compiler(connection=connection).as_sql()
         if self.subquery:
             sql = "(%s)" % sql
@@ -2401,6 +2400,11 @@ class Query(BaseExpression):
         self.extra_order_by = ()
         if clear_default:
             self.default_ordering = False
+
+    def clear_ordering_in_combined_queries(self):
+        for query in self.combined_queries:
+            query.clear_ordering(force=False)
+            query.clear_ordering_in_combined_queries()
 
     def set_group_by(self, allow_aliases=True):
         """

--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -419,7 +419,6 @@ class QuerySetSetOperationTests(TestCase):
         qs2 = base_qs.filter(name="a2")
         self.assertSequenceEqual(qs1.union(qs2).order_by("pk"), [a1, a2])
 
-    @skipUnlessDBFeature("supports_slicing_ordering_in_compound")
     def test_union_with_select_related_and_first(self):
         e1 = ExtraInfo.objects.create(value=7, info="e1")
         a1 = Author.objects.create(name="a1", num=1, extra=e1)
@@ -570,7 +569,6 @@ class QuerySetSetOperationTests(TestCase):
         # Combined queries don't mutate.
         self.assertCountEqual(qs, ["a1", "a2"])
 
-    @skipUnlessDBFeature("supports_slicing_ordering_in_compound")
     def test_union_in_with_ordering(self):
         qs1 = Number.objects.filter(num__gt=7).order_by("num")
         qs2 = Number.objects.filter(num__lt=2).order_by("num")
@@ -607,7 +605,6 @@ class QuerySetSetOperationTests(TestCase):
         qs = Author.objects.select_related("extra").order_by()
         self.assertEqual(qs.union(qs).count(), 1)
 
-    @skipUnlessDBFeature("supports_slicing_ordering_in_compound")
     def test_count_union_with_select_related_in_values(self):
         e1 = ExtraInfo.objects.create(value=1, info="e1")
         a1 = Author.objects.create(name="a1", num=1, extra=e1)
@@ -692,11 +689,9 @@ class QuerySetSetOperationTests(TestCase):
         msg = "LIMIT/OFFSET not allowed in subqueries of compound statements"
         with self.assertRaisesMessage(DatabaseError, msg):
             list(qs1.union(qs2[:10]))
-        msg = "ORDER BY not allowed in subqueries of compound statements"
-        with self.assertRaisesMessage(DatabaseError, msg):
-            list(qs1.order_by("id").union(qs2))
-        with self.assertRaisesMessage(DatabaseError, msg):
-            list(qs1.union(qs2).order_by("id").union(qs3))
+        # Unioning ordered queries is permitted.
+        list(qs1.order_by("id").union(qs2))
+        list(qs1.union(qs2).order_by("id").union(qs3))
 
     @skipIfDBFeature("supports_select_intersection")
     def test_unsupported_intersection_raises_db_error(self):

--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -1,4 +1,5 @@
 import operator
+from unittest import mock
 from datetime import datetime
 
 from django.db import DatabaseError, NotSupportedError, connection
@@ -12,6 +13,7 @@ from django.db.models import (
     Transform,
     Value,
 )
+from django.db.models.sql.compiler import SQLAggregateCompiler
 from django.db.models.functions import Cast, Mod
 from django.test import TestCase, skipIfDBFeature, skipUnlessDBFeature
 from django.test.utils import CaptureQueriesContext
@@ -683,6 +685,52 @@ class QuerySetSetOperationTests(TestCase):
         qs1 = Number.objects.order_by("num")[:2]
         qs2 = Number.objects.order_by("-num")[:2]
         self.assertNumbersEqual(qs1.union(qs2).order_by("-num")[:4], [9, 8, 1, 0])
+
+    def test_oracle_ordering_subqueries_sql(self):
+        qs1 = Number.objects.order_by("num")
+        qs2 = Number.objects.order_by("-num")
+        qs = qs1.union(qs2).order_by("-num")[:4]
+        with (
+            mock.patch.object(
+                connection.features, "supports_slicing_ordering_in_compound", True
+            ),
+            mock.patch.object(
+                connection.features, "requires_compound_order_by_subquery", True
+            ),
+            mock.patch.object(
+                connection.features,
+                "ignores_unnecessary_order_by_in_subqueries",
+                False,
+            ),
+        ):
+            sql = qs.query.get_compiler(connection=connection).as_sql()[0]
+        self.assertEqual(sql.count("ORDER BY"), 1)
+        self.assertIn('ORDER BY "col2" DESC', sql)
+
+    def test_oracle_count_union_with_select_related_in_values_sql(self):
+        captured = {}
+
+        def fake_execute_sql(compiler, result_type=None):
+            captured["sql"] = compiler.as_sql()[0]
+            return (1,)
+
+        qs = Author.objects.select_related("extra").values("pk", "name", "extra__value")
+        with (
+            mock.patch.object(
+                connection.features, "supports_slicing_ordering_in_compound", True
+            ),
+            mock.patch.object(
+                connection.features, "requires_compound_order_by_subquery", True
+            ),
+            mock.patch.object(
+                connection.features,
+                "ignores_unnecessary_order_by_in_subqueries",
+                False,
+            ),
+            mock.patch.object(SQLAggregateCompiler, "execute_sql", fake_execute_sql),
+        ):
+            qs.union(qs).count()
+        self.assertEqual(captured["sql"].count("ORDER BY"), 0)
 
     @skipIfDBFeature("supports_slicing_ordering_in_compound")
     def test_unsupported_ordering_slicing_raises_db_error(self):

--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -1,6 +1,5 @@
 import operator
 from datetime import datetime
-from unittest import mock
 
 from django.db import DatabaseError, NotSupportedError, connection
 from django.db.models import (
@@ -14,7 +13,6 @@ from django.db.models import (
     Value,
 )
 from django.db.models.functions import Cast, Mod
-from django.db.models.sql.compiler import SQLAggregateCompiler
 from django.test import TestCase, skipIfDBFeature, skipUnlessDBFeature
 from django.test.utils import CaptureQueriesContext
 
@@ -685,55 +683,6 @@ class QuerySetSetOperationTests(TestCase):
         qs1 = Number.objects.order_by("num")[:2]
         qs2 = Number.objects.order_by("-num")[:2]
         self.assertNumbersEqual(qs1.union(qs2).order_by("-num")[:4], [9, 8, 1, 0])
-
-    def test_oracle_ordering_subqueries_sql(self):
-        qs1 = Number.objects.order_by("num")
-        qs2 = Number.objects.order_by("-num")
-        qs = qs1.union(qs2).order_by("-num")[:4]
-        with (
-            mock.patch.object(
-                connection.features, "supports_slicing_ordering_in_compound", True
-            ),
-            mock.patch.object(
-                connection.features, "requires_compound_order_by_subquery", True
-            ),
-            mock.patch.object(
-                connection.features,
-                "ignores_unnecessary_order_by_in_subqueries",
-                False,
-            ),
-        ):
-            sql = qs.query.get_compiler(connection=connection).as_sql()[0]
-        self.assertEqual(sql.count("ORDER BY"), 1)
-        self.assertIn(
-            f"ORDER BY {connection.ops.quote_name('col2')} DESC",
-            sql,
-        )
-
-    def test_oracle_count_union_with_select_related_in_values_sql(self):
-        captured = {}
-
-        def fake_execute_sql(compiler, result_type=None):
-            captured["sql"] = compiler.as_sql()[0]
-            return (1,)
-
-        qs = Author.objects.select_related("extra").values("pk", "name", "extra__value")
-        with (
-            mock.patch.object(
-                connection.features, "supports_slicing_ordering_in_compound", True
-            ),
-            mock.patch.object(
-                connection.features, "requires_compound_order_by_subquery", True
-            ),
-            mock.patch.object(
-                connection.features,
-                "ignores_unnecessary_order_by_in_subqueries",
-                False,
-            ),
-            mock.patch.object(SQLAggregateCompiler, "execute_sql", fake_execute_sql),
-        ):
-            qs.union(qs).count()
-        self.assertEqual(captured["sql"].count("ORDER BY"), 0)
 
     @skipIfDBFeature("supports_slicing_ordering_in_compound")
     def test_unsupported_ordering_slicing_raises_db_error(self):

--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -705,7 +705,10 @@ class QuerySetSetOperationTests(TestCase):
         ):
             sql = qs.query.get_compiler(connection=connection).as_sql()[0]
         self.assertEqual(sql.count("ORDER BY"), 1)
-        self.assertIn('ORDER BY "col2" DESC', sql)
+        self.assertIn(
+            f"ORDER BY {connection.ops.quote_name('col2')} DESC",
+            sql,
+        )
 
     def test_oracle_count_union_with_select_related_in_values_sql(self):
         captured = {}

--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -1,6 +1,6 @@
 import operator
-from unittest import mock
 from datetime import datetime
+from unittest import mock
 
 from django.db import DatabaseError, NotSupportedError, connection
 from django.db.models import (
@@ -13,8 +13,8 @@ from django.db.models import (
     Transform,
     Value,
 )
-from django.db.models.sql.compiler import SQLAggregateCompiler
 from django.db.models.functions import Cast, Mod
+from django.db.models.sql.compiler import SQLAggregateCompiler
 from django.test import TestCase, skipIfDBFeature, skipUnlessDBFeature
 from django.test.utils import CaptureQueriesContext
 


### PR DESCRIPTION
#### Trac ticket number

ticket-36938

#### Branch description
Fix Oracle compound-query compilation by clearing unnecessary ordering from combined query components when Django compiles a union as a subquery or through Oracle's compound `ORDER BY` wrapper. This also removes the stale Oracle expected failure for `test_count_union_with_select_related_in_values`.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Used OpenAI Codex assistance and manually reviewed the final patch and test results before submission.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
