### PR TITLE
Fixed #37062 -- Added preserve_request support to RedirectView.

### DIFF
--- a/django/views/generic/base.py
+++ b/django/views/generic/base.py
@@ -235,6 +235,7 @@ class RedirectView(View):
     url = None
     pattern_name = None
     query_string = False
+    preserve_request = False
 
     def get_redirect_url(self, *args, **kwargs):
         """
@@ -261,9 +262,11 @@ class RedirectView(View):
         url = self.get_redirect_url(*args, **kwargs)
         if url:
             if self.permanent:
-                return HttpResponsePermanentRedirect(url)
+                return HttpResponsePermanentRedirect(
+                    url, preserve_request=self.preserve_request
+                )
             else:
-                return HttpResponseRedirect(url)
+                return HttpResponseRedirect(url, preserve_request=self.preserve_request)
         else:
             response = HttpResponseGone()
             log_response("Gone: %s", request.path, response=response, request=request)

--- a/docs/ref/class-based-views/base.txt
+++ b/docs/ref/class-based-views/base.txt
@@ -277,6 +277,15 @@ ancestor classes are  documented under the section title of **Ancestors
         then the query string is discarded. By default, ``query_string`` is
         ``False``.
 
+    .. attribute:: preserve_request
+
+        .. versionadded:: 6.1
+
+        Whether to preserve the HTTP method and body during the redirect. If
+        ``True``, then the redirect will use status code 307 instead of 302,
+        or 308 instead of 301 when :attr:`permanent` is ``True``. By default,
+        ``preserve_request`` is ``False``.
+
     **Methods**
 
     .. method:: get_redirect_url(*args, **kwargs)

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -258,7 +258,9 @@ Forms
 Generic Views
 ~~~~~~~~~~~~~
 
-* ...
+* The new :attr:`.RedirectView.preserve_request` attribute allows preserving
+  the HTTP method and body during redirects, using 307/308 status codes instead
+  of 302/301.
 
 Internationalization
 ~~~~~~~~~~~~~~~~~~~~

--- a/tests/generic_views/test_base.py
+++ b/tests/generic_views/test_base.py
@@ -479,6 +479,20 @@ class RedirectViewTest(LoggingAssertionMixin, SimpleTestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, "/bar/")
 
+    def test_preserve_request_temporary_redirect(self):
+        response = RedirectView.as_view(url="/bar/", preserve_request=True)(
+            self.rf.get("/foo/")
+        )
+        self.assertEqual(response.status_code, 307)
+        self.assertEqual(response.url, "/bar/")
+
+    def test_preserve_request_permanent_redirect(self):
+        response = RedirectView.as_view(
+            url="/bar/", preserve_request=True, permanent=True
+        )(self.rf.get("/foo/"))
+        self.assertEqual(response.status_code, 308)
+        self.assertEqual(response.url, "/bar/")
+
     def test_include_args(self):
         "GET arguments can be included in the redirected URL"
         response = RedirectView.as_view(url="/bar/")(self.rf.get("/foo/"))


### PR DESCRIPTION
#### Trac ticket number
ticket-37062

#### Branch description
RedirectView currently does not support the preserve_request argument,
which is available in the redirect() shortcut. This patch adds
preserve_request as a class-level attribute to RedirectView, mirroring
the existing behavior of redirect().

When preserve_request=True:
* permanent=False returns 307 instead of 302
* permanent=True returns 308 instead of 301

Default behavior is unchanged.

#### AI Assistance Disclosure (REQUIRED)
- [x] **No AI tools were used** in preparing this PR.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.