### PR TITLE
Fixed #32565 -- Moved internal UrlResolver used only by admindocs to admindocs.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1114,6 +1114,7 @@ answer newbie questions, and generally made Django that much better:
     Xia Kai <https://blog.xiaket.org/>
     Yann Fouillat <gagaro42@gmail.com>
     Yann Malet
+    Yannick Ezvan <yannick@ezvan.fr>
     Yash Jhunjhunwala
     Yasushi Masuda <whosaysni@gmail.com>
     ye7cakf02@sneakemail.com

--- a/django/contrib/admindocs/utils.py
+++ b/django/contrib/admindocs/utils.py
@@ -1,11 +1,13 @@
 "Misc. utility functions/classes for admin documentation generator."
 
+import functools
 import re
 from email.errors import HeaderParseError
 from email.parser import HeaderParser
 from inspect import cleandoc
 
 from django.urls import reverse
+from django.urls.resolvers import URLPattern
 from django.utils.regex_helper import _lazy_re_compile
 from django.utils.safestring import mark_safe
 
@@ -266,3 +268,37 @@ def remove_non_capturing_groups(pattern):
 
 def strip_p_tags(value):
     return mark_safe(value.replace("<p>", "").replace("</p>", ""))
+
+
+def _is_callback(name, url_resolver):
+    return name in _get_callback_strs(url_resolver)
+
+
+@functools.lru_cache(maxsize=None)
+def _get_callback_strs(url_resolver):
+    callback_strs = set()
+    return _collect_callback_strs(url_resolver, callback_strs)
+
+
+def _collect_callback_strs(url_resolver, callback_strs):
+    for url_pattern in url_resolver.url_patterns:
+        if isinstance(url_pattern, URLPattern):
+            callback_strs.add(_lookup_str(url_pattern))
+        else:
+            _collect_callback_strs(url_pattern, callback_strs)
+    return callback_strs
+
+
+def _lookup_str(url_pattern):
+    """
+    A string that identifies the view (e.g. 'path.to.view_function' or
+    'path.to.ClassBasedView').
+    """
+    callback = url_pattern.callback
+    if isinstance(callback, functools.partial):
+        callback = callback.func
+    if hasattr(callback, "view_class"):
+        callback = callback.view_class
+    elif not hasattr(callback, "__name__"):
+        return callback.__module__ + "." + callback.__class__.__name__
+    return callback.__module__ + "." + callback.__qualname__

--- a/django/contrib/admindocs/views.py
+++ b/django/contrib/admindocs/views.py
@@ -8,6 +8,7 @@ from django.contrib import admin
 from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.admindocs import utils
 from django.contrib.admindocs.utils import (
+    _is_callback,
     remove_non_capturing_groups,
     replace_metacharacters,
     replace_named_groups,
@@ -172,7 +173,7 @@ class ViewDetailView(BaseAdminDocsView):
     @staticmethod
     def _get_view_func(view):
         urlconf = get_urlconf()
-        if get_resolver(urlconf)._is_callback(view):
+        if _is_callback(view, get_resolver(urlconf)):
             mod, func = get_mod_func(view)
             try:
                 # Separate the module and function, e.g.

--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -484,21 +484,6 @@ class URLPattern:
                 extra_kwargs=self.default_args,
             )
 
-    @cached_property
-    def lookup_str(self):
-        """
-        A string that identifies the view (e.g. 'path.to.view_function' or
-        'path.to.ClassBasedView').
-        """
-        callback = self.callback
-        if isinstance(callback, functools.partial):
-            callback = callback.func
-        if hasattr(callback, "view_class"):
-            callback = callback.view_class
-        elif not hasattr(callback, "__name__"):
-            return callback.__module__ + "." + callback.__class__.__name__
-        return callback.__module__ + "." + callback.__qualname__
-
 
 class URLResolver:
     def __init__(
@@ -516,9 +501,6 @@ class URLResolver:
         self._reverse_dict = {}
         self._namespace_dict = {}
         self._app_dict = {}
-        # set of dotted paths to all functions and classes that are used in
-        # urlpatterns
-        self._callback_strs = set()
         self._populated = False
         self._local = Local()
 
@@ -559,7 +541,6 @@ class URLResolver:
                 p_pattern = url_pattern.pattern.regex.pattern
                 p_pattern = p_pattern.removeprefix("^")
                 if isinstance(url_pattern, URLPattern):
-                    self._callback_strs.add(url_pattern.lookup_str)
                     bits = normalize(url_pattern.pattern.regex.pattern)
                     lookups.appendlist(
                         url_pattern.callback,
@@ -618,7 +599,6 @@ class URLResolver:
                             namespaces[namespace] = (p_pattern + prefix, sub_pattern)
                         for app_name, namespace_list in url_pattern.app_dict.items():
                             apps.setdefault(app_name, []).extend(namespace_list)
-                    self._callback_strs.update(url_pattern._callback_strs)
             self._namespace_dict[language_code] = namespaces
             self._app_dict[language_code] = apps
             self._reverse_dict[language_code] = lookups
@@ -661,11 +641,6 @@ class URLResolver:
             return route2
         route2 = route2.removeprefix("^")
         return route1 + route2
-
-    def _is_callback(self, name):
-        if not self._populated:
-            self._populate()
-        return name in self._callback_strs
 
     def resolve(self, path):
         path = str(path)  # path may be a reverse_lazy object

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -515,6 +515,10 @@ Miscellaneous
   ``SimpleUploadedFile`` retain the previous behavior of evaluating based on
   the ``name`` attribute.
 
+* The undocumented ``URLResolver._is_callback()``,
+  ``URLResolver._callback_strs``, and ``URLPattern.lookup_str()`` are
+  moved to ``django.contrib.admindocs.utils``.
+
 .. _deprecated-features-6.1:
 
 Features deprecated in 6.1

--- a/tests/admin_docs/test_utils.py
+++ b/tests/admin_docs/test_utils.py
@@ -1,11 +1,14 @@
 import unittest
 
 from django.contrib.admindocs.utils import (
+    _is_callback,
     docutils_is_available,
     parse_docstring,
     parse_rst,
 )
+from django.test import SimpleTestCase
 from django.test.utils import captured_stderr
+from django.urls import get_resolver
 
 from .tests import AdminDocsSimpleTestCase
 
@@ -135,3 +138,38 @@ class TestUtils(AdminDocsSimpleTestCase):
         markup = "<p>reST, <cite>interpreted text</cite>, default role.</p>\n"
         parts = docutils.core.publish_parts(source=source, writer="html4css1")
         self.assertEqual(parts["fragment"], markup)
+
+
+class TestResolver(SimpleTestCase):
+    def test_namespaced_view_detail(self):
+        resolver = get_resolver("urlpatterns_reverse.nested_urls")
+        self.assertTrue(_is_callback("urlpatterns_reverse.nested_urls.view1", resolver))
+        self.assertTrue(_is_callback("urlpatterns_reverse.nested_urls.view2", resolver))
+        self.assertTrue(_is_callback("urlpatterns_reverse.nested_urls.View3", resolver))
+        self.assertTrue(_is_callback("urlpatterns_reverse.nested_urls.view4", resolver))
+        self.assertFalse(_is_callback("urlpatterns_reverse.nested_urls.blub", resolver))
+
+    def test_view_detail_as_method(self):
+        # Views that have a class name as part of their path.
+        resolver = get_resolver("urlpatterns_reverse.method_view_urls")
+        self.assertTrue(
+            _is_callback(
+                "urlpatterns_reverse.method_view_urls.ViewContainer.method_view",
+                resolver,
+            )
+        )
+        self.assertTrue(
+            _is_callback(
+                "urlpatterns_reverse.method_view_urls.ViewContainer.classmethod_view",
+                resolver,
+            )
+        )
+
+    def test_partial_view(self):
+        # Views wrapped in functools.partial.
+        resolver = get_resolver("urlpatterns_reverse.partial_view_urls")
+        self.assertTrue(
+            _is_callback(
+                "urlpatterns_reverse.partial_view_urls.view_with_args", resolver
+            )
+        )

--- a/tests/admin_docs/test_views.py
+++ b/tests/admin_docs/test_views.py
@@ -131,6 +131,24 @@ class AdminDocViewTests(TestDataMixin, AdminDocsTestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
+    def test_view_detail_does_not_recollect_callbacks(self):
+        """
+        Unsure that multiple requests to ViewDetailView
+        don't recollect on each request.
+        """
+        url = reverse(
+            "django-admindocs-views-detail",
+            args=["django.contrib.admindocs.views.BaseAdminDocsView"],
+        )
+        utils._get_callback_strs.cache_clear()
+        for _ in range(3):
+            self.client.get(url)
+        cache_info = utils._get_callback_strs.cache_info()
+        # First call need to collect callbacks
+        self.assertEqual(cache_info.misses, 1)
+        # Following calls hit the cache.
+        self.assertEqual(cache_info.hits, 2)
+
     def test_model_index(self):
         response = self.client.get(reverse("django-admindocs-models-index"))
         self.assertContains(

--- a/tests/apps/tests.py
+++ b/tests/apps/tests.py
@@ -184,6 +184,18 @@ class AppsTests(SimpleTestCase):
         self.assertIs(apps.is_installed("django.contrib.staticfiles"), True)
         self.assertIs(apps.is_installed("django.contrib.admindocs"), False)
 
+    @override_settings(
+        INSTALLED_APPS=["django.contrib.admindocs", *SOME_INSTALLED_APPS]
+    )
+    def test_valid_order_between_admin_docs_and_admin(self):
+        """
+        Regression test for #33955: Having "django.contrib.admindocs" before
+        "django.contrib.admin" in INSTALLED_APPS shouldn't break app loading
+        (regression test for #33955).
+        """
+        self.assertIs(apps.is_installed("django.contrib.admin"), True)
+        self.assertIs(apps.is_installed("django.contrib.admindocs"), True)
+
     @override_settings(INSTALLED_APPS=SOME_INSTALLED_APPS)
     def test_get_model(self):
         """

--- a/tests/urlpatterns_reverse/nested_urls.py
+++ b/tests/urlpatterns_reverse/nested_urls.py
@@ -14,10 +14,17 @@ class View3(View):
     pass
 
 
+def view4(request):
+    pass
+
+
+sub_nested = [path("view4/", view4, name="view4")]
+
 nested = (
     [
         path("view1/", view1, name="view1"),
         path("view3/", View3.as_view(), name="view3"),
+        path("sub_nested/", include(sub_nested)),
     ],
     "backend",
 )

--- a/tests/urlpatterns_reverse/partial_view_urls.py
+++ b/tests/urlpatterns_reverse/partial_view_urls.py
@@ -1,0 +1,12 @@
+from functools import partial
+
+from django.urls import path
+
+
+def view_with_args(request, arg=None):
+    pass
+
+
+urlpatterns = [
+    path("partial/", partial(view_with_args, arg="x"), name="partial-view"),
+]

--- a/tests/urlpatterns_reverse/tests.py
+++ b/tests/urlpatterns_reverse/tests.py
@@ -733,27 +733,6 @@ class ResolverTests(SimpleTestCase):
                                 % (e["name"], t.name),
                             )
 
-    def test_namespaced_view_detail(self):
-        resolver = get_resolver("urlpatterns_reverse.nested_urls")
-        self.assertTrue(resolver._is_callback("urlpatterns_reverse.nested_urls.view1"))
-        self.assertTrue(resolver._is_callback("urlpatterns_reverse.nested_urls.view2"))
-        self.assertTrue(resolver._is_callback("urlpatterns_reverse.nested_urls.View3"))
-        self.assertFalse(resolver._is_callback("urlpatterns_reverse.nested_urls.blub"))
-
-    def test_view_detail_as_method(self):
-        # Views which have a class name as part of their path.
-        resolver = get_resolver("urlpatterns_reverse.method_view_urls")
-        self.assertTrue(
-            resolver._is_callback(
-                "urlpatterns_reverse.method_view_urls.ViewContainer.method_view"
-            )
-        )
-        self.assertTrue(
-            resolver._is_callback(
-                "urlpatterns_reverse.method_view_urls.ViewContainer.classmethod_view"
-            )
-        )
-
     def test_populate_concurrency(self):
         """
         URLResolver._populate() can be called concurrently, but not more


### PR DESCRIPTION
ticket-32565

#### Branch description

Extracted function `UrlResolver._is_callback`, `UrlResolver.lookup_str` and attribute `UrlResolver._callback_strs` from UrlResolver to be closer to use inside admindocs.


#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [X] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

I used Claude Opus 4.7 to create a base of test that I had almost completely rewrite and do a first review of my changes.
I have manually reviewed, edited, and verified all code and documentation.

#### Checklist
- [X] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [X] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [X] This PR targets the `main` branch.
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [X] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
