### PR TITLE
Fixed #37060 -- Propagated AlterField through attname-based to_field …

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -36,7 +36,10 @@ def _is_relevant_relation(relation, altered_field):
         # Foreign key constraint on the primary key, which is being altered.
         return True
     # Is the constraint targeting the field being altered?
-    return altered_field.name in field.to_fields
+    return (
+        altered_field.name in field.to_fields
+        or altered_field.attname in field.to_fields
+    )
 
 
 def _all_related_fields(model):

--- a/django/db/backends/sqlite3/schema.py
+++ b/django/db/backends/sqlite3/schema.py
@@ -3,7 +3,10 @@ from decimal import Decimal
 
 from django.apps.registry import Apps
 from django.db import NotSupportedError
-from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.db.backends.base.schema import (
+    BaseDatabaseSchemaEditor,
+    _related_non_m2m_objects,
+)
 from django.db.backends.ddl_references import Statement
 from django.db.backends.utils import strip_quotes
 from django.db.models import CompositePrimaryKey, UniqueConstraint
@@ -391,17 +394,13 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         if new_field.unique and (
             old_type != new_type or old_collation != new_collation
         ):
-            related_models = set()
-            opts = new_field.model._meta
-            for remote_field in opts.related_objects:
+            related_models = {
+                rel.related_model
+                for _, rel in _related_non_m2m_objects(old_field, new_field)
                 # Ignore self-relationship since the table was already rebuilt.
-                if remote_field.related_model == model:
-                    continue
-                if not remote_field.many_to_many:
-                    if remote_field.field_name == new_field.name:
-                        related_models.add(remote_field.related_model)
-                elif new_field.primary_key and remote_field.through._meta.auto_created:
-                    related_models.add(remote_field.through)
+                if rel.related_model != model
+            }
+            opts = new_field.model._meta
             if new_field.primary_key:
                 for many_to_many in opts.many_to_many:
                     # Ignore self-relationship since the table was already

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -3093,6 +3093,114 @@ class OperationTests(OperationTestBase):
         )
         self.apply_operations(app_label, project_state, operations=[operation])
 
+    @skipUnlessDBFeature("supports_foreign_keys")
+    def test_alter_field_reloads_state_on_transitive_attname_to_field_type_change(
+        self,
+    ):
+        app_label = "test_alflrstfattnamettc"
+        project_state = self.apply_operations(
+            app_label,
+            ProjectState(),
+            operations=[
+                migrations.CreateModel(
+                    "Primary",
+                    fields=[
+                        ("id", models.AutoField(primary_key=True)),
+                        ("code", models.CharField(max_length=5, unique=True)),
+                    ],
+                ),
+                migrations.CreateModel(
+                    "Related",
+                    fields=[
+                        ("id", models.AutoField(primary_key=True)),
+                        (
+                            "primary",
+                            models.OneToOneField(
+                                f"{app_label}.Primary",
+                                models.CASCADE,
+                                to_field="code",
+                            ),
+                        ),
+                    ],
+                ),
+                migrations.CreateModel(
+                    "Dependent",
+                    fields=[
+                        ("id", models.AutoField(primary_key=True)),
+                        (
+                            "related",
+                            models.ForeignKey(
+                                f"{app_label}.Related",
+                                models.CASCADE,
+                                to_field="primary_id",
+                            ),
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+        def assert_column_lengths(length):
+            with connection.cursor() as cursor:
+                primary_length = [
+                    c.display_size
+                    for c in connection.introspection.get_table_description(
+                        cursor, f"{app_label}_primary"
+                    )
+                    if c.name == "code"
+                ][0]
+                related_length = [
+                    c.display_size
+                    for c in connection.introspection.get_table_description(
+                        cursor, f"{app_label}_related"
+                    )
+                    if c.name == "primary_id"
+                ][0]
+                dependent_length = [
+                    c.display_size
+                    for c in connection.introspection.get_table_description(
+                        cursor, f"{app_label}_dependent"
+                    )
+                    if c.name == "related_id"
+                ][0]
+            self.assertEqual(primary_length, length)
+            self.assertEqual(related_length, length)
+            self.assertEqual(dependent_length, length)
+
+        assert_column_lengths(5)
+        self.assertFKExists(
+            f"{app_label}_related",
+            ["primary_id"],
+            (f"{app_label}_primary", "code"),
+        )
+        self.assertFKExists(
+            f"{app_label}_dependent",
+            ["related_id"],
+            (f"{app_label}_related", "primary_id"),
+        )
+
+        operation = migrations.AlterField(
+            "Primary",
+            "code",
+            models.CharField(max_length=11, unique=True),
+        )
+        new_state = project_state.clone()
+        operation.state_forwards(app_label, new_state)
+        with connection.schema_editor() as editor:
+            operation.database_forwards(app_label, editor, project_state, new_state)
+
+        assert_column_lengths(11)
+        self.assertFKExists(
+            f"{app_label}_related",
+            ["primary_id"],
+            (f"{app_label}_primary", "code"),
+        )
+        self.assertFKExists(
+            f"{app_label}_dependent",
+            ["related_id"],
+            (f"{app_label}_related", "primary_id"),
+        )
+
     def test_alter_field_reloads_state_on_fk_target_changes(self):
         """
         If AlterField doesn't reload state appropriately, the second AlterField


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37060

#### Branch description
`AlterField` propagated type changes correctly when a transitive relation used `to_field` with the remote field name, but not when it used the accepted attname alias instead.
For a relation chain like:
- `Primary.code`
- `Related.primary = OneToOneField(..., to_field="code")`
- `Dependent.related = ForeignKey(..., to_field="primary_id")`
 
Altering `Primary.code` widened `Related.primary_id` but left `Dependent.related_id` unchanged.
This patch makes schema dependency discovery treat attname-based `to_field` values the same way as the corresponding field name, and adds a regression test for the transitive case.
#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

AI assistance used:
- OpenCode / GPT-5.4
- Used for code exploration, narrowing the bug scope, drafting the regression test, and drafting ticket / PR text.
- All code changes and test results were manually reviewed and verified.
#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
