### PR TITLE
Fixed #37054 - Precompute the Referrer-Policy header value during middleware initialization

### DIFF
--- a/django/middleware/security.py
+++ b/django/middleware/security.py
@@ -18,6 +18,14 @@ class SecurityMiddleware(MiddlewareMixin):
         self.referrer_policy = settings.SECURE_REFERRER_POLICY
         self.cross_origin_opener_policy = settings.SECURE_CROSS_ORIGIN_OPENER_POLICY
 
+        # Pre-compute referrer policy value to avoid string operations on every request
+        if self.referrer_policy:
+            self._referrer_policy_value = (
+                ",".join([v.strip() for v in self.referrer_policy.split(",")])
+                if isinstance(self.referrer_policy, str)
+                else ",".join(self.referrer_policy)
+            )
+
     def process_request(self, request):
         path = request.path.lstrip("/")
         if (
@@ -51,11 +59,7 @@ class SecurityMiddleware(MiddlewareMixin):
             # fallback.
             response.headers.setdefault(
                 "Referrer-Policy",
-                ",".join(
-                    [v.strip() for v in self.referrer_policy.split(",")]
-                    if isinstance(self.referrer_policy, str)
-                    else self.referrer_policy
-                ),
+                self._referrer_policy_value,
             )
 
         if self.cross_origin_opener_policy:


### PR DESCRIPTION
#### Trac ticket number
ticket-37054 

#### Branch description
The SecurityMiddleware runs on every Django request and adds security headers to responses. The original `process_response()` method constructs the Referrer-Policy header by performing string operations on every request:

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
Qwen3.5 27B was used to find the initial opportunity. 

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
