### PR TITLE
Fixed #37049 -- Raised ValueError when altering m2m through model to a different custom model.

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -919,16 +919,23 @@ class BaseDatabaseSchemaEditor:
             and (
                 old_field.remote_field.through
                 and new_field.remote_field.through
-                and not old_field.remote_field.through._meta.auto_created
-                and not new_field.remote_field.through._meta.auto_created
+                # Use meta label comparison instead of identity check to cover
+                # for cases when the same through model exists as two distinct
+                # class objects across different app registry states (e.g.
+                # during migrations, fake model classes are reconstructed per
+                # state).
+                and (
+                    old_field.remote_field.through._meta.label
+                    == new_field.remote_field.through._meta.label
+                )
             )
         ):
-            # Both sides have through models; this is a no-op.
+            # Both sides have the same through model; this is a no-op.
             return
         elif old_type is None or new_type is None:
             raise ValueError(
                 "Cannot alter field %s into %s - they are not compatible types "
-                "(you cannot alter to or from M2M fields, or add or remove "
+                "(you cannot alter to or from M2M fields, or add, remove, or change "
                 "through= on M2M fields)" % (old_field, new_field)
             )
         elif old_field.generated != new_field.generated or (

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -2692,12 +2692,67 @@ class SchemaTests(TransactionTestCase):
         new_field.set_attributes_from_name("authors")
         msg = (
             f"Cannot alter field {old_field} into {new_field} - they are not "
-            f"compatible types (you cannot alter to or from M2M fields, or add or "
-            f"remove through= on M2M fields)"
+            f"compatible types (you cannot alter to or from M2M fields, or add, "
+            f"remove, or change through= on M2M fields)"
         )
         with connection.schema_editor() as editor:
             with self.assertRaisesMessage(ValueError, msg):
                 editor.alter_field(LocalNoteWithM2MThrough, old_field, new_field)
+
+    def test_changing_custom_m2m_through(self):
+        """
+        Changing through model to use a different custom model should raise.
+        """
+
+        class LocalAuthorTag(Model):
+            author = ForeignKey("schema.LocalAuthorM2MThrough", CASCADE)
+            tag = ForeignKey("schema.TagM2MTest", CASCADE)
+
+            class Meta:
+                app_label = "schema"
+                apps = new_apps
+
+        class LocalAuthorTagOther(Model):
+            author = ForeignKey("schema.LocalAuthorM2MThrough", CASCADE)
+            tag = ForeignKey("schema.TagM2MTest", CASCADE)
+
+            class Meta:
+                app_label = "schema"
+                apps = new_apps
+
+        class LocalAuthorM2MThrough(Model):
+            name = CharField(max_length=255)
+            tags = ManyToManyField(
+                "schema.TagM2MTest", related_name="authors", through=LocalAuthorTag
+            )
+
+            class Meta:
+                app_label = "schema"
+                apps = new_apps
+
+        self.local_models = [LocalAuthorTag, LocalAuthorTagOther, LocalAuthorM2MThrough]
+
+        with connection.schema_editor() as editor:
+            editor.create_model(LocalAuthorTag)
+            editor.create_model(LocalAuthorM2MThrough)
+            editor.create_model(TagM2MTest)
+        # Ensure the m2m table is there
+        self.assertEqual(len(self.column_classes(LocalAuthorTag)), 3)
+        old_field = LocalAuthorM2MThrough._meta.get_field("tags")
+        new_field = ManyToManyField(
+            "schema.TagM2MTest", related_name="authors", through=LocalAuthorTagOther
+        )
+        new_field.contribute_to_class(LocalAuthorM2MThrough, "tags")
+        msg = (
+            f"Cannot alter field {old_field} into {new_field} - they are not "
+            f"compatible types (you cannot alter to or from M2M fields, or add, "
+            f"remove, or change through= on M2M fields)"
+        )
+        with connection.schema_editor() as editor:
+            with self.assertRaisesMessage(ValueError, msg):
+                editor.alter_field(
+                    LocalAuthorM2MThrough, old_field, new_field, strict=True
+                )
 
     def _test_m2m(self, M2MFieldClass):
         """
@@ -2782,7 +2837,7 @@ class SchemaTests(TransactionTestCase):
 
     def _test_m2m_through_alter(self, M2MFieldClass):
         """
-        Tests altering M2Ms with explicit through models (should no-op)
+        Altering M2Ms with the same custom through model should no-op.
         """
 
         class LocalAuthorTag(Model):


### PR DESCRIPTION
ticket-37049

Previously, alter_field() treated any change between two custom through models as a no-op, because the check only verified that both sides had non-auto-created through models. This meant silently ignoring a schema change that cannot be applied.

Refs ticket-22476. Bug in b25aee3b7bef07dd07bed2209efcdf1a8146112c.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
