### PR TITLE
Clarified `decorator_from_middleware()` docs to remove stale Django 1.9 reference

### DIFF
--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -181,9 +181,9 @@ The functions defined in this module share the following properties:
     middleware functionality on a per-view basis. The middleware is created
     with no params passed.
 
-    It assumes middleware that's compatible with the old style of Django 1.9
-    and earlier (having methods like ``process_request()``,
-    ``process_exception()``, and ``process_response()``).
+    The middleware is expected to implement one or more of the standard
+    hook methods: ``process_request()``, ``process_view()``,
+    ``process_exception()``, or ``process_response()``.
 
 .. function:: decorator_from_middleware_with_args(middleware_class)
 


### PR DESCRIPTION
#### Trac ticket number
ticket-37037

#### Branch description
The docs for `decorator_from_middleware()` in `docs/ref/utils.txt` stated it "assumes middleware that's compatible with the old style of Django 1.9 and earlier". `MIDDLEWARE_CLASSES` was removed in Django 2.0, and the function works with any middleware that implements the standard hook methods. The source docstring in `django/utils/decorators.py` contains no such restriction.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output. Claude (Anthropic) was used to help identify the issue and draft the fix. I reviewed and verified the change by checking the source code in `django/utils/decorators.py` and confirming `MIDDLEWARE_CLASSES` is absent from `docs/ref/settings.txt`.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.