### PR TITLE
Removed OrderedDict representer from PyYAML serializer.

### DIFF
--- a/django/core/serializers/pyyaml.py
+++ b/django/core/serializers/pyyaml.py
@@ -4,7 +4,6 @@ YAML serializer.
 Requires PyYaml (https://pyyaml.org/), but that's checked for in __init__.
 """
 
-import collections
 import datetime
 import decimal
 
@@ -28,9 +27,6 @@ class DjangoSafeDumper(SafeDumper):
     def represent_decimal(self, data):
         return self.represent_scalar("tag:yaml.org,2002:str", str(data))
 
-    def represent_ordered_dict(self, data):
-        return self.represent_mapping("tag:yaml.org,2002:map", data.items())
-
     def represent_time(self, data):
         # Base YAML doesn't support serialization of time types (as opposed to
         # dates or datetimes, which it does support). Converting them to
@@ -40,9 +36,6 @@ class DjangoSafeDumper(SafeDumper):
 
 
 DjangoSafeDumper.add_representer(decimal.Decimal, DjangoSafeDumper.represent_decimal)
-DjangoSafeDumper.add_representer(
-    collections.OrderedDict, DjangoSafeDumper.represent_ordered_dict
-)
 DjangoSafeDumper.add_representer(datetime.time, DjangoSafeDumper.represent_time)
 
 


### PR DESCRIPTION
Added in 5bc3123479bd97dc9d8a36fa9a3421a71063d1da, it was obsoleted when OrderedDict usage was removed in 24b82cd201e21060fbc02117dc16d1702877a1f3.