### PR TITLE
Fixed #37048: Documented backwards incompatible changes to undocumented APIs.

### DIFF
--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -435,6 +435,9 @@ backends.
 
 * The ``object-tools`` block is hoisted out of the ``content`` block in forms.
 
+* The undocumented ``InclusionAdminNode.__init__()`` now takes the template tag
+  ``name`` as the first positional argument.
+
 :mod:`django.contrib.gis`
 -------------------------
 
@@ -496,6 +499,9 @@ Miscellaneous
 
 * :class:`~django.contrib.contenttypes.fields.GenericForeignKey` now uses a
   separate descriptor class: the private ``GenericForeignKeyDescriptor``.
+
+* The undocumented ``django.template.library.parse_bits()`` function no longer
+  accepts the ``takes_context`` argument.
 
 * The minimum supported version of SQLite is increased from 3.31.0 to 3.37.0.
 


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37048

#### Branch description

[#36728](https://code.djangoproject.com/ticket/36728) introduced a backwards incompatible change to [InclusionAdminNode](https://github.com/django/django/pull/20086/changes#diff-f60f94cb07bce796697e9d0357602fd6675a9891eaa57b8bd4cb70ae4ee3dda4R14) and [parse_bits](https://github.com/django/django/commit/0ac548635eee801d5de49bec482b7b8e1e97ef59#diff-4ea91e90ebf87795fbf00d2f3bd8bb6333ef908db1adc0bc2b19f6dd5b71490fL397).

Since both these functions are undocumented the original ticket was closed as wontfix, but adding a note to the changelog should help 3rd party libs to migrate.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [ ] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
