### PR TITLE
Fixed #27825 -- Documented that model instantiation does not coerce field values.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -991,6 +991,7 @@ answer newbie questions, and generally made Django that much better:
     Slawek Mikula <slawek dot mikula at gmail dot com>
     sloonz <simon.lipp@insa-lyon.fr>
     smurf@smurf.noris.de
+    Somi Jeong <https://github.com/1wos>
     sopel
     Sreehari K V <sreeharivijayan619@gmail.com>
     Sridhar Marella <sridhar562345@gmail.com>

--- a/docs/ref/models/instances.txt
+++ b/docs/ref/models/instances.txt
@@ -68,6 +68,16 @@ need to :meth:`~Model.save`.
 
         book = Book.objects.create_book("Pride and Prejudice")
 
+.. admonition:: Setting attributes does not convert types
+
+    Setting a model attribute does not convert the value to the field's Python
+    type. That conversion happens when the model is :ref:`validated
+    <validating-objects>`. Although a field assigned a value of a different
+    type (for example, a string assigned to a
+    :class:`~django.db.models.UUIDField`) may be converted when
+    :meth:`~Model.save` executes a query, the in-memory instance will keep the
+    original value until it is :ref:`reloaded <refreshing-objects>`.
+
 Customizing model loading
 -------------------------
 
@@ -130,6 +140,8 @@ are loaded from the database::
 The example above shows a full ``from_db()`` implementation to clarify how that
 is done. In this case it would be possible to use a ``super()`` call in the
 ``from_db()`` method.
+
+.. _refreshing-objects:
 
 Refreshing objects from database
 ================================


### PR DESCRIPTION
#### Trac ticket number

ticket-27825

#### Branch description

Adds a `.. note::` to the "Creating objects" section of `docs/ref/models/instances.txt` clarifying that model instantiation (and direct attribute assignment) does not coerce values to the field's Python type. The note explains the practical consequence — equality checks and `obj in queryset` membership tests can fail until the instance is reloaded — and points to `refresh_from_db()` as the fix.

This addresses the feedback from @jacobtylerwalls on the previous attempt (PR #21034), specifically:

1. **Placement.** The previous patch placed the note in the middle of the "Creating objects" section in `docs/topics/db/queries.txt`, which Jacob flagged as the wrong section. This patch moves it to the model-instance reference where the API behaviour is documented, at the end of the "Creating objects" section before "Customizing model loading".
2. **Why this matters.** The note now contains a concrete, user-facing consequence drawn from #35434 (UUID equality / queryset membership failures), as Jacob requested.

Also adds an entry to `AUTHORS`. (PR #21173 for #34122 is also currently open and adds the same line; if both PRs are merged, the duplicate can be removed in either.)

This is a documentation-only change. Builds cleanly with `make html`.

#### AI Assistance Disclosure (REQUIRED)
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

AI assistance used:
- Claude Code / Claude Opus 4.7
- Used for vocabulary and tone refinement, and to cross-check the placement decision against the structure of `docs/ref/models/instances.txt` and the prior reviewer feedback on PR #21034.
- All wording, structural decisions, and final review were author-driven.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests. <!-- N/A: documentation-only change. -->
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes. <!-- N/A: no UI changes. -->
