### PR TITLE
Refs #31398 -- Fixed database flushing when routers exclude existing tables

### DIFF
--- a/django/core/management/sql.py
+++ b/django/core/management/sql.py
@@ -8,9 +8,7 @@ def sql_flush(style, connection, reset_sequences=True, allow_cascade=False):
     """
     Return a list of the SQL statements used to flush the database.
     """
-    tables = connection.introspection.django_table_names(
-        only_existing=True, include_views=False
-    )
+    tables = connection.introspection.managed_table_names()
     return connection.ops.sql_flush(
         style,
         tables,

--- a/django/db/backends/base/introspection.py
+++ b/django/db/backends/base/introspection.py
@@ -100,6 +100,24 @@ class BaseDatabaseIntrospection:
             if model._meta.can_migrate(self.connection)
         )
 
+    def managed_table_names(self):
+        """
+        Return a list of table names for all managed Django models that
+        physically exist on this connection, without consulting the database
+        router. This is suitable for operations (e.g. flushing) that must act
+        on every physical table regardless of routing rules.
+        """
+        from django.apps import apps
+
+        existing_tables = set(self.table_names(include_views=False))
+        return [
+            model._meta.db_table
+            for model in apps.get_models(include_auto_created=True)
+            if model._meta.managed
+            and model._meta.can_migrate(self.connection)
+            and self.identifier_converter(model._meta.db_table) in existing_tables
+        ]
+
     def django_table_names(self, only_existing=False, include_views=True):
         """
         Return a list of all table names that have associated Django models and

--- a/tests/backends/base/test_operations.py
+++ b/tests/backends/base/test_operations.py
@@ -1,6 +1,7 @@
 import decimal
 
 from django.core.management.color import no_style
+from django.core.management.sql import sql_flush
 from django.db import NotSupportedError, connection, models, transaction
 from django.db.backends.base.operations import BaseDatabaseOperations
 from django.db.models import DurationField
@@ -284,3 +285,28 @@ class SqlFlushTests(TransactionTestCase):
                 self.assertEqual(author.pk, 1)
                 book = Book.objects.create(author=author)
                 self.assertEqual(book.pk, 1)
+
+    def test_sql_flush_ignores_router_to_include_all_managed_tables(self):
+        class RouterBlocksModelRouter:
+            """A router that claims Author doesn't belong to the default DB."""
+
+            def allow_migrate(self, db, app_label, model_name=None, **hints):
+                if app_label == "backends" and model_name == "author":
+                    return db != "default"
+                return None
+
+        # Write an Author directly to the default DB, bypassing the router.
+        Author.objects.using("default").create(name="John Doe")
+        self.assertTrue(Author.objects.using("default").exists())
+
+        with override_settings(DATABASE_ROUTERS=[RouterBlocksModelRouter()]):
+            sql_list = sql_flush(
+                no_style(),
+                connection,
+                reset_sequences=True,
+                allow_cascade=True,
+            )
+            connection.ops.execute_sql_flush(sql_list)
+
+        # Author table must have been flushed.
+        self.assertFalse(Author.objects.using("default").exists())

--- a/tests/introspection/tests.py
+++ b/tests/introspection/tests.py
@@ -1,6 +1,6 @@
 from django.db import DatabaseError, connection
 from django.db.models import DB_CASCADE, DB_SET_DEFAULT, DB_SET_NULL, DO_NOTHING, Index
-from django.test import TransactionTestCase, skipUnlessDBFeature
+from django.test import TransactionTestCase, override_settings, skipUnlessDBFeature
 
 from .models import (
     Article,
@@ -81,6 +81,22 @@ class IntrospectionTests(TransactionTestCase):
     def test_unmanaged_through_model(self):
         tables = connection.introspection.django_table_names()
         self.assertNotIn(ArticleReporter._meta.db_table, tables)
+
+    def test_managed_table_names_ignores_router(self):
+        class BlockIntrospectionRouter:
+            def allow_migrate(self, db, app_label, **hints):
+                if app_label == "introspection":
+                    return False
+                return None
+
+        with override_settings(DATABASE_ROUTERS=[BlockIntrospectionRouter()]):
+            # django_table_names() respects the router and excludes them.
+            router_tables = connection.introspection.django_table_names()
+            # managed_table_names() bypasses the router.
+            all_tables = connection.introspection.managed_table_names()
+
+        self.assertNotIn(Reporter._meta.db_table, router_tables)
+        self.assertIn(Reporter._meta.db_table, all_tables)
 
     def test_installed_models(self):
         tables = [Article._meta.db_table, Reporter._meta.db_table]


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-31398

#### Branch description

* Fixed database flushing when database routers exclude models from a connection.
* This was visible on databases that do not support transactions (e.g. MySQL MyISAM), where test isolation depends on flush-based cleanup.

⚠️ This also changes `manage.py flush`/`manage.py sqlflush` behavior in multi-database setups. Previously, table selection was router-aware, which could cause `flush` to skip managed tables that physically existed on the selected connection. After this change, `flush` operates on the managed tables that actually exist on the database. 

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [X] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
  - Github Copilot was used to create the reproduction setup and validate the fix. The final output is verified by the PR author.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.


#### Reproduction steps for the ticket scenario

- Created `tests/test_mysql_myisam.py` with
```python
DATABASES = {
    "default": {
        "ENGINE": "django.db.backends.mysql",
        "NAME": "django_main",
        "USER": "django",
        "PASSWORD": "django",
        "HOST": "127.0.0.1",
        "PORT": "3306",
        "OPTIONS": {
            "init_command": "SET default_storage_engine=MYISAM",
        },
    },
    "other": {
        "ENGINE": "django.db.backends.mysql",
        "NAME": "django_other",
        "USER": "django",
        "PASSWORD": "django",
        "HOST": "127.0.0.1",
        "PORT": "3306",
        "OPTIONS": {
            "init_command": "SET default_storage_engine=MYISAM",
        },
    },
}

SECRET_KEY = "django_tests_secret_key"
PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
USE_TZ = False
```

- Start a mysql server with docker

```bash
docker run --name django-mysql \                                                                  
  -e MYSQL_ROOT_PASSWORD=rootpass \               
  -p 3306:3306 \                                   
  -d mysql:8.4 
```

and create two databases

```bash
docker exec -i django-mysql mysql -uroot -prootpass <<'SQL'                                    
CREATE DATABASE django_main CHARACTER SET utf8mb4;
CREATE DATABASE django_other CHARACTER SET utf8mb4;
CREATE USER 'django'@'%' IDENTIFIED BY 'django';
GRANT ALL PRIVILEGES ON *.* TO 'django'@'%' WITH GRANT OPTION;
FLUSH PRIVILEGES;
SQL
```

Run the mentioned test case 

```bash
./tests/runtests.py --settings=test_mysql_myisam --parallel=1 multiple_database.tests.AuthTestCase
```

