### PR TITLE
Fixed #37067 -- Added closing separator to django_file_prefixes()

### DIFF
--- a/django/utils/deprecation.py
+++ b/django/utils/deprecation.py
@@ -16,7 +16,9 @@ def django_file_prefixes():
     file = getattr(django, "__file__", None)
     if file is None:
         return ()
-    return (os.path.dirname(file),)
+
+    base = os.path.dirname(os.path.dirname(__file__))
+    return (os.path.join(base, ""),)
 
 
 class RemovedInNextVersionWarning(DeprecationWarning):

--- a/tests/deprecation/tests.py
+++ b/tests/deprecation/tests.py
@@ -31,7 +31,40 @@ class DjangoFilePrefixesTests(SimpleTestCase):
         prefixes = django_file_prefixes()
         self.assertIsInstance(prefixes, tuple)
         self.assertEqual(len(prefixes), 1)
-        self.assertTrue(prefixes[0].endswith(f"{os.path.sep}django"))
+        # /django must be in the prefix
+        self.assertTrue(os.path.normpath(prefixes[0]).endswith(f"{os.path.sep}django"))
+
+    def test_prefix_has_trailing_separator(self):
+        """django_file_prefixes() should end with a separator to avoid
+        matching packages like django_something."""
+        for prefix in django_file_prefixes():
+            self.assertTrue(
+                prefix.endswith(os.sep),
+            )
+
+    def test_sibling_package_not_skipped(self):
+        """Warnings from packages like django_something should
+        not be in django_file_prefixes and should not be skipped."""
+
+        something_file = os.path.dirname(django.__file__) + "_something/__init__.py"
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            exec(
+                compile("warn()", something_file, "exec"),
+                {
+                    "warn": lambda: warnings.warn(
+                        "deprecated.",
+                        DeprecationWarning,
+                        skip_file_prefixes=django_file_prefixes(),
+                    )
+                },
+            )
+
+        self.assertEqual(len(caught), 1)
+        self.assertEqual(
+            os.path.normcase(caught[0].filename), os.path.normcase(something_file)
+        )
 
 
 class RenameManagerMethods(RenameMethodsBase):
@@ -207,4 +240,42 @@ class RenameMethodsTests(SimpleTestCase):
     def test_removedafternextversionwarning_pending(self):
         self.assertTrue(
             issubclass(RemovedAfterNextVersionWarning, PendingDeprecationWarning)
+        )
+
+
+class DjangoSkipsSiblingPackagesTests(SimpleTestCase):
+    def setUp(self):
+        django_file_prefixes.cache_clear()
+        self.addCleanup(django_file_prefixes.cache_clear)
+
+    def test_prefix_has_trailing_separator(self):
+        """django_file_prefixes() should end with a separator to avoid
+        matching packages like django_something."""
+        for prefix in django_file_prefixes():
+            self.assertTrue(
+                prefix.endswith(os.sep),
+            )
+
+    def test_warnings_skip_past_packages_start_with_django(self):
+        """Warnings from packages like django_something should
+        not be in django_file_prefixes and should not be skipped."""
+
+        something_file = os.path.dirname(django.__file__) + "_something/__init__.py"
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            exec(
+                compile("warn()", something_file, "exec"),
+                {
+                    "warn": lambda: warnings.warn(
+                        "deprecated.",
+                        DeprecationWarning,
+                        skip_file_prefixes=django_file_prefixes(),
+                    )
+                },
+            )
+
+        self.assertEqual(len(caught), 1)
+        self.assertEqual(
+            os.path.normcase(caught[0].filename), os.path.normcase(something_file)
         )


### PR DESCRIPTION
ticket-37067 

#### Branch description
Added closing separator for the function.
Updated one of the previous test for
django_file_prefixes to match new changes.

Added test that verifies that
django_file_prefixes result ends with separator

Added test that runs a warn function from
fake file from fake package type of
django_something and checks that the warning
is not skipped.


#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
ChatGpt 5.3 was used for test_sibling_package_not_skipped for exec + compile approach

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
