### PR TITLE
Refs CVE-2026-25674 -- Clarified role of umask in upload permissions.

### DIFF
--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -1636,6 +1636,12 @@ when using the :djadmin:`collectstatic` management command. See
     modes must be specified. If you try to use ``644``, you'll get totally
     incorrect behavior.
 
+.. admonition:: A numeric value trumps umask
+
+    When this setting has a numeric value (one you've set yourself, or the
+    default ``0o644``), this value will be used as is, and a umask will not
+    be applied to it. The umask will apply only if this setting is ``None``.
+
 .. setting:: FILE_UPLOAD_TEMP_DIR
 
 ``FILE_UPLOAD_TEMP_DIR``


### PR DESCRIPTION
#### Trac ticket number

N/A - CVE-2026-25674

#### Branch description
In discussions in the security team on the resolution of [CVE-2026-25674](https://www.djangoproject.com/weblog/2026/mar/03/security-releases/), we decided we should warn users that the process/system umask does not modify the permissions when a mode value is specified for `FILE_UPLOAD_PERMISSIONS` and `FILE_UPLOAD_DIRECTORY_PERMISSIONS`.

#### AI Assistance Disclosure (REQUIRED)
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
