### PR TITLE
Fixed #37066 -- Wrapped async iteration sites in (maybe_)aclosing.

### DIFF
--- a/django/contrib/auth/backends.py
+++ b/django/contrib/auth/backends.py
@@ -1,3 +1,5 @@
+from contextlib import aclosing
+
 from asgiref.sync import sync_to_async
 
 from django.contrib.auth import get_user_model
@@ -137,11 +139,12 @@ class ModelBackend(BaseBackend):
             else:
                 perms = getattr(self, "_get_%s_permissions" % from_name)(user_obj)
             perms = perms.values_list("content_type__app_label", "codename").order_by()
-            setattr(
-                user_obj,
-                perm_cache_name,
-                {"%s.%s" % (ct, name) async for ct, name in perms},
-            )
+            async with aclosing(aiter(perms)) as it:
+                setattr(
+                    user_obj,
+                    perm_cache_name,
+                    {"%s.%s" % (ct, name) async for ct, name in it},
+                )
         return getattr(user_obj, perm_cache_name)
 
     def get_user_permissions(self, user_obj, obj=None):

--- a/django/core/paginator.py
+++ b/django/core/paginator.py
@@ -5,6 +5,7 @@ from math import ceil
 
 from asgiref.sync import sync_to_async
 
+from django.utils.asyncio import maybe_aclosing
 from django.utils.deprecation import RemovedInDjango70Warning
 from django.utils.functional import cached_property
 from django.utils.inspect import method_has_no_args
@@ -370,8 +371,9 @@ class AsyncPage:
 
     async def __aiter__(self):
         if hasattr(self.object_list, "__aiter__"):
-            async for obj in self.object_list:
-                yield obj
+            async with maybe_aclosing(aiter(self.object_list)) as it:
+                async for obj in it:
+                    yield obj
         else:
             for obj in self.object_list:
                 yield obj
@@ -414,7 +416,8 @@ class AsyncPage:
         """
         if not isinstance(self.object_list, list):
             if hasattr(self.object_list, "__aiter__"):
-                self.object_list = [obj async for obj in self.object_list]
+                async with maybe_aclosing(aiter(self.object_list)) as it:
+                    self.object_list = [obj async for obj in it]
             else:
                 self.object_list = await sync_to_async(list)(self.object_list)
         return self.object_list

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -5,7 +5,7 @@ The main QuerySet implementation. This provides the public API for the ORM.
 import copy
 import operator
 import warnings
-from contextlib import nullcontext
+from contextlib import aclosing, nullcontext
 from functools import reduce
 from itertools import chain, islice
 from weakref import ref as weak_ref
@@ -589,28 +589,29 @@ class QuerySet(AltersData):
         iterable = self._iterable_class(
             self, chunked_fetch=use_chunked_fetch, chunk_size=chunk_size
         )
-        if self._prefetch_related_lookups:
-            results = []
+        async with aclosing(aiter(iterable)) as iterator:
+            if self._prefetch_related_lookups:
+                results = []
 
-            async for item in iterable:
-                results.append(item)
-                if len(results) >= chunk_size:
+                async for item in iterator:
+                    results.append(item)
+                    if len(results) >= chunk_size:
+                        await aprefetch_related_objects(
+                            results, *self._prefetch_related_lookups
+                        )
+                        for result in results:
+                            yield result
+                        results.clear()
+
+                if results:
                     await aprefetch_related_objects(
                         results, *self._prefetch_related_lookups
                     )
                     for result in results:
                         yield result
-                    results.clear()
-
-            if results:
-                await aprefetch_related_objects(
-                    results, *self._prefetch_related_lookups
-                )
-                for result in results:
-                    yield result
-        else:
-            async for item in iterable:
-                yield item
+            else:
+                async for item in iterator:
+                    yield item
 
     def aggregate(self, *args, **kwargs):
         """

--- a/django/http/response.py
+++ b/django/http/response.py
@@ -7,6 +7,7 @@ import re
 import sys
 import time
 import warnings
+from contextlib import aclosing
 from email.header import Header
 from http.client import responses
 from urllib.parse import urlsplit
@@ -19,6 +20,7 @@ from django.core.exceptions import DisallowedRedirect
 from django.core.serializers.json import DjangoJSONEncoder
 from django.http.cookie import SimpleCookie
 from django.utils import timezone
+from django.utils.asyncio import maybe_aclosing
 from django.utils.datastructures import CaseInsensitiveMapping
 from django.utils.encoding import iri_to_uri
 from django.utils.functional import cached_property
@@ -485,8 +487,9 @@ class StreamingHttpResponse(HttpResponseBase):
             _iterator = self._iterator
 
             async def awrapper():
-                async for part in _iterator:
-                    yield self.make_bytes(part)
+                async with maybe_aclosing(_iterator) as it:
+                    async for part in it:
+                        yield self.make_bytes(part)
 
             return awrapper()
         else:
@@ -521,16 +524,18 @@ class StreamingHttpResponse(HttpResponseBase):
             # async iterator. Consume in async_to_sync and map back.
             async def to_list(_iterator):
                 as_list = []
-                async for chunk in _iterator:
-                    as_list.append(chunk)
+                async with maybe_aclosing(_iterator) as it:
+                    async for chunk in it:
+                        as_list.append(chunk)
                 return as_list
 
             return map(self.make_bytes, iter(async_to_sync(to_list)(self._iterator)))
 
     async def __aiter__(self):
         try:
-            async for part in self.streaming_content:
-                yield part
+            async with aclosing(aiter(self.streaming_content)) as content:
+                async for part in content:
+                    yield part
         except TypeError:
             warnings.warn(
                 "StreamingHttpResponse must consume synchronous iterators in order to "

--- a/django/shortcuts.py
+++ b/django/shortcuts.py
@@ -4,6 +4,8 @@ of MVC. In other words, these functions/classes introduce controlled coupling
 for convenience's sake.
 """
 
+from contextlib import aclosing
+
 from django.http import (
     Http404,
     HttpResponse,
@@ -153,7 +155,8 @@ async def aget_list_or_404(klass, *args, **kwargs):
             "First argument to aget_list_or_404() must be a Model, Manager, or "
             f"QuerySet, not '{klass__name}'."
         )
-    obj_list = [obj async for obj in queryset.filter(*args, **kwargs)]
+    async with aclosing(aiter(queryset.filter(*args, **kwargs))) as it:
+        obj_list = [obj async for obj in it]
     if not obj_list:
         raise Http404(
             _("No %s matches the given query.") % queryset.model._meta.object_name

--- a/django/test/client.py
+++ b/django/test/client.py
@@ -23,6 +23,7 @@ from django.http import HttpHeaders, HttpRequest, QueryDict, SimpleCookie
 from django.test import signals
 from django.test.utils import ContextList
 from django.urls import resolve
+from django.utils.asyncio import maybe_aclosing
 from django.utils.encoding import force_bytes
 from django.utils.functional import SimpleLazyObject
 from django.utils.http import urlencode
@@ -128,8 +129,9 @@ def closing_iterator_wrapper(iterable, close):
 
 async def aclosing_iterator_wrapper(iterable, close):
     try:
-        async for chunk in iterable:
-            yield chunk
+        async with maybe_aclosing(aiter(iterable)) as it:
+            async for chunk in it:
+                yield chunk
     finally:
         request_finished.disconnect(close_old_connections)
         close()  # will fire request_finished

--- a/django/utils/asyncio.py
+++ b/django/utils/asyncio.py
@@ -1,8 +1,27 @@
+import contextlib
 import os
 from asyncio import get_running_loop
 from functools import wraps
 
 from django.core.exceptions import SynchronousOnlyOperation
+
+
+def maybe_aclosing(iterator):
+    """
+    Return a context manager that calls ``aclose()`` on *iterator* on exit
+    if it has one, otherwise a no-op context manager that yields *iterator*
+    unchanged.
+
+    Use to consume a caller-supplied async iterable that may or may not be
+    a real async generator. Wrapping with :func:`contextlib.aclosing`
+    unconditionally would raise ``AttributeError`` at ``__aexit__`` for any
+    iterator without ``aclose()``.
+    """
+    return (
+        contextlib.aclosing(iterator)
+        if hasattr(iterator, "aclose")
+        else contextlib.nullcontext(iterator)
+    )
 
 
 def async_unsafe(message):

--- a/django/utils/text.py
+++ b/django/utils/text.py
@@ -11,6 +11,7 @@ from html.parser import HTMLParser
 from io import BytesIO
 
 from django.core.exceptions import SuspiciousFileOperation
+from django.utils.asyncio import maybe_aclosing
 from django.utils.functional import (
     SimpleLazyObject,
     cached_property,
@@ -397,12 +398,13 @@ async def acompress_sequence(sequence, *, max_random_bytes=None):
     ) as zfile:
         # Output headers...
         yield buf.read()
-        async for item in sequence:
-            zfile.write(item)
-            zfile.flush()
-            data = buf.read()
-            if data:
-                yield data
+        async with maybe_aclosing(aiter(sequence)) as it:
+            async for item in it:
+                zfile.write(item)
+                zfile.flush()
+                data = buf.read()
+                if data:
+                    yield data
     yield buf.read()
 
 

--- a/docs/topics/async.txt
+++ b/docs/topics/async.txt
@@ -399,3 +399,26 @@ trigger the thread safety checks:
 Rather, you should encapsulate all database access within a helper function
 that can be called with ``sync_to_async()`` without relying on the connection
 object in the calling code.
+
+``maybe_aclosing()``
+====================
+
+.. function:: maybe_aclosing(iterator)
+
+.. versionadded:: 6.1
+
+Return a context manager that calls ``aclose()`` on *iterator* on exit if it
+has one, otherwise a no-op context manager that yields *iterator* unchanged.
+Use it to consume a caller-supplied async iterable that may not be a real
+async generator::
+
+    from django.utils.asyncio import maybe_aclosing
+
+
+    async def consume(iterable):
+        async with maybe_aclosing(aiter(iterable)) as it:
+            async for item in it:
+                ...
+
+Wrapping with :func:`contextlib.aclosing` unconditionally would raise
+``AttributeError`` at ``__aexit__`` for any iterator without ``aclose()``.

--- a/tests/async/tests.py
+++ b/tests/async/tests.py
@@ -9,7 +9,7 @@ from django.core.cache import DEFAULT_CACHE_ALIAS, caches
 from django.core.exceptions import ImproperlyConfigured, SynchronousOnlyOperation
 from django.http import HttpResponse, HttpResponseNotAllowed
 from django.test import RequestFactory, SimpleTestCase
-from django.utils.asyncio import async_unsafe
+from django.utils.asyncio import async_unsafe, maybe_aclosing
 from django.views.generic.base import View
 
 from .models import SimpleModel
@@ -63,6 +63,44 @@ class AsyncUnsafeTest(SimpleTestCase):
             self.dangerous_method()
         except SynchronousOnlyOperation:
             self.fail("SynchronousOnlyOperation should not be raised.")
+
+
+class MaybeAClosingTest(SimpleTestCase):
+    async def test_calls_aclose_on_iterator_with_aclose(self):
+        finally_ran = False
+
+        async def gen():
+            nonlocal finally_ran
+            try:
+                yield 1
+                yield 2
+            finally:
+                finally_ran = True
+
+        iterator = gen()
+        async with maybe_aclosing(iterator) as it:
+            self.assertIs(it, iterator)
+            self.assertEqual(await anext(it), 1)
+        self.assertTrue(finally_ran)
+
+    async def test_no_aclose_on_iterator_without_aclose(self):
+        class PlainAsyncIterator:
+            def __init__(self):
+                self.values = iter([1, 2])
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                try:
+                    return next(self.values)
+                except StopIteration:
+                    raise StopAsyncIteration
+
+        iterator = PlainAsyncIterator()
+        async with maybe_aclosing(iterator) as it:
+            self.assertIs(it, iterator)
+            self.assertEqual(await anext(it), 1)
 
 
 class SyncView(View):

--- a/tests/httpwrappers/tests.py
+++ b/tests/httpwrappers/tests.py
@@ -4,6 +4,7 @@ import os
 import pickle
 import unittest
 import uuid
+from contextlib import aclosing
 
 from django.core.exceptions import DisallowedRedirect
 from django.core.serializers.json import DjangoJSONEncoder
@@ -814,6 +815,22 @@ class StreamingHttpResponseTests(SimpleTestCase):
 
         with self.assertRaisesMessage(AttributeError, msg):
             r.text
+
+    async def test_streaming_response_closes_user_generator_promptly(self):
+        finally_ran = False
+
+        async def body():
+            nonlocal finally_ran
+            try:
+                yield b"chunk"
+            finally:
+                finally_ran = True
+
+        response = StreamingHttpResponse(body())
+        async with aclosing(aiter(response)) as content:
+            async for _ in content:
+                break
+        self.assertTrue(finally_ran)
 
 
 class FileCloseTests(SimpleTestCase):

--- a/tests/pagination/tests.py
+++ b/tests/pagination/tests.py
@@ -3,9 +3,11 @@ import inspect
 import pathlib
 import unittest.mock
 import warnings
+from contextlib import aclosing
 from datetime import datetime
 
 from django.core.paginator import (
+    AsyncPage,
     AsyncPaginator,
     BasePaginator,
     EmptyPage,
@@ -990,3 +992,20 @@ class ModelPaginationTests(TestCase):
         # It returns the same list that was converted on the first call.
         second_called_objs = await p.aget_object_list()
         self.assertEqual(id(first_called_objs), id(second_called_objs))
+
+    async def test_async_page_aiteration_closes_object_list_promptly(self):
+        finally_ran = False
+
+        async def object_list():
+            nonlocal finally_ran
+            try:
+                yield 1
+                yield 2
+            finally:
+                finally_ran = True
+
+        page = AsyncPage(object_list(), number=1, paginator=None)
+        async with aclosing(aiter(page)) as it:
+            async for _ in it:
+                break
+        self.assertTrue(finally_ran)

--- a/tests/test_client/tests.py
+++ b/tests/test_client/tests.py
@@ -23,6 +23,7 @@ rather than the HTML rendered to the end-user.
 import copy
 import itertools
 import tempfile
+from contextlib import aclosing
 from unittest import mock
 
 from django.contrib.auth.models import Permission, User
@@ -37,6 +38,7 @@ from django.test import (
     modify_settings,
     override_settings,
 )
+from django.test.client import aclosing_iterator_wrapper
 from django.urls import reverse_lazy
 from django.utils.decorators import async_only_middleware
 from django.views.generic import RedirectView
@@ -1212,6 +1214,23 @@ class AsyncClientTest(TestCase):
         response = await self.async_client.get("/async_get_view/")
         self.assertTrue(hasattr(response, "resolver_match"))
         self.assertEqual(response.resolver_match.url_name, "async_get_view")
+
+    async def test_aclosing_iterator_wrapper_closes_inner_iterable_promptly(self):
+        finally_ran = False
+
+        async def iterable():
+            nonlocal finally_ran
+            try:
+                yield b"chunk"
+            finally:
+                finally_ran = True
+
+        async with aclosing(
+            aclosing_iterator_wrapper(iterable(), close=lambda: None)
+        ) as wrapped:
+            async for _ in wrapped:
+                break
+        self.assertTrue(finally_ran)
 
     @modify_settings(
         MIDDLEWARE={"prepend": "test_client.tests.async_middleware_urlconf"},

--- a/tests/utils_tests/test_text.py
+++ b/tests/utils_tests/test_text.py
@@ -1,12 +1,13 @@
 import gzip
 import json
 import sys
+from contextlib import aclosing
 
 from django.core.exceptions import SuspiciousFileOperation
 from django.test import SimpleTestCase
 from django.utils import text
 from django.utils.functional import lazystr
-from django.utils.text import format_lazy
+from django.utils.text import acompress_sequence, format_lazy
 from django.utils.translation import gettext_lazy, override
 
 IS_WIDE_BUILD = len("\U0001f4a9") == 1
@@ -417,6 +418,22 @@ class TestUtilsText(SimpleTestCase):
         self.assertEqual(gzip.decompress(out), original)
         self.assertLess(len(out), len(original))
         self.assertGreater(len(compressed_chunks), 2)
+
+    async def test_acompress_sequence_closes_inner_sequence_promptly(self):
+        finally_ran = False
+
+        async def sequence():
+            nonlocal finally_ran
+            try:
+                yield b"chunk1" * 1024
+                yield b"chunk2" * 1024
+            finally:
+                finally_ran = True
+
+        async with aclosing(acompress_sequence(sequence())) as compressed:
+            await anext(compressed)  # gzip header
+            await anext(compressed)  # first sequence-derived chunk
+        self.assertTrue(finally_ran)
 
     def test_format_lazy(self):
         self.assertEqual("django/test", format_lazy("{}/{}", "django", lazystr("test")))


### PR DESCRIPTION
#### Trac ticket number

ticket-37066

#### Branch description

Several places in Django consume a (possibly user-supplied) async iterable with a bare `async for` (or `[... async for ... in ...]` comprehension) without wrapping it in `contextlib.aclosing()`. When the consumer exits the loop early — via `break`, `return`, an exception in the body, or cancellation that lands while the generator is suspended at a `yield` (between `__anext__` calls, on a user-body `await`) — the underlying async generator is not closed at that point. Its `aclose()` is deferred until asyncio's asyncgen finalizer hook fires it (next loop tick if the generator is collected promptly, or `loop.shutdown_asyncgens()` at teardown), so any `try`/`finally` inside the generator (database transactions, connection releases, file handles, locks) runs at a non-deterministic later time, and may not run at all if the generator outlives the loop.

`django/core/handlers/asgi.py` already uses `aclosing(aiter(response))` for exactly this reason. This PR applies the same pattern at every other site and adds a small `maybe_aclosing` helper for cases where the iterable may be caller-supplied (and so may not have `aclose()`).

Sites wrapped (one per `async for` / async comprehension over a not-locally-defined iterable):

- `contrib/auth/backends.py`: `_aget_permissions` (`aclosing`)
- `core/paginator.py`: `AsyncPage.__aiter__` (`maybe_aclosing`)
- `core/paginator.py`: `AsyncPage.aget_object_list` (`maybe_aclosing`)
- `db/models/query.py`: `QuerySet.aiterator` (`aclosing`, single hoisted wrap across both prefetch and no-prefetch branches)
- `http/response.py`: `StreamingHttpResponse.streaming_content` (`awrapper`) (`maybe_aclosing`)
- `http/response.py`: `StreamingHttpResponse.__iter__` (`to_list`) (`maybe_aclosing`)
- `http/response.py`: `StreamingHttpResponse.__aiter__` (`aclosing`)
- `shortcuts.py`: `aget_list_or_404` (`aclosing`)
- `test/client.py`: `aclosing_iterator_wrapper` (`maybe_aclosing`)
- `utils/text.py`: `acompress_sequence` (`maybe_aclosing`)

Regression tests cover the four sites where an early-exit consumer can observe the leak (`StreamingHttpResponse.__aiter__`, `acompress_sequence`, `AsyncPage.__aiter__`, `aclosing_iterator_wrapper`) plus unit tests for the `maybe_aclosing` helper. Each regression test fails on `main` and passes with the fix applied.

`maybe_aclosing` is added as public API in `django.utils.asyncio` (alongside `async_unsafe`), with a docstring and a section in `docs/topics/async.txt`.

#### AI Assistance Disclosure (REQUIRED)

- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Anthropic Claude (`claude-opus-4-7`) via Claude Code CLI was used to draft the patch, the regression tests, and the docs. All file paths, line numbers, behavioural claims, and test failures were re-verified against the current `main` checkout by running the tests with the implementation stashed.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes. <!-- N/A — no UI changes -->