### PR TITLE
Fixed #37047 -- Fixed crash in Query.orderby_issubset_groupby for descending and random order_by strings.

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -2376,14 +2376,15 @@ class Query(BaseExpression):
             return True
         # Don't pollute the original query (might disrupt joins).
         q = self.clone()
-        order_by_set = {
-            (
-                order_by.resolve_expression(q)
-                if hasattr(order_by, "resolve_expression")
-                else F(order_by).resolve_expression(q)
-            )
-            for order_by in q.order_by
-        }
+        order_by_set = set()
+        for order_by in q.order_by:
+            if hasattr(order_by, "resolve_expression"):
+                order_by_set.add(order_by.resolve_expression(q))
+            elif order_by == "?":
+                # Random ordering can't be compared against group by.
+                return False
+            else:
+                order_by_set.add(F(order_by.removeprefix("-")).resolve_expression(q))
         return order_by_set.issubset(self.group_by)
 
     def clear_ordering(self, force=False, clear_default=True):

--- a/tests/aggregation_regress/tests.py
+++ b/tests/aggregation_regress/tests.py
@@ -188,6 +188,14 @@ class AggregationTests(TestCase):
         )
         self.assertEqual(qs.order_by("id").count(), len(qs.order_by("id")))
         self.assertEqual(qs.extra(order_by=["id"]).count(), len(qs.order_by("id")))
+        self.assertEqual(qs.order_by("-id").count(), len(qs.order_by("-id")))
+        self.assertEqual(
+            qs.order_by("-publications").count(), len(qs.order_by("-publications"))
+        )
+        self.assertEqual(
+            qs.order_by("-contact__name").count(), len(qs.order_by("-contact__name"))
+        )
+        self.assertEqual(qs.order_by("?").count(), len(qs.order_by("?")))
 
     def test_annotation_with_value(self):
         values = (


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37047

#### Branch description
ticket-26434 caused a crash. It can be reproduced with:

```python
User.objects.values("is_staff").annotate(latest=Max("date_joined")).order_by("-latest").count()
```

You should see the following exception:

```
django.core.exceptions.FieldError: Cannot resolve keyword '-latest' into field. Choices are: activity_logs, date_joined, email, first_name, groups, id, is_active, is_administrator, is_staff, is_superuser, last_login, last_name, latest, logentry, module_access, password, user_permissions, username
```


#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude Code (Opus 4.7) was used to track down the source of the issue and to generate the fix. I have added the extra test cases manually and also verified that the fix works on my codebase. The `?` edge case was discovered by Claude (not me) but I manually reproduced it as well.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
