### PR TITLE
Refs #35007 -- Pinned exact biome version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "npm": ">=1.3.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.4.12",
+    "@biomejs/biome": "2.4.12",
     "puppeteer": "^24.22.0",
     "grunt": "^1.6.1",
     "grunt-cli": "^1.5.0",


### PR DESCRIPTION

#### Trac ticket number
ticket-35007

#### Branch description
Avoid drift against the following in biome.json:
"$schema": "https://biomejs.dev/schemas/2.4.12/schema.json"

See logs:
```
Notice: The configuration schema version does not match the CLI version 2.4.13
biome.json:2:16 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  i The configuration schema version does not match the CLI version 2.4.13
  
    1 │ {
  > 2 │     "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
      │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    3 │     "files": {
    4 │         "includes": [
  
  i   Expected:                     2.4.13
      Found:                        2.4.12
  
  
  i Run the command biome migrate to migrate the configuration file.
  

Checked 51 files in 159ms. No fixes applied.
Found 1 info.
```

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

