### PR TITLE
Clarified that submitters may not mark their own ticket as accepted.

### DIFF
--- a/docs/internals/contributing/triaging-tickets.txt
+++ b/docs/internals/contributing/triaging-tickets.txt
@@ -419,6 +419,10 @@ Then, you can help out by:
 However, we do ask the following of all general community members working in
 the ticket database:
 
+* Please **don't** promote your own tickets to "Accepted". Another community
+  member should review the report and set this stage after reproducing and
+  confirming the issue.
+
 * Please **don't** promote your own tickets to "Ready for checkin". You
   may mark other people's tickets that you've reviewed as "Ready for
   checkin", but you should get at minimum one other community member to


### PR DESCRIPTION
#### Trac ticket number

N/A - docs

#### Branch description
Ticket submitters are expected not to mark their own tickets as "Accepted", as evidenced by multiple comments in Trac. This change adds a point to the triaging documentation explicitly stating a ticket may not be "Accepted" by the submitter.

Forum discussion: https://forum.djangoproject.com/t/dont-accept-your-own-tickets/44867

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
-- N/A --
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
