### PR TITLE
Fixed #36602 -- Refactored showmigrations to use structured migration data.

### DIFF
--- a/django/core/management/commands/showmigrations.py
+++ b/django/core/management/commands/showmigrations.py
@@ -10,18 +10,18 @@ from django.db.migrations.recorder import MigrationRecorder
 
 class MigrationStatus(StrEnum):
     """
-    ``status`` field on each row returned by :meth:`Command.get_migration_data`.
+    ``status`` field on each row from :meth:`Command.get_migration_data`.
 
-    Members subclass :class:`str`, so they compare equal to their string values
-    and serialize like plain strings.
+    Members subclass :class:`str`, so they compare equal to their string
+    values and serialize like plain strings.
 
-    * :attr:`APPLIED` — Recorded in ``django_migrations`` for this migration name
-      and reflected in the loader's applied set (``[X]`` in the default list
-      output).
-    * :attr:`UNRECORDED` — The loader treats this migration as applied (e.g. all
-      replaced migrations of a squash are recorded), but there is no row yet for
-      this migration name in ``django_migrations`` (``[-]`` and the "finish
-      recording" hint).
+    * :attr:`APPLIED` — Recorded in ``django_migrations`` for this migration
+      name and reflected in the loader's applied set (``[X]`` in the default
+      list output).
+    * :attr:`UNRECORDED` — The loader treats this migration as applied (e.g.
+      all replaced migrations of a squash are recorded), but there is no row
+      yet for this migration name in ``django_migrations`` (``[-]`` and the
+      "finish recording" hint).
     * :attr:`UNAPPLIED` — Not applied (``[ ]`` in the default list output).
     """
 
@@ -123,12 +123,12 @@ class Command(BaseCommand):
         Return a list of dicts describing migrations for list or plan output.
 
         Each row includes ``app``, ``name``, ``title``, ``status``, and
-        ``applied_at``. Use ``plan=False`` (the default) for per-app list ordering;
-        use ``plan=True`` for global apply order as in ``showmigrations --plan``,
-        in which case each row also has ``dependency_labels`` (list of
-        ``app.name`` dependency strings). List mode may include a placeholder row
-        per app with ``name`` and ``title`` set to ``None`` when the app has no
-        migrations.
+        ``applied_at``. Use ``plan=False`` (the default) for per-app list
+        ordering; use ``plan=True`` for global apply order as in
+        ``showmigrations --plan``, in which case each row also has
+        ``dependency_labels`` (list of ``app.name`` dependency strings). List
+        mode may include a placeholder row per app with ``name`` and ``title``
+        set to ``None`` when the app has no migrations.
 
         Subclasses overriding this method should keep the same keyword-only
         parameters and preserve the row structure (including
@@ -239,14 +239,15 @@ class Command(BaseCommand):
         Print default ``showmigrations`` list output for structured list rows.
 
         Writes an app label before that app's migrations. Each migration line
-        uses ``[X]``, ``[-]``, or ``[ ]`` for applied, unrecorded, and unapplied
-        states (see :class:`.MigrationStatus`). Unrecorded rows include the
-        hint to run ``migrate`` to finish recording. Placeholder rows (empty
-        ``name`` and ``title``) print only the app label and ``(no migrations)``.
+        uses ``[X]``, ``[-]``, or ``[ ]`` for applied, unrecorded, and
+        unapplied states (see :class:`.MigrationStatus`). Unrecorded rows
+        include the hint to run ``migrate`` to finish recording. Placeholder
+        rows (empty ``name`` and ``title``) print only the app label and
+        ``(no migrations)``.
 
         When verbosity is 2 or higher, applied and unrecorded lines may append
-        ``(applied at ...)`` when the row provides ``applied_at``. Expects rows
-        from :meth:`get_migration_data` with ``plan=False``.
+        ``(applied at ...)`` when the row provides ``applied_at``. Expects
+        rows from :meth:`get_migration_data` with ``plan=False``.
         """
         current_app = None
         for migration in migration_rows:
@@ -270,7 +271,9 @@ class Command(BaseCommand):
                     )
                 self.stdout.write(output)
             elif status == MigrationStatus.UNRECORDED:
-                display_title = title + " Run 'manage.py migrate' to finish recording."
+                display_title = title + (
+                    " Run 'manage.py migrate' to finish recording."
+                )
                 output = " [-] %s" % display_title
                 if self.verbosity >= 2 and applied_at is not None:
                     output += " (applied at %s)" % applied_at.strftime(

--- a/django/core/management/commands/showmigrations.py
+++ b/django/core/management/commands/showmigrations.py
@@ -1,10 +1,33 @@
 import sys
+from enum import StrEnum
 
 from django.apps import apps
 from django.core.management.base import BaseCommand
 from django.db import DEFAULT_DB_ALIAS, connections
 from django.db.migrations.loader import MigrationLoader
 from django.db.migrations.recorder import MigrationRecorder
+
+
+class MigrationStatus(StrEnum):
+    """
+    ``status`` field on each row returned by :meth:`Command.get_migration_data`.
+
+    Members subclass :class:`str`, so they compare equal to their string values
+    and serialize like plain strings.
+
+    * :attr:`APPLIED` — Recorded in ``django_migrations`` for this migration name
+      and reflected in the loader's applied set (``[X]`` in the default list
+      output).
+    * :attr:`UNRECORDED` — The loader treats this migration as applied (e.g. all
+      replaced migrations of a squash are recorded), but there is no row yet for
+      this migration name in ``django_migrations`` (``[-]`` and the "finish
+      recording" hint).
+    * :attr:`UNAPPLIED` — Not applied (``[ ]`` in the default list output).
+    """
+
+    APPLIED = "applied"
+    UNRECORDED = "unrecorded"
+    UNAPPLIED = "unapplied"
 
 
 class Command(BaseCommand):
@@ -61,10 +84,11 @@ class Command(BaseCommand):
         db = options["database"]
         connection = connections[db]
 
-        if options["format"] == "plan":
-            return self.show_plan(connection, options["app_label"])
-        else:
-            return self.show_list(connection, options["app_label"])
+        plan = options["format"] == "plan"
+        rows = self.get_migration_data(
+            connection, app_names=options["app_label"], plan=plan
+        )
+        return self.show_plan(rows) if plan else self.show_list(rows)
 
     def _validate_app_names(self, loader, app_names):
         has_bad_names = False
@@ -77,67 +101,44 @@ class Command(BaseCommand):
         if has_bad_names:
             sys.exit(2)
 
-    def show_list(self, connection, app_names=None):
-        """
-        Show a list of all migrations on the system, or only those of
-        some named apps.
-        """
-        # Load migrations from disk/DB
-        loader = MigrationLoader(connection, ignore_no_migrations=True)
-        recorder = MigrationRecorder(connection)
-        recorded_migrations = recorder.applied_migrations()
-        graph = loader.graph
-        # If we were passed a list of apps, validate it
-        if app_names:
-            self._validate_app_names(loader, app_names)
-        # Otherwise, show all apps in alphabetic order
-        else:
-            app_names = sorted(loader.migrated_apps)
-        # For each app, print its migrations in order from oldest (roots) to
-        # newest (leaves).
-        for app_name in app_names:
-            self.stdout.write(app_name, self.style.MIGRATE_LABEL)
-            shown = set()
-            for node in graph.leaf_nodes(app_name):
-                for plan_node in graph.forwards_plan(node):
-                    if plan_node not in shown and plan_node[0] == app_name:
-                        # Give it a nice title if it's a squashed one
-                        title = plan_node[1]
-                        if graph.nodes[plan_node].replaces:
-                            title += " (%s squashed migrations)" % len(
-                                graph.nodes[plan_node].replaces
-                            )
-                        applied_migration = loader.applied_migrations.get(plan_node)
-                        # Mark it as applied/unapplied
-                        if applied_migration:
-                            if plan_node in recorded_migrations:
-                                output = " [X] %s" % title
-                            else:
-                                title += " Run 'manage.py migrate' to finish recording."
-                                output = " [-] %s" % title
-                            if self.verbosity >= 2 and hasattr(
-                                applied_migration, "applied"
-                            ):
-                                output += (
-                                    " (applied at %s)"
-                                    % applied_migration.applied.strftime(
-                                        "%Y-%m-%d %H:%M:%S"
-                                    )
-                                )
-                            self.stdout.write(output)
-                        else:
-                            self.stdout.write(" [ ] %s" % title)
-                        shown.add(plan_node)
-            # If we didn't print anything, then a small message
-            if not shown:
-                self.stdout.write(" (no migrations)", self.style.ERROR)
+    def _migration_row(
+        self,
+        *,
+        app,
+        name,
+        title,
+        status,
+        applied_at,
+    ):
+        return {
+            "app": app,
+            "name": name,
+            "title": title,
+            "status": status,
+            "applied_at": applied_at,
+        }
 
-    def show_plan(self, connection, app_names=None):
+    def get_migration_data(self, connection, *, app_names=None, plan=False):
         """
-        Show all known migrations (or only those of the specified app_names)
-        in the order they will be applied.
+        Return a list of dicts describing migrations for list or plan output.
+
+        Each row includes ``app``, ``name``, ``title``, ``status``, and
+        ``applied_at``. Use ``plan=False`` (the default) for per-app list ordering;
+        use ``plan=True`` for global apply order as in ``showmigrations --plan``,
+        in which case each row also has ``dependency_labels`` (list of
+        ``app.name`` dependency strings). List mode may include a placeholder row
+        per app with ``name`` and ``title`` set to ``None`` when the app has no
+        migrations.
+
+        Subclasses overriding this method should keep the same keyword-only
+        parameters and preserve the row structure (including
+        ``dependency_labels`` when ``plan`` is true).
         """
-        # Load migrations from disk/DB
+        if plan:
+            return self._plan_migration_rows(connection, app_names)
+        return self._list_migration_rows(connection, app_names)
+
+    def _plan_migration_rows(self, connection, app_names):
         loader = MigrationLoader(connection)
         graph = loader.graph
         if app_names:
@@ -145,33 +146,157 @@ class Command(BaseCommand):
             targets = [key for key in graph.leaf_nodes() if key[0] in app_names]
         else:
             targets = graph.leaf_nodes()
-        plan = []
+        rows = []
         seen = set()
-
-        # Generate the plan
         for target in targets:
             for migration in graph.forwards_plan(target):
                 if migration not in seen:
                     node = graph.node_map[migration]
-                    plan.append(node)
+                    name = node.key[1]
+                    applied = node.key in loader.applied_migrations
+                    status = (
+                        MigrationStatus.APPLIED
+                        if applied
+                        else MigrationStatus.UNAPPLIED
+                    )
+                    dependency_labels = [
+                        "%s.%s" % parent.key for parent in sorted(node.parents)
+                    ]
+                    rows.append(
+                        {
+                            **self._migration_row(
+                                app=node.key[0],
+                                name=name,
+                                title=name,
+                                status=status,
+                                applied_at=None,
+                            ),
+                            "dependency_labels": dependency_labels,
+                        }
+                    )
                     seen.add(migration)
+        return rows
 
-        # Output
-        def print_deps(node):
-            out = []
-            for parent in sorted(node.parents):
-                out.append("%s.%s" % parent.key)
-            if out:
-                return " ... (%s)" % ", ".join(out)
-            return ""
+    def _list_migration_rows(self, connection, app_names):
+        loader = MigrationLoader(connection, ignore_no_migrations=True)
+        recorder = MigrationRecorder(connection)
+        recorded_migrations = recorder.applied_migrations()
+        graph = loader.graph
+        if app_names:
+            self._validate_app_names(loader, app_names)
+        else:
+            app_names = sorted(loader.migrated_apps)
 
-        for node in plan:
-            deps = ""
-            if self.verbosity >= 2:
-                deps = print_deps(node)
-            if node.key in loader.applied_migrations:
-                self.stdout.write("[X]  %s.%s%s" % (node.key[0], node.key[1], deps))
+        rows = []
+        for app_name in app_names:
+            shown = set()
+            for node in graph.leaf_nodes(app_name):
+                for plan_node in graph.forwards_plan(node):
+                    if plan_node not in shown and plan_node[0] == app_name:
+                        title = plan_node[1]
+                        if graph.nodes[plan_node].replaces:
+                            title += " (%s squashed migrations)" % len(
+                                graph.nodes[plan_node].replaces
+                            )
+                        applied_migration = loader.applied_migrations.get(plan_node)
+                        if applied_migration:
+                            if plan_node in recorded_migrations:
+                                status = MigrationStatus.APPLIED
+                            else:
+                                status = MigrationStatus.UNRECORDED
+                            applied_at = (
+                                applied_migration.applied
+                                if hasattr(applied_migration, "applied")
+                                else None
+                            )
+                        else:
+                            status = MigrationStatus.UNAPPLIED
+                            applied_at = None
+                        rows.append(
+                            self._migration_row(
+                                app=app_name,
+                                name=plan_node[1],
+                                title=title,
+                                status=status,
+                                applied_at=applied_at,
+                            )
+                        )
+                        shown.add(plan_node)
+            if not shown:
+                rows.append(
+                    self._migration_row(
+                        app=app_name,
+                        name=None,
+                        title=None,
+                        status=None,
+                        applied_at=None,
+                    )
+                )
+        return rows
+
+    def show_list(self, migration_rows):
+        """
+        Print default ``showmigrations`` list output for structured list rows.
+
+        Writes an app label before that app's migrations. Each migration line
+        uses ``[X]``, ``[-]``, or ``[ ]`` for applied, unrecorded, and unapplied
+        states (see :class:`.MigrationStatus`). Unrecorded rows include the
+        hint to run ``migrate`` to finish recording. Placeholder rows (empty
+        ``name`` and ``title``) print only the app label and ``(no migrations)``.
+
+        When verbosity is 2 or higher, applied and unrecorded lines may append
+        ``(applied at ...)`` when the row provides ``applied_at``. Expects rows
+        from :meth:`get_migration_data` with ``plan=False``.
+        """
+        current_app = None
+        for migration in migration_rows:
+            app_name = migration["app"]
+            if migration["name"] is None and migration["title"] is None:
+                self.stdout.write(app_name, self.style.MIGRATE_LABEL)
+                self.stdout.write(" (no migrations)", self.style.ERROR)
+                current_app = app_name
+                continue
+            if app_name != current_app:
+                self.stdout.write(app_name, self.style.MIGRATE_LABEL)
+                current_app = app_name
+            title = migration["title"]
+            status = migration["status"]
+            applied_at = migration["applied_at"]
+            if status == MigrationStatus.APPLIED:
+                output = " [X] %s" % title
+                if self.verbosity >= 2 and applied_at is not None:
+                    output += " (applied at %s)" % applied_at.strftime(
+                        "%Y-%m-%d %H:%M:%S"
+                    )
+                self.stdout.write(output)
+            elif status == MigrationStatus.UNRECORDED:
+                display_title = title + " Run 'manage.py migrate' to finish recording."
+                output = " [-] %s" % display_title
+                if self.verbosity >= 2 and applied_at is not None:
+                    output += " (applied at %s)" % applied_at.strftime(
+                        "%Y-%m-%d %H:%M:%S"
+                    )
+                self.stdout.write(output)
             else:
-                self.stdout.write("[ ]  %s.%s%s" % (node.key[0], node.key[1], deps))
-        if not plan:
+                self.stdout.write(" [ ] %s" % title)
+
+    def show_plan(self, migration_rows):
+        """
+        Print ``showmigrations --plan`` output for rows from
+        :meth:`get_migration_data` with ``plan=True``.
+
+        One line per migration: ``[X]`` or ``[ ]`` followed by ``app.name``. At
+        verbosity 2 and above, append direct dependencies from each row's
+        ``dependency_labels``. If ``migration_rows`` is empty, print
+        ``(no migrations)``.
+        """
+        for entry in migration_rows:
+            deps = ""
+            if self.verbosity >= 2 and entry["dependency_labels"]:
+                deps = " ... (%s)" % ", ".join(entry["dependency_labels"])
+            if entry["status"] == MigrationStatus.APPLIED:
+                self.stdout.write("[X]  %s.%s%s" % (entry["app"], entry["name"], deps))
+            else:
+                self.stdout.write("[ ]  %s.%s%s" % (entry["app"], entry["name"], deps))
+        if not migration_rows:
             self.stdout.write("(no migrations)", self.style.ERROR)

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -493,6 +493,15 @@ short-term maintenance releases. Django 6.1 supports MariaDB 10.11 and higher.
 Miscellaneous
 -------------
 
+* Subclasses of ``django.core.management.commands.showmigrations.Command`` that
+  override ``show_list()`` or ``show_plan()`` must update those methods to
+  accept structured data (``show_list(self, migration_data)`` and
+  ``show_plan(self, plan_data)``) instead of a database connection. Use
+  ``get_migration_data()`` (which returns a list of uniform row dicts for both
+  list and plan modes) to customize collected data before display. Pass
+  ``plan=True`` or ``plan=False`` to match ``--plan`` or list output when calling
+  it outside :meth:`~django.core.management.commands.showmigrations.Command.handle`.
+
 * Providing ``fail_silently=True``, ``auth_user``, or ``auth_password`` to mail
   sending functions (such as :func:`~django.core.mail.send_mail`) while also
   providing a ``connection`` now raises a ``TypeError``.

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -499,8 +499,9 @@ Miscellaneous
   ``show_plan(self, plan_data)``) instead of a database connection. Use
   ``get_migration_data()`` (which returns a list of uniform row dicts for both
   list and plan modes) to customize collected data before display. Pass
-  ``plan=True`` or ``plan=False`` to match ``--plan`` or list output when calling
-  it outside :meth:`~django.core.management.commands.showmigrations.Command.handle`.
+  ``plan=True`` or ``plan=False`` to match ``--plan`` or list output
+  when calling it outside
+  :meth:`~django.core.management.commands.showmigrations.Command.handle`.
 
 * Providing ``fail_silently=True``, ``auth_user``, or ``auth_password`` to mail
   sending functions (such as :func:`~django.core.mail.send_mail`) while also

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -499,9 +499,9 @@ Miscellaneous
   ``show_plan(self, plan_data)``) instead of a database connection. Use
   ``get_migration_data()`` (which returns a list of uniform row dicts for both
   list and plan modes) to customize collected data before display. Pass
-  ``plan=True`` or ``plan=False`` to match ``--plan`` or list output
-  when calling it outside
-  :meth:`~django.core.management.commands.showmigrations.Command.handle`.
+  ``plan=True`` or ``plan=False`` to match ``--plan`` or list output when
+  calling ``get_migration_data()`` outside
+  ``django.core.management.commands.showmigrations.Command.handle``.
 
 * Providing ``fail_silently=True``, ``auth_user``, or ``auth_password`` to mail
   sending functions (such as :func:`~django.core.mail.send_mail`) while also

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -17,6 +17,12 @@ from django.core.management.commands.makemigrations import (
     Command as MakeMigrationsCommand,
 )
 from django.core.management.commands.migrate import Command as MigrateCommand
+from django.core.management.commands.showmigrations import (
+    Command as ShowMigrationsCommand,
+)
+from django.core.management.commands.showmigrations import (
+    MigrationStatus,
+)
 from django.db import (
     ConnectionHandler,
     DatabaseError,
@@ -554,6 +560,124 @@ class MigrateTests(MigrationTestBase):
         finally:
             # Unmigrate everything.
             call_command("migrate", "migrations", "zero", verbosity=0)
+
+    @override_settings(MIGRATION_MODULES={"migrations": "migrations.test_migrations"})
+    def test_get_migration_data_list(self):
+        cmd = ShowMigrationsCommand(
+            stdout=io.StringIO(), stderr=io.StringIO(), no_color=True
+        )
+        rows = cmd.get_migration_data(connection)
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(
+            rows[0],
+            {
+                "app": "migrations",
+                "name": "0001_initial",
+                "title": "0001_initial",
+                "status": MigrationStatus.UNAPPLIED,
+                "applied_at": None,
+            },
+        )
+        self.assertEqual(
+            rows[1],
+            {
+                "app": "migrations",
+                "name": "0002_second",
+                "title": "0002_second",
+                "status": MigrationStatus.UNAPPLIED,
+                "applied_at": None,
+            },
+        )
+
+        call_command("migrate", "migrations", "0001", verbosity=0)
+        try:
+            rows = cmd.get_migration_data(connection, app_names=["migrations"])
+            self.assertEqual(rows[0]["status"], MigrationStatus.APPLIED)
+            self.assertEqual(rows[1]["status"], MigrationStatus.UNAPPLIED)
+            self.assertIsNotNone(rows[0]["applied_at"])
+            self.assertIsNone(rows[1]["applied_at"])
+        finally:
+            call_command("migrate", "migrations", "zero", verbosity=0)
+
+    @override_settings(
+        MIGRATION_MODULES={"migrations": "migrations.test_migrations_squashed"}
+    )
+    def test_get_migration_data_list_squashed(self):
+        cmd = ShowMigrationsCommand(
+            stdout=io.StringIO(), stderr=io.StringIO(), no_color=True
+        )
+        rows = cmd.get_migration_data(connection)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["app"], "migrations")
+        self.assertEqual(rows[0]["name"], "0001_squashed_0002")
+        self.assertEqual(rows[0]["title"], "0001_squashed_0002 (2 squashed migrations)")
+        self.assertEqual(rows[0]["status"], MigrationStatus.UNAPPLIED)
+        self.assertIsNone(rows[0]["applied_at"])
+
+    @override_settings(
+        MIGRATION_MODULES={"migrations": "migrations.test_migrations_squashed"}
+    )
+    def test_get_migration_data_squashed_unrecorded(self):
+        recorder = MigrationRecorder(connection)
+        recorder.record_applied("migrations", "0001_initial")
+        recorder.record_applied("migrations", "0002_second")
+        try:
+            cmd = ShowMigrationsCommand(
+                stdout=io.StringIO(), stderr=io.StringIO(), no_color=True
+            )
+            rows = cmd.get_migration_data(connection)
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0]["name"], "0001_squashed_0002")
+            self.assertEqual(rows[0]["status"], MigrationStatus.UNRECORDED)
+        finally:
+            recorder.record_unapplied("migrations", "0001_initial")
+            recorder.record_unapplied("migrations", "0002_second")
+
+    @override_settings(
+        MIGRATION_MODULES={"migrations": "migrations.test_migrations_run_before"}
+    )
+    def test_get_migration_data_plan(self):
+        cmd = ShowMigrationsCommand(
+            stdout=io.StringIO(), stderr=io.StringIO(), no_color=True
+        )
+        plan = cmd.get_migration_data(connection, plan=True)
+        self.assertEqual(len(plan), 3)
+        self.assertEqual(
+            plan[0],
+            {
+                "app": "migrations",
+                "name": "0001_initial",
+                "title": "0001_initial",
+                "status": MigrationStatus.UNAPPLIED,
+                "applied_at": None,
+                "dependency_labels": [],
+            },
+        )
+        self.assertEqual(
+            plan[1],
+            {
+                "app": "migrations",
+                "name": "0003_third",
+                "title": "0003_third",
+                "status": MigrationStatus.UNAPPLIED,
+                "applied_at": None,
+                "dependency_labels": ["migrations.0001_initial"],
+            },
+        )
+        self.assertEqual(
+            plan[2],
+            {
+                "app": "migrations",
+                "name": "0002_second",
+                "title": "0002_second",
+                "status": MigrationStatus.UNAPPLIED,
+                "applied_at": None,
+                "dependency_labels": [
+                    "migrations.0001_initial",
+                    "migrations.0003_third",
+                ],
+            },
+        )
 
     @override_settings(
         MIGRATION_MODULES={"migrations": "migrations.test_migrations_run_before"}


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-36602

#### Branch description

This PR refactors `django-admin showmigrations` so migration list and plan output are driven by **structured data** collected in one place, instead of passing a live DB connection into display helpers.

- Adds a small **`MigrationStatus`** enum (applied / unrecorded / unapplied) and refactors **`get_migration_data()`** to return uniform row dicts for both **`list`** and **`plan`** modes.
- Updates **`show_list()`** and **`show_plan()`** to take that structured data (a **backwards-incompatible** change for subclasses of `showmigrations.Command` that override those methods).
- Extends **`tests/migrations/test_commands.py`** for status and `applied_at` behavior.
- Documents the subclass API change under **Miscellaneous** in **`docs/releases/6.1.txt`**.

Trac: https://code.djangoproject.com/ticket/36602

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [X] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

**Disclosure:** Cursor (including its AI features) was used for **docstring generation**, **locating the right tests to extend**, and **drafting/editing the release note** entry in `docs/releases/6.1.txt`. The resulting code, tests, docs, and runtime behavior were **reviewed, adjusted, and verified locally** by the author before opening this PR.

#### Checklist
- [X] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [X] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [X] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes. <!-- N/A: no admin/UI changes; CLI only. -->