### PR TITLE
Refs #31398 -- Fix sql flush to ignore database routers when collecting tables to flush

### DIFF
--- a/django/core/management/sql.py
+++ b/django/core/management/sql.py
@@ -9,7 +9,7 @@ def sql_flush(style, connection, reset_sequences=True, allow_cascade=False):
     Return a list of the SQL statements used to flush the database.
     """
     tables = connection.introspection.django_table_names(
-        only_existing=True, include_views=False
+        only_existing=True, include_views=False, use_router=False
     )
     return connection.ops.sql_flush(
         style,

--- a/django/db/backends/base/introspection.py
+++ b/django/db/backends/base/introspection.py
@@ -89,26 +89,36 @@ class BaseDatabaseIntrospection:
             "get_table_description() method."
         )
 
-    def get_migratable_models(self):
+    def get_migratable_models(self, *, use_router=True):
         from django.apps import apps
         from django.db import router
 
-        return (
-            model
-            for app_config in apps.get_app_configs()
-            for model in router.get_migratable_models(app_config, self.connection.alias)
-            if model._meta.can_migrate(self.connection)
-        )
+        if use_router:
+            models = (
+                model
+                for app_config in apps.get_app_configs()
+                for model in router.get_migratable_models(
+                    app_config, self.connection.alias
+                )
+            )
+        else:
+            models = apps.get_models(include_auto_created=True)
 
-    def django_table_names(self, only_existing=False, include_views=True):
+        return (model for model in models if model._meta.can_migrate(self.connection))
+
+    def django_table_names(
+        self, only_existing=False, include_views=True, use_router=True
+    ):
         """
         Return a list of all table names that have associated Django models and
         are in INSTALLED_APPS.
 
         If only_existing is True, include only the tables in the database.
+        If use_router is False, include all managed models regardless of
+        what the database router says (useful for flushing/cleanup operations).
         """
         tables = set()
-        for model in self.get_migratable_models():
+        for model in self.get_migratable_models(use_router=use_router):
             if not model._meta.managed:
                 continue
             tables.add(model._meta.db_table)

--- a/tests/backends/base/test_operations.py
+++ b/tests/backends/base/test_operations.py
@@ -1,6 +1,7 @@
 import decimal
 
 from django.core.management.color import no_style
+from django.core.management.sql import sql_flush
 from django.db import NotSupportedError, connection, models, transaction
 from django.db.backends.base.operations import BaseDatabaseOperations
 from django.db.models import DurationField
@@ -284,3 +285,28 @@ class SqlFlushTests(TransactionTestCase):
                 self.assertEqual(author.pk, 1)
                 book = Book.objects.create(author=author)
                 self.assertEqual(book.pk, 1)
+
+    def test_sql_flush_ignores_router_to_include_all_managed_tables(self):
+        class RouterBlocksModelRouter:
+            """A router that claims Author doesn't belong to the default DB."""
+
+            def allow_migrate(self, db, app_label, model_name=None, **hints):
+                if app_label == "backends" and model_name == "author":
+                    return db != "default"
+                return None
+
+        # Write an Author directly to the default DB, bypassing the router.
+        Author.objects.using("default").create(name="John Doe")
+        self.assertTrue(Author.objects.using("default").exists())
+
+        with override_settings(DATABASE_ROUTERS=[RouterBlocksModelRouter()]):
+            sql_list = sql_flush(
+                no_style(),
+                connection,
+                reset_sequences=True,
+                allow_cascade=True,
+            )
+            connection.ops.execute_sql_flush(sql_list)
+
+        # Author table must have been flushed.
+        self.assertFalse(Author.objects.using("default").exists())

--- a/tests/introspection/tests.py
+++ b/tests/introspection/tests.py
@@ -1,6 +1,6 @@
 from django.db import DatabaseError, connection
 from django.db.models import DB_CASCADE, DB_SET_DEFAULT, DB_SET_NULL, DO_NOTHING, Index
-from django.test import TransactionTestCase, skipUnlessDBFeature
+from django.test import TransactionTestCase, override_settings, skipUnlessDBFeature
 
 from .models import (
     Article,
@@ -81,6 +81,21 @@ class IntrospectionTests(TransactionTestCase):
     def test_unmanaged_through_model(self):
         tables = connection.introspection.django_table_names()
         self.assertNotIn(ArticleReporter._meta.db_table, tables)
+
+    def test_django_table_names_use_router_false_bypasses_router(self):
+        class RejectAllRouter:
+            def allow_migrate(self, db, app_label, **hints):
+                return False
+
+        with override_settings(DATABASE_ROUTERS=[RejectAllRouter()]):
+            self.assertNotIn(
+                Reporter._meta.db_table,
+                connection.introspection.django_table_names(use_router=True),
+            )
+            self.assertIn(
+                Reporter._meta.db_table,
+                connection.introspection.django_table_names(use_router=False),
+            )
 
     def test_installed_models(self):
         tables = [Article._meta.db_table, Reporter._meta.db_table]


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-31398

#### Branch description

* Addressed failing test for Databases that do not support transactions (eg MySQL MyISAM). 
* Fixed database flushing when database routers exclude models from a connection.

`sql_flush()` previously relied on `django_table_names()` with router-aware model selection. In multi-database tests, this could skip flushing tables that physically existed on the connection if the router said those models shouldn't migrate there. As a result, rows written explicitly with .using() / .db_manager() could survive between tests.

This change makes `sql_flush()` collect Django tables without consulting the database router, while still limiting the result to tables that actually exist on the connection.

On a transactional backend, leaked writes are often rolled back at test end, so the bad flush table selection may not bite immediately. On non-transactional DBs, there is no rollback safety net. So correctness of flush is critical. If flush skips a real table, stale rows persist into next test, causing collisions like duplicate key errors.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [X] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
  - Github Copilot was used to create the reproduction setup and validate the fix. The final output is verified by the PR author.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.


#### Reproduction steps for the ticket scenario

- Created `tests/test_mysql_myisam.py` with
```python
DATABASES = {
    "default": {
        "ENGINE": "django.db.backends.mysql",
        "NAME": "django_main",
        "USER": "django",
        "PASSWORD": "django",
        "HOST": "127.0.0.1",
        "PORT": "3306",
        "OPTIONS": {
            "init_command": "SET default_storage_engine=MYISAM",
        },
    },
    "other": {
        "ENGINE": "django.db.backends.mysql",
        "NAME": "django_other",
        "USER": "django",
        "PASSWORD": "django",
        "HOST": "127.0.0.1",
        "PORT": "3306",
        "OPTIONS": {
            "init_command": "SET default_storage_engine=MYISAM",
        },
    },
}

SECRET_KEY = "django_tests_secret_key"
PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
USE_TZ = False
```

- Start a mysql server with docker

```bash
docker run --name django-mysql \                                                                  
  -e MYSQL_ROOT_PASSWORD=rootpass \               
  -p 3306:3306 \                                   
  -d mysql:8.4 
```

and create two databases

```bash
docker exec -i django-mysql mysql -uroot -prootpass <<'SQL'                                    
CREATE DATABASE django_main CHARACTER SET utf8mb4;
CREATE DATABASE django_other CHARACTER SET utf8mb4;
CREATE USER 'django'@'%' IDENTIFIED BY 'django';
GRANT ALL PRIVILEGES ON *.* TO 'django'@'%' WITH GRANT OPTION;
FLUSH PRIVILEGES;
SQL
```

Run the mentioned test case 

```bash
./tests/runtests.py --settings=test_mysql_myisam --parallel=1 multiple_database.tests.AuthTestCase
```

