### PR TITLE
Fixed #34122 -- Added reference docs for ForeignObject.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -990,6 +990,7 @@ answer newbie questions, and generally made Django that much better:
     Slawek Mikula <slawek dot mikula at gmail dot com>
     sloonz <simon.lipp@insa-lyon.fr>
     smurf@smurf.noris.de
+    Somi Jeong <https://github.com/1wos>
     sopel
     Sreehari K V <sreeharivijayan619@gmail.com>
     Sridhar Marella <sridhar562345@gmail.com>

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -2033,6 +2033,94 @@ The possible values for :attr:`~ForeignKey.on_delete` are found in
 
     If in doubt, leave it to its default of ``True``.
 
+.. _foreign-object:
+
+``ForeignObject``
+-----------------
+
+.. class:: ForeignObject(to, on_delete, from_fields, to_fields, **options)
+
+A generalization of :class:`ForeignKey` that supports relationships spanning
+multiple columns. Unlike :class:`ForeignKey`, ``ForeignObject`` does not
+create database columns, foreign key constraints, or indexes -- it reuses
+existing fields on the source model and defines the relationship in Python
+only.
+
+In most cases, you should prefer :class:`ForeignKey`. ``ForeignObject`` is
+intended for relating to a model that uses a :class:`CompositePrimaryKey`,
+or for custom multi-column joins where the underlying columns are managed
+separately. See :doc:`/topics/composite-primary-key` for a worked example::
+
+    from django.db import models
+
+
+    class Foo(models.Model):
+        item_order_id = models.CharField(max_length=20)
+        item_product_id = models.IntegerField()
+        item = models.ForeignObject(
+            OrderLineItem,
+            on_delete=models.CASCADE,
+            from_fields=("item_order_id", "item_product_id"),
+            to_fields=("order_id", "product_id"),
+        )
+
+The relationship supports the usual ORM features such as
+:meth:`~django.db.models.query.QuerySet.select_related` and reverse
+accessors.
+
+Database Representation
+~~~~~~~~~~~~~~~~~~~~~~~
+
+``ForeignObject`` does not add columns, constraints, or indexes to the
+database schema. The columns referenced by :attr:`~ForeignObject.from_fields`
+must already exist on the model. Django uses them as-is when constructing
+the ``JOIN`` clause and never appends an ``_id`` suffix.
+
+.. _foreign-object-arguments:
+
+Arguments
+~~~~~~~~~
+
+``ForeignObject`` requires :attr:`~ForeignObject.from_fields` and
+:attr:`~ForeignObject.to_fields` in addition to ``to`` and ``on_delete``.
+Other arguments common to :class:`ForeignKey` (such as
+:attr:`~ForeignKey.related_name`, :attr:`~ForeignKey.related_query_name`,
+and :attr:`~ForeignKey.limit_choices_to`) behave the same way.
+
+.. attribute:: ForeignObject.from_fields
+
+    A tuple of field names on the source model used in the join. Each
+    name must correspond to an existing field on the model.
+
+    When ``from_fields`` contains more than one entry, it cannot appear
+    in :attr:`~django.db.models.Options.indexes`,
+    :attr:`~django.db.models.Options.constraints`, or
+    :attr:`~django.db.models.Options.unique_together`. Doing so raises
+    ``models.E049``.
+
+.. attribute:: ForeignObject.to_fields
+
+    A tuple of field names on the target model used in the join. The
+    order must match :attr:`~ForeignObject.from_fields`. The target
+    columns must satisfy a uniqueness constraint -- through
+    ``unique=True``,
+    :attr:`Meta.unique_together <django.db.models.Options.unique_together>`,
+    a :class:`~django.db.models.UniqueConstraint`, or by matching the
+    target's :class:`CompositePrimaryKey` columns. Otherwise the
+    :ref:`system check framework <field-checking>` raises ``fields.E310``,
+    ``fields.E311``, or ``fields.E312``. ``to_fields`` cannot reference a
+    :class:`CompositePrimaryKey` field directly. Doing so raises
+    ``fields.E347``.
+
+.. attribute:: ForeignObject.on_delete
+
+    Behaves the same as :attr:`ForeignKey.on_delete`. Because
+    ``ForeignObject`` does not create a database-level foreign-key
+    constraint, cascading happens only through Django's ORM (during
+    :meth:`~django.db.models.Model.delete` and
+    :meth:`~django.db.models.query.QuerySet.delete`). Raw SQL ``DELETE``
+    statements bypass it.
+
 ``ManyToManyField``
 -------------------
 

--- a/docs/topics/composite-primary-key.txt
+++ b/docs/topics/composite-primary-key.txt
@@ -107,8 +107,8 @@ supported::
 Because ``ForeignKey`` currently cannot reference models with composite primary
 keys.
 
-To work around this limitation, ``ForeignObject`` can be used as an
-alternative::
+For relations to a model with a composite primary key, use
+:class:`~django.db.models.ForeignObject`::
 
     class Foo(models.Model):
         item_order_id = models.CharField(max_length=20)
@@ -120,9 +120,7 @@ alternative::
             to_fields=("order_id", "product_id"),
         )
 
-``ForeignObject`` is much like ``ForeignKey``, except that it doesn't create
-any columns (e.g. ``item_id``), foreign key constraints or indexes in the
-database, and the ``on_delete`` argument is ignored.
+See :ref:`foreign-object` for the full reference.
 
 .. _cpk-and-database-functions:
 


### PR DESCRIPTION
#### Trac ticket number

ticket-34122

#### Branch description

Adds reference documentation for `ForeignObject` to `docs/ref/models/fields.txt`, mirroring the structure of the existing `ForeignKey` entry.

Sarah Boyce reopened the ticket on 2026-04-20, confirming `ForeignObject` should be treated as public API. The class has been part of `django.db.models` since 1.6 and is in active use as a building block for generic relations and `CompositePrimaryKey` joins.

The new section documents the public surface — `from_fields`, `to_fields`, and `on_delete` — and notes that the remaining arguments behave the same as their `ForeignKey` counterparts.

Changes:
- `docs/ref/models/fields.txt` — new `ForeignObject` reference section between `ForeignKey` and `ManyToManyField`.
- `docs/topics/composite-primary-key.txt` — replaced inline behaviour description with a `:ref:` link to the new section.
- `docs/releases/6.1.txt` — release note under "Models".
- `AUTHORS` — added entry.

`on_delete` is described as enforced at the ORM level (cascading via `Model.delete()` / `QuerySet.delete()`) but not at the database level, clarifying earlier topic-guide wording that could be read as "ignored".

This is a documentation-only change. Builds cleanly with `make html`.

#### AI Assistance Disclosure (REQUIRED)
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

AI assistance used:
- Claude Code / Claude Opus 4.7
- Used for vocabulary refinement, cross-checking the documented signature and error codes against `django/db/models/fields/related.py` and `django/db/models/base.py`, and drafting the section against the existing `ForeignKey` reference structure.
- All wording, structural decisions, and final review were author-driven.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests. <!-- N/A: documentation-only change. -->
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes. <!-- N/A: no UI changes. -->

