### PR TITLE
Fixed #37067 - Added trailing separator to django_file_prefixes().

### DIFF
--- a/django/utils/deprecation.py
+++ b/django/utils/deprecation.py
@@ -16,7 +16,7 @@ def django_file_prefixes():
     file = getattr(django, "__file__", None)
     if file is None:
         return ()
-    return (os.path.dirname(file),)
+    return (os.path.join(os.path.dirname(file), ""),)
 
 
 class RemovedInNextVersionWarning(DeprecationWarning):

--- a/tests/deprecation/tests.py
+++ b/tests/deprecation/tests.py
@@ -31,7 +31,14 @@ class DjangoFilePrefixesTests(SimpleTestCase):
         prefixes = django_file_prefixes()
         self.assertIsInstance(prefixes, tuple)
         self.assertEqual(len(prefixes), 1)
-        self.assertTrue(prefixes[0].endswith(f"{os.path.sep}django"))
+        self.assertTrue(prefixes[0].endswith(f"{os.path.sep}django{os.path.sep}"))
+
+    def test_does_not_match_packages_prefixed_with_django(self):
+        (django_prefix,) = django_file_prefixes()
+        django_dir = django_prefix.removesuffix(os.path.sep)
+        site_packages_dir = os.path.dirname(django_dir)
+        package_file = os.path.join(site_packages_dir, "django_goodies", "__init__.py")
+        self.assertFalse(package_file.startswith(django_prefix))
 
 
 class RenameManagerMethods(RenameMethodsBase):


### PR DESCRIPTION

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37067

#### Branch description
`django_file_prefixes()` returned Django’s package directory without a trailing path separator. Because `warnings.warn(..., skip_file_prefixes=...)` does a prefix match, this could incorrectly skip frames from sibling packages whose paths start with `django` (for example, `django_goodies`), misattributing deprecation warnings. This change makes the returned prefix separator terminated so only files inside
the Django package are matched.

Added regression coverage in `tests/deprecation/tests.py` to verify:
- the returned prefix ends with `.../django/` (platform separator-aware), and
- paths from `django_*` sibling packages are not matched by the prefix.
#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [ ] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
