### PR TITLE
Fixed #32915 -- Surfaced settings import errors in management commands.

### DIFF
--- a/django/core/management/__init__.py
+++ b/django/core/management/__init__.py
@@ -352,6 +352,28 @@ class ManagementUtility:
         sys.exit(0)
 
     def execute(self):
+        try:
+            self._execute()
+        finally:
+            # Surface settings-loading errors on every exit path. Only fires
+            # when the user asked for a settings module (via
+            # DJANGO_SETTINGS_MODULE or --settings); commands like startproject
+            # legitimately run without any settings configured. Skip during
+            # bash completion, whose stdout is consumed by the shell (#32915).
+            if (
+                self.settings_exception is not None
+                and os.environ.get("DJANGO_SETTINGS_MODULE")
+                and "DJANGO_AUTO_COMPLETE" not in os.environ
+            ):
+                style = color_style()
+                sys.stderr.write(
+                    style.NOTICE(
+                        "Note that settings are not properly configured "
+                        "(error: %s).\n" % self.settings_exception
+                    )
+                )
+
+    def _execute(self):
         """
         Given the command-line arguments, figure out which subcommand is being
         run, create a parser appropriate to that command, and run it.

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -272,6 +272,12 @@ Management Commands
   :data:`~django.db.models.signals.m2m_changed` signals with ``raw=True`` when
   loading fixtures.
 
+* ``django-admin`` and ``manage.py`` now display a notice on standard error
+  when the configured settings module fails to import, regardless of the
+  subcommand invoked. Previously this notice was shown only when running
+  ``manage.py`` with no arguments, so other commands could complete silently
+  despite broken settings.
+
 Migrations
 ~~~~~~~~~~
 

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -112,7 +112,7 @@ class AdminScriptTestCase(SimpleTestCase):
                 paths.append(os.path.dirname(backend_dir))
         return paths
 
-    def run_test(self, args, settings_file=None, apps=None, umask=-1):
+    def run_test(self, args, settings_file=None, apps=None, umask=-1, extra_env=None):
         base_dir = os.path.dirname(self.test_dir)
         # The base dir for Django's tests is one level up.
         tests_dir = os.path.dirname(os.path.dirname(__file__))
@@ -135,6 +135,8 @@ class AdminScriptTestCase(SimpleTestCase):
         test_environ["PYTHONPATH"] = os.pathsep.join(python_path)
         test_environ["PYTHONWARNINGS"] = ""
         test_environ["PYTHON_COLORS"] = "0"
+        if extra_env:
+            test_environ.update(extra_env)
 
         p = subprocess.run(
             [sys.executable, *args],
@@ -149,7 +151,7 @@ class AdminScriptTestCase(SimpleTestCase):
     def run_django_admin(self, args, settings_file=None, umask=-1):
         return self.run_test(["-m", "django", *args], settings_file, umask=umask)
 
-    def run_manage(self, args, settings_file=None, manage_py=None):
+    def run_manage(self, args, settings_file=None, manage_py=None, extra_env=None):
         template_manage_py = (
             os.path.join(os.path.dirname(__file__), manage_py)
             if manage_py
@@ -168,7 +170,7 @@ class AdminScriptTestCase(SimpleTestCase):
         with open(test_manage_py, "w") as fp:
             fp.write(manage_py_contents)
 
-        return self.run_test(["./manage.py", *args], settings_file)
+        return self.run_test(["./manage.py", *args], settings_file, extra_env=extra_env)
 
     def assertInAfterFormatting(self, member, container, msg=None):
         if HAS_BLACK:
@@ -897,6 +899,15 @@ class ManageNoSettings(AdminScriptTestCase):
         self.assertNoOutput(out)
         self.assertOutput(err, "No module named '?bad_settings'?", regex=True)
 
+    def test_runserver_with_bad_settings(self):
+        """
+        runserver surfaces the settings error when the settings module fails
+        to import (refs #32915).
+        """
+        args = ["runserver", "--settings=bad_settings", "--nostatic"]
+        out, err = self.run_manage(args)
+        self.assertOutput(err, "settings are not properly configured")
+
 
 class ManageDefaultSettings(AdminScriptTestCase):
     """A series of tests for manage.py when using a settings.py file that
@@ -1431,8 +1442,8 @@ class ManageSettingsWithSettingsErrors(AdminScriptTestCase):
 
     def test_help(self):
         """
-        Test listing available commands output note when only core commands are
-        available.
+        manage.py help lists only core commands and surfaces the settings
+        error on stderr when settings fail to import.
         """
         self.write_settings(
             "settings.py",
@@ -1442,6 +1453,58 @@ class ManageSettingsWithSettingsErrors(AdminScriptTestCase):
         args = ["help"]
         out, err = self.run_manage(args)
         self.assertOutput(out, "only Django core commands are listed")
+        self.assertOutput(err, "settings are not properly configured")
+
+    def test_version_surfaces_settings_error(self):
+        """
+        manage.py version surfaces a settings import error on stderr instead
+        of exiting silently (refs #32915).
+        """
+        self.write_settings(
+            "settings.py",
+            extra="from django.core.exceptions import ImproperlyConfigured\n"
+            "raise ImproperlyConfigured('broken setting')",
+        )
+        out, err = self.run_manage(["version"])
+        self.assertOutput(out, get_version())
+        self.assertOutput(err, "settings are not properly configured")
+        self.assertOutput(err, "broken setting")
+
+    def test_app_command_surfaces_settings_error(self):
+        """
+        When settings fail to import, app commands are absent from
+        get_commands() and fetch_command re-raises ImproperlyConfigured.
+        The settings notice must still be surfaced on stderr (refs #32915).
+        """
+        self.write_settings(
+            "settings.py",
+            extra="from django.core.exceptions import ImproperlyConfigured\n"
+            "raise ImproperlyConfigured('broken setting')",
+        )
+        out, err = self.run_manage(["noargs_command"])
+        self.assertNoOutput(out)
+        self.assertOutput(err, "settings are not properly configured")
+        self.assertOutput(err, "broken setting")
+
+    def test_autocomplete_does_not_emit_settings_error(self):
+        """
+        bash completion's stdout is consumed by the shell, so the settings
+        notice must not be emitted during autocomplete even if settings
+        failed to import (refs #32915).
+        """
+        self.write_settings(
+            "settings.py",
+            extra="from django.core.exceptions import ImproperlyConfigured\n"
+            "raise ImproperlyConfigured('broken setting')",
+        )
+        out, err = self.run_manage(
+            [],
+            extra_env={
+                "DJANGO_AUTO_COMPLETE": "1",
+                "COMP_WORDS": "manage.py ",
+                "COMP_CWORD": "1",
+            },
+        )
         self.assertNoOutput(err)
 
 

--- a/tests/settings_tests/tests.py
+++ b/tests/settings_tests/tests.py
@@ -339,6 +339,12 @@ class SettingsTests(SimpleTestCase):
         with self.assertRaisesMessage(ValueError, "Incorrect timezone setting: test"):
             settings._setup()
 
+    def test_unable_to_import_a_random_module(self):
+        exc = ModuleNotFoundError("No module named 'fake_module'", name="fake_module")
+        with mock.patch("importlib.import_module", side_effect=exc):
+            with self.assertRaisesMessage(ImportError, "No module named 'fake_module'"):
+                Settings("fake_settings_module")
+
 
 class TestComplexSettingOverride(SimpleTestCase):
     def setUp(self):


### PR DESCRIPTION
#### Trac ticket number
ticket-32915

#### Branch description
Previously the captured `settings_exception` was only written to stderr when `main_help_text()` was invoked, i.e. when running `manage.py` or `manage.py help` with no additional arguments. Every other invocation exited without mentioning that settings failed to load.

Wrapped `ManagementUtility.execute()` in a try/finally that always writes the captured `settings_exception` to stderr on exit. Skipped when `DJANGO_SETTINGS_MODULE` is unset (commands like `startproject` legitimately run without any settings) and during bash completion (`DJANGO_AUTO_COMPLETE`), whose stdout is consumed by the shell.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

I used Claude Opus 4.7 for assistance. All the code was fully reviewed or edited by me.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
