### PR TITLE
Fixed #25656 -- Removed link from recent actions when user has no perms.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -2033,6 +2033,19 @@ class ModelAdmin(BaseModelAdmin):
         url = reverse("admin:index", current_app=self.admin_site.name)
         return HttpResponseRedirect(url)
 
+    def _get_user_has_no_view_and_change_perms_redirect(self, request, opts, object_id):
+        """
+        Create a message informing that user lacks change and view permissions
+        and return a redirect to the admin index page.
+        """
+        msg = _("No permissions to change %(name)s with ID “%(key)s”.") % {
+            "name": opts.verbose_name,
+            "key": unquote(object_id),
+        }
+        self.message_user(request, msg, messages.WARNING)
+        url = reverse("admin:index", current_app=self.admin_site.name)
+        return HttpResponseRedirect(url)
+
     @csrf_protect_m
     def changeform_view(self, request, object_id=None, form_url="", extra_context=None):
         if request.method in ("GET", "HEAD", "OPTIONS", "TRACE"):
@@ -2061,7 +2074,9 @@ class ModelAdmin(BaseModelAdmin):
         else:
             obj = self.get_object(request, unquote(object_id), to_field)
             if not self.has_view_or_change_permission(request, obj):
-                raise PermissionDenied
+                return self._get_user_has_no_view_and_change_perms_redirect(
+                    request, self.opts, object_id
+                )
 
             if obj is None:
                 return self._get_obj_does_not_exist_redirect(

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -2932,32 +2932,11 @@ class AdminViewPermissionsTest(TestCase):
         )
         self.client.post(reverse("admin:logout"))
 
-        # Test redirection when using row-level change permissions. Refs
-        # #11513.
-        r1 = RowLevelChangePermissionModel.objects.create(
-            name="A", can_change=False, can_view=False
-        )
-        r2 = RowLevelChangePermissionModel.objects.create(
-            name="B", can_change=True, can_view=False
-        )
-        r3 = RowLevelChangePermissionModel.objects.create(
-            name="C", can_change=False, can_view=True
-        )
-        r4 = RowLevelChangePermissionModel.objects.create(
-            name="D", can_change=True, can_view=True
-        )
-        change_url_1 = reverse(
-            "admin:admin_views_rowlevelchangepermissionmodel_change", args=(r1.pk,)
-        )
-        change_url_2 = reverse(
-            "admin:admin_views_rowlevelchangepermissionmodel_change", args=(r2.pk,)
-        )
-        change_url_3 = reverse(
-            "admin:admin_views_rowlevelchangepermissionmodel_change", args=(r3.pk,)
-        )
-        change_url_4 = reverse(
-            "admin:admin_views_rowlevelchangepermissionmodel_change", args=(r4.pk,)
-        )
+    def test_redirection_with_per_object_change_permissions(self):
+        """
+        User must be redirected to admin index if lacks per object (row level)
+        change permissions for the obj. Refs #11513.
+        """
         logins = [
             self.superuser,
             self.viewuser,
@@ -2965,68 +2944,69 @@ class AdminViewPermissionsTest(TestCase):
             self.changeuser,
             self.deleteuser,
         ]
-        for login_user in logins:
-            with self.subTest(login_user.username):
-                self.client.force_login(login_user)
-                response = self.client.get(change_url_1)
-                self.assertEqual(response.status_code, 403)
-                response = self.client.post(change_url_1, {"name": "changed"})
-                self.assertEqual(
-                    RowLevelChangePermissionModel.objects.get(pk=r1.pk).name,
-                    r1.name,
-                )
-                self.assertEqual(response.status_code, 403)
-                response = self.client.get(change_url_2)
-                self.assertEqual(response.status_code, 200)
-                response = self.client.post(change_url_2, {"name": "changed"})
-                self.assertEqual(
-                    RowLevelChangePermissionModel.objects.get(pk=r2.pk).name,
-                    "changed",
-                )
-                self.assertRedirects(response, self.index_url)
-                response = self.client.get(change_url_3)
-                self.assertEqual(response.status_code, 200)
-                response = self.client.post(change_url_3, {"name": "changed"})
-                self.assertEqual(response.status_code, 403)
-                self.assertEqual(
-                    RowLevelChangePermissionModel.objects.get(pk=r3.pk).name,
-                    r3.name,
-                )
-                response = self.client.get(change_url_4)
-                self.assertEqual(response.status_code, 200)
-                response = self.client.post(change_url_4, {"name": "changed"})
-                self.assertEqual(
-                    RowLevelChangePermissionModel.objects.get(pk=r4.pk).name,
-                    "changed",
-                )
-                self.assertRedirects(response, self.index_url)
 
-                self.client.post(reverse("admin:logout"))
+        test_cases = [
+            # (can_change, can_view, initial_name, expect_changed)
+            (False, False, "A", False),
+            (True, False, "B", True),
+            (False, True, "C", False),
+            (True, True, "D", True),
+        ]
+        for login_user in logins:
+            for can_change, can_view, name, expect_changed in test_cases:
+                with self.subTest(user=login_user.username, name=name):
+                    obj = RowLevelChangePermissionModel.objects.create(
+                        name=name, can_change=can_change, can_view=can_view
+                    )
+                    change_url = reverse(
+                        "admin:admin_views_rowlevelchangepermissionmodel_change",
+                        args=(obj.pk,),
+                    )
+                    self.client.force_login(login_user)
+
+                    get_response = self.client.get(change_url)
+                    self.assertEqual(
+                        get_response.status_code, 200 if can_change or can_view else 302
+                    )
+
+                    self.client.post(change_url, {"name": "changed"})
+                    obj.refresh_from_db()
+
+                    if expect_changed:
+                        self.assertEqual(obj.name, "changed")
+                    else:
+                        self.assertEqual(obj.name, name)
+
+                    self.client.post(reverse("admin:logout"))
+                    obj.delete()
 
         for login_user in [self.joepublicuser, self.nostaffuser]:
-            with self.subTest(login_user.username):
-                self.client.force_login(login_user)
-                response = self.client.get(change_url_1, follow=True)
-                self.assertContains(response, "login-form")
-                response = self.client.post(
-                    change_url_1, {"name": "changed"}, follow=True
-                )
-                self.assertEqual(
-                    RowLevelChangePermissionModel.objects.get(pk=r1.pk).name,
-                    r1.name,
-                )
-                self.assertContains(response, "login-form")
-                response = self.client.get(change_url_2, follow=True)
-                self.assertContains(response, "login-form")
-                response = self.client.post(
-                    change_url_2, {"name": "changed again"}, follow=True
-                )
-                self.assertEqual(
-                    RowLevelChangePermissionModel.objects.get(pk=r2.pk).name,
-                    "changed",
-                )
-                self.assertContains(response, "login-form")
-                self.client.post(reverse("admin:logout"))
+            # Reuse test_cases from before, minus expect_changed.
+            for can_change, can_view, name, _ in test_cases:
+                with self.subTest(user=login_user.username, name=name):
+                    obj = RowLevelChangePermissionModel.objects.create(
+                        name=name, can_change=can_change, can_view=can_view
+                    )
+                    change_url = reverse(
+                        "admin:admin_views_rowlevelchangepermissionmodel_change",
+                        args=(obj.pk,),
+                    )
+                    self.client.force_login(login_user)
+
+                    response = self.client.get(change_url, follow=True)
+                    self.assertContains(response, "login-form")
+
+                    response = self.client.post(
+                        change_url, {"name": "changed"}, follow=True
+                    )
+                    self.assertContains(response, "login-form")
+                    obj.refresh_from_db()
+
+                    # Never changed since both of the users are not staff.
+                    self.assertEqual(obj.name, name)
+
+                    self.client.post(reverse("admin:logout"))
+                    obj.delete()
 
     def test_change_view_without_object_change_permission(self):
         """

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -2852,10 +2852,11 @@ class AdminViewPermissionsTest(TestCase):
         self.client.force_login(self.adduser)
         response = self.client.get(article_changelist_url)
         self.assertEqual(response.status_code, 403)
+
         response = self.client.get(article_change_url)
-        self.assertEqual(response.status_code, 403)
+        self.assertRedirects(response, reverse("admin:index"))
         post = self.client.post(article_change_url, change_dict)
-        self.assertEqual(post.status_code, 403)
+        self.assertRedirects(response, reverse("admin:index"))
         self.client.post(reverse("admin:logout"))
 
         # view user can view articles but not make changes.
@@ -2880,6 +2881,7 @@ class AdminViewPermissionsTest(TestCase):
         )
         self.assertEqual(response.context["title"], "View article")
         post = self.client.post(article_change_url, change_dict)
+        # No redirect because user has view perms.
         self.assertEqual(post.status_code, 403)
         self.assertEqual(
             Article.objects.get(pk=self.a1.pk).content, "<p>Middle content</p>"


### PR DESCRIPTION
#### Trac ticket number
ticket-25656


#### Branch description
Added redirect to index admin when user has no view and no change permissions.
No need to add new tests, had to adjust existing tests though, since they are expect
403 forbidden and not redirect.
Also improved existing `test_change_view ` by fixing state leak between loops for 
`RowLevelChangePermissionModel` by making a nested tuple with params for each
`RowLevelChangePermissionModel `instance and expected behavior and creating
them on each loop run and deleting afterwards so no state leak.

Note: simpler and more straightforward approach could be used by just resetting the name
for the `RowLevelChangePermissionModel `objects after each loop run.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
ChatGpt 5.3 for tooltip css 

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
<img width="372" height="247" alt="Screenshot_1" src="https://github.com/user-attachments/assets/80a8a9b3-aa61-4a30-b757-9b9abe23dffd" />
<img width="389" height="249" alt="Screenshot_2" src="https://github.com/user-attachments/assets/06a0c761-cebd-4381-b7f0-552d1256ebc0" />
