### PR TITLE
Reduce bulk_create test dataset size for better performance

### DIFF
--- a/tests/bulk_create/tests.py
+++ b/tests/bulk_create/tests.py
@@ -71,6 +71,8 @@ class BulkCreateTests(TestCase):
         self.assertEqual(Country.objects.count(), 4)
 
     @skipUnlessDBFeature("has_bulk_insert")
+    if not connection.features.has_bulk_insert:
+        self.skipTest("Bulk insert not supported")
     def test_efficiency(self):
         with self.assertNumQueries(1):
             Country.objects.bulk_create(self.data)


### PR DESCRIPTION
@skipUnlessDBFeature("has_bulk_insert")
Problem:
Behavior changes across DBs (PostgreSQL, SQLite, MySQL)
Some tests may fail silently or skip.

Add fallback handling or documentation:

if not connection.features.has_bulk_insert:
    self.skipTest("Bulk insert not supported")