### PR TITLE
Fixed #37064 -- Fixed SimpleTestCase crash on un-wrapped connection

### DIFF
--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -278,7 +278,8 @@ class SimpleTestCase(unittest.TestCase):
             )
             for name, _ in disallowed_methods:
                 method = getattr(connection, name)
-                setattr(connection, name, method.wrapped)
+                if isinstance(method, _DatabaseFailure):
+                    setattr(connection, name, method.wrapped)
 
     @classmethod
     def ensure_connection_patch_method(cls):

--- a/docs/releases/6.0.5.txt
+++ b/docs/releases/6.0.5.txt
@@ -13,3 +13,9 @@ Bugfixes
   ``django/contrib/admin/templates/admin/change_list.html`` template added in
   Django 6.0 that could be problematic when overriding the ``pagination`` block
   (:ticket:`37029`).
+
+* Fixed a crash in ``SimpleTestCase._remove_databases_failures()`` when a
+  disallowed connection method was replaced between ``setUpClass()`` and
+  ``tearDownClass()`` (e.g. due to connection recycling), which raised
+  ``AttributeError: 'function' object has no attribute 'wrapped'`` during
+  teardown.

--- a/tests/test_utils/test_simpletestcase.py
+++ b/tests/test_utils/test_simpletestcase.py
@@ -4,7 +4,9 @@ from io import StringIO
 from unittest import mock
 from unittest.suite import _DebugResult
 
+from django.db import connections
 from django.test import SimpleTestCase
+from django.test.testcases import _DatabaseFailure
 
 
 class ErrorTestCase(SimpleTestCase):
@@ -147,3 +149,48 @@ class DebugInvocationTests(SimpleTestCase):
         self.assertFalse(_post_teardown.called)
         self.assertFalse(_pre_setup.called)
         self.isolate_debug_test(test_suite, result)
+
+
+class RemoveDatabasesFailuresTests(SimpleTestCase):
+    """Regression tests for SimpleTestCase._remove_databases_failures."""
+
+    databases = {"default"}
+
+    def _pick_other_alias(self):
+        for alias in connections:
+            if alias != "default":
+                return alias
+        self.skipTest("Test requires a second database alias.")
+
+    def test_teardown_noops_when_method_is_not_wrapped(self):
+        """
+        If a connection method is replaced between setUpClass and
+        tearDownClass (e.g. the connection was recycled), teardown must
+        not crash with AttributeError on ``method.wrapped``.
+        """
+        alias = self._pick_other_alias()
+        connection = connections[alias]
+        name, _ = next(
+            iter(connection.features.disallowed_simple_test_case_connection_methods)
+        )
+        original = getattr(connection, name)
+        try:
+            setattr(connection, name, lambda *a, **kw: None)
+            self.__class__._remove_databases_failures()
+        finally:
+            setattr(connection, name, original)
+
+    def test_teardown_still_unwraps_database_failures(self):
+        """The happy path must continue to restore wrapped methods."""
+        alias = self._pick_other_alias()
+        connection = connections[alias]
+        name, _ = next(
+            iter(connection.features.disallowed_simple_test_case_connection_methods)
+        )
+        original = getattr(connection, name)
+        setattr(connection, name, _DatabaseFailure(original, "msg"))
+        try:
+            self.__class__._remove_databases_failures()
+            self.assertIs(getattr(connection, name), original)
+        finally:
+            setattr(connection, name, original)


### PR DESCRIPTION
#### Trac ticket number

ticket-37064

#### Branch description

`SimpleTestCase._remove_databases_failures()` unconditionally accesses `method.wrapped` on every disallowed connection method it iterates, which crashes with `AttributeError: 'function' object has no attribute 'wrapped'` when the method is not a `_DatabaseFailure` instance. This happens when the SQLite backend recycles connection objects between `setUpClass` and `tearDownClass`, when `cls.databases` is mutated after setup, or when a subclass skipped `super().setUpClass()` but still inherits the `addClassCleanup`.

Adds an `isinstance(method, _DatabaseFailure)` guard so teardown only restores methods that setup actually wrapped. One-line behaviour change, two regression tests (crash-avoidance + happy-path preservation), and a 6.0.5 release-notes entry. See Trac #37064 for the full reproducer and prior discussion on #36942 / PR #20758.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Opus 4.7 help draft the patch

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.