### PR TITLE
Cleaned up references to accepted PEPs in docs.

### DIFF
--- a/docs/ref/exceptions.txt
+++ b/docs/ref/exceptions.txt
@@ -285,9 +285,9 @@ The Django wrappers for database exceptions behave exactly the same as
 the underlying database exceptions. See :pep:`249`, the Python Database API
 Specification v2.0, for further information.
 
-As per :pep:`3134`, a ``__cause__`` attribute is set with the original
-(underlying) database exception, allowing access to any additional
-information provided.
+A :attr:`~BaseException.__cause__` attribute is set with the original
+(underlying) database exception, allowing access to any additional information
+provided.
 
 .. exception:: models.ProtectedError
 

--- a/docs/ref/files/uploads.txt
+++ b/docs/ref/files/uploads.txt
@@ -76,7 +76,7 @@ Here are some useful attributes of ``UploadedFile``:
         for line in uploadedfile:
             do_something_with(line)
 
-    Lines are split using :pep:`universal newlines <278>`. The following are
+    Lines are split using :term:`python:universal newlines`. The following are
     recognized as ending a line: the Unix end-of-line convention ``'\n'``, the
     Windows convention ``'\r\n'``, and the old Macintosh convention ``'\r'``.
 

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -2637,9 +2637,9 @@ If you pass ``in_bulk()`` an empty list, you'll get an empty dictionary.
 
 *Asynchronous version*: ``aiterator()``
 
-Evaluates the ``QuerySet`` (by performing the query) and returns an iterator
-(see :pep:`234`) over the results, or an asynchronous iterator (see :pep:`492`)
-if you call its asynchronous version ``aiterator``.
+Evaluates the ``QuerySet`` (by performing the query) and returns an
+:term:`python:iterator` over the results, or an :term:`python:asynchronous
+iterator` if you call its asynchronous version ``aiterator``.
 
 A ``QuerySet`` typically caches its results internally so that repeated
 evaluations do not result in additional queries. In contrast, ``iterator()``

--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -1337,7 +1337,7 @@ Overriding settings
 
 For testing purposes it's often useful to change a setting temporarily and
 revert to the original value after running the testing code. For this use case
-Django provides a standard Python context manager (see :pep:`343`) called
+Django provides a standard :ref:`context manager <context-managers>` called
 :meth:`~django.test.SimpleTestCase.settings`, which can be used like this::
 
     from django.test import TestCase
@@ -1390,8 +1390,7 @@ neither does ``remove`` when the value doesn't exist.
 .. function:: override_settings(**kwargs)
 
 In case you want to override a setting for a test method, Django provides the
-:func:`~django.test.override_settings` decorator (see :pep:`318`). It's used
-like this::
+:func:`~django.test.override_settings` :term:`python:decorator`::
 
     from django.test import TestCase, override_settings
 


### PR DESCRIPTION
#### Trac ticket number
N/A - docs cleanup

#### Branch description
Where the docs used `:pep:` links for established Python language features, replaced them with direct references to the Python docs (usually glossary terms).

For most Django docs readers, the Python docs will provide a more direct explanation of the language. (For readers wanting the history and rationale behind the features, the Python docs often link to the original PEPs.)

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- n/a I have checked the "Has patch" ticket flag in the Trac system.
- n/a I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- n/a I have attached screenshots in both light and dark modes for any UI changes.
