### PR TITLE
Fixed #37064 -- Fixed SimpleTestCase crash on un-wrapped connection m…

### DIFF
--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -278,7 +278,8 @@ class SimpleTestCase(unittest.TestCase):
             )
             for name, _ in disallowed_methods:
                 method = getattr(connection, name)
-                setattr(connection, name, method.wrapped)
+                if isinstance(method, _DatabaseFailure):
+                    setattr(connection, name, method.wrapped)
 
     @classmethod
     def ensure_connection_patch_method(cls):

--- a/docs/releases/6.0.5.txt
+++ b/docs/releases/6.0.5.txt
@@ -13,3 +13,10 @@ Bugfixes
   ``django/contrib/admin/templates/admin/change_list.html`` template added in
   Django 6.0 that could be problematic when overriding the ``pagination`` block
   (:ticket:`37029`).
+
+* Fixed a crash in ``SimpleTestCase._remove_databases_failures()`` when a
+  disallowed connection method was replaced between ``setUpClass()`` and
+  ``tearDownClass()`` by a third-party library wrapping cursors (e.g. a
+  GraphQL or SQL debug middleware that does not unwrap before teardown),
+  which raised ``AttributeError: 'function' object has no attribute
+  'wrapped'`` during teardown.

--- a/tests/test_utils/test_simpletestcase.py
+++ b/tests/test_utils/test_simpletestcase.py
@@ -4,7 +4,9 @@ from io import StringIO
 from unittest import mock
 from unittest.suite import _DebugResult
 
+from django.db import connections
 from django.test import SimpleTestCase
+from django.test.testcases import _DatabaseFailure
 
 
 class ErrorTestCase(SimpleTestCase):
@@ -147,3 +149,95 @@ class DebugInvocationTests(SimpleTestCase):
         self.assertFalse(_post_teardown.called)
         self.assertFalse(_pre_setup.called)
         self.isolate_debug_test(test_suite, result)
+
+
+class RemoveDatabasesFailuresTests(SimpleTestCase):
+    """Regression tests for SimpleTestCase._remove_databases_failures."""
+
+    databases = {"default"}
+
+    def _pick_other_alias(self):
+        for alias in connections:
+            if alias != "default":
+                return alias
+        self.skipTest("Test requires a second database alias.")
+
+    def setUp(self):
+        """Snapshot every disallowed method on the non-default alias.
+
+        ``_remove_databases_failures`` has side effects across all
+        disallowed methods of all non-allowed aliases, so each test
+        must restore the full state for the next test to start from
+        a known-good (wrapped) baseline.
+        """
+        super().setUp()
+        alias = self._pick_other_alias()
+        connection = connections[alias]
+        self._method_snapshot = {
+            name: getattr(connection, name)
+            for name, _ in connection.features.disallowed_simple_test_case_connection_methods
+        }
+
+    def tearDown(self):
+        alias = self._pick_other_alias()
+        connection = connections[alias]
+        for name, original in self._method_snapshot.items():
+            setattr(connection, name, original)
+        super().tearDown()
+
+    def test_teardown_noops_when_method_is_not_wrapped(self):
+        """
+        If a connection method is replaced between setUpClass and
+        tearDownClass (e.g. the connection was recycled), teardown must
+        not crash with AttributeError on ``method.wrapped``.
+        """
+        alias = self._pick_other_alias()
+        connection = connections[alias]
+        name, _ = next(
+            iter(connection.features.disallowed_simple_test_case_connection_methods)
+        )
+        setattr(connection, name, lambda *a, **kw: None)
+        # Should not raise even though the lambda has no ``.wrapped``.
+        self.__class__._remove_databases_failures()
+
+    def test_teardown_still_unwraps_database_failures(self):
+        """The happy path must continue to restore wrapped methods."""
+        alias = self._pick_other_alias()
+        connection = connections[alias]
+        name, _ = next(
+            iter(connection.features.disallowed_simple_test_case_connection_methods)
+        )
+        # ``setUpClass`` wrapped this alias's methods, so the snapshot
+        # holds a ``_DatabaseFailure``; the real method is one layer down.
+        snapshot = self._method_snapshot[name]
+        real_method = snapshot.wrapped if isinstance(snapshot, _DatabaseFailure) else snapshot
+        setattr(connection, name, _DatabaseFailure(real_method, "msg"))
+        self.__class__._remove_databases_failures()
+        self.assertIs(getattr(connection, name), real_method)
+
+    def test_teardown_noops_against_third_party_cursor_wrapping(self):
+        """
+        Regression test for the ``wrap_cursor`` pattern used by
+        django-debug-toolbar, graphene-django, and similar tools.
+
+        Such libraries replace ``connection.cursor`` with a closure that
+        holds the previous cursor in an instance attribute and never
+        sets a ``.wrapped`` attribute on the closure itself.  Teardown
+        must not crash when one of these closures is still installed
+        at class-cleanup time.
+        """
+        alias = self._pick_other_alias()
+        connection = connections[alias]
+        # Mimic the wrap_cursor-style replacement.
+        connection._third_party_cursor = connection.cursor
+
+        def cursor():
+            return connection._third_party_cursor()
+
+        connection.cursor = cursor
+        try:
+            # Should not raise even though ``cursor.wrapped`` doesn't
+            # exist on the closure.
+            self.__class__._remove_databases_failures()
+        finally:
+            del connection._third_party_cursor


### PR DESCRIPTION
#### Trac ticket number

ticket-37064

#### Branch description

`SimpleTestCase._remove_databases_failures()` unconditionally accesses `method.wrapped` on every disallowed connection method it iterates, which crashes with `AttributeError: 'function' object has no attribute 'wrapped'` when the method is not a `_DatabaseFailure` instance. This happens when a third-party library wraps `connection.cursor` between `setUpClass` and `tearDownClass` and does not unwrap before teardown (the confirmed reproducer is `graphene_django.debug.DjangoDebugMiddleware`'s `wrap_cursor`; django-debug-toolbar and django-silk use the same pattern), when `cls.databases` is mutated after setup, or when a subclass skipped `super().setUpClass()` but still inherits the `addClassCleanup`.

Adds an `isinstance(method, _DatabaseFailure)` guard so teardown only restores methods that setup actually wrapped. One-line behaviour change, three regression tests (crash-avoidance with a plain callable, happy-path preservation, and an explicit `wrap_cursor` closure regression), and a 6.0.5 release-notes entry. See Trac #37064 for the full reproducer and prior discussion on #36942 / PR #20758.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Opus 4.7 wrote the tests, feel free to drop them if you want, i wrote the two lines in django/test/testcases.py, was easy to fix once found.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.