### PR TITLE
Fixed #37050 -- Improved error message for missing variable after 'as' in simple_tag/simple_block_tag.

### DIFF
--- a/django/template/library.py
+++ b/django/template/library.py
@@ -139,6 +139,10 @@ class Library:
                 if len(bits) >= 2 and bits[-2] == "as":
                     target_var = bits[-1]
                     bits = bits[:-2]
+                if bits and bits[-1] == "as":
+                    raise TemplateSyntaxError(
+                        f"'{function_name}' tag requires a variable name after 'as'"
+                    )
                 args, kwargs = parse_bits(
                     parser,
                     bits,
@@ -221,6 +225,10 @@ class Library:
                 if len(bits) >= 2 and bits[-2] == "as":
                     target_var = bits[-1]
                     bits = bits[:-2]
+                if bits and bits[-1] == "as":
+                    raise TemplateSyntaxError(
+                        f"'{function_name}' tag requires a variable name after 'as'"
+                    )
 
                 nodelist = parser.parse((end_name,))
                 parser.delete_first_token()

--- a/tests/template_tests/test_custom.py
+++ b/tests/template_tests/test_custom.py
@@ -173,6 +173,14 @@ class SimpleTagTests(TagTestCase):
                 "{% simple_unlimited_args_kwargs 37 "
                 'eggs="scrambled" eggs="scrambled" %}',
             ),
+            (
+                "'no_params' tag requires a variable name after 'as'",
+                "{% load custom %}{% no_params as %}",
+            ),
+            (
+                "'one_param' tag requires a variable name after 'as'",
+                "{% load custom %}{% one_param 37 as %}",
+            ),
         ]
 
         for entry in errors:
@@ -420,6 +428,14 @@ class SimpleBlockTagTests(TagTestCase):
                 "Unclosed tag on line 1: 'simple_one_default_block'. Looking for one "
                 "of: endsimple_one_default_block.",
                 "{% load custom %}{% simple_one_default_block %}Some content",
+            ),
+            (
+                "'div' tag requires a variable name after 'as'",
+                "{% load custom %}{% div as %}content{% enddiv %}",
+            ),
+            (
+                "'one_param_block' tag requires a variable name after 'as'",
+                "{% load custom %}{% one_param_block 37 as %}content{% endone_param_block %}",
             ),
         ]
 


### PR DESCRIPTION
#### Trac ticket number
ticket-37050

#### Branch description
When using Library.simple_tag() or Library.simple_block_tag(), templates that end with 'as' but omit the target variable currently raise a generic argument error. This PR adds an explicit check and raises a clear 'TemplateSyntaxError' informing the user that a variable name is required after 'as'.

#### AI Assistance Disclosure (REQUIRED)
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
The GitHub workflow steps were assisted by AI on Google Search, as well as the English translation of the technical descriptions. All code changes have been reviewed and verified manually.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://djangoproject.com).
- [x] This PR **does not** disclose a security vulnerability.
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
