### PR TITLE
Fixed #37039 -- Removed outdated note from QuerySet.iterator() docs.

### DIFF
--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -2643,9 +2643,8 @@ iterator` if you call its asynchronous version ``aiterator``.
 
 A ``QuerySet`` typically caches its results internally so that repeated
 evaluations do not result in additional queries. In contrast, ``iterator()``
-will read results directly, without doing any caching at the ``QuerySet`` level
-(internally, the default iterator calls ``iterator()`` and caches the return
-value). For a ``QuerySet`` which returns a large number of objects that you
+will read results directly, without doing any caching at the ``QuerySet``
+level. For a ``QuerySet`` which returns a large number of objects that you
 only need to access once, this can result in better performance and a
 significant reduction in memory.
 


### PR DESCRIPTION
#### Trac ticket number
ticket-37039

#### Branch description
The QuerySet.iterator() documentation stated that
"the default iterator calls iterator() and caches
the return value", but this is no longer accurate
as __iter__() no longer calls iterator() since
commit f3b7c05.

Simply removed the outdated parenthetical note
as suggested in ticket #37039.

#### AI Assistance Disclosure (REQUIRED)
- [x] If AI tools were used, I have disclosed
which ones, and fully reviewed and verified
their output.

I used Claude (claude.ai) as an AI assistant
to help understand the codebase. All changes
were reviewed and verified by me personally.

#### Checklist
- [x] This PR follows the contribution guidelines
- [x] This PR does not disclose a security vulnerability
- [x] This PR targets the main branch
- [x] The commit message is written in past tense
- [x] I have checked the "Has patch" ticket flag in Trac