### PR TITLE
Fixed #35857 -- Corrected timesince() and timeuntil() across DST transitions.

### DIFF
--- a/django/utils/timesince.py
+++ b/django/utils/timesince.py
@@ -71,7 +71,31 @@ def timesince(d, now=None, reversed=False, time_strings=None, depth=2):
 
     if reversed:
         d, now = now, d
-    delta = now - d
+    both_aware = is_aware(now) and is_aware(d)
+
+    def build_pivot(total_months):
+        if not total_months:
+            return d
+        years, months = divmod(total_months, 12)
+        pivot_year = d.year + years
+        pivot_month = d.month + months
+        if pivot_month > 12:
+            pivot_month -= 12
+            pivot_year += 1
+        return datetime.datetime(
+            pivot_year,
+            pivot_month,
+            min(MONTHS_DAYS[pivot_month - 1], d.day),
+            d.hour,
+            d.minute,
+            d.second,
+            tzinfo=d.tzinfo,
+        )
+
+    if both_aware:
+        delta = now.astimezone(datetime.UTC) - d.astimezone(datetime.UTC)
+    else:
+        delta = now - d
 
     # Ignore microseconds.
     since = delta.days * 24 * 60 * 60 + delta.seconds
@@ -81,31 +105,32 @@ def timesince(d, now=None, reversed=False, time_strings=None, depth=2):
 
     # Get years and months.
     total_months = (now.year - d.year) * 12 + (now.month - d.month)
-    if d.day > now.day or (d.day == now.day and d.time() > now.time()):
-        total_months -= 1
+    total_months = max(total_months, 0)
     years, months = divmod(total_months, 12)
 
     # Calculate the remaining time.
     # Create a "pivot" datetime shifted from d by years and months, then use
     # that to determine the other parts.
-    if years or months:
-        pivot_year = d.year + years
-        pivot_month = d.month + months
-        if pivot_month > 12:
-            pivot_month -= 12
-            pivot_year += 1
-        pivot = datetime.datetime(
-            pivot_year,
-            pivot_month,
-            min(MONTHS_DAYS[pivot_month - 1], d.day),
-            d.hour,
-            d.minute,
-            d.second,
-            tzinfo=d.tzinfo,
-        )
+    pivot = build_pivot(total_months)
+    if total_months:
+        if both_aware:
+            pivot_is_later = pivot.astimezone(datetime.UTC) > now.astimezone(
+                datetime.UTC
+            )
+        else:
+            pivot_is_later = pivot > now
     else:
-        pivot = d
-    remaining_time = (now - pivot).total_seconds()
+        pivot_is_later = False
+    if pivot_is_later:
+        total_months -= 1
+        years, months = divmod(total_months, 12)
+        pivot = build_pivot(total_months)
+    if both_aware:
+        remaining_time = (
+            now.astimezone(datetime.UTC) - pivot.astimezone(datetime.UTC)
+        ).total_seconds()
+    else:
+        remaining_time = (now - pivot).total_seconds()
     partials = [years, months]
     for chunk in TIME_CHUNKS:
         count = int(remaining_time // chunk)

--- a/django/utils/timesince.py
+++ b/django/utils/timesince.py
@@ -127,9 +127,7 @@ def timesince(d, now=None, reversed=False, time_strings=None, depth=2):
         years, months = divmod(total_months, 12)
         pivot = build_pivot(total_months)
     if both_aware:
-        remaining_time = (
-            now_utc - pivot.astimezone(datetime.UTC)
-        ).total_seconds()
+        remaining_time = (now_utc - pivot.astimezone(datetime.UTC)).total_seconds()
     else:
         remaining_time = (now - pivot).total_seconds()
     partials = [years, months]

--- a/django/utils/timesince.py
+++ b/django/utils/timesince.py
@@ -119,7 +119,9 @@ def timesince(d, now=None, reversed=False, time_strings=None, depth=2):
         if both_aware:
             pivot_is_later = pivot.astimezone(datetime.UTC) > now_utc
         else:
-            pivot_is_later = pivot > now
+            pivot_is_later = d.day > now.day or (
+                d.day == now.day and d.time() > now.time()
+            )
     else:
         pivot_is_later = False
     if pivot_is_later:

--- a/django/utils/timesince.py
+++ b/django/utils/timesince.py
@@ -93,7 +93,9 @@ def timesince(d, now=None, reversed=False, time_strings=None, depth=2):
         )
 
     if both_aware:
-        delta = now.astimezone(datetime.UTC) - d.astimezone(datetime.UTC)
+        d_utc = d.astimezone(datetime.UTC)
+        now_utc = now.astimezone(datetime.UTC)
+        delta = now_utc - d_utc
     else:
         delta = now - d
 
@@ -105,6 +107,7 @@ def timesince(d, now=None, reversed=False, time_strings=None, depth=2):
 
     # Get years and months.
     total_months = (now.year - d.year) * 12 + (now.month - d.month)
+    # Guard against DST rollback crossing a local month boundary backward.
     total_months = max(total_months, 0)
     years, months = divmod(total_months, 12)
 
@@ -114,9 +117,7 @@ def timesince(d, now=None, reversed=False, time_strings=None, depth=2):
     pivot = build_pivot(total_months)
     if total_months:
         if both_aware:
-            pivot_is_later = pivot.astimezone(datetime.UTC) > now.astimezone(
-                datetime.UTC
-            )
+            pivot_is_later = pivot.astimezone(datetime.UTC) > now_utc
         else:
             pivot_is_later = pivot > now
     else:
@@ -127,7 +128,7 @@ def timesince(d, now=None, reversed=False, time_strings=None, depth=2):
         pivot = build_pivot(total_months)
     if both_aware:
         remaining_time = (
-            now.astimezone(datetime.UTC) - pivot.astimezone(datetime.UTC)
+            now_utc - pivot.astimezone(datetime.UTC)
         ).total_seconds()
     else:
         remaining_time = (now - pivot).total_seconds()

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -394,6 +394,11 @@ Utilities
 * :func:`~django.utils.dateparse.parse_duration` now supports ISO 8601
   time periods expressed in weeks (``PnW``).
 
+* :func:`~django.utils.timesince.timesince` and
+  :func:`~django.utils.timesince.timeuntil` now correctly calculate elapsed
+  time across DST (Daylight Saving Time) transitions when using timezone-aware
+  datetimes, by converting to UTC before computing the difference.
+
 Validators
 ~~~~~~~~~~
 

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -394,8 +394,8 @@ Utilities
 * :func:`~django.utils.dateparse.parse_duration` now supports ISO 8601
   time periods expressed in weeks (``PnW``).
 
-* :func:`~django.utils.timesince.timesince` and
-  :func:`~django.utils.timesince.timeuntil` now correctly calculate elapsed
+* ``django.utils.timesince.timesince()`` and
+  ``django.utils.timesince.timeuntil()`` now correctly calculate elapsed
   time across DST (Daylight Saving Time) transitions when using timezone-aware
   datetimes, by converting to UTC before computing the difference.
 

--- a/tests/utils_tests/test_timesince.py
+++ b/tests/utils_tests/test_timesince.py
@@ -278,6 +278,36 @@ class TimesinceTests(TestCase):
             with self.subTest(value):
                 self.assertEqual(timesince(value, now_utc), expected)
 
+    def test_across_dst_fallback_with_zoneinfo(self):
+        berlin = zoneinfo.ZoneInfo("Europe/Berlin")
+        t = datetime.datetime(2024, 10, 27, 2, 55, tzinfo=berlin)
+        ten_minutes_later = datetime.datetime(2024, 10, 27, 2, 5, fold=1, tzinfo=berlin)
+        seventy_minutes_later = datetime.datetime(
+            2024, 10, 27, 3, 5, tzinfo=berlin
+        )
+
+        self.assertEqual(timesince(t, ten_minutes_later), "10\xa0minutes")
+        self.assertEqual(
+            timesince(t, seventy_minutes_later),
+            "1\xa0hour, 10\xa0minutes",
+        )
+
+    def test_across_dst_fallback_same_wall_time_with_different_fold(self):
+        berlin = zoneinfo.ZoneInfo("Europe/Berlin")
+        earlier = datetime.datetime(2024, 10, 27, 2, 5, fold=0, tzinfo=berlin)
+        later = datetime.datetime(2024, 10, 27, 2, 5, fold=1, tzinfo=berlin)
+
+        self.assertEqual(timesince(earlier, later), "1\xa0hour")
+        self.assertEqual(timeuntil(later, earlier), "1\xa0hour")
+
+    def test_across_dst_spring_forward_with_zoneinfo(self):
+        berlin = zoneinfo.ZoneInfo("Europe/Berlin")
+        start = datetime.datetime(2025, 3, 30, 1, 55, tzinfo=berlin)
+        ten_minutes_later = datetime.datetime(2025, 3, 30, 3, 5, tzinfo=berlin)
+
+        self.assertEqual(timesince(start, ten_minutes_later), "10\xa0minutes")
+        self.assertEqual(timeuntil(ten_minutes_later, start), "10\xa0minutes")
+
 
 @requires_tz_support
 @override_settings(USE_TZ=True)

--- a/tests/utils_tests/test_timesince.py
+++ b/tests/utils_tests/test_timesince.py
@@ -289,6 +289,11 @@ class TimesinceTests(TestCase):
             timesince(t, seventy_minutes_later),
             "1\xa0hour, 10\xa0minutes",
         )
+        self.assertEqual(timeuntil(ten_minutes_later, t), "10\xa0minutes")
+        self.assertEqual(
+            timeuntil(seventy_minutes_later, t),
+            "1\xa0hour, 10\xa0minutes",
+        )
 
     def test_across_dst_fallback_same_wall_time_with_different_fold(self):
         berlin = zoneinfo.ZoneInfo("Europe/Berlin")

--- a/tests/utils_tests/test_timesince.py
+++ b/tests/utils_tests/test_timesince.py
@@ -282,9 +282,7 @@ class TimesinceTests(TestCase):
         berlin = zoneinfo.ZoneInfo("Europe/Berlin")
         t = datetime.datetime(2024, 10, 27, 2, 55, tzinfo=berlin)
         ten_minutes_later = datetime.datetime(2024, 10, 27, 2, 5, fold=1, tzinfo=berlin)
-        seventy_minutes_later = datetime.datetime(
-            2024, 10, 27, 3, 5, tzinfo=berlin
-        )
+        seventy_minutes_later = datetime.datetime(2024, 10, 27, 3, 5, tzinfo=berlin)
 
         self.assertEqual(timesince(t, ten_minutes_later), "10\xa0minutes")
         self.assertEqual(


### PR DESCRIPTION
#### Trac ticket number

[ticket-35857](https://code.djangoproject.com/ticket/35857)
#### Branch description
Corrected `timesince()` and `timeuntil()` for timezone-aware datetimes across DST transitions.
Previously, these functions could return incorrect elapsed times around DST fallback transitions because month/year boundary handling relied on wall-clock comparisons such as `d.time() > now.time()`, which can be misleading for ambiguous local times. In cases like the `Europe/Berlin` fallback transition, a later aware datetime could be interpreted as earlier and produce results such as `0 minutes` instead of `10 minutes`.
This patch computes elapsed time for aware datetimes in UTC, so minute/hour-based differences reflect the actual passage of time across DST transitions. The existing calendar-based month/year handling is preserved, with the pivot comparison adjusted so it doesn't mis-handle ambiguous times.
Added regression tests covering:
- DST fallback transitions in `Europe/Berlin`
- ambiguous `fold` times with the same wall-clock representation
- DST spring-forward transitions
- both `timesince()` and `timeuntil()`
Also added a release note entry for the behavior change.

#### AI Assistance Disclosure (REQUIRED)
- [ ] No AI tools were used in preparing this PR.
- [x] If AI tools were used, I have disclosed which ones, and fully reviewed and verified their output.
I used Claude Code assistance while preparing this PR and fully reviewed and verified the final changes myself.

#### Checklist
- [x] This PR follows the contribution guidelines.
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.