### PR TITLE
Fixed #37039 -- Removed outdated note from QuerySet.iterator() docs.

### DIFF
--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -2643,9 +2643,8 @@ if you call its asynchronous version ``aiterator``.
 
 A ``QuerySet`` typically caches its results internally so that repeated
 evaluations do not result in additional queries. In contrast, ``iterator()``
-will read results directly, without doing any caching at the ``QuerySet`` level
-(internally, the default iterator calls ``iterator()`` and caches the return
-value). For a ``QuerySet`` which returns a large number of objects that you
+will read results directly, without doing any caching at the ``QuerySet`` level.
+For a ``QuerySet`` which returns a large number of objects that you
 only need to access once, this can result in better performance and a
 significant reduction in memory.
 


### PR DESCRIPTION
The iterator() documentation stated that "the default iterator calls 
iterator() and caches the return value", but this is no longer accurate 
as __iter__() no longer calls iterator() since this change:
https://github.com/django/django/commit/f3b7c059367a4e82bbfc7e4f0d42b10975e79f0c

Simply removed the outdated parenthetical note as suggested in ticket #37039.