### PR TITLE
Fixed #37266 -- Used logical properties and values in CSS.

### DIFF
--- a/biome-plugins/use-logical-css-properties.grit
+++ b/biome-plugins/use-logical-css-properties.grit
@@ -1,0 +1,147 @@
+// Flag non-logical CSS properties and values, enforcing logical equivalents.
+// Mappings taken from MDN's "Logical properties and values" guide:
+// https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Logical_properties_and_values
+//
+// Implementation notes:
+// - Each check uses `maybe { ... }` so branches run independently and every
+//   matching branch fires its diagnostic; `or` short-circuits on first match.
+// - Each branch binds its matched declaration to a unique variable (`$r1`..)
+//   because GritQL variables are pattern-scoped — reusing a name across
+//   branches makes later branches fail to bind.
+// - For `margin`/`padding`/`border*`/`inset` shorthands, the 1-value form is
+//   direction-neutral (`margin: 10px` = all sides equal) and is left alone;
+//   only the 2/3/4-value forms, whose order is physical (top/right/bottom/
+//   left), are flagged.
+language css;
+
+`$selector { $props }` where {
+    // Sizing
+    maybe { $props <: contains `width: $_` as $r1,      register_diagnostic(span=$r1, message="Prefer logical `inline-size` over `width`.", severity="error") },
+    maybe { $props <: contains `height: $_` as $r2,     register_diagnostic(span=$r2, message="Prefer logical `block-size` over `height`.", severity="error") },
+    maybe { $props <: contains `min-width: $_` as $r3,  register_diagnostic(span=$r3, message="Prefer logical `min-inline-size` over `min-width`.", severity="error") },
+    maybe { $props <: contains `min-height: $_` as $r4, register_diagnostic(span=$r4, message="Prefer logical `min-block-size` over `min-height`.", severity="error") },
+    maybe { $props <: contains `max-width: $_` as $r5,  register_diagnostic(span=$r5, message="Prefer logical `max-inline-size` over `max-width`.", severity="error") },
+    maybe { $props <: contains `max-height: $_` as $r6, register_diagnostic(span=$r6, message="Prefer logical `max-block-size` over `max-height`.", severity="error") },
+
+    // Multi-value directional shorthands. The 2/3/4-value forms order values
+    // top/right/bottom/left, so they encode physical direction.
+    maybe { $props <: contains `margin: $_ $_` as $r7,             register_diagnostic(span=$r7,  message="Avoid the multi-value `margin` shorthand; use logical `margin-block` / `margin-inline` (or `margin-{block,inline}-{start,end}`).", severity="error") },
+    maybe { $props <: contains `margin: $_ $_ $_` as $r8,          register_diagnostic(span=$r8,  message="Avoid the multi-value `margin` shorthand; use logical `margin-block` / `margin-inline` (or `margin-{block,inline}-{start,end}`).", severity="error") },
+    maybe { $props <: contains `margin: $_ $_ $_ $_` as $r9,       register_diagnostic(span=$r9,  message="Avoid the multi-value `margin` shorthand; use logical `margin-block` / `margin-inline` (or `margin-{block,inline}-{start,end}`).", severity="error") },
+    maybe { $props <: contains `padding: $_ $_` as $r10,           register_diagnostic(span=$r10, message="Avoid the multi-value `padding` shorthand; use logical `padding-block` / `padding-inline` (or `padding-{block,inline}-{start,end}`).", severity="error") },
+    maybe { $props <: contains `padding: $_ $_ $_` as $r11,        register_diagnostic(span=$r11, message="Avoid the multi-value `padding` shorthand; use logical `padding-block` / `padding-inline` (or `padding-{block,inline}-{start,end}`).", severity="error") },
+    maybe { $props <: contains `padding: $_ $_ $_ $_` as $r12,     register_diagnostic(span=$r12, message="Avoid the multi-value `padding` shorthand; use logical `padding-block` / `padding-inline` (or `padding-{block,inline}-{start,end}`).", severity="error") },
+    maybe { $props <: contains `border-width: $_ $_` as $r13,      register_diagnostic(span=$r13, message="Avoid the multi-value `border-width` shorthand; use logical `border-block-width` / `border-inline-width`.", severity="error") },
+    maybe { $props <: contains `border-width: $_ $_ $_` as $r14,   register_diagnostic(span=$r14, message="Avoid the multi-value `border-width` shorthand; use logical `border-block-width` / `border-inline-width`.", severity="error") },
+    maybe { $props <: contains `border-width: $_ $_ $_ $_` as $r15, register_diagnostic(span=$r15, message="Avoid the multi-value `border-width` shorthand; use logical `border-block-width` / `border-inline-width`.", severity="error") },
+    maybe { $props <: contains `border-style: $_ $_` as $r16,      register_diagnostic(span=$r16, message="Avoid the multi-value `border-style` shorthand; use logical `border-block-style` / `border-inline-style`.", severity="error") },
+    maybe { $props <: contains `border-style: $_ $_ $_` as $r17,   register_diagnostic(span=$r17, message="Avoid the multi-value `border-style` shorthand; use logical `border-block-style` / `border-inline-style`.", severity="error") },
+    maybe { $props <: contains `border-style: $_ $_ $_ $_` as $r18, register_diagnostic(span=$r18, message="Avoid the multi-value `border-style` shorthand; use logical `border-block-style` / `border-inline-style`.", severity="error") },
+    maybe { $props <: contains `border-color: $_ $_` as $r19,      register_diagnostic(span=$r19, message="Avoid the multi-value `border-color` shorthand; use logical `border-block-color` / `border-inline-color`.", severity="error") },
+    maybe { $props <: contains `border-color: $_ $_ $_` as $r20,   register_diagnostic(span=$r20, message="Avoid the multi-value `border-color` shorthand; use logical `border-block-color` / `border-inline-color`.", severity="error") },
+    maybe { $props <: contains `border-color: $_ $_ $_ $_` as $r21, register_diagnostic(span=$r21, message="Avoid the multi-value `border-color` shorthand; use logical `border-block-color` / `border-inline-color`.", severity="error") },
+    maybe { $props <: contains `border-radius: $_ $_` as $r22,      register_diagnostic(span=$r22, message="Avoid the multi-value `border-radius` shorthand; use logical `border-start-start-radius`, `border-start-end-radius`, `border-end-start-radius`, `border-end-end-radius`.", severity="error") },
+    maybe { $props <: contains `border-radius: $_ $_ $_` as $r23,   register_diagnostic(span=$r23, message="Avoid the multi-value `border-radius` shorthand; use logical `border-start-start-radius`, `border-start-end-radius`, `border-end-start-radius`, `border-end-end-radius`.", severity="error") },
+    maybe { $props <: contains `border-radius: $_ $_ $_ $_` as $r24, register_diagnostic(span=$r24, message="Avoid the multi-value `border-radius` shorthand; use logical `border-start-start-radius`, `border-start-end-radius`, `border-end-start-radius`, `border-end-end-radius`.", severity="error") },
+    maybe { $props <: contains `inset: $_ $_` as $r25,             register_diagnostic(span=$r25, message="Avoid the multi-value `inset` shorthand; use logical `inset-block` / `inset-inline` (or `inset-{block,inline}-{start,end}`).", severity="error") },
+    maybe { $props <: contains `inset: $_ $_ $_` as $r26,          register_diagnostic(span=$r26, message="Avoid the multi-value `inset` shorthand; use logical `inset-block` / `inset-inline` (or `inset-{block,inline}-{start,end}`).", severity="error") },
+    maybe { $props <: contains `inset: $_ $_ $_ $_` as $r27,       register_diagnostic(span=$r27, message="Avoid the multi-value `inset` shorthand; use logical `inset-block` / `inset-inline` (or `inset-{block,inline}-{start,end}`).", severity="error") },
+
+    // Margin per-side
+    maybe { $props <: contains `margin-top: $_` as $r28,    register_diagnostic(span=$r28, message="Prefer logical `margin-block-start` over `margin-top`.", severity="error") },
+    maybe { $props <: contains `margin-bottom: $_` as $r29, register_diagnostic(span=$r29, message="Prefer logical `margin-block-end` over `margin-bottom`.", severity="error") },
+    maybe { $props <: contains `margin-left: $_` as $r30,   register_diagnostic(span=$r30, message="Prefer logical `margin-inline-start` over `margin-left`.", severity="error") },
+    maybe { $props <: contains `margin-right: $_` as $r31,  register_diagnostic(span=$r31, message="Prefer logical `margin-inline-end` over `margin-right`.", severity="error") },
+
+    // Padding per-side
+    maybe { $props <: contains `padding-top: $_` as $r32,    register_diagnostic(span=$r32, message="Prefer logical `padding-block-start` over `padding-top`.", severity="error") },
+    maybe { $props <: contains `padding-bottom: $_` as $r33, register_diagnostic(span=$r33, message="Prefer logical `padding-block-end` over `padding-bottom`.", severity="error") },
+    maybe { $props <: contains `padding-left: $_` as $r34,   register_diagnostic(span=$r34, message="Prefer logical `padding-inline-start` over `padding-left`.", severity="error") },
+    maybe { $props <: contains `padding-right: $_` as $r35,  register_diagnostic(span=$r35, message="Prefer logical `padding-inline-end` over `padding-right`.", severity="error") },
+
+    // Border shorthand per-side
+    maybe { $props <: contains `border-top: $_` as $r36,    register_diagnostic(span=$r36, message="Prefer logical `border-block-start` over `border-top`.", severity="error") },
+    maybe { $props <: contains `border-bottom: $_` as $r37, register_diagnostic(span=$r37, message="Prefer logical `border-block-end` over `border-bottom`.", severity="error") },
+    maybe { $props <: contains `border-left: $_` as $r38,   register_diagnostic(span=$r38, message="Prefer logical `border-inline-start` over `border-left`.", severity="error") },
+    maybe { $props <: contains `border-right: $_` as $r39,  register_diagnostic(span=$r39, message="Prefer logical `border-inline-end` over `border-right`.", severity="error") },
+
+    // Border color per-side
+    maybe { $props <: contains `border-top-color: $_` as $r40,    register_diagnostic(span=$r40, message="Prefer logical `border-block-start-color` over `border-top-color`.", severity="error") },
+    maybe { $props <: contains `border-bottom-color: $_` as $r41, register_diagnostic(span=$r41, message="Prefer logical `border-block-end-color` over `border-bottom-color`.", severity="error") },
+    maybe { $props <: contains `border-left-color: $_` as $r42,   register_diagnostic(span=$r42, message="Prefer logical `border-inline-start-color` over `border-left-color`.", severity="error") },
+    maybe { $props <: contains `border-right-color: $_` as $r43,  register_diagnostic(span=$r43, message="Prefer logical `border-inline-end-color` over `border-right-color`.", severity="error") },
+
+    // Border style per-side
+    maybe { $props <: contains `border-top-style: $_` as $r44,    register_diagnostic(span=$r44, message="Prefer logical `border-block-start-style` over `border-top-style`.", severity="error") },
+    maybe { $props <: contains `border-bottom-style: $_` as $r45, register_diagnostic(span=$r45, message="Prefer logical `border-block-end-style` over `border-bottom-style`.", severity="error") },
+    maybe { $props <: contains `border-left-style: $_` as $r46,   register_diagnostic(span=$r46, message="Prefer logical `border-inline-start-style` over `border-left-style`.", severity="error") },
+    maybe { $props <: contains `border-right-style: $_` as $r47,  register_diagnostic(span=$r47, message="Prefer logical `border-inline-end-style` over `border-right-style`.", severity="error") },
+
+    // Border width per-side
+    maybe { $props <: contains `border-top-width: $_` as $r48,    register_diagnostic(span=$r48, message="Prefer logical `border-block-start-width` over `border-top-width`.", severity="error") },
+    maybe { $props <: contains `border-bottom-width: $_` as $r49, register_diagnostic(span=$r49, message="Prefer logical `border-block-end-width` over `border-bottom-width`.", severity="error") },
+    maybe { $props <: contains `border-left-width: $_` as $r50,   register_diagnostic(span=$r50, message="Prefer logical `border-inline-start-width` over `border-left-width`.", severity="error") },
+    maybe { $props <: contains `border-right-width: $_` as $r51,  register_diagnostic(span=$r51, message="Prefer logical `border-inline-end-width` over `border-right-width`.", severity="error") },
+
+    // Border radius per-corner
+    maybe { $props <: contains `border-top-left-radius: $_` as $r52,     register_diagnostic(span=$r52, message="Prefer logical `border-start-start-radius` over `border-top-left-radius`.", severity="error") },
+    maybe { $props <: contains `border-top-right-radius: $_` as $r53,    register_diagnostic(span=$r53, message="Prefer logical `border-start-end-radius` over `border-top-right-radius`.", severity="error") },
+    maybe { $props <: contains `border-bottom-left-radius: $_` as $r54,  register_diagnostic(span=$r54, message="Prefer logical `border-end-start-radius` over `border-bottom-left-radius`.", severity="error") },
+    maybe { $props <: contains `border-bottom-right-radius: $_` as $r55, register_diagnostic(span=$r55, message="Prefer logical `border-end-end-radius` over `border-bottom-right-radius`.", severity="error") },
+
+    // Positioning / inset offsets
+    maybe { $props <: contains `top: $_` as $r56,    register_diagnostic(span=$r56, message="Prefer logical `inset-block-start` over `top`.", severity="error") },
+    maybe { $props <: contains `bottom: $_` as $r57, register_diagnostic(span=$r57, message="Prefer logical `inset-block-end` over `bottom`.", severity="error") },
+    maybe { $props <: contains `left: $_` as $r58,   register_diagnostic(span=$r58, message="Prefer logical `inset-inline-start` over `left`.", severity="error") },
+    maybe { $props <: contains `right: $_` as $r59,  register_diagnostic(span=$r59, message="Prefer logical `inset-inline-end` over `right`.", severity="error") },
+
+    // Flow-relative values on otherwise-logical properties
+    maybe { $props <: contains `float: left` as $r60,       register_diagnostic(span=$r60, message="Prefer logical `float: inline-start` over `float: left`.", severity="error") },
+    maybe { $props <: contains `float: right` as $r61,      register_diagnostic(span=$r61, message="Prefer logical `float: inline-end` over `float: right`.", severity="error") },
+    maybe { $props <: contains `clear: left` as $r62,       register_diagnostic(span=$r62, message="Prefer logical `clear: inline-start` over `clear: left`.", severity="error") },
+    maybe { $props <: contains `clear: right` as $r63,      register_diagnostic(span=$r63, message="Prefer logical `clear: inline-end` over `clear: right`.", severity="error") },
+    maybe { $props <: contains `text-align: left` as $r64,  register_diagnostic(span=$r64, message="Prefer logical `text-align: start` over `text-align: left`.", severity="error") },
+    maybe { $props <: contains `text-align: right` as $r65, register_diagnostic(span=$r65, message="Prefer logical `text-align: end` over `text-align: right`.", severity="error") },
+
+    // Overflow axes
+    maybe { $props <: contains `overflow-x: $_` as $r66, register_diagnostic(span=$r66, message="Prefer logical `overflow-inline` over `overflow-x`.", severity="error") },
+    maybe { $props <: contains `overflow-y: $_` as $r67, register_diagnostic(span=$r67, message="Prefer logical `overflow-block` over `overflow-y`.", severity="error") },
+
+    // Overscroll-behavior axes
+    maybe { $props <: contains `overscroll-behavior-x: $_` as $r68, register_diagnostic(span=$r68, message="Prefer logical `overscroll-behavior-inline` over `overscroll-behavior-x`.", severity="error") },
+    maybe { $props <: contains `overscroll-behavior-y: $_` as $r69, register_diagnostic(span=$r69, message="Prefer logical `overscroll-behavior-block` over `overscroll-behavior-y`.", severity="error") },
+
+    // Scroll margin per-side
+    maybe { $props <: contains `scroll-margin-top: $_` as $r70,    register_diagnostic(span=$r70, message="Prefer logical `scroll-margin-block-start` over `scroll-margin-top`.", severity="error") },
+    maybe { $props <: contains `scroll-margin-bottom: $_` as $r71, register_diagnostic(span=$r71, message="Prefer logical `scroll-margin-block-end` over `scroll-margin-bottom`.", severity="error") },
+    maybe { $props <: contains `scroll-margin-left: $_` as $r72,   register_diagnostic(span=$r72, message="Prefer logical `scroll-margin-inline-start` over `scroll-margin-left`.", severity="error") },
+    maybe { $props <: contains `scroll-margin-right: $_` as $r73,  register_diagnostic(span=$r73, message="Prefer logical `scroll-margin-inline-end` over `scroll-margin-right`.", severity="error") },
+
+    // Scroll margin multi-value shorthand
+    maybe { $props <: contains `scroll-margin: $_ $_` as $r74,       register_diagnostic(span=$r74, message="Avoid the multi-value `scroll-margin` shorthand; use logical `scroll-margin-block` / `scroll-margin-inline`.", severity="error") },
+    maybe { $props <: contains `scroll-margin: $_ $_ $_` as $r75,    register_diagnostic(span=$r75, message="Avoid the multi-value `scroll-margin` shorthand; use logical `scroll-margin-block` / `scroll-margin-inline`.", severity="error") },
+    maybe { $props <: contains `scroll-margin: $_ $_ $_ $_` as $r76, register_diagnostic(span=$r76, message="Avoid the multi-value `scroll-margin` shorthand; use logical `scroll-margin-block` / `scroll-margin-inline`.", severity="error") },
+
+    // Scroll padding per-side
+    maybe { $props <: contains `scroll-padding-top: $_` as $r77,    register_diagnostic(span=$r77, message="Prefer logical `scroll-padding-block-start` over `scroll-padding-top`.", severity="error") },
+    maybe { $props <: contains `scroll-padding-bottom: $_` as $r78, register_diagnostic(span=$r78, message="Prefer logical `scroll-padding-block-end` over `scroll-padding-bottom`.", severity="error") },
+    maybe { $props <: contains `scroll-padding-left: $_` as $r79,   register_diagnostic(span=$r79, message="Prefer logical `scroll-padding-inline-start` over `scroll-padding-left`.", severity="error") },
+    maybe { $props <: contains `scroll-padding-right: $_` as $r80,  register_diagnostic(span=$r80, message="Prefer logical `scroll-padding-inline-end` over `scroll-padding-right`.", severity="error") },
+
+    // Scroll padding multi-value shorthand
+    maybe { $props <: contains `scroll-padding: $_ $_` as $r81,       register_diagnostic(span=$r81, message="Avoid the multi-value `scroll-padding` shorthand; use logical `scroll-padding-block` / `scroll-padding-inline`.", severity="error") },
+    maybe { $props <: contains `scroll-padding: $_ $_ $_` as $r82,    register_diagnostic(span=$r82, message="Avoid the multi-value `scroll-padding` shorthand; use logical `scroll-padding-block` / `scroll-padding-inline`.", severity="error") },
+    maybe { $props <: contains `scroll-padding: $_ $_ $_ $_` as $r83, register_diagnostic(span=$r83, message="Avoid the multi-value `scroll-padding` shorthand; use logical `scroll-padding-block` / `scroll-padding-inline`.", severity="error") },
+
+    // Contain-intrinsic sizing
+    maybe { $props <: contains `contain-intrinsic-width: $_` as $r84,  register_diagnostic(span=$r84, message="Prefer logical `contain-intrinsic-inline-size` over `contain-intrinsic-width`.", severity="error") },
+    maybe { $props <: contains `contain-intrinsic-height: $_` as $r85, register_diagnostic(span=$r85, message="Prefer logical `contain-intrinsic-block-size` over `contain-intrinsic-height`.", severity="error") },
+
+    // Resize axis values
+    maybe { $props <: contains `resize: horizontal` as $r86, register_diagnostic(span=$r86, message="Prefer logical `resize: inline` over `resize: horizontal`.", severity="error") },
+    maybe { $props <: contains `resize: vertical` as $r87,   register_diagnostic(span=$r87, message="Prefer logical `resize: block` over `resize: vertical`.", severity="error") },
+
+    // Caption-side values
+    maybe { $props <: contains `caption-side: top` as $r88,    register_diagnostic(span=$r88, message="Prefer logical `caption-side: block-start` over `caption-side: top`.", severity="error") },
+    maybe { $props <: contains `caption-side: bottom` as $r89, register_diagnostic(span=$r89, message="Prefer logical `caption-side: block-end` over `caption-side: bottom`.", severity="error") }
+}

--- a/biome-plugins/use-logical-css-properties.grit
+++ b/biome-plugins/use-logical-css-properties.grit
@@ -1,147 +1,41 @@
-// Flag non-logical CSS properties and values, enforcing logical equivalents.
-// Mappings taken from MDN's "Logical properties and values" guide:
-// https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Logical_properties_and_values
-//
-// Implementation notes:
-// - Each check uses `maybe { ... }` so branches run independently and every
-//   matching branch fires its diagnostic; `or` short-circuits on first match.
-// - Each branch binds its matched declaration to a unique variable (`$r1`..)
-//   because GritQL variables are pattern-scoped — reusing a name across
-//   branches makes later branches fail to bind.
-// - For `margin`/`padding`/`border*`/`inset` shorthands, the 1-value form is
-//   direction-neutral (`margin: 10px` = all sides equal) and is left alone;
-//   only the 2/3/4-value forms, whose order is physical (top/right/bottom/
-//   left), are flagged.
-language css;
+engine biome(1.0)
+language css
 
-`$selector { $props }` where {
-    // Sizing
-    maybe { $props <: contains `width: $_` as $r1,      register_diagnostic(span=$r1, message="Prefer logical `inline-size` over `width`.", severity="error") },
-    maybe { $props <: contains `height: $_` as $r2,     register_diagnostic(span=$r2, message="Prefer logical `block-size` over `height`.", severity="error") },
-    maybe { $props <: contains `min-width: $_` as $r3,  register_diagnostic(span=$r3, message="Prefer logical `min-inline-size` over `min-width`.", severity="error") },
-    maybe { $props <: contains `min-height: $_` as $r4, register_diagnostic(span=$r4, message="Prefer logical `min-block-size` over `min-height`.", severity="error") },
-    maybe { $props <: contains `max-width: $_` as $r5,  register_diagnostic(span=$r5, message="Prefer logical `max-inline-size` over `max-width`.", severity="error") },
-    maybe { $props <: contains `max-height: $_` as $r6, register_diagnostic(span=$r6, message="Prefer logical `max-block-size` over `max-height`.", severity="error") },
-
-    // Multi-value directional shorthands. The 2/3/4-value forms order values
-    // top/right/bottom/left, so they encode physical direction.
-    maybe { $props <: contains `margin: $_ $_` as $r7,             register_diagnostic(span=$r7,  message="Avoid the multi-value `margin` shorthand; use logical `margin-block` / `margin-inline` (or `margin-{block,inline}-{start,end}`).", severity="error") },
-    maybe { $props <: contains `margin: $_ $_ $_` as $r8,          register_diagnostic(span=$r8,  message="Avoid the multi-value `margin` shorthand; use logical `margin-block` / `margin-inline` (or `margin-{block,inline}-{start,end}`).", severity="error") },
-    maybe { $props <: contains `margin: $_ $_ $_ $_` as $r9,       register_diagnostic(span=$r9,  message="Avoid the multi-value `margin` shorthand; use logical `margin-block` / `margin-inline` (or `margin-{block,inline}-{start,end}`).", severity="error") },
-    maybe { $props <: contains `padding: $_ $_` as $r10,           register_diagnostic(span=$r10, message="Avoid the multi-value `padding` shorthand; use logical `padding-block` / `padding-inline` (or `padding-{block,inline}-{start,end}`).", severity="error") },
-    maybe { $props <: contains `padding: $_ $_ $_` as $r11,        register_diagnostic(span=$r11, message="Avoid the multi-value `padding` shorthand; use logical `padding-block` / `padding-inline` (or `padding-{block,inline}-{start,end}`).", severity="error") },
-    maybe { $props <: contains `padding: $_ $_ $_ $_` as $r12,     register_diagnostic(span=$r12, message="Avoid the multi-value `padding` shorthand; use logical `padding-block` / `padding-inline` (or `padding-{block,inline}-{start,end}`).", severity="error") },
-    maybe { $props <: contains `border-width: $_ $_` as $r13,      register_diagnostic(span=$r13, message="Avoid the multi-value `border-width` shorthand; use logical `border-block-width` / `border-inline-width`.", severity="error") },
-    maybe { $props <: contains `border-width: $_ $_ $_` as $r14,   register_diagnostic(span=$r14, message="Avoid the multi-value `border-width` shorthand; use logical `border-block-width` / `border-inline-width`.", severity="error") },
-    maybe { $props <: contains `border-width: $_ $_ $_ $_` as $r15, register_diagnostic(span=$r15, message="Avoid the multi-value `border-width` shorthand; use logical `border-block-width` / `border-inline-width`.", severity="error") },
-    maybe { $props <: contains `border-style: $_ $_` as $r16,      register_diagnostic(span=$r16, message="Avoid the multi-value `border-style` shorthand; use logical `border-block-style` / `border-inline-style`.", severity="error") },
-    maybe { $props <: contains `border-style: $_ $_ $_` as $r17,   register_diagnostic(span=$r17, message="Avoid the multi-value `border-style` shorthand; use logical `border-block-style` / `border-inline-style`.", severity="error") },
-    maybe { $props <: contains `border-style: $_ $_ $_ $_` as $r18, register_diagnostic(span=$r18, message="Avoid the multi-value `border-style` shorthand; use logical `border-block-style` / `border-inline-style`.", severity="error") },
-    maybe { $props <: contains `border-color: $_ $_` as $r19,      register_diagnostic(span=$r19, message="Avoid the multi-value `border-color` shorthand; use logical `border-block-color` / `border-inline-color`.", severity="error") },
-    maybe { $props <: contains `border-color: $_ $_ $_` as $r20,   register_diagnostic(span=$r20, message="Avoid the multi-value `border-color` shorthand; use logical `border-block-color` / `border-inline-color`.", severity="error") },
-    maybe { $props <: contains `border-color: $_ $_ $_ $_` as $r21, register_diagnostic(span=$r21, message="Avoid the multi-value `border-color` shorthand; use logical `border-block-color` / `border-inline-color`.", severity="error") },
-    maybe { $props <: contains `border-radius: $_ $_` as $r22,      register_diagnostic(span=$r22, message="Avoid the multi-value `border-radius` shorthand; use logical `border-start-start-radius`, `border-start-end-radius`, `border-end-start-radius`, `border-end-end-radius`.", severity="error") },
-    maybe { $props <: contains `border-radius: $_ $_ $_` as $r23,   register_diagnostic(span=$r23, message="Avoid the multi-value `border-radius` shorthand; use logical `border-start-start-radius`, `border-start-end-radius`, `border-end-start-radius`, `border-end-end-radius`.", severity="error") },
-    maybe { $props <: contains `border-radius: $_ $_ $_ $_` as $r24, register_diagnostic(span=$r24, message="Avoid the multi-value `border-radius` shorthand; use logical `border-start-start-radius`, `border-start-end-radius`, `border-end-start-radius`, `border-end-end-radius`.", severity="error") },
-    maybe { $props <: contains `inset: $_ $_` as $r25,             register_diagnostic(span=$r25, message="Avoid the multi-value `inset` shorthand; use logical `inset-block` / `inset-inline` (or `inset-{block,inline}-{start,end}`).", severity="error") },
-    maybe { $props <: contains `inset: $_ $_ $_` as $r26,          register_diagnostic(span=$r26, message="Avoid the multi-value `inset` shorthand; use logical `inset-block` / `inset-inline` (or `inset-{block,inline}-{start,end}`).", severity="error") },
-    maybe { $props <: contains `inset: $_ $_ $_ $_` as $r27,       register_diagnostic(span=$r27, message="Avoid the multi-value `inset` shorthand; use logical `inset-block` / `inset-inline` (or `inset-{block,inline}-{start,end}`).", severity="error") },
-
-    // Margin per-side
-    maybe { $props <: contains `margin-top: $_` as $r28,    register_diagnostic(span=$r28, message="Prefer logical `margin-block-start` over `margin-top`.", severity="error") },
-    maybe { $props <: contains `margin-bottom: $_` as $r29, register_diagnostic(span=$r29, message="Prefer logical `margin-block-end` over `margin-bottom`.", severity="error") },
-    maybe { $props <: contains `margin-left: $_` as $r30,   register_diagnostic(span=$r30, message="Prefer logical `margin-inline-start` over `margin-left`.", severity="error") },
-    maybe { $props <: contains `margin-right: $_` as $r31,  register_diagnostic(span=$r31, message="Prefer logical `margin-inline-end` over `margin-right`.", severity="error") },
-
-    // Padding per-side
-    maybe { $props <: contains `padding-top: $_` as $r32,    register_diagnostic(span=$r32, message="Prefer logical `padding-block-start` over `padding-top`.", severity="error") },
-    maybe { $props <: contains `padding-bottom: $_` as $r33, register_diagnostic(span=$r33, message="Prefer logical `padding-block-end` over `padding-bottom`.", severity="error") },
-    maybe { $props <: contains `padding-left: $_` as $r34,   register_diagnostic(span=$r34, message="Prefer logical `padding-inline-start` over `padding-left`.", severity="error") },
-    maybe { $props <: contains `padding-right: $_` as $r35,  register_diagnostic(span=$r35, message="Prefer logical `padding-inline-end` over `padding-right`.", severity="error") },
-
-    // Border shorthand per-side
-    maybe { $props <: contains `border-top: $_` as $r36,    register_diagnostic(span=$r36, message="Prefer logical `border-block-start` over `border-top`.", severity="error") },
-    maybe { $props <: contains `border-bottom: $_` as $r37, register_diagnostic(span=$r37, message="Prefer logical `border-block-end` over `border-bottom`.", severity="error") },
-    maybe { $props <: contains `border-left: $_` as $r38,   register_diagnostic(span=$r38, message="Prefer logical `border-inline-start` over `border-left`.", severity="error") },
-    maybe { $props <: contains `border-right: $_` as $r39,  register_diagnostic(span=$r39, message="Prefer logical `border-inline-end` over `border-right`.", severity="error") },
-
-    // Border color per-side
-    maybe { $props <: contains `border-top-color: $_` as $r40,    register_diagnostic(span=$r40, message="Prefer logical `border-block-start-color` over `border-top-color`.", severity="error") },
-    maybe { $props <: contains `border-bottom-color: $_` as $r41, register_diagnostic(span=$r41, message="Prefer logical `border-block-end-color` over `border-bottom-color`.", severity="error") },
-    maybe { $props <: contains `border-left-color: $_` as $r42,   register_diagnostic(span=$r42, message="Prefer logical `border-inline-start-color` over `border-left-color`.", severity="error") },
-    maybe { $props <: contains `border-right-color: $_` as $r43,  register_diagnostic(span=$r43, message="Prefer logical `border-inline-end-color` over `border-right-color`.", severity="error") },
-
-    // Border style per-side
-    maybe { $props <: contains `border-top-style: $_` as $r44,    register_diagnostic(span=$r44, message="Prefer logical `border-block-start-style` over `border-top-style`.", severity="error") },
-    maybe { $props <: contains `border-bottom-style: $_` as $r45, register_diagnostic(span=$r45, message="Prefer logical `border-block-end-style` over `border-bottom-style`.", severity="error") },
-    maybe { $props <: contains `border-left-style: $_` as $r46,   register_diagnostic(span=$r46, message="Prefer logical `border-inline-start-style` over `border-left-style`.", severity="error") },
-    maybe { $props <: contains `border-right-style: $_` as $r47,  register_diagnostic(span=$r47, message="Prefer logical `border-inline-end-style` over `border-right-style`.", severity="error") },
-
-    // Border width per-side
-    maybe { $props <: contains `border-top-width: $_` as $r48,    register_diagnostic(span=$r48, message="Prefer logical `border-block-start-width` over `border-top-width`.", severity="error") },
-    maybe { $props <: contains `border-bottom-width: $_` as $r49, register_diagnostic(span=$r49, message="Prefer logical `border-block-end-width` over `border-bottom-width`.", severity="error") },
-    maybe { $props <: contains `border-left-width: $_` as $r50,   register_diagnostic(span=$r50, message="Prefer logical `border-inline-start-width` over `border-left-width`.", severity="error") },
-    maybe { $props <: contains `border-right-width: $_` as $r51,  register_diagnostic(span=$r51, message="Prefer logical `border-inline-end-width` over `border-right-width`.", severity="error") },
-
-    // Border radius per-corner
-    maybe { $props <: contains `border-top-left-radius: $_` as $r52,     register_diagnostic(span=$r52, message="Prefer logical `border-start-start-radius` over `border-top-left-radius`.", severity="error") },
-    maybe { $props <: contains `border-top-right-radius: $_` as $r53,    register_diagnostic(span=$r53, message="Prefer logical `border-start-end-radius` over `border-top-right-radius`.", severity="error") },
-    maybe { $props <: contains `border-bottom-left-radius: $_` as $r54,  register_diagnostic(span=$r54, message="Prefer logical `border-end-start-radius` over `border-bottom-left-radius`.", severity="error") },
-    maybe { $props <: contains `border-bottom-right-radius: $_` as $r55, register_diagnostic(span=$r55, message="Prefer logical `border-end-end-radius` over `border-bottom-right-radius`.", severity="error") },
-
-    // Positioning / inset offsets
-    maybe { $props <: contains `top: $_` as $r56,    register_diagnostic(span=$r56, message="Prefer logical `inset-block-start` over `top`.", severity="error") },
-    maybe { $props <: contains `bottom: $_` as $r57, register_diagnostic(span=$r57, message="Prefer logical `inset-block-end` over `bottom`.", severity="error") },
-    maybe { $props <: contains `left: $_` as $r58,   register_diagnostic(span=$r58, message="Prefer logical `inset-inline-start` over `left`.", severity="error") },
-    maybe { $props <: contains `right: $_` as $r59,  register_diagnostic(span=$r59, message="Prefer logical `inset-inline-end` over `right`.", severity="error") },
-
-    // Flow-relative values on otherwise-logical properties
-    maybe { $props <: contains `float: left` as $r60,       register_diagnostic(span=$r60, message="Prefer logical `float: inline-start` over `float: left`.", severity="error") },
-    maybe { $props <: contains `float: right` as $r61,      register_diagnostic(span=$r61, message="Prefer logical `float: inline-end` over `float: right`.", severity="error") },
-    maybe { $props <: contains `clear: left` as $r62,       register_diagnostic(span=$r62, message="Prefer logical `clear: inline-start` over `clear: left`.", severity="error") },
-    maybe { $props <: contains `clear: right` as $r63,      register_diagnostic(span=$r63, message="Prefer logical `clear: inline-end` over `clear: right`.", severity="error") },
-    maybe { $props <: contains `text-align: left` as $r64,  register_diagnostic(span=$r64, message="Prefer logical `text-align: start` over `text-align: left`.", severity="error") },
-    maybe { $props <: contains `text-align: right` as $r65, register_diagnostic(span=$r65, message="Prefer logical `text-align: end` over `text-align: right`.", severity="error") },
-
-    // Overflow axes
-    maybe { $props <: contains `overflow-x: $_` as $r66, register_diagnostic(span=$r66, message="Prefer logical `overflow-inline` over `overflow-x`.", severity="error") },
-    maybe { $props <: contains `overflow-y: $_` as $r67, register_diagnostic(span=$r67, message="Prefer logical `overflow-block` over `overflow-y`.", severity="error") },
-
-    // Overscroll-behavior axes
-    maybe { $props <: contains `overscroll-behavior-x: $_` as $r68, register_diagnostic(span=$r68, message="Prefer logical `overscroll-behavior-inline` over `overscroll-behavior-x`.", severity="error") },
-    maybe { $props <: contains `overscroll-behavior-y: $_` as $r69, register_diagnostic(span=$r69, message="Prefer logical `overscroll-behavior-block` over `overscroll-behavior-y`.", severity="error") },
-
-    // Scroll margin per-side
-    maybe { $props <: contains `scroll-margin-top: $_` as $r70,    register_diagnostic(span=$r70, message="Prefer logical `scroll-margin-block-start` over `scroll-margin-top`.", severity="error") },
-    maybe { $props <: contains `scroll-margin-bottom: $_` as $r71, register_diagnostic(span=$r71, message="Prefer logical `scroll-margin-block-end` over `scroll-margin-bottom`.", severity="error") },
-    maybe { $props <: contains `scroll-margin-left: $_` as $r72,   register_diagnostic(span=$r72, message="Prefer logical `scroll-margin-inline-start` over `scroll-margin-left`.", severity="error") },
-    maybe { $props <: contains `scroll-margin-right: $_` as $r73,  register_diagnostic(span=$r73, message="Prefer logical `scroll-margin-inline-end` over `scroll-margin-right`.", severity="error") },
-
-    // Scroll margin multi-value shorthand
-    maybe { $props <: contains `scroll-margin: $_ $_` as $r74,       register_diagnostic(span=$r74, message="Avoid the multi-value `scroll-margin` shorthand; use logical `scroll-margin-block` / `scroll-margin-inline`.", severity="error") },
-    maybe { $props <: contains `scroll-margin: $_ $_ $_` as $r75,    register_diagnostic(span=$r75, message="Avoid the multi-value `scroll-margin` shorthand; use logical `scroll-margin-block` / `scroll-margin-inline`.", severity="error") },
-    maybe { $props <: contains `scroll-margin: $_ $_ $_ $_` as $r76, register_diagnostic(span=$r76, message="Avoid the multi-value `scroll-margin` shorthand; use logical `scroll-margin-block` / `scroll-margin-inline`.", severity="error") },
-
-    // Scroll padding per-side
-    maybe { $props <: contains `scroll-padding-top: $_` as $r77,    register_diagnostic(span=$r77, message="Prefer logical `scroll-padding-block-start` over `scroll-padding-top`.", severity="error") },
-    maybe { $props <: contains `scroll-padding-bottom: $_` as $r78, register_diagnostic(span=$r78, message="Prefer logical `scroll-padding-block-end` over `scroll-padding-bottom`.", severity="error") },
-    maybe { $props <: contains `scroll-padding-left: $_` as $r79,   register_diagnostic(span=$r79, message="Prefer logical `scroll-padding-inline-start` over `scroll-padding-left`.", severity="error") },
-    maybe { $props <: contains `scroll-padding-right: $_` as $r80,  register_diagnostic(span=$r80, message="Prefer logical `scroll-padding-inline-end` over `scroll-padding-right`.", severity="error") },
-
-    // Scroll padding multi-value shorthand
-    maybe { $props <: contains `scroll-padding: $_ $_` as $r81,       register_diagnostic(span=$r81, message="Avoid the multi-value `scroll-padding` shorthand; use logical `scroll-padding-block` / `scroll-padding-inline`.", severity="error") },
-    maybe { $props <: contains `scroll-padding: $_ $_ $_` as $r82,    register_diagnostic(span=$r82, message="Avoid the multi-value `scroll-padding` shorthand; use logical `scroll-padding-block` / `scroll-padding-inline`.", severity="error") },
-    maybe { $props <: contains `scroll-padding: $_ $_ $_ $_` as $r83, register_diagnostic(span=$r83, message="Avoid the multi-value `scroll-padding` shorthand; use logical `scroll-padding-block` / `scroll-padding-inline`.", severity="error") },
-
-    // Contain-intrinsic sizing
-    maybe { $props <: contains `contain-intrinsic-width: $_` as $r84,  register_diagnostic(span=$r84, message="Prefer logical `contain-intrinsic-inline-size` over `contain-intrinsic-width`.", severity="error") },
-    maybe { $props <: contains `contain-intrinsic-height: $_` as $r85, register_diagnostic(span=$r85, message="Prefer logical `contain-intrinsic-block-size` over `contain-intrinsic-height`.", severity="error") },
-
-    // Resize axis values
-    maybe { $props <: contains `resize: horizontal` as $r86, register_diagnostic(span=$r86, message="Prefer logical `resize: inline` over `resize: horizontal`.", severity="error") },
-    maybe { $props <: contains `resize: vertical` as $r87,   register_diagnostic(span=$r87, message="Prefer logical `resize: block` over `resize: vertical`.", severity="error") },
-
-    // Caption-side values
-    maybe { $props <: contains `caption-side: top` as $r88,    register_diagnostic(span=$r88, message="Prefer logical `caption-side: block-start` over `caption-side: top`.", severity="error") },
-    maybe { $props <: contains `caption-side: bottom` as $r89, register_diagnostic(span=$r89, message="Prefer logical `caption-side: block-end` over `caption-side: bottom`.", severity="error") }
+or {
+    // Physical properties.
+    CssDeclarationWithSemicolon() as $decl where {
+        $decl <: r"([\w-]+)\s*:[\s\S]*"($property),
+        $property <: r"[\w-]*(?:left|right)[\w-]*",
+        $property <: r"[a-z][\w-]*",
+        register_diagnostic(
+            span=$decl,
+            message="Prefer the logical inline equivalent over `left`/`right`.",
+            severity="error",
+        )
+    },
+    // Physical values.
+    CssDeclarationWithSemicolon() as $decl where {
+        $decl <: r"(?:float|clear|text-align)\s*:\s*(?:left|right)\s*;?",
+        register_diagnostic(
+            span=$decl,
+            message="Prefer the logical flow-relative value over `left`/`right`.",
+            severity="error",
+        )
+    },
+    // 4-value shorthands.
+    CssDeclarationWithSemicolon() as $decl where {
+        $decl <: or {
+            `margin: $_ $_ $_ $_;`,
+            `padding: $_ $_ $_ $_;`,
+            `inset: $_ $_ $_ $_;`,
+            `border-width: $_ $_ $_ $_;`,
+            `border-style: $_ $_ $_ $_;`,
+            `border-color: $_ $_ $_ $_;`
+        },
+        register_diagnostic(
+            span=$decl,
+            message="Avoid the 4-value box shorthand.",
+            severity="error",
+        )
+    }
 }

--- a/biome-plugins/use-logical-css-properties.grit
+++ b/biome-plugins/use-logical-css-properties.grit
@@ -1,0 +1,41 @@
+engine biome(1.0)
+language css
+
+or {
+    // Physical properties.
+    CssDeclarationWithSemicolon() as $decl where {
+        $decl <: r"([\w-]+)\s*:[\s\S]*"($property),
+        $property <: r"[\w-]*(?:left|right)[\w-]*",
+        $property <: r"[a-z][\w-]*",
+        register_diagnostic(
+            span=$decl,
+            message="Prefer the logical inline equivalent over `left`/`right`.",
+            severity="error",
+        )
+    },
+    // Physical values.
+    CssDeclarationWithSemicolon() as $decl where {
+        $decl <: r"(?:float|clear|text-align)\s*:\s*(?:left|right)\s*;?",
+        register_diagnostic(
+            span=$decl,
+            message="Prefer the logical flow-relative value over `left`/`right`.",
+            severity="error",
+        )
+    },
+    // 4-value shorthands.
+    CssDeclarationWithSemicolon() as $decl where {
+        $decl <: or {
+            `margin: $_ $_ $_ $_;`,
+            `padding: $_ $_ $_ $_;`,
+            `inset: $_ $_ $_ $_;`,
+            `border-width: $_ $_ $_ $_;`,
+            `border-style: $_ $_ $_ $_;`,
+            `border-color: $_ $_ $_ $_;`
+        },
+        register_diagnostic(
+            span=$decl,
+            message="Avoid the 4-value box shorthand.",
+            severity="error",
+        )
+    }
+}

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,6 @@
 {
     "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
+    "plugins": ["./biome-plugins/use-logical-css-properties.grit"],
     "files": {
         "includes": [
             "django/contrib/admin/static/admin/css/**/*.css",

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,6 @@
 {
     "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+    "plugins": ["./biome-plugins/use-logical-css-properties.grit"],
     "files": {
         "includes": [
             "django/contrib/admin/static/admin/css/**/*.css",

--- a/django/contrib/admin/static/admin/css/autocomplete.css
+++ b/django/contrib/admin/static/admin/css/autocomplete.css
@@ -51,7 +51,7 @@ select.admin-autocomplete {
     .select2-selection--single
     .select2-selection__clear {
     cursor: pointer;
-    float: right;
+    float: inline-end;
     font-weight: bold;
 }
 
@@ -67,7 +67,7 @@ select.admin-autocomplete {
     height: 26px;
     position: absolute;
     top: 1px;
-    right: 1px;
+    inset-inline-end: 1px;
     width: 20px;
 }
 
@@ -75,29 +75,16 @@ select.admin-autocomplete {
     .select2-selection--single
     .select2-selection__arrow
     b {
-    border-color: #888 transparent transparent transparent;
+    border-color: #888 transparent transparent;
     border-style: solid;
-    border-width: 5px 4px 0 4px;
+    border-width: 5px 4px 0;
     height: 0;
-    left: 50%;
-    margin-left: -4px;
+    inset-inline-start: 50%;
+    margin-inline-start: -4px;
     margin-top: -2px;
     position: absolute;
     top: 50%;
     width: 0;
-}
-
-.select2-container--admin-autocomplete[dir="rtl"]
-    .select2-selection--single
-    .select2-selection__clear {
-    float: left;
-}
-
-.select2-container--admin-autocomplete[dir="rtl"]
-    .select2-selection--single
-    .select2-selection__arrow {
-    left: 1px;
-    right: auto;
 }
 
 .select2-container--admin-autocomplete.select2-container--disabled
@@ -116,8 +103,8 @@ select.admin-autocomplete {
     .select2-selection--single
     .select2-selection__arrow
     b {
-    border-color: transparent transparent #888 transparent;
-    border-width: 0 4px 5px 4px;
+    border-color: transparent transparent #888;
+    border-width: 0 4px 5px;
 }
 
 .select2-container--admin-autocomplete .select2-selection--multiple {
@@ -133,7 +120,8 @@ select.admin-autocomplete {
     box-sizing: border-box;
     list-style: none;
     margin: 0;
-    padding: 0 10px 5px 5px;
+    padding-block: 0 5px;
+    padding-inline: 5px 10px;
     width: 100%;
     display: flex;
     flex-wrap: wrap;
@@ -151,18 +139,18 @@ select.admin-autocomplete {
     .select2-selection__placeholder {
     color: var(--body-quiet-color);
     margin-top: 5px;
-    float: left;
+    float: inline-start;
 }
 
 .select2-container--admin-autocomplete
     .select2-selection--multiple
     .select2-selection__clear {
     cursor: pointer;
-    float: right;
+    float: inline-end;
     font-weight: bold;
     margin: 5px;
     position: absolute;
-    right: 0;
+    inset-inline-end: 0;
 }
 
 .select2-container--admin-autocomplete
@@ -172,8 +160,8 @@ select.admin-autocomplete {
     border: 1px solid var(--border-color);
     border-radius: 4px;
     cursor: default;
-    float: left;
-    margin-right: 5px;
+    float: inline-start;
+    margin-inline-end: 5px;
     margin-top: 5px;
     padding: 0 5px;
 }
@@ -185,7 +173,7 @@ select.admin-autocomplete {
     cursor: pointer;
     display: inline-block;
     font-weight: bold;
-    margin-right: 2px;
+    margin-inline-end: 2px;
 }
 
 .select2-container--admin-autocomplete
@@ -196,28 +184,8 @@ select.admin-autocomplete {
 
 .select2-container--admin-autocomplete[dir="rtl"]
     .select2-selection--multiple
-    .select2-selection__choice,
-.select2-container--admin-autocomplete[dir="rtl"]
-    .select2-selection--multiple
-    .select2-selection__placeholder,
-.select2-container--admin-autocomplete[dir="rtl"]
-    .select2-selection--multiple
     .select2-search--inline {
-    float: right;
-}
-
-.select2-container--admin-autocomplete[dir="rtl"]
-    .select2-selection--multiple
-    .select2-selection__choice {
-    margin-left: 5px;
-    margin-right: auto;
-}
-
-.select2-container--admin-autocomplete[dir="rtl"]
-    .select2-selection--multiple
-    .select2-selection__choice__remove {
-    margin-left: 2px;
-    margin-right: auto;
+    float: inline-start;
 }
 
 .select2-container--admin-autocomplete.select2-container--focus
@@ -241,16 +209,16 @@ select.admin-autocomplete {
     .select2-selection--single,
 .select2-container--admin-autocomplete.select2-container--open.select2-container--above
     .select2-selection--multiple {
-    border-top-left-radius: 0;
-    border-top-right-radius: 0;
+    border-start-start-radius: 0;
+    border-start-end-radius: 0;
 }
 
 .select2-container--admin-autocomplete.select2-container--open.select2-container--below
     .select2-selection--single,
 .select2-container--admin-autocomplete.select2-container--open.select2-container--below
     .select2-selection--multiple {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
 }
 
 .select2-container--admin-autocomplete .select2-search--dropdown {
@@ -304,22 +272,22 @@ select.admin-autocomplete {
 .select2-container--admin-autocomplete
     .select2-results__option
     .select2-results__option {
-    padding-left: 1em;
+    padding-inline-start: 1em;
 }
 
 .select2-container--admin-autocomplete
     .select2-results__option
     .select2-results__option
     .select2-results__group {
-    padding-left: 0;
+    padding-inline-start: 0;
 }
 
 .select2-container--admin-autocomplete
     .select2-results__option
     .select2-results__option
     .select2-results__option {
-    margin-left: -1em;
-    padding-left: 2em;
+    margin-inline-start: -1em;
+    padding-inline-start: 2em;
 }
 
 .select2-container--admin-autocomplete
@@ -327,18 +295,8 @@ select.admin-autocomplete {
     .select2-results__option
     .select2-results__option
     .select2-results__option {
-    margin-left: -2em;
-    padding-left: 3em;
-}
-
-.select2-container--admin-autocomplete
-    .select2-results__option
-    .select2-results__option
-    .select2-results__option
-    .select2-results__option
-    .select2-results__option {
-    margin-left: -3em;
-    padding-left: 4em;
+    margin-inline-start: -2em;
+    padding-inline-start: 3em;
 }
 
 .select2-container--admin-autocomplete
@@ -346,10 +304,9 @@ select.admin-autocomplete {
     .select2-results__option
     .select2-results__option
     .select2-results__option
-    .select2-results__option
     .select2-results__option {
-    margin-left: -4em;
-    padding-left: 5em;
+    margin-inline-start: -3em;
+    padding-inline-start: 4em;
 }
 
 .select2-container--admin-autocomplete
@@ -358,10 +315,21 @@ select.admin-autocomplete {
     .select2-results__option
     .select2-results__option
     .select2-results__option
+    .select2-results__option {
+    margin-inline-start: -4em;
+    padding-inline-start: 5em;
+}
+
+.select2-container--admin-autocomplete
+    .select2-results__option
+    .select2-results__option
+    .select2-results__option
+    .select2-results__option
+    .select2-results__option
     .select2-results__option
     .select2-results__option {
-    margin-left: -5em;
-    padding-left: 6em;
+    margin-inline-start: -5em;
+    padding-inline-start: 6em;
 }
 
 .select2-container--admin-autocomplete

--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -154,7 +154,7 @@ p,
 ol,
 ul,
 dl {
-    margin: 0.2em 0 0.8em 0;
+    margin: 0.2em 0 0.8em;
 }
 
 p {
@@ -178,7 +178,7 @@ h1 {
 
 h2 {
     font-size: 1rem;
-    margin: 1em 0 0.5em 0;
+    margin: 1em 0 0.5em;
 }
 
 h2.subhead {
@@ -188,21 +188,21 @@ h2.subhead {
 
 h3 {
     font-size: 0.875rem;
-    margin: 0.8em 0 0.3em 0;
+    margin: 0.8em 0 0.3em;
     color: var(--body-medium-color);
     font-weight: bold;
 }
 
 h4 {
     font-size: 0.75rem;
-    margin: 1em 0 0.8em 0;
+    margin: 1em 0 0.8em;
     padding-bottom: 3px;
     color: var(--body-medium-color);
 }
 
 h5 {
     font-size: 0.625rem;
-    margin: 1.5em 0 0.5em 0;
+    margin: 1.5em 0 0.5em;
     color: var(--body-quiet-color);
     text-transform: uppercase;
     letter-spacing: 1px;
@@ -230,7 +230,7 @@ dt {
 }
 
 dd {
-    margin-left: 0;
+    margin-inline-start: 0;
 }
 
 form {
@@ -253,9 +253,9 @@ details summary {
 blockquote {
     font-size: 0.6875rem;
     color: var(--body-quiet-color);
-    margin-left: 2px;
-    padding-left: 10px;
-    border-left: 5px solid currentColor;
+    margin-inline-start: 2px;
+    padding-inline-start: 10px;
+    border-inline-start: 5px solid currentColor;
 }
 
 code,
@@ -361,7 +361,7 @@ th {
 
 th {
     font-weight: 500;
-    text-align: left;
+    text-align: start;
 }
 
 thead th,
@@ -419,7 +419,7 @@ thead th.sorted {
 }
 
 thead th.sorted .text {
-    padding-right: 42px;
+    padding-inline-end: 42px;
 }
 
 table thead th .text span {
@@ -448,9 +448,9 @@ table thead th.sorted:hover a.sortremove {
 
 table thead th.sorted .sortoptions {
     display: block;
-    padding: 9px 5px 0 5px;
-    float: right;
-    text-align: right;
+    padding: 9px 5px 0;
+    float: inline-end;
+    text-align: end;
 }
 
 table thead th.sorted .sortpriority {
@@ -458,8 +458,7 @@ table thead th.sorted .sortpriority {
     min-width: 12px;
     text-align: center;
     vertical-align: 3px;
-    margin-left: 2px;
-    margin-right: 2px;
+    margin-inline: 2px;
 }
 
 table thead th.sorted .sortoptions a {
@@ -479,7 +478,7 @@ table thead th.sorted .sortoptions a.sortremove:after {
     content: "\\";
     position: absolute;
     top: -6px;
-    left: 3px;
+    inset-inline-start: 3px;
     font-weight: 200;
     font-size: 1.125rem;
     color: var(--body-quiet-color);
@@ -657,17 +656,16 @@ input[type="button"][disabled].default {
 .module h4,
 .module dl,
 .module pre {
-    padding-left: 10px;
-    padding-right: 10px;
+    padding-inline: 10px;
 }
 
 .module blockquote {
-    margin-left: 12px;
+    margin-inline-start: 12px;
 }
 
 .module ul,
 .module ol {
-    margin-left: 1.5em;
+    margin-inline-start: 1.5em;
 }
 
 .module h3 {
@@ -681,7 +679,7 @@ input[type="button"][disabled].default {
     padding: 8px;
     font-weight: 400;
     font-size: 0.8125rem;
-    text-align: left;
+    text-align: start;
     background: var(--header-bg);
     color: var(--header-link-color);
 }
@@ -708,8 +706,9 @@ ul.messagelist li {
     display: block;
     font-weight: 400;
     font-size: 0.8125rem;
-    padding: 10px 10px 10px 65px;
-    margin: 0 0 10px 0;
+    padding-block: 10px;
+    padding-inline: 65px 10px;
+    margin: 0 0 10px;
     color: var(--body-fg);
     word-break: break-word;
     background-color: var(--message-info-bg);
@@ -755,7 +754,7 @@ ul.messagelist li.error {
     font-weight: 700;
     display: block;
     padding: 10px 12px;
-    margin: 0 0 10px 0;
+    margin: 0 0 10px;
     color: var(--error-fg);
     border: 1px solid var(--error-fg);
     border-radius: 4px;
@@ -806,7 +805,8 @@ td ul.errorlist + textarea {
 
 .description {
     font-size: 0.75rem;
-    padding: 5px 0 0 12px;
+    padding-block: 5px 0;
+    padding-inline: 12px 0;
 }
 
 /* BREADCRUMBS */
@@ -849,28 +849,28 @@ ol.breadcrumbs a:hover {
 
 .viewlink,
 .inlineviewlink {
-    padding-left: 16px;
+    padding-inline-start: 16px;
     background: url(../img/icon-viewlink.svg) 0 center no-repeat;
 }
 
 .hidelink {
-    padding-left: 16px;
+    padding-inline-start: 16px;
     background: url(../img/icon-hidelink.svg) 0 center no-repeat;
 }
 
 .addlink {
-    padding-left: 16px;
+    padding-inline-start: 16px;
     background: url(../img/icon-addlink.svg) 0 1px no-repeat;
 }
 
 .changelink,
 .inlinechangelink {
-    padding-left: 16px;
+    padding-inline-start: 16px;
     background: url(../img/icon-changelink.svg) 0 2px no-repeat;
 }
 
 .deletelink {
-    padding-left: 16px;
+    padding-inline-start: 16px;
     background: url(../img/icon-deletelink.svg) 0 1px no-repeat;
 }
 
@@ -907,7 +907,7 @@ a.deletelink:hover {
 }
 
 .object-tools li + li {
-    margin-left: 15px;
+    margin-inline-start: 15px;
 }
 
 .object-tools a {
@@ -917,7 +917,7 @@ a.deletelink:hover {
 .object-tools a:link,
 .object-tools a:visited {
     display: block;
-    float: left;
+    float: inline-start;
     padding: 3px 12px;
     background: var(--object-tools-bg);
     color: var(--object-tools-fg);
@@ -940,7 +940,7 @@ a.deletelink:hover {
 .object-tools a.addlink {
     background-repeat: no-repeat;
     background-position: right 7px center;
-    padding-right: 26px;
+    padding-inline-end: 26px;
 }
 
 .object-tools a.viewsitelink {
@@ -1000,7 +1000,7 @@ a.deletelink:hover {
 }
 
 .skip-to-content-link:focus {
-    left: 0px;
+    inset-inline-start: 0px;
     top: 0px;
 }
 
@@ -1013,15 +1013,15 @@ a.deletelink:hover {
 }
 
 #content-main {
-    float: left;
+    float: inline-start;
     width: 100%;
 }
 
 #content-related {
-    float: right;
+    float: inline-end;
     width: 260px;
     position: relative;
-    margin-right: -300px;
+    margin-inline-end: -300px;
 }
 
 @media (forced-colors: active) {
@@ -1033,21 +1033,21 @@ a.deletelink:hover {
 /* COLUMN TYPES */
 
 .colMS {
-    margin-right: 300px;
+    margin-inline-end: 300px;
 }
 
 .colSM {
-    margin-left: 300px;
+    margin-inline-start: 300px;
 }
 
 .colSM #content-related {
-    float: left;
-    margin-right: 0;
-    margin-left: -300px;
+    float: inline-start;
+    margin-inline-end: 0;
+    margin-inline-start: -300px;
 }
 
 .colSM #content-main {
-    float: right;
+    float: inline-end;
 }
 
 .popup .colM {
@@ -1105,7 +1105,7 @@ a.deletelink:hover {
 #branding h2 {
     padding: 0 10px;
     font-size: 0.875rem;
-    margin: -8px 0 8px 0;
+    margin: -8px 0 8px;
     font-weight: normal;
     color: var(--header-color);
 }
@@ -1126,9 +1126,10 @@ a.deletelink:hover {
 }
 
 #user-tools {
-    float: right;
-    margin: 0 0 0 20px;
-    text-align: right;
+    float: inline-end;
+    margin-block: 0;
+    margin-inline: 20px 0;
+    text-align: end;
 }
 
 #user-tools,
@@ -1179,8 +1180,7 @@ a.deletelink:hover {
 }
 
 #content-related p {
-    padding-left: 16px;
-    padding-right: 16px;
+    padding-inline: 16px;
 }
 
 #content-related .actionlist {
@@ -1191,7 +1191,7 @@ a.deletelink:hover {
 #content-related .actionlist li {
     line-height: 1.2;
     margin-bottom: 10px;
-    padding-left: 18px;
+    padding-inline-start: 18px;
 }
 
 #content-related .module h2 {
@@ -1225,7 +1225,8 @@ a.deletelink:hover {
     padding: 10px 15px;
     color: var(--button-fg);
     background: var(--close-button-bg);
-    margin: 0 0 0 10px;
+    margin-block: 0;
+    margin-inline: 10px 0;
 }
 
 .delete-confirmation form .cancel-link:active,
@@ -1264,7 +1265,7 @@ a.deletelink:hover {
 
 .paginator ul {
     margin: 0;
-    margin-right: 6px;
+    margin-inline-end: 6px;
 }
 
 .paginator ul li {
@@ -1298,7 +1299,7 @@ a.deletelink:hover {
 }
 
 .paginator input {
-    margin-left: auto;
+    margin-inline-start: auto;
 }
 
 .base-svgs {
@@ -1350,9 +1351,10 @@ a.deletelink:hover {
     border: 1px solid var(--border-color);
     border-radius: 4px;
     font-size: 0.875rem;
-    padding: 0 0 0 4px;
+    padding-block: 0;
+    padding-inline: 4px 0;
     margin: 0;
-    margin-left: 10px;
+    margin-inline-start: 10px;
 }
 
 .actions select:focus {

--- a/django/contrib/admin/static/admin/css/changelists.css
+++ b/django/contrib/admin/static/admin/css/changelists.css
@@ -28,7 +28,7 @@
 }
 
 .change-list .filtered table {
-    border-right: none;
+    border-inline-end: none;
 }
 
 .change-list .filtered {
@@ -42,7 +42,7 @@
 }
 
 .change-list .filtered table tbody th {
-    padding-right: 1em;
+    padding-inline-end: 1em;
 }
 
 #changelist-form .results {
@@ -153,7 +153,7 @@
 
 #changelist-search img {
     vertical-align: middle;
-    margin-right: 4px;
+    margin-inline-end: 4px;
 }
 
 #changelist-search .help {
@@ -166,8 +166,9 @@
     flex: 0 0 240px;
     order: 1;
     background: var(--darkened-bg);
-    border-left: none;
-    margin: 0 0 0 30px;
+    border-inline-start: none;
+    margin-block: 0;
+    margin-inline: 30px 0;
 }
 
 @media (forced-colors: active) {
@@ -226,8 +227,8 @@
 
 #changelist-filter li {
     list-style-type: none;
-    margin-left: 0;
-    padding-left: 0;
+    margin-inline-start: 0;
+    padding-inline-start: 0;
 }
 
 #changelist-filter a {
@@ -241,9 +242,9 @@
 }
 
 #changelist-filter li.selected {
-    border-left: 5px solid var(--hairline-color);
-    padding-left: 10px;
-    margin-left: -15px;
+    border-inline-start: 5px solid var(--hairline-color);
+    padding-inline-start: 10px;
+    margin-inline-start: -15px;
 }
 
 #changelist-filter li.selected a {
@@ -290,7 +291,7 @@
 /* ACTIONS */
 
 .filtered .actions {
-    border-right: none;
+    border-inline-end: none;
 }
 
 #changelist table input {

--- a/django/contrib/admin/static/admin/css/dashboard.css
+++ b/django/contrib/admin/static/admin/css/dashboard.css
@@ -14,13 +14,13 @@
 
 .dashboard .module table td a {
     display: block;
-    padding-right: 0.6em;
+    padding-inline-end: 0.6em;
 }
 
 /* RECENT ACTIONS MODULE */
 
 .module ul.actionlist {
-    margin-left: 0;
+    margin-inline-start: 0;
 }
 
 ul.actionlist li {

--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -23,7 +23,7 @@
 }
 
 form .form-row p {
-    padding-left: 0;
+    padding-inline-start: 0;
 }
 
 .flex-container {
@@ -62,7 +62,7 @@ label.required {
 /* RADIO BUTTONS */
 
 form div.radiolist div {
-    padding-right: 7px;
+    padding-inline-end: 7px;
 }
 
 form div.radiolist.inline div {
@@ -71,22 +71,24 @@ form div.radiolist.inline div {
 
 form div.radiolist label {
     display: inline-block;
-    padding: 4px 10px 0 0;
+    padding-block: 4px 0;
+    padding-inline: 0 10px;
 }
 
 form div.radiolist input[type="radio"] {
-    margin: -2px 4px 0 0;
+    margin-block: -2px 0;
+    margin-inline: 0 4px;
     padding: 0;
 }
 
 form ul.inline {
-    margin-left: 0;
+    margin-inline-start: 0;
     padding: 0;
 }
 
 form ul.inline li {
-    float: left;
-    padding-right: 7px;
+    float: inline-start;
+    padding-inline-end: 7px;
 }
 
 /* FIELDSETS */
@@ -124,7 +126,7 @@ fieldset .inline-heading,
     padding: 6px 0;
     margin-top: 0;
     margin-bottom: 0;
-    margin-left: 0;
+    margin-inline-start: 0;
     overflow-wrap: break-word;
 }
 
@@ -150,7 +152,7 @@ form .aligned div.radiolist {
 }
 
 form .aligned fieldset div.help {
-    margin-left: 0;
+    margin-inline-start: 0;
 }
 
 form .aligned p.help:last-child,
@@ -164,17 +166,18 @@ form .aligned ul li {
 }
 
 form .aligned div.help ul {
-    padding-left: 0;
-    margin-left: 0;
+    padding-inline-start: 0;
+    margin-inline-start: 0;
 }
 
 form .aligned table p {
-    margin-left: 0;
-    padding-left: 0;
+    margin-inline-start: 0;
+    padding-inline-start: 0;
 }
 
 .aligned .vCheckboxLabel {
-    padding: 1px 0 0 5px;
+    padding-block: 1px 0;
+    padding-inline: 5px 0;
 }
 
 .aligned .vCheckboxLabel + p.help,
@@ -238,7 +241,7 @@ body.popup .submit-row {
 }
 
 .submit-row a.deletelink {
-    margin-left: auto;
+    margin-inline-start: auto;
 }
 
 .submit-row a.deletelink {
@@ -287,7 +290,7 @@ body.popup .submit-row {
 
 .vDateField,
 .vTimeField {
-    margin-right: 2px;
+    margin-inline-end: 2px;
     margin-bottom: 4px;
 }
 
@@ -360,16 +363,15 @@ body.popup .submit-row {
     font-size: 0.8125rem;
     background: var(--darkened-bg);
     border: 1px solid var(--hairline-color);
-    border-left-color: var(--darkened-bg);
-    border-right-color: var(--darkened-bg);
+    border-inline-color: var(--darkened-bg);
 }
 
 .inline-related h3 span.delete {
-    float: right;
+    float: inline-end;
 }
 
 .inline-related h3 span.delete label {
-    margin-left: 2px;
+    margin-inline-start: 2px;
     font-size: 0.6875rem;
 }
 
@@ -401,7 +403,8 @@ body.popup .submit-row {
 }
 
 .inline-group .tabular tr td.original {
-    padding: 2px 0 0 0;
+    padding-block: 2px 0;
+    padding-inline: 0;
     width: 0;
 }
 
@@ -416,7 +419,7 @@ body.popup .submit-row {
 
 .inline-group .tabular td.original p {
     position: absolute;
-    left: 0;
+    inset-inline-start: 0;
     height: 1.2em;
     padding: 2px 9px;
     overflow: hidden;
@@ -450,7 +453,7 @@ body.popup .submit-row {
 /* RELATED FIELD ADD ONE / LOOKUP */
 
 .related-lookup {
-    margin-left: 5px;
+    margin-inline-start: 5px;
     display: inline-block;
     vertical-align: middle;
     background-repeat: no-repeat;
@@ -465,8 +468,8 @@ body.popup .submit-row {
 
 form .related-widget-wrapper ul {
     display: inline-block;
-    margin-left: 0;
-    padding-left: 0;
+    margin-inline-start: 0;
+    padding-inline-start: 0;
 }
 
 form .related-widget-wrapper a.change-related img {

--- a/django/contrib/admin/static/admin/css/login.css
+++ b/django/contrib/admin/static/admin/css/login.css
@@ -52,7 +52,8 @@
 }
 
 .login .submit-row {
-    padding: 1em 0 0 0;
+    padding-block: 1em 0;
+    padding-inline: 0;
     margin: 0;
     text-align: center;
 }

--- a/django/contrib/admin/static/admin/css/nav_sidebar.css
+++ b/django/contrib/admin/static/admin/css/nav_sidebar.css
@@ -6,24 +6,19 @@
 
 .toggle-nav-sidebar {
     z-index: 20;
-    left: 0;
+    inset-inline-start: 0;
     display: flex;
     align-items: center;
     justify-content: center;
     flex: 0 0 23px;
     width: 23px;
     border: 0;
-    border-right: 1px solid var(--hairline-color);
+    border-inline-end: 1px solid var(--hairline-color);
     background-color: var(--body-bg);
     cursor: pointer;
     font-size: 1.25rem;
     color: var(--link-fg);
     padding: 0;
-}
-
-[dir="rtl"] .toggle-nav-sidebar {
-    border-left: 1px solid var(--hairline-color);
-    border-right: 0;
 }
 
 .toggle-nav-sidebar:hover,
@@ -34,21 +29,12 @@
 #nav-sidebar {
     z-index: 15;
     flex: 0 0 275px;
-    left: -276px;
-    margin-left: -276px;
+    inset-inline-start: -276px;
+    margin-inline-start: -276px;
     border-top: 1px solid transparent;
-    border-right: 1px solid var(--hairline-color);
+    border-inline-end: 1px solid var(--hairline-color);
     background-color: var(--body-bg);
     overflow: auto;
-}
-
-[dir="rtl"] #nav-sidebar {
-    border-left: 1px solid var(--hairline-color);
-    border-right: 0;
-    left: 0;
-    margin-left: 0;
-    right: -276px;
-    margin-right: -276px;
 }
 
 .toggle-nav-sidebar::before {
@@ -64,12 +50,8 @@
 }
 
 .main.shifted > #nav-sidebar {
-    margin-left: 0;
+    margin-inline-start: 0;
     visibility: visible;
-}
-
-[dir="rtl"] .main.shifted > #nav-sidebar {
-    margin-right: 0;
 }
 
 #nav-sidebar .module th {
@@ -79,17 +61,11 @@
 
 #nav-sidebar .module th,
 #nav-sidebar .module caption {
-    padding-left: 16px;
+    padding-inline-start: 16px;
 }
 
 #nav-sidebar .module td {
     white-space: nowrap;
-}
-
-[dir="rtl"] #nav-sidebar .module th,
-[dir="rtl"] #nav-sidebar .module caption {
-    padding-left: 8px;
-    padding-right: 16px;
 }
 
 #nav-sidebar .current-app .section:link,

--- a/django/contrib/admin/static/admin/css/responsive.css
+++ b/django/contrib/admin/static/admin/css/responsive.css
@@ -54,7 +54,7 @@ button {
         margin: 0;
         font-weight: 400;
         line-height: 1.85;
-        text-align: left;
+        text-align: start;
     }
 
     #user-tools a {
@@ -69,23 +69,23 @@ button {
     }
 
     #content-related {
-        margin-right: -290px;
+        margin-inline-end: -290px;
     }
 
     .colSM #content-related {
-        margin-left: -290px;
+        margin-inline-start: -290px;
     }
 
     .colMS {
-        margin-right: 290px;
+        margin-inline-end: 290px;
     }
 
     .colSM {
-        margin-left: 290px;
+        margin-inline-start: 290px;
     }
 
     .dashboard .module table td a {
-        padding-right: 0;
+        padding-inline-end: 0;
     }
 
     td .changelink,
@@ -114,7 +114,8 @@ button {
         flex: 1 0 auto;
         width: 0;
         height: 1.375rem;
-        margin: 0 10px 0 6px;
+        margin-block: 0;
+        margin-inline: 6px 10px;
     }
 
     #toolbar form input[type="submit"] {
@@ -124,7 +125,8 @@ button {
     #changelist-search .quiet {
         width: 0;
         flex: 1 0 auto;
-        margin: 5px 0 0 25px;
+        margin-block: 5px 0;
+        margin-inline: 25px 0;
     }
 
     .actions {
@@ -151,7 +153,8 @@ button {
     .actions span.question,
     .actions span.action-counter {
         font-size: 0.6875rem;
-        margin: 0 10px 0 0;
+        margin-block: 0;
+        margin-inline: 0 10px;
     }
 
     #changelist-filter {
@@ -220,11 +223,11 @@ button {
     .aligned .datetimeshortcuts,
     .aligned .related-lookup + strong {
         align-self: center;
-        margin-left: 0.5rem;
+        margin-inline-start: 0.5rem;
     }
 
     form .aligned div.radiolist {
-        margin-left: 2px;
+        margin-inline-start: 2px;
     }
 
     .submit-row {
@@ -346,7 +349,8 @@ button {
     /* Messages */
 
     ul.messagelist li {
-        padding: 10px 10px 10px 55px;
+        padding-block: 10px;
+        padding-inline: 55px 10px;
         background-position-x: 30px;
     }
 
@@ -435,7 +439,7 @@ button {
     }
 
     #changelist-filter {
-        margin-left: 0;
+        margin-inline-start: 0;
     }
 
     .actions label {
@@ -505,7 +509,8 @@ button {
 
     .aligned .vCheckboxLabel {
         flex: 1 0;
-        padding: 1px 0 0 5px;
+        padding-block: 1px 0;
+        padding-inline: 5px 0;
     }
 
     .aligned p.file-upload {
@@ -513,7 +518,7 @@ button {
     }
 
     span.clearable-file-input {
-        margin-left: 15px;
+        margin-inline-start: 15px;
     }
 
     span.clearable-file-input label {
@@ -576,7 +581,7 @@ button {
     }
 
     .selector ul.selector-chooser li {
-        float: left;
+        float: inline-start;
     }
 
     .selector-remove {
@@ -639,7 +644,7 @@ button {
     }
 
     .inline-group[data-inline-type="stacked"] .inline-related h3 .inline_label {
-        margin-right: auto;
+        margin-inline-end: auto;
     }
 
     .inline-group[data-inline-type="stacked"] .inline-related h3 span.delete {
@@ -673,7 +678,8 @@ button {
     .inline-group div.add-row a,
     .inline-group .tabular tr.add-row td a {
         display: block;
-        padding: 8px 10px 8px 26px;
+        padding-block: 8px;
+        padding-inline: 26px 10px;
         background-position: 8px 9px;
     }
 
@@ -704,7 +710,8 @@ button {
     /* Messages */
 
     ul.messagelist li {
-        padding: 10px 10px 10px 40px;
+        padding-block: 10px;
+        padding-inline: 40px 10px;
         background-position-x: 15px;
     }
 
@@ -775,7 +782,7 @@ button {
     .clockbox {
         position: fixed !important;
         top: 50% !important;
-        left: 50% !important;
+        inset-inline-start: 50% !important;
         transform: translate(-50%, -50%);
         margin: 0;
         border: none;

--- a/django/contrib/admin/static/admin/css/responsive_rtl.css
+++ b/django/contrib/admin/static/admin/css/responsive_rtl.css
@@ -1,46 +1,12 @@
 /* TABLETS */
 
 @media (max-width: 1024px) {
-    [dir="rtl"] .colMS {
-        margin-right: 0;
-    }
-
-    [dir="rtl"] #user-tools {
-        text-align: right;
-    }
-
-    [dir="rtl"] .actions label {
-        padding-left: 10px;
-        padding-right: 0;
-    }
-
-    [dir="rtl"] .actions select {
-        margin-left: 0;
-        margin-right: 15px;
-    }
-
-    [dir="rtl"] .change-list .filtered .results,
-    [dir="rtl"] .change-list .filtered .paginator,
-    [dir="rtl"] .filtered #toolbar,
-    [dir="rtl"] .filtered div.xfull,
-    [dir="rtl"] .filtered .actions,
-    [dir="rtl"] #changelist-filter {
-        margin-left: 0;
-    }
-
     [dir="rtl"] .inline-group div.add-row a,
     [dir="rtl"] .inline-group .tabular tr.add-row td a {
-        padding: 8px 26px 8px 10px;
         background-position: calc(100% - 8px) 9px;
     }
 
-    [dir="rtl"] .dashboard .module table td a {
-        padding-left: 0;
-        padding-right: 16px;
-    }
-
     [dir="rtl"] ul.messagelist li {
-        padding: 10px 55px 10px 10px;
         background-position-x: calc(100% - 30px);
     }
 }
@@ -48,15 +14,6 @@
 /* MOBILE */
 
 @media (max-width: 767px) {
-    [dir="rtl"] #changelist-filter {
-        margin-left: 0;
-        margin-right: 0;
-    }
-
-    [dir="rtl"] .aligned .vCheckboxLabel {
-        padding: 1px 5px 0 0;
-    }
-
     [dir="rtl"] .selector-remove {
         background-position: 0 0;
     }
@@ -76,7 +33,6 @@
     }
 
     [dir="rtl"] ul.messagelist li {
-        padding: 10px 40px 10px 10px;
         background-position-x: calc(100% - 15px);
     }
 }

--- a/django/contrib/admin/static/admin/css/rtl.css
+++ b/django/contrib/admin/static/admin/css/rtl.css
@@ -1,127 +1,21 @@
 /* GLOBAL */
 
-th {
-    text-align: right;
-}
-
-.module h2,
-.module caption {
-    text-align: right;
-}
-
-.module ul,
-.module ol {
-    margin-left: 0;
-    margin-right: 1.5em;
-}
-
 .viewlink,
+.inlineviewlink,
 .addlink,
 .changelink,
+.inlinechangelink,
 .hidelink {
-    padding-left: 0;
-    padding-right: 16px;
     background-position-x: 100%;
 }
 
 .deletelink {
-    padding-left: 0;
-    padding-right: 16px;
     background-position: 100% 1px;
 }
 
-.object-tools li + li {
-    margin-right: 15px;
-    margin-left: 0;
-}
-
-thead th:first-child,
-tfoot td:first-child {
-    border-left: none;
-}
-
-/* LAYOUT */
-
-#user-tools {
-    right: auto;
-    left: 0;
-    text-align: left;
-}
-
-div.breadcrumbs {
-    text-align: right;
-}
-
-#content-main {
-    float: right;
-}
-
-#content-related {
-    float: left;
-    margin-left: -300px;
-    margin-right: auto;
-}
-
-.colMS {
-    margin-left: 300px;
-    margin-right: 0;
-}
-
-/* SORTABLE TABLES */
-
-table thead th.sorted .sortoptions {
-    float: left;
-}
-
-thead th.sorted .text {
-    padding-right: 0;
-    padding-left: 42px;
-}
-
-/* dashboard styles */
-
-.dashboard .module table td a {
-    padding-left: 0.6em;
-    padding-right: 16px;
-}
-
-/* changelists styles */
-
-.change-list .filtered table {
-    border-left: none;
-    border-right: 0px none;
-}
-
-#changelist-filter {
-    border-left: none;
-    border-right: none;
-    margin-left: 0;
-    margin-right: 30px;
-}
-
-#changelist-filter li.selected {
-    border-left: none;
-    padding-left: 10px;
-    margin-left: 0;
-    border-right: 5px solid var(--hairline-color);
-    padding-right: 10px;
-    margin-right: -15px;
-}
-
-#changelist table tbody td:first-child,
-#changelist table tbody th:first-child {
-    border-right: none;
-    border-left: none;
-}
-
-.paginator ul {
-    margin-left: 6px;
-    margin-right: 0;
-}
-
-.paginator input {
-    margin-left: 0;
-    margin-right: auto;
+.object-tools a.viewsitelink,
+.object-tools a.addlink {
+    background-position: left 7px center;
 }
 
 /* FORMS */
@@ -130,43 +24,14 @@ form .aligned ul {
     margin: 0;
 }
 
-form ul.inline li {
-    float: right;
-    padding-right: 0;
-    padding-left: 7px;
-}
-
-.submit-row {
-    text-align: right;
-}
-
 /* WIDGETS */
 
 .calendarnav-previous {
-    top: 0;
-    left: auto;
-    right: 10px;
     background: url(../img/calendar-icons.svg) 0 -15px no-repeat;
 }
 
 .calendarnav-next {
-    top: 0;
-    right: auto;
-    left: 10px;
     background: url(../img/calendar-icons.svg) 0 0 no-repeat;
-}
-
-.calendar caption,
-.calendarbox h2 {
-    text-align: center;
-}
-
-.selector {
-    float: right;
-}
-
-.selector .selector-filter {
-    text-align: right;
 }
 
 .selector-add {
@@ -199,47 +64,12 @@ form ul.inline li {
     background-position: 0 -176px;
 }
 
-.inline-deletelink {
-    float: left;
-}
-
 form .form-row p.datetime {
     overflow: hidden;
 }
 
-.related-widget-wrapper {
-    float: right;
-}
-
 /* MISC */
 
-.inline-related h2,
-.inline-group h2 {
-    text-align: right;
-}
-
-.inline-related h3 span.delete {
-    padding-right: 20px;
-    padding-left: inherit;
-    left: 10px;
-    right: inherit;
-    float: left;
-}
-
-.inline-related h3 span.delete label {
-    margin-left: inherit;
-    margin-right: 2px;
-}
-
-.inline-group .tabular td.original p {
-    right: 0;
-}
-
-.selector .selector-chooser {
-    margin: 0;
-}
-
 ul.messagelist li {
-    padding: 10px 65px 10px 10px;
     background-position-x: calc(100% - 40px);
 }

--- a/django/contrib/admin/static/admin/css/widgets.css
+++ b/django/contrib/admin/static/admin/css/widgets.css
@@ -73,14 +73,14 @@
     color: var(--body-quiet-color);
     font-size: 0.625rem;
     margin: 0;
-    text-align: left;
+    text-align: start;
     display: flex;
     gap: 8px;
 }
 
 .selector .selector-filter label,
 .inline-group .aligned .selector .selector-filter label {
-    float: left;
+    float: inline-start;
     margin: 7px 0 0;
     width: 18px;
     height: 18px;
@@ -172,7 +172,7 @@
 .selector-chooseall,
 .selector-clearall {
     display: inline-block;
-    text-align: left;
+    text-align: start;
     padding: 4px 5px;
     margin: 0 auto;
     overflow: hidden;
@@ -214,7 +214,7 @@
 /* STACKED SELECTORS */
 
 .stacked {
-    float: left;
+    float: inline-start;
     width: 490px;
     display: block;
 }
@@ -241,15 +241,16 @@
     display: flex;
     height: 30px;
     width: 64px;
-    margin: 0 auto 10px auto;
+    margin: 0 auto 10px;
     background-color: #eee;
     border-radius: 10px;
     transform: none;
 }
 
 .stacked .selector-chooser li {
-    float: left;
-    padding: 3px 3px 3px 5px;
+    float: inline-start;
+    padding-block: 3px;
+    padding-inline: 5px 3px;
 }
 
 .stacked .selector-chooseall,
@@ -295,7 +296,8 @@
     background: url(../img/icon-unknown.svg) 0 0 no-repeat;
     display: inline-block;
     vertical-align: middle;
-    margin: -2px 0 0 2px;
+    margin-block: -2px 0;
+    margin-inline: 2px 0;
     width: 13px;
     height: 13px;
 }
@@ -341,8 +343,8 @@ p.datetime label {
 
 table p.datetime {
     font-size: 0.6875rem;
-    margin-left: 0;
-    padding-left: 0;
+    margin-inline-start: 0;
+    padding-inline-start: 0;
 }
 
 .datetimeshortcuts button {
@@ -419,7 +421,7 @@ p.file-upload {
 }
 
 .file-upload .deletelink {
-    margin-left: 5px;
+    margin-inline-start: 5px;
 }
 
 span.clearable-file-input label {
@@ -567,12 +569,12 @@ span.clearable-file-input label {
 }
 
 .calendarnav-previous {
-    left: 10px;
+    inset-inline-start: 10px;
     background: url(../img/calendar-icons.svg) 0 0 no-repeat;
 }
 
 .calendarnav-next {
-    right: 10px;
+    inset-inline-end: 10px;
     background: url(../img/calendar-icons.svg) 0 -15px no-repeat;
 }
 
@@ -609,7 +611,7 @@ ul.timelist,
 /* EDIT INLINE */
 
 .inline-deletelink {
-    float: right;
+    float: inline-end;
     text-indent: -9999px;
     background: url(../img/inline-delete.svg) center center no-repeat;
     background-size: contain;

--- a/django/contrib/gis/static/gis/css/ol3.css
+++ b/django/contrib/gis/static/gis/css/ol3.css
@@ -1,9 +1,6 @@
 .dj_map_wrapper {
     position: relative;
-    float: left;
-}
-html[dir="rtl"] .dj_map_wrapper {
-    float: right;
+    float: inline-start;
 }
 
 .switch-type {
@@ -16,7 +13,7 @@ html[dir="rtl"] .dj_map_wrapper {
 
 .type-Point {
     background-image: url("../img/draw_point_off.svg");
-    right: 5px;
+    inset-inline-end: 5px;
 }
 .type-Point.type-active {
     background-image: url("../img/draw_point_on.svg");
@@ -24,7 +21,7 @@ html[dir="rtl"] .dj_map_wrapper {
 
 .type-LineString {
     background-image: url("../img/draw_line_off.svg");
-    right: 30px;
+    inset-inline-end: 30px;
 }
 .type-LineString.type-active {
     background-image: url("../img/draw_line_on.svg");
@@ -32,7 +29,7 @@ html[dir="rtl"] .dj_map_wrapper {
 
 .type-Polygon {
     background-image: url("../img/draw_polygon_off.svg");
-    right: 55px;
+    inset-inline-end: 55px;
 }
 .type-Polygon.type-active {
     background-image: url("../img/draw_polygon_on.svg");

--- a/docs/_theme/djangodocs-epub/static/epub.css
+++ b/docs/_theme/djangodocs-epub/static/epub.css
@@ -6,7 +6,8 @@ h1 {
 ol,
 ul {
     margin: 0;
-    padding: 0 0 0 1.3em;
+    padding-block: 0;
+    padding-inline: 1.3em 0;
 }
 
 /* Images should never exceed the width of the page. */
@@ -24,13 +25,13 @@ img {
     text-align: center;
 }
 .epub-cover h1 {
-    margin: 4em 0 0 0;
+    margin: 4em 0 0;
 }
 .epub-cover h2 {
     margin: 1em 0;
 }
 .epub-cover h3 {
-    margin: 3em 0 2em 0;
+    margin: 3em 0 2em;
 }
 
 /* Code examples should never exceed the width of the page, so wrap instead. */
@@ -72,7 +73,8 @@ fitted after the icon, to allow text resizing with breaking. */
 .admonition {
     background-position: 9px 0.8em;
     background-repeat: no-repeat;
-    padding: 0.8em 1em 0.8em 65px;
+    padding-block: 0.8em;
+    padding-inline: 65px 1em;
     margin: 1em 0;
     border: 0.01em solid black;
 }

--- a/docs/_theme/djangodocs/static/console-tabs.css
+++ b/docs/_theme/djangodocs/static/console-tabs.css
@@ -1,7 +1,7 @@
 @import url("{{ pathto('_static/fontawesome/css/fa-brands.min.css', 1) }}");
 
 .console-block {
-    text-align: right;
+    text-align: end;
 }
 
 .console-block *:before,
@@ -11,7 +11,7 @@
 
 .console-block > section {
     display: none;
-    text-align: left;
+    text-align: start;
 }
 
 .console-block > input.c-tab-unix,

--- a/docs/_theme/djangodocs/static/djangodocs.css
+++ b/docs/_theme/djangodocs/static/djangodocs.css
@@ -14,12 +14,12 @@ body {
     min-width: 995px;
     max-width: 100em;
     margin: auto;
-    text-align: left;
+    text-align: start;
     padding-top: 16px;
     margin-top: 0;
 }
 #hd {
-    padding: 4px 0 12px 0;
+    padding: 4px 0 12px;
 }
 #bd {
     background: #234f32;
@@ -75,7 +75,7 @@ a.reference em {
 /*** sidebar ***/
 #sidebar div.sphinxsidebarwrapper {
     font-size: 92%;
-    margin-right: 14px;
+    margin-inline-end: 14px;
 }
 #sidebar h3,
 #sidebar h4 {
@@ -98,7 +98,7 @@ a.reference em {
 div.nav {
     margin: 0;
     font-size: 11px;
-    text-align: right;
+    text-align: end;
     color: #487858;
 }
 #hd div.nav {
@@ -113,7 +113,7 @@ div.nav {
 #global-nav {
     position: absolute;
     top: 5px;
-    margin-left: -5px;
+    margin-inline-start: -5px;
     padding: 7px 0;
     color: #263e2b;
 }
@@ -125,7 +125,7 @@ div.nav {
     padding: 0 4px;
 }
 #global-nav a.about {
-    padding-left: 0;
+    padding-inline-start: 0;
 }
 #global-nav:hover {
     color: #fff;
@@ -140,15 +140,16 @@ div.nav {
     position: relative;
 }
 #yui-main div.yui-b {
-    margin: 0 0 0 20px;
+    margin-block: 0;
+    margin-inline: 20px 0;
     background: white;
     color: black;
-    padding: 0.3em 2em 1em 2em;
+    padding: 0.3em 2em 1em;
 }
 
 /*** basic styles ***/
 dd {
-    margin-left: 15px;
+    margin-inline-start: 15px;
 }
 h1,
 h2,
@@ -218,8 +219,7 @@ dl {
 }
 #yui-main div.yui-b img {
     max-width: 50em;
-    margin-left: auto;
-    margin-right: auto;
+    margin-inline: auto;
     display: block;
 }
 caption {
@@ -227,7 +227,7 @@ caption {
     font-weight: bold;
     margin-top: 0.5em;
     margin-bottom: 0.5em;
-    margin-left: 2px;
+    margin-inline-start: 2px;
     text-align: center;
 }
 blockquote {
@@ -237,7 +237,7 @@ blockquote {
         125% / 1.2em "Trebuchet MS",
         sans-serif;
     color: #234f32;
-    border-left: 2px solid #94da3a;
+    border-inline-start: 2px solid #94da3a;
 }
 strong {
     font-weight: bold;
@@ -252,10 +252,10 @@ ins {
 
 /*** lists ***/
 ul {
-    padding-left: 30px;
+    padding-inline-start: 30px;
 }
 ol {
-    padding-left: 30px;
+    padding-inline-start: 30px;
 }
 ol.arabic li {
     list-style-type: decimal;
@@ -274,17 +274,17 @@ ol li {
     margin-bottom: 0.4em;
 }
 ul ul {
-    padding-left: 1.2em;
+    padding-inline-start: 1.2em;
 }
 ul ul ul {
-    padding-left: 1em;
+    padding-inline-start: 1em;
 }
 ul.linklist,
 ul.toc {
-    padding-left: 0;
+    padding-inline-start: 0;
 }
 ul.toc ul {
-    margin-left: 0.6em;
+    margin-inline-start: 0.6em;
 }
 ul.toc ul li {
     list-style-type: square;
@@ -311,7 +311,7 @@ ol.toc li {
     font-size: 125%;
     padding: 0.5em;
     line-height: 1.2em;
-    clear: right;
+    clear: inline-end;
 }
 ol.toc li.b {
     background-color: #e0ffb8;
@@ -322,9 +322,9 @@ ol.toc li a:hover {
 }
 ol.toc span.release-date {
     color: #487858;
-    float: right;
+    float: inline-end;
     font-size: 85%;
-    padding-right: 0.5em;
+    padding-inline-end: 0.5em;
 }
 ol.toc span.comment-count {
     font-size: 75%;
@@ -348,7 +348,7 @@ table.docutils th {
 }
 table.docutils thead th {
     border-bottom: 2px solid #dfdfdf;
-    text-align: left;
+    text-align: start;
     font-weight: bold;
     white-space: nowrap;
 }
@@ -446,15 +446,15 @@ div.literal-block-wrapper pre {
 }
 .note,
 .admonition {
-    padding-left: 65px;
+    padding-inline-start: 65px;
     background: url(docicons-note.png) 0.8em 0.8em no-repeat;
 }
 div.admonition-philosophy {
-    padding-left: 65px;
+    padding-inline-start: 65px;
     background: url(docicons-philosophy.png) 0.8em 0.8em no-repeat;
 }
 div.admonition-behind-the-scenes {
-    padding-left: 65px;
+    padding-inline-start: 65px;
     background: url(docicons-behindscenes.png) 0.8em 0.8em no-repeat;
 }
 .admonition.warning {
@@ -478,7 +478,7 @@ div.deprecated {
 a.headerlink {
     color: #c60f0f;
     font-size: 0.8em;
-    margin-left: 4px;
+    margin-inline-start: 4px;
     opacity: 0;
     text-decoration: none;
 }
@@ -497,7 +497,7 @@ a.headerlink:focus {
 
 /*** index ***/
 table.indextable td {
-    text-align: left;
+    text-align: start;
     vertical-align: top;
 }
 table.indextable dl,

--- a/docs/_theme/djangodocs/static/homepage.css
+++ b/docs/_theme/djangodocs/static/homepage.css
@@ -10,11 +10,12 @@
 }
 
 #index #s-getting-help {
-    float: right;
+    float: inline-end;
     width: 35em;
     background: #e1ece2;
     padding: 1em;
-    margin: 2em 0 2em 2em;
+    margin-block: 2em;
+    margin-inline: 2em 0;
 }
 #index #s-getting-help h2 {
     margin: 0;
@@ -26,7 +27,8 @@
 #index #s-django-documentation div.section div.section {
     background: #e1ece2;
     padding: 1em;
-    margin: 2em 0 2em 40.3em;
+    margin-block: 2em;
+    margin-inline: 40.3em 0;
 }
 #index #s-django-documentation div.section div.section a.reference {
     white-space: nowrap;
@@ -36,7 +38,7 @@
 #index #s-add-on-contrib-applications dl,
 #index #s-solving-specific-problems dl,
 #index #s-reference dl {
-    float: left;
+    float: inline-start;
     width: 41em;
 }
 
@@ -44,5 +46,5 @@
 #index #s-solving-specific-problems,
 #index #s-reference,
 #index #s-and-all-the-rest {
-    clear: left;
+    clear: inline-start;
 }


### PR DESCRIPTION
#### Trac ticket number
[37266](https://code.djangoproject.com/ticket/37266)

#### Branch description
Provide a concise overview of the issue or rationale behind the proposed changes.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Originally coded with Claude Opus 4.7, updated with 4.8, some hand-editing for the comments and user facing strings. Then up to 5.0 :) to fix all the linting, and do a bunch of testing to check for regressions. I don't think I even wrote any code myself on this one.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.

This change has led to some visual changes in RTL (but not in LTR). I consider them all to be improvements as they more closely match what you'd expect when mirroring the LTR. Screenshots of changes below (some are quite small, bit of padding, etc.)

Change list before:
<img width="1440" height="900" alt="changelist-1-before" src="https://github.com/user-attachments/assets/df0de813-915f-4b89-b4b6-a0b88d1ecdb6" />

Change list after:
<img width="1440" height="900" alt="changelist-2-after" src="https://github.com/user-attachments/assets/3d24a8c8-81c5-47e6-aa7a-de16906613ed" />

Change form before:
<img width="1440" height="2146" alt="change-form-1-before" src="https://github.com/user-attachments/assets/bc65aefa-fb05-41f1-9b14-c8442120b6e7" />

Change form after:
<img width="1440" height="2146" alt="change-form-2-after" src="https://github.com/user-attachments/assets/3eb9515c-9dee-4637-bc3f-f4e733750516" />

Delete confirm before:
<img width="1440" height="900" alt="delete-confirm-1-before" src="https://github.com/user-attachments/assets/b750179b-ceae-48f0-91a9-1f63dae69505" />

Delete confirm after:
<img width="1440" height="900" alt="delete-confirm-2-after" src="https://github.com/user-attachments/assets/6e4e9cc3-099d-4311-80ed-7de235966285" />


The AI made it easy to iterate over all the pages and check for changes in computed styles, so I'm much more confident than I feel I should be for a change of this size.