### PR TITLE
Refs #37068 -- Avoided table rebuild on SQLite for adding/removing check constraints.

### DIFF
--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -172,3 +172,9 @@ class DatabaseFeatures(BaseDatabaseFeatures):
 
     can_introspect_json_field = property(operator.attrgetter("supports_json_field"))
     has_json_object_function = property(operator.attrgetter("supports_json_field"))
+
+    supports_alter_column_constraints = Database.sqlite_version_info >= (
+        3,
+        53,
+        1,
+    )

--- a/django/db/backends/sqlite3/schema.py
+++ b/django/db/backends/sqlite3/schema.py
@@ -9,7 +9,7 @@ from django.db.backends.base.schema import (
 )
 from django.db.backends.ddl_references import Statement
 from django.db.backends.utils import strip_quotes
-from django.db.models import CompositePrimaryKey, UniqueConstraint
+from django.db.models import CheckConstraint, CompositePrimaryKey, UniqueConstraint
 
 
 class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
@@ -484,6 +484,13 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             or constraint.deferrable
         ):
             super().add_constraint(model, constraint)
+        # On SQLite 3.53.1+, use newly supported "ALTER TABLE ...
+        # ADD CONSTRAINT ... CHECK ...".
+        elif (
+            isinstance(constraint, CheckConstraint)
+            and self.connection.features.supports_alter_column_constraints
+        ):
+            super().add_constraint(model, constraint)
         else:
             self._remake_table(model)
 
@@ -493,6 +500,13 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             or constraint.contains_expressions
             or constraint.include
             or constraint.deferrable
+        ):
+            super().remove_constraint(model, constraint)
+        # On SQLite 3.53.1+, use newly supported "ALTER TABLE ...
+        # DROP CONSTRAINT ...".
+        elif (
+            isinstance(constraint, CheckConstraint)
+            and self.connection.features.supports_alter_column_constraints
         ):
             super().remove_constraint(model, constraint)
         else:

--- a/tests/backends/sqlite/tests.py
+++ b/tests/backends/sqlite/tests.py
@@ -16,9 +16,25 @@ from django.db import (
     connections,
     transaction,
 )
-from django.db.models import Aggregate, Avg, StdDev, Sum, Variance
+from django.db.models import (
+    Aggregate,
+    Avg,
+    CheckConstraint,
+    IntegerField,
+    Model,
+    Q,
+    StdDev,
+    Sum,
+    Variance,
+)
 from django.db.utils import ConnectionHandler
-from django.test import SimpleTestCase, TestCase, TransactionTestCase, override_settings
+from django.test import (
+    SimpleTestCase,
+    TestCase,
+    TransactionTestCase,
+    override_settings,
+    skipUnlessDBFeature,
+)
 from django.test.utils import CaptureQueriesContext, isolate_apps
 
 from ..models import Item, Object, Square
@@ -181,6 +197,29 @@ class SchemaTests(TransactionTestCase):
         with self.assertRaisesMessage(NotSupportedError, msg):
             with transaction.atomic(), connection.schema_editor(atomic=True):
                 pass
+
+    @skipUnlessDBFeature("supports_alter_column_constraints")
+    @isolate_apps("backends")
+    def test_add_remove_check_constraint_without_remake(self):
+        class Puppy(Model):
+            age = IntegerField()
+
+        constraint = CheckConstraint(condition=Q(age__gte=0), name="age_gte_0")
+
+        with connection.schema_editor() as editor:
+            editor.create_model(Puppy)
+
+            try:
+
+                with mock.patch.object(editor, "_remake_table") as remake:
+                    editor.add_constraint(Puppy, constraint)
+                    remake.assert_not_called()
+
+                    editor.remove_constraint(Puppy, constraint)
+                    remake.assert_not_called()
+
+            finally:
+                editor.delete_model(Puppy)
 
     def test_constraint_checks_disabled_atomic_allowed(self):
         """


### PR DESCRIPTION
#### Trac ticket number

ticket-37068

#### Branch description

Deal with one part of the ticket and use the base add/remove constraint methods on newer SQLite versions.

Tested by building [pysqlite3](https://pypi.org/project/pysqlite3/) against SQLite 3.53.1 and patching it into Django using this diff:

```diff
diff --git ./tests/runtests.py ./tests/runtests.py
index c24481f8cb..5fd3ce2f18 100755
--- ./tests/runtests.py
+++ ./tests/runtests.py
@@ -13,6 +13,40 @@
 import warnings
 from pathlib import Path
 
+import pysqlite3
+
+if not hasattr(pysqlite3.Connection, "getlimit"):
+    # pysqlite3 doesn't expose Connection.getlimit or SQLITE_LIMIT_COLUMN.
+    pysqlite3.SQLITE_LIMIT_COLUMN = 2
+    pysqlite3.dbapi2.SQLITE_LIMIT_COLUMN = 2
+    pysqlite3.SQLITE_LIMIT_VARIABLE_NUMBER = 9
+    pysqlite3.dbapi2.SQLITE_LIMIT_VARIABLE_NUMBER = 9
+    # pysqlite3 doesn't expose Connection.getlimit; stub it via a connect() wrapper
+    # that returns a subclass with the method added.
+    _real_connect = pysqlite3.connect
+
+    class _Connection(pysqlite3.Connection):
+        _limits = {}
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self._limits = {}
+
+        def getlimit(self, category):
+            return self._limits.get(category, {2: 2000, 9: 32766}.get(category, 2000))
+
+        def setlimit(self, category, value):
+            self._limits[category] = value
+
+    def _patched_connect(*args, **kwargs):
+        kwargs.setdefault("factory", _Connection)
+        return _real_connect(*args, **kwargs)
+
+    pysqlite3.connect = _patched_connect
+    pysqlite3.dbapi2.connect = _patched_connect
+
+sys.modules["sqlite3"] = pysqlite3
+
 try:
     import django
 except ImportError as e:
```

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

I used a bit of Claude to write the code but heavily edited the output.

I also had Claude build pysqlite3 for me against SQLite and write the necessary monkeypatching to include the newer Python SQLite limit APIs, in the above test diff.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
