### PR TITLE
Fixed #37036 -- Fixed TypeError when using defer() with FETCH_PEERS on FK fields.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -422,6 +422,7 @@ answer newbie questions, and generally made Django that much better:
     Grzegorz Ślusarek <grzegorz.slusarek@gmail.com>
     Guilherme Mesquita Gondim <semente@taurinus.org>
     Guillaume Pannatier <guillaume.pannatier@gmail.com>
+    Gurpreet Singh <https://www.garybadwal.com/>
     Gustavo Picon
     hambaloney
     Hang Park <hangpark@kaist.ac.kr>

--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -296,7 +296,7 @@ class DeferredAttribute:
         db = instances[0]._state.db
         value_by_pk = (
             self.field.model._base_manager.using(db)
-            .values_list(attname)
+            .values_list(attname, flat=True)
             .in_bulk({i.pk for i in instances})
         )
         for instance in instances:

--- a/tests/defer/tests.py
+++ b/tests/defer/tests.py
@@ -219,6 +219,20 @@ class DeferTests(AssertionMixin, TestCase):
         with self.assertNumQueries(1):
             p1.value
 
+    def test_defer_fk_fetch_mode_fetch_peers(self):
+        p1, p2 = Primary.objects.fetch_mode(FETCH_PEERS).defer("related")
+        with self.assertNumQueries(2):
+            self.assertEqual(p1.related, self.s1)
+        with self.assertNumQueries(0):
+            self.assertEqual(p2.related, self.s1)
+
+    def test_only_fk_fetch_mode_fetch_peers(self):
+        p1, p2 = Primary.objects.fetch_mode(FETCH_PEERS).only("name")
+        with self.assertNumQueries(2):
+            self.assertEqual(p1.related, self.s1)
+        with self.assertNumQueries(0):
+            self.assertEqual(p2.related, self.s1)
+
     def test_only_fetch_mode_raise(self):
         p1 = Primary.objects.fetch_mode(RAISE).only("name").get(name="p1")
         msg = "Fetching of Primary.value blocked."

--- a/tests/many_to_one/tests.py
+++ b/tests/many_to_one/tests.py
@@ -1002,3 +1002,16 @@ class ManyToOneTests(TestCase):
             a2._state.fetch_mode,
             FETCH_PEERS,
         )
+
+    def test_fetch_mode_fetch_peers_reverse_with_deferred_fk(self):
+        Article.objects.create(
+            headline="Another article",
+            pub_date=datetime.date(2005, 7, 27),
+            reporter=self.r,
+        )
+        r = Reporter.objects.fetch_mode(FETCH_PEERS).get(pk=self.r.pk)
+        a1, a2 = r.article_set.defer("reporter")
+        with self.assertNumQueries(2):
+            self.assertEqual(a1.reporter, self.r)
+        with self.assertNumQueries(0):
+            self.assertEqual(a2.reporter, self.r)


### PR DESCRIPTION
#### Trac ticket number

ticket-37036

#### Branch description

`DeferredAttribute.fetch_many()` used `.values_list(attname).in_bulk()` to batch-load deferred field values for peer instances. Without `flat=True`, `in_bulk()` returns values as single-element tuples (e.g., `(None,)`) rather than scalar values (e.g., `None`). These tuples were then incorrectly set on model instances via `setattr`, causing a `TypeError` when the value was later used as a foreign key lookup (e.g., `Field 'id' expected a number but got (None,)`).

The fix adds `flat=True` to the `values_list()` call so that `in_bulk()` returns scalar values, which are correctly set on instances.

#### AI Assistance Disclosure (REQUIRED)
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting (https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in the past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.