### PR TITLE
Refs #35943 -- Fixed admin_views.test_related_object_lookups crash when selenium is not installed.

### DIFF
--- a/tests/admin_views/test_related_object_lookups.py
+++ b/tests/admin_views/test_related_object_lookups.py
@@ -1,5 +1,3 @@
-from selenium.common.exceptions import TimeoutException
-
 from django.contrib.admin.tests import AdminSeleniumTestCase
 from django.contrib.auth.models import User
 from django.test import override_settings
@@ -183,6 +181,7 @@ class SeleniumTests(AdminSeleniumTestCase):
         )
 
     def test_child_popup_not_closed_when_parent_minimized(self):
+        from selenium.common.exceptions import TimeoutException
         from selenium.webdriver.common.by import By
 
         album_add_url = reverse("admin:admin_views_album_add")


### PR DESCRIPTION
ticket-35943

#### Branch description

```
Failed to import test module: admin_views.test_related_object_lookups
Traceback (most recent call last):
  File "/home/jenkins/.local/share/uv/python/cpython-3.14-linux-x86_64-gnu/lib/python3.14/unittest/loader.py", line 426, in _find_test_path
    module = self._get_module_from_name(name)
  File "/home/jenkins/.local/share/uv/python/cpython-3.14-linux-x86_64-gnu/lib/python3.14/unittest/loader.py", line 367, in _get_module_from_name
    __import__(name)
    ~~~~~~~~~~^^^^^^
  File "/home/jenkins/workspace/main-no-requirements/database/sqlite3/label/noble/python/python3.14/tests/admin_views/test_related_object_lookups.py", line 1, in <module>
    from selenium.common.exceptions import TimeoutException
ModuleNotFoundError: No module named 'selenium'
```

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.