### PR TITLE
Fixed #37070 -- Added .clear_messages() method to django.contrib.mess…

### DIFF
--- a/django/contrib/messages/api.py
+++ b/django/contrib/messages/api.py
@@ -4,6 +4,7 @@ from django.contrib.messages.storage import default_storage
 __all__ = (
     "add_message",
     "get_messages",
+    "clear_messages",
     "get_level",
     "set_level",
     "debug",
@@ -46,6 +47,14 @@ def get_messages(request):
     an empty list.
     """
     return getattr(request, "_messages", [])
+
+
+def clear_messages(request):
+    """
+    Clear all messages on the request.
+    """
+    if hasattr(request, "_messages"):
+        request._messages.clear()
 
 
 def get_level(request):

--- a/django/contrib/messages/storage/base.py
+++ b/django/contrib/messages/storage/base.py
@@ -157,6 +157,15 @@ class BaseStorage:
         message = Message(level, message, extra_tags=extra_tags)
         self._queued_messages.append(message)
 
+    def clear(self):
+        """
+        Clear all messages.
+        """
+        self.used = True
+        self._queued_messages = []
+        if hasattr(self, "_loaded_data"):
+            self._loaded_data = []
+
     def _get_level(self):
         """
         Return the minimum recorded level.

--- a/docs/ref/contrib/messages.txt
+++ b/docs/ref/contrib/messages.txt
@@ -91,6 +91,10 @@ To write your own storage class, subclass the ``BaseStorage`` class in
 ``django.contrib.messages.storage.base`` and implement the ``_get`` and
 ``_store`` methods.
 
+.. method:: storage.base.BaseStorage.clear()
+
+    Clear all messages.
+
 .. _message-level:
 
 Message levels
@@ -181,6 +185,10 @@ used tags (which are usually represented as HTML classes for the message)::
 Displaying messages
 -------------------
 .. function:: get_messages(request)
+
+.. function:: clear_messages(request)
+
+    Clear all messages on the request.
 
 **In your template**, use something like:
 

--- a/tests/messages_tests/base.py
+++ b/tests/messages_tests/base.py
@@ -93,6 +93,15 @@ class BaseTests:
         storage.add(constants.INFO, "Test message 2", extra_tags="tag")
         self.assertEqual(len(storage), 2)
 
+    def test_clear(self):
+        storage = self.get_storage()
+        storage.add(constants.INFO, "Test message 1")
+        storage.add(constants.INFO, "Test message 2", extra_tags="tag")
+        self.assertEqual(len(storage), 2)
+        storage.clear()
+        self.assertEqual(len(storage), 0)
+        self.assertTrue(storage.used)
+
     def test_add_lazy_translation(self):
         storage = self.get_storage()
         response = self.get_response()

--- a/tests/messages_tests/test_api.py
+++ b/tests/messages_tests/test_api.py
@@ -18,6 +18,17 @@ class ApiTests(SimpleTestCase):
         [message] = self.storage.store
         self.assertEqual(msg, message.message)
 
+    def test_clear_messages(self):
+        self.request._messages = self.storage
+        messages.add_message(self.request, messages.DEBUG, "some message")
+        self.assertEqual(len(self.storage.store), 1)
+        messages.clear_messages(self.request)
+        self.assertEqual(len(self.storage.store), 0)
+
+    def test_clear_messages_middleware_missing(self):
+        # Should fail silently if middleware is missing.
+        messages.clear_messages(self.request)
+
     def test_request_is_none(self):
         msg = "add_message() argument must be an HttpRequest object, not 'NoneType'."
         self.request._messages = self.storage

--- a/tests/messages_tests/utils.py
+++ b/tests/messages_tests/utils.py
@@ -10,5 +10,8 @@ class DummyStorage:
     def add(self, level, message, extra_tags=""):
         self.store.append(Message(level, message, extra_tags))
 
+    def clear(self):
+        self.store = []
+
     def __iter__(self):
         return iter(self.store)


### PR DESCRIPTION
Fixed #37070 -- Added .clear_messages() method to django.contrib.messages.

#### Trac ticket number
ticket-37070

#### Branch description
Fixes #37070.

This adds a `clear_messages()` function to the `django.contrib.messages.api` and a `.clear()` method to the base storage class to allow explicitly clearing messages without having to iterate through them via `get_messages()`. 

Added tests and updated the docs accordingly.

#### AI Assistance Disclosure (REQUIRED)
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
