### PR TITLE
Fixed #37014 -- Emulated db_default in SQLite by omitting columns from INSERT.

### DIFF
--- a/django/db/backends/sqlite3/compiler.py
+++ b/django/db/backends/sqlite3/compiler.py
@@ -1,0 +1,94 @@
+from itertools import groupby
+
+from django.db.models.expressions import DatabaseDefault
+
+from django.db.models.sql.compiler import (  # isort:skip
+    SQLAggregateCompiler,
+    SQLCompiler,
+    SQLDeleteCompiler,
+    SQLInsertCompiler as BaseSQLInsertCompiler,
+    SQLUpdateCompiler,
+)
+
+__all__ = [
+    "SQLAggregateCompiler",
+    "SQLCompiler",
+    "SQLDeleteCompiler",
+    "SQLInsertCompiler",
+    "SQLUpdateCompiler",
+]
+
+
+class SQLInsertCompiler(BaseSQLInsertCompiler):
+    def _is_db_default(self, field, val):
+        if isinstance(val, DatabaseDefault):
+            return True
+        if val is None and field.db_default is not None and not field.null:
+            return True
+        return False
+
+    def pre_save_val(self, field, obj):
+        val = super().pre_save_val(field, obj)
+        if self._is_db_default(field, val):
+            return None
+        return val
+
+    def as_sql(self):
+        # SQLite lacks a DEFAULT keyword for INSERT statements. Columns with
+        # a DatabaseDefault must be omitted from the column list to trigger
+        # the internal database schema default.
+        if self.query.objs:
+            first_obj = self.query.objs[0]
+            base_pre_save_val = super().pre_save_val
+            static_fields = [
+                field
+                for field in self.query.fields
+                if not self._is_db_default(field, base_pre_save_val(field, first_obj))
+            ]
+
+            original_fields = self.query.fields
+            self.query.fields = static_fields
+            try:
+                return super().as_sql()
+            finally:
+                self.query.fields = original_fields
+
+        return super().as_sql()
+
+    def execute_sql(self, returning_fields=None):
+        if len(self.query.objs) <= 1:
+            return super().execute_sql(returning_fields)
+
+        default_fields = [f for f in self.query.fields if f.db_default is not None]
+        if not default_fields:
+            return super().execute_sql(returning_fields)
+
+        base_pre_save_val = super().pre_save_val
+
+        def get_signature(obj):
+            return tuple(
+                self._is_db_default(f, base_pre_save_val(f, obj))
+                for f in default_fields
+            )
+
+        batches = [
+            list(group) for _, group in groupby(self.query.objs, key=get_signature)
+        ]
+
+        if len(batches) == 1:
+            return super().execute_sql(returning_fields)
+
+        # Partition into contiguous batches with identical signatures to
+        # maximize bulk efficiency while preserving insertion order.
+        results = []
+        for batch_objs in batches:
+            batch_query = self.query.chain()
+            batch_query.objs = batch_objs
+
+            res = batch_query.get_compiler(self.using).execute_sql(returning_fields)
+            if returning_fields:
+                results.extend(res)
+            else:
+                results.append(res)
+
+        return results

--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -54,7 +54,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         "expressions.tests.FTimeDeltaTests.test_mixed_comparisons1",
     }
     insert_test_table_with_defaults = 'INSERT INTO {} ("null") VALUES (1)'
-    supports_default_keyword_in_insert = False
+    supports_default_keyword_in_insert = True
     supports_unlimited_charfield = True
     supports_no_precision_decimalfield = True
     can_return_columns_from_insert = True

--- a/django/db/backends/sqlite3/operations.py
+++ b/django/db/backends/sqlite3/operations.py
@@ -27,6 +27,7 @@ DATETIME_FIELDS = (models.DateField, models.DateTimeField, models.TimeField)
 
 
 class DatabaseOperations(BaseDatabaseOperations):
+    compiler_module = "django.db.backends.sqlite3.compiler"
     cast_char_field_without_max_length = "text"
     cast_data_types = {
         "DateField": "TEXT",

--- a/tests/expressions/models.py
+++ b/tests/expressions/models.py
@@ -5,6 +5,7 @@ Tests for F() query expression syntax.
 import uuid
 
 from django.db import models
+from django.db.models.functions import ExtractHour, Now
 
 
 class Manager(models.Model):
@@ -122,3 +123,8 @@ class JSONFieldModel(models.Model):
 
     class Meta:
         required_db_features = {"supports_json_field"}
+
+
+class SQLiteTimezoneEmulationModel(models.Model):
+    other_field = models.CharField(max_length=100, db_default="default_val")
+    created_hour = models.IntegerField(db_default=ExtractHour(Now()))

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -75,8 +75,10 @@ from django.test.utils import (
     Approximate,
     CaptureQueriesContext,
     isolate_apps,
+    override_settings,
     register_lookup,
 )
+from django.utils import timezone
 from django.utils.functional import SimpleLazyObject
 from django.utils.version import PY314
 
@@ -92,6 +94,7 @@ from .models import (
     RemoteEmployee,
     Result,
     SimulationRun,
+    SQLiteTimezoneEmulationModel,
     Text,
     Time,
 )
@@ -3052,3 +3055,38 @@ class OrderByTests(SimpleTestCase):
             F("field").asc(nulls_first=False)
         with self.assertRaisesMessage(ValueError, msg):
             F("field").desc(nulls_last=False)
+
+
+class SQLiteTimezoneEmulationTests(TestCase):
+    @override_settings(USE_TZ=True, TIME_ZONE="UTC")
+    def test_db_default_emulation_ignores_override(self):
+        expected_hour = timezone.now().hour
+
+        with self.settings(TIME_ZONE="Asia/Kathmandu"):
+            obj = SQLiteTimezoneEmulationModel.objects.create()
+            obj.refresh_from_db()
+            self.assertEqual(obj.created_hour, expected_hour)
+
+    @override_settings(USE_TZ=True, TIME_ZONE="UTC")
+    def test_db_default_bulk_create_mix(self):
+        expected_hour = timezone.now().hour
+
+        with self.settings(TIME_ZONE="Asia/Kathmandu"):
+            SQLiteTimezoneEmulationModel.objects.bulk_create(
+                [
+                    SQLiteTimezoneEmulationModel(
+                        other_field="provided", created_hour=99
+                    ),
+                    SQLiteTimezoneEmulationModel(other_field="defaulted"),
+                ]
+            )
+
+            obj_provided = SQLiteTimezoneEmulationModel.objects.get(
+                other_field="provided"
+            )
+            obj_defaulted = SQLiteTimezoneEmulationModel.objects.get(
+                other_field="defaulted"
+            )
+
+            self.assertEqual(obj_provided.created_hour, 99)
+            self.assertEqual(obj_defaulted.created_hour, expected_hour)


### PR DESCRIPTION
SQLite lacks a DEFAULT keyword for INSERT statements, which previously forced a Python-side emulation of database defaults which resulted in incorrect transformations when global state, such as overridden timezones in tests, interfered with the expected capturing of expressions like Now() or Extract() at definition time.

Moving the responsibility for default value from Python-side to database was necessary to guarantee consistent behavior. This ensured the database's internal state is respected regardless of the Django process's configuration or test environment overrides.

Thanks, Jacob Walls for the report.

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37014

#### Branch description
Moved the responsibility for db_default generation from the Python layer to the database schema by implementing a custom SQLInsertCompiler for SQLite. By omitting columns using DatabaseDefault from the INSERT statement, the database is forced to handle value generation natively. This prevents incorrect value transformations that previously occurred when global state, such as overridden TIME_ZONE settings in tests, interfered with expressions like Now() or Extract() before they reached the database.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
I used Gemini's assistance in implementing the SQLInsertCompiler logic.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
