### PR TITLE
Fixed #37045 -- renamed `savepoint` to `savepoint_create`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -944,6 +944,7 @@ answer newbie questions, and generally made Django that much better:
     Sachin Jat <sanch.jat@gmail.com>
     Sage M. Abdullah <https://github.com/laymonage>
     Sam Newman <http://www.magpiebrain.com/>
+    Sam Searles-Bryant <https://github.com/samueljsb>
     Samruddhi Dharankar <sdharank@ics.uci.edu>
     Sander Dijkhuis <sander.dijkhuis@gmail.com>
     Sanket Saurav <sanketsaurav@gmail.com>

--- a/django/db/transaction.py
+++ b/django/db/transaction.py
@@ -1,3 +1,4 @@
+import warnings
 from contextlib import ContextDecorator, contextmanager
 
 from django.db import (
@@ -7,6 +8,7 @@ from django.db import (
     ProgrammingError,
     connections,
 )
+from django.utils.deprecation import RemovedInDjango70Warning
 
 
 class TransactionManagementError(ProgrammingError):
@@ -46,6 +48,20 @@ def rollback(using=None):
 
 
 def savepoint(using=None):
+    """
+    Create a savepoint (if supported and required by the backend) inside the
+    current transaction. Return an identifier for the savepoint that will be
+    used for the subsequent rollback or commit.
+    """
+    warnings.warn(
+        "savepoint() is deprecated. Use savepoint_create() instead.",
+        stacklevel=2,
+        category=RemovedInDjango70Warning,
+    )
+    return savepoint_create(using=using)
+
+
+def savepoint_create(using=None):
     """
     Create a savepoint (if supported and required by the backend) inside the
     current transaction. Return an identifier for the savepoint that will be

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -73,6 +73,9 @@ details on these changes.
   ``django.contrib.postgres.aggregates.BitOr``, and
   ``django.contrib.postgres.aggregates.BitXor`` classes will be removed.
 
+* ``django.db.transaction.savepoint`` alias to
+  ``django.db.transaction.savepoint_create`` will be removed.
+
 .. _deprecation-removed-in-6.1:
 
 6.1

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -553,6 +553,9 @@ Miscellaneous
   :class:`~django.db.models.BitOr`, and :class:`~django.db.models.BitXor`
   classes.
 
+* ``django.db.transaction.savepoint`` has been deprecated in favor of
+  ``django.db.transaction.savepoint_create``.
+
 Features removed in 6.1
 =======================
 

--- a/docs/topics/db/transactions.txt
+++ b/docs/topics/db/transactions.txt
@@ -550,6 +550,14 @@ Savepoints are controlled by three functions in :mod:`django.db.transaction`:
     Creates a new savepoint. This marks a point in the transaction that is
     known to be in a "good" state. Returns the savepoint ID (``sid``).
 
+    .. deprecated:: 6.1
+        ``savepoint`` has been renamed to ``savepoint_create``.
+
+.. function:: savepoint_create(using=None)
+
+    Creates a new savepoint. This marks a point in the transaction that is
+    known to be in a "good" state. Returns the savepoint ID (``sid``).
+
 .. function:: savepoint_commit(sid, using=None)
 
     Releases savepoint ``sid``. The changes performed since the savepoint was
@@ -579,7 +587,7 @@ The following example demonstrates the use of savepoints::
         a.save()
         # transaction now contains a.save()
 
-        sid = transaction.savepoint()
+        sid = transaction.savepoint_create()
 
         b.save()
         # transaction now contains a.save() and b.save()
@@ -692,7 +700,7 @@ you can roll back the single offending operation, rather than the entire
 transaction. For example::
 
     a.save()  # Succeeds, and never undone by savepoint rollback
-    sid = transaction.savepoint()
+    sid = transaction.savepoint_create()
     try:
         b.save()  # Could throw exception
         transaction.savepoint_commit(sid)

--- a/tests/transactions/tests.py
+++ b/tests/transactions/tests.py
@@ -17,6 +17,7 @@ from django.test import (
     skipIfDBFeature,
     skipUnlessDBFeature,
 )
+from django.utils.deprecation import RemovedInDjango70Warning
 
 from .models import Reporter
 
@@ -214,7 +215,7 @@ class AtomicTests(TransactionTestCase):
     def test_prevent_rollback(self):
         with transaction.atomic():
             reporter = Reporter.objects.create(first_name="Tintin")
-            sid = transaction.savepoint()
+            sid = transaction.savepoint_create()
             # trigger a database error inside an inner atomic without savepoint
             with self.assertRaises(DatabaseError):
                 with transaction.atomic(savepoint=False):
@@ -589,3 +590,10 @@ class DurableTransactionTests(DurableTestsBase, TransactionTestCase):
 
 class DurableTests(DurableTestsBase, TestCase):
     pass
+
+
+class SavepointTests(TestCase):
+    def test_deprecation_warning(self):
+        msg = "savepoint() is deprecated. Use savepoint_create() instead."
+        with self.assertRaisesMessage(RemovedInDjango70Warning, msg):
+            transaction.savepoint()


### PR DESCRIPTION
#### Trac ticket number

ticket-37045

#### Branch description

This makes the name consistent with the `savepoint_commit` and `savepoint_rollback` functions. The previous name is maintained as a deprecated alias.

This also frees up the `savepoint` name, which would allow the context manager from `django-subatomic` to be included in Django.

#### AI Assistance Disclosure (REQUIRED)

- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
