### PR TITLE
Refs #373, #34122 -- Removed warning that ForeignObject is an internal tool.

### DIFF
--- a/docs/topics/composite-primary-key.txt
+++ b/docs/topics/composite-primary-key.txt
@@ -124,11 +124,6 @@ alternative::
 any columns (e.g. ``item_id``), foreign key constraints or indexes in the
 database, and the ``on_delete`` argument is ignored.
 
-.. warning::
-
-    ``ForeignObject`` is an internal API. This means it is not covered by our
-    :ref:`deprecation policy <internal-release-deprecation-policy>`.
-
 .. _cpk-and-database-functions:
 
 Composite primary keys and database functions


### PR DESCRIPTION
ForeignObject should not be treated as an internal tool. In the past we made changes in its API with a proper deprecation, e.g. 8b1ff0da4b162e87edebd94e61f2cd153e9e159d.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.