### PR TITLE
Fixed #37057 -- Adjusted UniqueConstraint handling of UNKNOWN condition.

### DIFF
--- a/django/db/models/constraints.py
+++ b/django/db/models/constraints.py
@@ -6,6 +6,8 @@ from django.core.exceptions import FieldDoesNotExist, ValidationError
 from django.db import connections
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.expressions import Exists, ExpressionList, F, RawSQL
+from django.db.models.fields import BooleanField
+from django.db.models.functions import Coalesce
 from django.db.models.indexes import IndexExpression
 from django.db.models.lookups import Exact, IsNull
 from django.db.models.query_utils import Q
@@ -212,7 +214,11 @@ class CheckConstraint(BaseConstraint):
         # Ignore constraints with excluded fields in condition.
         if exclude and self._expression_refs_exclude(model, self.condition, exclude):
             return
-        if not Q(self.condition).check(against, using=using):
+        condition = self.condition
+        if connections[using].features.supports_comparing_boolean_expr:
+            # Checks constraints do not fail when they evaluate to UNKNOWN.
+            condition = Coalesce(condition, True, output_field=BooleanField())
+        if not Q(condition).check(against, using=using):
             raise ValidationError(
                 self.get_violation_error_message(), code=self.violation_error_code
             )

--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -165,8 +165,7 @@ class Q(tree.Node):
         matches against the expressions.
         """
         # Avoid circular imports.
-        from django.db.models import BooleanField, Value
-        from django.db.models.functions import Coalesce
+        from django.db.models import Value
         from django.db.models.sql import Query
         from django.db.models.sql.constants import SINGLE
 
@@ -178,10 +177,7 @@ class Q(tree.Node):
         query.add_annotation(Value(1), "_check")
         connection = connections[using]
         # This will raise a FieldError if a field is missing in "against".
-        if connection.features.supports_comparing_boolean_expr:
-            query.add_q(Q(Coalesce(self, True, output_field=BooleanField())))
-        else:
-            query.add_q(self)
+        query.add_q(self)
         compiler = query.get_compiler(using=using)
         context_manager = (
             transaction.atomic(using=using)

--- a/tests/constraints/tests.py
+++ b/tests/constraints/tests.py
@@ -1297,6 +1297,19 @@ class UniqueConstraintTests(TestCase):
         with self.assertRaisesMessage(ValidationError, msg):
             constraint.validate(Product, Product(price=None))
 
+    @skipUnlessDBFeature("supports_comparing_boolean_expr")
+    def test_validate_nullable_condition(self):
+        GeneratedFieldStoredProduct.objects.create(name="Product", price=42)
+        constraint = models.UniqueConstraint(
+            fields=["name"],
+            name="uniq_name_for_positive_price",
+            condition=models.Q(price__gt=0),
+        )
+        constraint.validate(
+            GeneratedFieldStoredProduct,
+            GeneratedFieldStoredProduct(name="Product", price=None),
+        )
+
     def test_name(self):
         constraints = get_constraints(UniqueConstraintProduct._meta.db_table)
         expected_name = "name_color_uniq"


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37057

#### Branch description

When we adjusted `UNKNOWN` handling for `CheckConstraint` in refs #16038 (ticket-33996) we assumed that all usage of `Q.check` would benefit from this approach.

However while `CHECK` constraints enforcement do ignore conditions involving `NULL` that resolve to `UNKNOWN` it's not the case for other type of constraints such as `UNIQUE` ones.

Given how `UNKNOWN` should be treated depends on the callers context it appears that a better strategy for `COALESCE` wrapping is to force them to apply it if necessary.

Thanks @drews for the report.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
