### PR TITLE
Fixed #37025 -- Deprecated async support in RemoteUserMiddleware and PersistentRemoteUserMiddleware in favor of separate async only middleware classes.

### DIFF
--- a/django/contrib/auth/middleware.py
+++ b/django/contrib/auth/middleware.py
@@ -1,3 +1,4 @@
+import warnings
 from functools import partial
 from inspect import iscoroutinefunction, markcoroutinefunction
 from urllib.parse import urlsplit
@@ -9,7 +10,8 @@ from django.contrib.auth.backends import RemoteUserBackend
 from django.contrib.auth.views import redirect_to_login
 from django.core.exceptions import ImproperlyConfigured
 from django.shortcuts import resolve_url
-from django.utils.deprecation import MiddlewareMixin
+from django.utils.decorators import async_only_middleware
+from django.utils.deprecation import MiddlewareMixin, RemovedInDjango70Warning
 from django.utils.functional import SimpleLazyObject
 
 
@@ -107,13 +109,17 @@ class RemoteUserMiddleware:
     """
 
     sync_capable = True
+    # RemovedInDjango70Warning: When the deprecation ends, decorate this
+    # middleware with @sync_only_middleware.
     async_capable = True
 
     def __init__(self, get_response):
         if get_response is None:
             raise ValueError("get_response must be provided.")
         self.get_response = get_response
+        # RemovedInDjango70Warning.
         self.is_async = iscoroutinefunction(get_response)
+        # RemovedInDjango70Warning.
         if self.is_async:
             markcoroutinefunction(self)
         super().__init__()
@@ -168,10 +174,17 @@ class RemoteUserMiddleware:
             # user in.
             auth.login(request, user)
 
+    # RemovedInDjango70Warning.
     async def __acall__(self, request):
+        msg = (
+            "Async support of RemoteUserMiddleware is deprecated. Use "
+            "AsyncRemoteUserMiddleware instead."
+        )
+        warnings.warn(msg, category=RemovedInDjango70Warning, stacklevel=2)
         await self.aprocess_request(request)
         return await self.get_response(request)
 
+    # RemovedInDjango70Warning.
     async def aprocess_request(self, request):
         # AuthenticationMiddleware is required so that request.user exists.
         if not hasattr(request, "user"):
@@ -242,7 +255,92 @@ class RemoteUserMiddleware:
             if isinstance(stored_backend, RemoteUserBackend):
                 auth.logout(request)
 
+    # RemovedInDjango70Warning.
     async def _aremove_invalid_user(self, request):
+        """
+        Remove the current authenticated user in the request which is invalid
+        but only if the user is authenticated via the RemoteUserBackend.
+        """
+        try:
+            stored_backend = load_backend(
+                await request.session.aget(auth.BACKEND_SESSION_KEY, "")
+            )
+        except ImportError:
+            # Backend failed to load.
+            await auth.alogout(request)
+        else:
+            if isinstance(stored_backend, RemoteUserBackend):
+                await auth.alogout(request)
+
+
+@async_only_middleware
+class AsyncRemoteUserMiddleware:
+    header = "REMOTE_USER"
+    force_logout_if_no_header = True
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        markcoroutinefunction(self)
+
+    async def __call__(self, request):
+        await self.process_request(request)
+        return await self.get_response(request)
+
+    async def process_request(self, request):
+        # AuthenticationMiddleware is required so that request.auser exists.
+        if not hasattr(request, "auser"):
+            raise ImproperlyConfigured(
+                "The Django remote user auth middleware requires the"
+                " authentication middleware to be installed. Edit your"
+                " MIDDLEWARE setting to insert"
+                " 'django.contrib.auth.middleware.AuthenticationMiddleware'"
+                f" before the {self.__class__.__name__} class."
+            )
+        try:
+            username = request.headers[self.header]
+        except KeyError:
+            # If specified header doesn't exist then remove any existing
+            # authenticated remote-user, or return (leaving request.user set to
+            # AnonymousUser by the AuthenticationMiddleware).
+            if self.force_logout_if_no_header:
+                user = await request.auser()
+                if user.is_authenticated:
+                    await self._remove_invalid_user(request)
+            return
+        user = await request.auser()
+        # If the user is already authenticated and that user is the user we are
+        # getting passed in the headers, then the correct user is already
+        # persisted in the session and we don't need to continue.
+        if user.is_authenticated:
+            if user.get_username() == await self.clean_username(username, request):
+                return
+            else:
+                # An authenticated user is associated with the request, but
+                # it does not match the authorized user in the header.
+                await self._remove_invalid_user(request)
+
+        # We are seeing this user for the first time in this session, attempt
+        # to authenticate the user.
+        user = await auth.aauthenticate(request, remote_user=username)
+        if user:
+            # User is valid. Persist the user in the session by logging the
+            # user in.
+            await auth.alogin(request, user)
+
+    async def clean_username(self, username, request):
+        """
+        Allow the backend to clean the username, if the backend defines a
+        clean_username method.
+        """
+        backend_str = await request.session.aget(auth.BACKEND_SESSION_KEY)
+        backend = auth.load_backend(backend_str)
+        try:
+            username = backend.clean_username(username)
+        except AttributeError:  # Backend has no clean_username method.
+            pass
+        return username
+
+    async def _remove_invalid_user(self, request):
         """
         Remove the current authenticated user in the request which is invalid
         but only if the user is authenticated via the RemoteUserBackend.
@@ -270,4 +368,17 @@ class PersistentRemoteUserMiddleware(RemoteUserMiddleware):
     Django's authentication mechanism.
     """
 
+    force_logout_if_no_header = False
+
+    # RemovedInDjango70Warning.
+    async def __acall__(self, request):
+        msg = (
+            "Async support of PersistentRemoteUserMiddleware is deprecated. Use "
+            "AsyncPersistentRemoteUserMiddleware instead."
+        )
+        warnings.warn(msg, category=RemovedInDjango70Warning, stacklevel=2)
+        return await super().__acall__(request)
+
+
+class AsyncPersistentRemoteUserMiddleware(AsyncRemoteUserMiddleware):
     force_logout_if_no_header = False

--- a/django/contrib/auth/middleware.py
+++ b/django/contrib/auth/middleware.py
@@ -164,9 +164,8 @@ class RemoteUserMiddleware:
         # to authenticate the user.
         user = auth.authenticate(request, remote_user=username)
         if user:
-            # User is valid. Set request.user and persist user in the session
-            # by logging the user in.
-            request.user = user
+            # User is valid. Persist the user in the session by logging the
+            # user in.
             auth.login(request, user)
 
     async def __acall__(self, request):
@@ -210,9 +209,8 @@ class RemoteUserMiddleware:
         # to authenticate the user.
         user = await auth.aauthenticate(request, remote_user=username)
         if user:
-            # User is valid. Set request.user and persist user in the session
-            # by logging the user in.
-            request.user = user
+            # User is valid. Persist the user in the session by logging the
+            # user in.
             await auth.alogin(request, user)
 
     def clean_username(self, username, request):

--- a/django/contrib/auth/middleware.py
+++ b/django/contrib/auth/middleware.py
@@ -138,7 +138,7 @@ class RemoteUserMiddleware:
                 " authentication middleware to be installed. Edit your"
                 " MIDDLEWARE setting to insert"
                 " 'django.contrib.auth.middleware.AuthenticationMiddleware'"
-                " before the RemoteUserMiddleware class."
+                f" before the {self.__class__.__name__} class."
             )
         try:
             username = request.META[self.header]
@@ -181,7 +181,7 @@ class RemoteUserMiddleware:
                 " authentication middleware to be installed. Edit your"
                 " MIDDLEWARE setting to insert"
                 " 'django.contrib.auth.middleware.AuthenticationMiddleware'"
-                " before the RemoteUserMiddleware class."
+                f" before the {self.__class__.__name__} class."
             )
         try:
             username = request.META["HTTP_" + self.header]

--- a/docs/howto/auth-remote-user.txt
+++ b/docs/howto/auth-remote-user.txt
@@ -14,14 +14,30 @@ Windows Authentication or Apache and `mod_authnz_ldap`_, `CAS`_, `WebAuth`_,
 .. _WebAuth: https://uit.stanford.edu/service/authentication
 .. _mod_auth_sspi: https://sourceforge.net/projects/mod-auth-sspi
 
-When the web server takes care of authentication it typically sets the
-``REMOTE_USER`` environment variable for use in the underlying application. In
-Django, ``REMOTE_USER`` is made available in the :attr:`request.META
+Under WSGI, when the web server takes care of authentication it typically sets
+the ``REMOTE_USER`` environment variable for use in the underlying application.
+In Django, ``REMOTE_USER`` is made available in the :attr:`request.META
 <django.http.HttpRequest.META>` attribute. Django can be configured to make
 use of the ``REMOTE_USER`` value using the ``RemoteUserMiddleware``
 or ``PersistentRemoteUserMiddleware``, and
 :class:`~django.contrib.auth.backends.RemoteUserBackend` classes found in
 :mod:`django.contrib.auth`.
+
+Under ASGI, the web server or reverse proxy does not provide a ``REMOTE_USER``
+environment variable. Instead, the authenticated user is conveyed via an HTTP
+header. ``AsyncRemoteUserMiddleware`` reads this value from
+``request.headers``, where header names are treated case-insensitively. By
+default, it looks for a ``REMOTE_USER`` header, though this can be customized.
+In this case, Django can be configured to make use of the ``REMOTE_USER``
+value using the ``AsyncRemoteUserMiddleware`` or
+``AsyncPersistentRemoteUserMiddleware``, and
+:class:`~django.contrib.auth.backends.RemoteUserBackend` classes.
+
+.. versionchanged:: 6.1
+
+    :class:`django.contrib.auth.middleware.AsyncRemoteUserMiddleware` and
+    :class:`django.contrib.auth.middleware.AsyncPersistentRemoteUserMiddleware`
+    were added.
 
 Configuration
 =============
@@ -38,6 +54,16 @@ First, you must add the
         "...",
     ]
 
+When using ASGI, you must use the
+:class:`django.contrib.auth.middleware.AsyncRemoteUserMiddleware`::
+
+    MIDDLEWARE = [
+        "...",
+        "django.contrib.auth.middleware.AuthenticationMiddleware",
+        "django.contrib.auth.middleware.AsyncRemoteUserMiddleware",
+        "...",
+    ]
+
 Next, you must replace the :class:`~django.contrib.auth.backends.ModelBackend`
 with :class:`~django.contrib.auth.backends.RemoteUserBackend` in the
 :setting:`AUTHENTICATION_BACKENDS` setting::
@@ -46,9 +72,12 @@ with :class:`~django.contrib.auth.backends.RemoteUserBackend` in the
         "django.contrib.auth.backends.RemoteUserBackend",
     ]
 
-With this setup, ``RemoteUserMiddleware`` will detect the username in
-``request.META['REMOTE_USER']`` and will authenticate and auto-login that user
-using the :class:`~django.contrib.auth.backends.RemoteUserBackend`.
+Under WSGI, with this setup, ``RemoteUserMiddleware`` will detect the username
+in ``request.META['REMOTE_USER']`` and will authenticate and auto-login that
+user using the :class:`~django.contrib.auth.backends.RemoteUserBackend`.
+
+Under ASGI, ``AsyncRemoteUserMiddleware`` will detect the username in
+``request.headers['REMOTE_USER']``.
 
 Be aware that this particular setup disables authentication with the default
 ``ModelBackend``. This means that if the ``REMOTE_USER`` value is not set
@@ -74,7 +103,7 @@ regardless of ``AUTHENTICATION_BACKENDS``.
     :class:`~django.contrib.auth.backends.AllowAllUsersRemoteUserBackend` if
     you want to allow them to.
 
-If your authentication mechanism uses a custom HTTP header and not
+Under WSGI, if your authentication mechanism uses a custom HTTP header and not
 ``REMOTE_USER``, you can subclass ``RemoteUserMiddleware`` and set the
 ``header`` attribute to the desired ``request.META`` key. For example:
 
@@ -97,28 +126,35 @@ instead of :class:`django.contrib.auth.middleware.RemoteUserMiddleware`::
         "...",
     ]
 
+``AsyncRemoteUserMiddleware`` obtains the username from ``request.headers``
+rather than ``request.META``. Therefore, header names should be specified in
+their standard HTTP form (e.g. ``X-Remote-User``), rather than the ``HTTP_*``
+format used in ``request.META``. To use a different header, subclass
+:class:`~django.contrib.auth.middleware.AsyncRemoteUserMiddleware` and set the
+``header`` attribute to the desired header name:
+
+.. code-block:: python
+   :caption: ``mysite/middleware.py``
+
+    from django.contrib.auth.middleware import AsyncRemoteUserMiddleware
+
+
+    class CustomHeaderRemoteUserMiddleware(AsyncRemoteUserMiddleware):
+        header = "X-Remote-User"
+
+As before, this middleware should then be added to the :setting:`MIDDLEWARE`
+setting in place of
+:class:`django.contrib.auth.middleware.AsyncRemoteUserMiddleware`.
+
 .. warning::
 
-    ``RemoteUserMiddleware`` must not be deployed in configurations where a
-    client can supply the header. You must be sure that your web server or
+    ``AsyncRemoteUserMiddleware`` must not be deployed in configurations where
+    a client can supply the header. You must be sure that your web server or
     reverse proxy always sets or strips that header based on the appropriate
     authentication checks, never permitting an end user to submit a fake (or
     "spoofed") header value. In particular, ASGI deployments cannot be exposed
     directly to the internet (that is, without a reverse proxy) when using this
     middleware.
-
-    Since the HTTP headers ``X-Auth-User`` and ``X-Auth_User`` (for example)
-    both normalize to the ``HTTP_X_AUTH_USER`` key in ``request.META``, you
-    must also check that your web server doesn't allow a spoofed header using
-    underscores in place of dashes.
-
-    Under WSGI, this warning doesn't apply to ``RemoteUserMiddleware`` in its
-    default configuration with ``header = "REMOTE_USER"``, since a key that
-    doesn't start with ``HTTP_`` in ``request.META`` can only be set by your
-    WSGI server, not directly from an HTTP request header. This warning *does*
-    apply by default on ASGI, because in the async path, the middleware
-    prepends ``HTTP_`` to the defined header name before looking it up in
-    ``request.META``.
 
 If you need more control, you can create your own authentication backend
 that inherits from :class:`~django.contrib.auth.backends.RemoteUserBackend` and
@@ -129,16 +165,17 @@ override one or more of its attributes and methods.
 Using ``REMOTE_USER`` on login pages only
 =========================================
 
-The ``RemoteUserMiddleware`` authentication middleware assumes that the HTTP
-request header ``REMOTE_USER`` is present with all authenticated requests. That
-might be expected and practical when Basic HTTP Auth with ``htpasswd`` or
-similar mechanisms are used, but with Negotiate (GSSAPI/Kerberos) or other
-resource intensive authentication methods, the authentication in the front-end
-HTTP server is usually only set up for one or a few login URLs, and after
-successful authentication, the application is supposed to maintain the
-authenticated session itself.
+The ``RemoteUserMiddleware`` and ``AsyncRemoteUserMiddleware`` authentication
+middleware assumes that the HTTP request header ``REMOTE_USER`` is present with
+all authenticated requests. That might be expected and practical when Basic
+HTTP Auth with ``htpasswd`` or similar mechanisms are used, but with Negotiate
+(GSSAPI/Kerberos) or other resource intensive authentication methods, the
+authentication in the front-end HTTP server is usually only set up for one or a
+few login URLs, and after successful authentication, the application is
+supposed to maintain the authenticated session itself.
 
-:class:`~django.contrib.auth.middleware.PersistentRemoteUserMiddleware`
+:class:`~django.contrib.auth.middleware.PersistentRemoteUserMiddleware` and
+:class:`~django.contrib.auth.middleware.AsyncPersistentRemoteUserMiddleware`
 provides support for this use case. It will maintain the authenticated session
 until explicit logout by the user. The class can be used as a drop-in
 replacement of :class:`~django.contrib.auth.middleware.RemoteUserMiddleware`

--- a/docs/ref/middleware.txt
+++ b/docs/ref/middleware.txt
@@ -579,11 +579,36 @@ Customize the login URL or field name for authenticated views with the
     :doc:`/howto/auth-remote-user` for usage details, including security
     considerations.
 
+    .. deprecated:: 6.1
+
+        Async support of this middleware is deprecated.
+
+.. class:: AsyncRemoteUserMiddleware
+
+    .. versionadded:: 6.1
+
+    Middleware for utilizing web server provided authentication under ASGI
+    deployments. See :doc:`/howto/auth-remote-user` for usage details,
+    including security considerations.
+
 .. class:: PersistentRemoteUserMiddleware
 
     Middleware for utilizing web server provided authentication when enabled
     only on the login page. See :ref:`persistent-remote-user-middleware-howto`
     for usage details, including security considerations.
+
+    .. deprecated:: 6.1
+
+        Async support of this middleware is deprecated.
+
+.. class:: AsyncPersistentRemoteUserMiddleware
+
+    .. versionadded:: 6.1
+
+    Middleware for utilizing web server provided authentication when enabled
+    only on the login page under ASGI deployments. See
+    :ref:`persistent-remote-user-middleware-howto` for usage details, including
+    security considerations.
 
 CSRF protection middleware
 --------------------------

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -137,6 +137,12 @@ Minor features
 * The new :attr:`.Permission.user_perm_str` property returns the string
   suitable to use with :meth:`.User.has_perm`.
 
+* The new async only middleware classes
+  :class:`django.contrib.auth.middleware.AsyncRemoteUserMiddleware` and
+  :class:`django.contrib.auth.middleware.AsyncPersistentRemoteUserMiddleware`
+  were added. Async support for ``RemoteUserMiddleware`` and
+  ``PersistentRemoteUserMiddleware`` has been deprecated.
+
 :mod:`django.contrib.contenttypes`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -537,6 +543,15 @@ Miscellaneous
 
 Features deprecated in 6.1
 ==========================
+
+Async support of ``RemoteUserMiddleware`` and ``PersistentRemoteUserMiddleware``
+--------------------------------------------------------------------------------
+
+Async support of ``RemoteUserMiddleware`` and
+``PersistentRemoteUserMiddleware`` is deprecated. Please use
+:class:`django.contrib.auth.middleware.AsyncRemoteUserMiddleware` and
+:class:`django.contrib.auth.middleware.AsyncPersistentRemoteUserMiddleware`
+instead.
 
 Miscellaneous
 -------------

--- a/tests/auth_tests/test_remote_user.py
+++ b/tests/auth_tests/test_remote_user.py
@@ -5,6 +5,7 @@ from django.contrib.auth import aauthenticate, authenticate
 from django.contrib.auth.backends import RemoteUserBackend
 from django.contrib.auth.middleware import RemoteUserMiddleware
 from django.contrib.auth.models import User
+from django.core.exceptions import ImproperlyConfigured
 from django.middleware.csrf import _get_new_csrf_string, _mask_cipher_secret
 from django.test import (
     AsyncClient,
@@ -489,3 +490,48 @@ class PersistentRemoteUserTest(RemoteUserTest):
         response = await self.async_client.get("/remote_user/")
         self.assertFalse(response.context["user"].is_anonymous)
         self.assertEqual(response.context["user"].username, "knownuser")
+
+
+@override_settings(ROOT_URLCONF="auth_tests.urls")
+class RemoteUserImproperlyConfigured(TestCase):
+    msg = (
+        "The Django remote user auth middleware requires the authentication middleware "
+        "to be installed. Edit your MIDDLEWARE setting to insert 'django.contrib.auth."
+        "middleware.AuthenticationMiddleware' before the %s class."
+    )
+
+    @override_settings(
+        MIDDLEWARE=["django.contrib.auth.middleware.RemoteUserMiddleware"]
+    )
+    def test_improperly_configured_message_remote_user(self):
+        with self.assertRaisesMessage(
+            ImproperlyConfigured, self.msg % "RemoteUserMiddleware"
+        ):
+            self.client.get("/remote_user/")
+
+    @override_settings(
+        MIDDLEWARE=["django.contrib.auth.middleware.PersistentRemoteUserMiddleware"]
+    )
+    def test_improperly_configured_message_persistent_remote_user(self):
+        with self.assertRaisesMessage(
+            ImproperlyConfigured, self.msg % "PersistentRemoteUserMiddleware"
+        ):
+            self.client.get("/remote_user/")
+
+    @override_settings(
+        MIDDLEWARE=["django.contrib.auth.middleware.RemoteUserMiddleware"]
+    )
+    async def test_improperly_configured_message_remote_user_async(self):
+        with self.assertRaisesMessage(
+            ImproperlyConfigured, self.msg % "RemoteUserMiddleware"
+        ):
+            await self.async_client.get("/remote_user/")
+
+    @override_settings(
+        MIDDLEWARE=["django.contrib.auth.middleware.PersistentRemoteUserMiddleware"]
+    )
+    async def test_improperly_configured_message_persistent_remote_user_async(self):
+        with self.assertRaisesMessage(
+            ImproperlyConfigured, self.msg % "PersistentRemoteUserMiddleware"
+        ):
+            await self.async_client.get("/remote_user/")

--- a/tests/auth_tests/test_remote_user.py
+++ b/tests/auth_tests/test_remote_user.py
@@ -3,7 +3,10 @@ from datetime import UTC, datetime
 from django.conf import settings
 from django.contrib.auth import aauthenticate, authenticate
 from django.contrib.auth.backends import RemoteUserBackend
-from django.contrib.auth.middleware import RemoteUserMiddleware
+from django.contrib.auth.middleware import (
+    AsyncRemoteUserMiddleware,
+    RemoteUserMiddleware,
+)
 from django.contrib.auth.models import User
 from django.core.exceptions import ImproperlyConfigured
 from django.middleware.csrf import _get_new_csrf_string, _mask_cipher_secret
@@ -11,9 +14,11 @@ from django.test import (
     AsyncClient,
     Client,
     TestCase,
+    ignore_warnings,
     modify_settings,
     override_settings,
 )
+from django.utils.deprecation import RemovedInDjango70Warning
 
 
 @override_settings(ROOT_URLCONF="auth_tests.urls")
@@ -58,6 +63,8 @@ class RemoteUserTest(TestCase):
         self.assertTrue(response.context["user"].is_anonymous)
         self.assertEqual(User.objects.count(), num_users)
 
+    # RemovedInDjango70Warning.
+    @ignore_warnings(category=RemovedInDjango70Warning)
     async def test_no_remote_user_async(self):
         """See test_no_remote_user."""
         num_users = await User.objects.acount()
@@ -99,6 +106,8 @@ class RemoteUserTest(TestCase):
         response = csrf_client.post("/remote_user/", data, **headers)
         self.assertEqual(response.status_code, 200)
 
+    # RemovedInDjango70Warning.
+    @ignore_warnings(category=RemovedInDjango70Warning)
     async def test_csrf_validation_passes_after_process_request_login_async(self):
         """See test_csrf_validation_passes_after_process_request_login."""
         csrf_client = AsyncClient(enforce_csrf_checks=True)
@@ -139,6 +148,8 @@ class RemoteUserTest(TestCase):
         response = self.client.get("/remote_user/", **{self.header: "newuser"})
         self.assertEqual(User.objects.count(), num_users + 1)
 
+    # RemovedInDjango70Warning.
+    @ignore_warnings(category=RemovedInDjango70Warning)
     async def test_unknown_user_async(self):
         """See test_unknown_user."""
         num_users = await User.objects.acount()
@@ -171,6 +182,8 @@ class RemoteUserTest(TestCase):
         self.assertEqual(response.context["user"].username, "knownuser2")
         self.assertEqual(User.objects.count(), num_users)
 
+    # RemovedInDjango70Warning.
+    @ignore_warnings(category=RemovedInDjango70Warning)
     async def test_known_user_async(self):
         """See test_known_user."""
         await User.objects.acreate(username="knownuser")
@@ -211,6 +224,8 @@ class RemoteUserTest(TestCase):
         response = self.client.get("/remote_user/", **{self.header: self.known_user})
         self.assertEqual(default_login, response.context["user"].last_login)
 
+    # RemovedInDjango70Warning.
+    @ignore_warnings(category=RemovedInDjango70Warning)
     async def test_last_login_async(self):
         """See test_last_login."""
         user = await User.objects.acreate(username="knownuser")
@@ -255,6 +270,8 @@ class RemoteUserTest(TestCase):
         response = self.client.get("/remote_user/")
         self.assertEqual(response.context["user"].username, "modeluser")
 
+    # RemovedInDjango70Warning.
+    @ignore_warnings(category=RemovedInDjango70Warning)
     async def test_header_disappears_async(self):
         """See test_header_disappears."""
         await User.objects.acreate(username="knownuser")
@@ -291,6 +308,8 @@ class RemoteUserTest(TestCase):
         # In backends that do not create new users, it is '' (anonymous user)
         self.assertNotEqual(response.context["user"].username, "knownuser")
 
+    # RemovedInDjango70Warning.
+    @ignore_warnings(category=RemovedInDjango70Warning)
     async def test_user_switch_forces_new_login_async(self):
         """See test_user_switch_forces_new_login."""
         await User.objects.acreate(username="knownuser")
@@ -313,7 +332,171 @@ class RemoteUserTest(TestCase):
         response = self.client.get("/remote_user/", **{self.header: "knownuser"})
         self.assertTrue(response.context["user"].is_anonymous)
 
+    # RemovedInDjango70Warning.
+    @ignore_warnings(category=RemovedInDjango70Warning)
     async def test_inactive_user_async(self):
+        await User.objects.acreate(username="knownuser", is_active=False)
+        response = await self.async_client.get(
+            "/remote_user/", **{self.header: "knownuser"}
+        )
+        self.assertTrue(response.context["user"].is_anonymous)
+
+    # RemovedInDjango70Warning.
+    async def test_deprecation_msg(self):
+        msg = (
+            "Async support of RemoteUserMiddleware is deprecated. Use "
+            "AsyncRemoteUserMiddleware instead."
+        )
+        with self.assertWarnsMessage(RemovedInDjango70Warning, msg):
+            await self.async_client.get("/remote_user/")
+
+
+@override_settings(ROOT_URLCONF="auth_tests.urls")
+class AsyncRemoteUserTest(TestCase):
+    middleware = "django.contrib.auth.middleware.AsyncRemoteUserMiddleware"
+    backend = "django.contrib.auth.backends.RemoteUserBackend"
+    header = "REMOTE_USER"
+    email_header = "REMOTE_EMAIL"
+
+    # Usernames to be passed in REMOTE_USER for the test_known_user test case.
+    known_user = "knownuser"
+    known_user2 = "knownuser2"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.enterClassContext(
+            modify_settings(
+                AUTHENTICATION_BACKENDS={"append": cls.backend},
+                MIDDLEWARE={"append": cls.middleware},
+            )
+        )
+        super().setUpClass()
+
+    async def test_no_remote_user(self):
+        num_users = await User.objects.acount()
+
+        response = await self.async_client.get("/remote_user/")
+        self.assertTrue(response.context["user"].is_anonymous)
+        self.assertEqual(await User.objects.acount(), num_users)
+
+        response = await self.async_client.get("/remote_user/", **{self.header: ""})
+        self.assertTrue(response.context["user"].is_anonymous)
+        self.assertEqual(await User.objects.acount(), num_users)
+
+    async def test_csrf_validation_passes_after_process_request_login(self):
+        csrf_client = AsyncClient(enforce_csrf_checks=True)
+        csrf_secret = _get_new_csrf_string()
+        csrf_token = _mask_cipher_secret(csrf_secret)
+        csrf_token_form = _mask_cipher_secret(csrf_secret)
+        headers = {self.header: "fakeuser"}
+        data = {"csrfmiddlewaretoken": csrf_token_form}
+
+        # Verify that CSRF is configured for the view
+        csrf_client.cookies.load({settings.CSRF_COOKIE_NAME: csrf_token})
+        response = await csrf_client.post("/remote_user/", **headers)
+        self.assertEqual(response.status_code, 403)
+        self.assertIn(b"CSRF verification failed.", response.content)
+
+        # This request will call django.contrib.auth.alogin() which will call
+        # django.middleware.csrf.rotate_token() thus changing the value of
+        # request.META['CSRF_COOKIE'] from the user submitted value set by
+        # CsrfViewMiddleware.process_request() to the new csrftoken value set
+        # by rotate_token(). Csrf validation should still pass when the view is
+        # later processed by CsrfViewMiddleware.process_view()
+        csrf_client.cookies.load({settings.CSRF_COOKIE_NAME: csrf_token})
+        response = await csrf_client.post("/remote_user/", data, **headers)
+        self.assertEqual(response.status_code, 200)
+
+    async def test_unknown_user(self):
+        num_users = await User.objects.acount()
+        response = await self.async_client.get(
+            "/remote_user/", **{self.header: "newuser"}
+        )
+        self.assertEqual(response.context["user"].username, "newuser")
+        self.assertEqual(await User.objects.acount(), num_users + 1)
+        await User.objects.aget(username="newuser")
+
+        # Another request with same user should not create any new users.
+        response = await self.async_client.get(
+            "/remote_user/", **{self.header: "newuser"}
+        )
+        self.assertEqual(await User.objects.acount(), num_users + 1)
+
+    async def test_known_user(self):
+        await User.objects.acreate(username="knownuser")
+        await User.objects.acreate(username="knownuser2")
+        num_users = await User.objects.acount()
+        response = await self.async_client.get(
+            "/remote_user/", **{self.header: self.known_user}
+        )
+        self.assertEqual(response.context["user"].username, "knownuser")
+        self.assertEqual(await User.objects.acount(), num_users)
+        # A different user passed in the headers causes the new user
+        # to be logged in.
+        response = await self.async_client.get(
+            "/remote_user/", **{self.header: self.known_user2}
+        )
+        self.assertEqual(response.context["user"].username, "knownuser2")
+        self.assertEqual(await User.objects.acount(), num_users)
+
+    async def test_last_login(self):
+        user = await User.objects.acreate(username="knownuser")
+        # Set last_login to something so we can determine if it changes.
+        default_login = datetime(2000, 1, 1)
+        if settings.USE_TZ:
+            default_login = default_login.replace(tzinfo=UTC)
+        user.last_login = default_login
+        await user.asave()
+
+        response = await self.async_client.get(
+            "/remote_user/", **{self.header: self.known_user}
+        )
+        self.assertNotEqual(default_login, response.context["user"].last_login)
+
+        user = await User.objects.aget(username="knownuser")
+        user.last_login = default_login
+        await user.asave()
+        response = await self.async_client.get(
+            "/remote_user/", **{self.header: self.known_user}
+        )
+        self.assertEqual(default_login, response.context["user"].last_login)
+
+    async def test_header_disappears(self):
+        await User.objects.acreate(username="knownuser")
+        # Known user authenticates
+        response = await self.async_client.get(
+            "/remote_user/", **{self.header: self.known_user}
+        )
+        self.assertEqual(response.context["user"].username, "knownuser")
+        # During the session, the REMOTE_USER header disappears. Should trigger
+        # logout.
+        response = await self.async_client.get("/remote_user/")
+        self.assertTrue(response.context["user"].is_anonymous)
+        # verify the remoteuser middleware will not remove a user
+        # authenticated via another backend
+        await User.objects.acreate_user(username="modeluser", password="foo")
+        await self.async_client.alogin(username="modeluser", password="foo")
+        await aauthenticate(username="modeluser", password="foo")
+        response = await self.async_client.get("/remote_user/")
+        self.assertEqual(response.context["user"].username, "modeluser")
+
+    async def test_user_switch_forces_new_login(self):
+        await User.objects.acreate(username="knownuser")
+        # Known user authenticates
+        response = await self.async_client.get(
+            "/remote_user/", **{self.header: self.known_user}
+        )
+        self.assertEqual(response.context["user"].username, "knownuser")
+        # During the session, the REMOTE_USER changes to a different user.
+        response = await self.async_client.get(
+            "/remote_user/", **{self.header: "newnewuser"}
+        )
+        # The current user is not the prior remote_user.
+        # In backends that create a new user, username is "newnewuser"
+        # In backends that do not create new users, it is '' (anonymous user)
+        self.assertNotEqual(response.context["user"].username, "knownuser")
+
+    async def test_inactive_user(self):
         await User.objects.acreate(username="knownuser", is_active=False)
         response = await self.async_client.get(
             "/remote_user/", **{self.header: "knownuser"}
@@ -341,7 +524,20 @@ class RemoteUserNoCreateTest(RemoteUserTest):
         self.assertTrue(response.context["user"].is_anonymous)
         self.assertEqual(User.objects.count(), num_users)
 
+    @ignore_warnings(category=RemovedInDjango70Warning)
     async def test_unknown_user_async(self):
+        num_users = await User.objects.acount()
+        response = await self.async_client.get(
+            "/remote_user/", **{self.header: "newuser"}
+        )
+        self.assertTrue(response.context["user"].is_anonymous)
+        self.assertEqual(await User.objects.acount(), num_users)
+
+
+class AsyncRemoteUserNoCreateTest(AsyncRemoteUserTest):
+    backend = "auth_tests.test_remote_user.RemoteUserNoCreateBackend"
+
+    async def test_unknown_user(self):
         num_users = await User.objects.acount()
         response = await self.async_client.get(
             "/remote_user/", **{self.header: "newuser"}
@@ -360,7 +556,19 @@ class AllowAllUsersRemoteUserBackendTest(RemoteUserTest):
         response = self.client.get("/remote_user/", **{self.header: self.known_user})
         self.assertEqual(response.context["user"].username, user.username)
 
+    @ignore_warnings(category=RemovedInDjango70Warning)
     async def test_inactive_user_async(self):
+        user = await User.objects.acreate(username="knownuser", is_active=False)
+        response = await self.async_client.get(
+            "/remote_user/", **{self.header: self.known_user}
+        )
+        self.assertEqual(response.context["user"].username, user.username)
+
+
+class AsyncAllowAllUsersRemoteUserBackendTest(AsyncRemoteUserTest):
+    backend = "django.contrib.auth.backends.AllowAllUsersRemoteUserBackend"
+
+    async def test_inactive_user(self):
         user = await User.objects.acreate(username="knownuser", is_active=False)
         response = await self.async_client.get(
             "/remote_user/", **{self.header: self.known_user}
@@ -388,6 +596,13 @@ class CustomRemoteUserBackend(RemoteUserBackend):
         if not created:
             user.last_name = user.username
         user.save()
+        return user
+
+    async def aconfigure_user(self, request, user, created=True):
+        user.email = request.headers.get(AsyncRemoteUserTest.email_header, "")
+        if not created:
+            user.last_name = user.username
+        await user.asave()
         return user
 
 
@@ -437,6 +652,41 @@ class RemoteUserCustomTest(RemoteUserTest):
         self.assertEqual(newuser.email, "user@example.com")
 
 
+class AsyncRemoteUserCustomTest(AsyncRemoteUserTest):
+    backend = "auth_tests.test_remote_user.CustomRemoteUserBackend"
+    known_user = "knownuser@example.com"
+    known_user2 = "knownuser2@example.com"
+
+    async def test_known_user(self):
+        """
+        The strings passed in REMOTE_USER should be cleaned and the known users
+        should not have been configured with an email address.
+        """
+        await super().test_known_user()
+        knownuser = await User.objects.aget(username="knownuser")
+        knownuser2 = await User.objects.aget(username="knownuser2")
+        self.assertEqual(knownuser.email, "")
+        self.assertEqual(knownuser2.email, "")
+        self.assertEqual(knownuser.last_name, "knownuser")
+        self.assertEqual(knownuser2.last_name, "knownuser2")
+
+    async def test_unknown_user(self):
+        num_users = await User.objects.acount()
+        response = await self.async_client.get(
+            "/remote_user/",
+            **{
+                self.header: "newuser",
+                self.email_header: "user@example.com",
+            },
+        )
+        self.assertEqual(response.context["user"].username, "newuser")
+        self.assertEqual(response.context["user"].email, "user@example.com")
+        self.assertEqual(response.context["user"].last_name, "")
+        self.assertEqual(await User.objects.acount(), num_users + 1)
+        newuser = await User.objects.aget(username="newuser")
+        self.assertEqual(newuser.email, "user@example.com")
+
+
 class CustomHeaderMiddleware(RemoteUserMiddleware):
     """
     Middleware that overrides custom HTTP auth user header.
@@ -452,6 +702,15 @@ class CustomHeaderRemoteUserTest(RemoteUserTest):
     """
 
     middleware = "auth_tests.test_remote_user.CustomHeaderMiddleware"
+    header = "HTTP_AUTHUSER"
+
+
+class AsyncCustomHeaderMiddleware(AsyncRemoteUserMiddleware):
+    header = "HTTP_AUTHUSER"
+
+
+class AsyncCustomHeaderRemoteUserTest(AsyncRemoteUserTest):
+    middleware = "auth_tests.test_remote_user.AsyncCustomHeaderMiddleware"
     header = "HTTP_AUTHUSER"
 
 
@@ -478,8 +737,36 @@ class PersistentRemoteUserTest(RemoteUserTest):
         self.assertFalse(response.context["user"].is_anonymous)
         self.assertEqual(response.context["user"].username, "knownuser")
 
+    # RemovedInDjango70Warning.
+    @ignore_warnings(category=RemovedInDjango70Warning)
     async def test_header_disappears_async(self):
         """See test_header_disappears."""
+        await User.objects.acreate(username="knownuser")
+        # Known user authenticates
+        response = await self.async_client.get(
+            "/remote_user/", **{self.header: self.known_user}
+        )
+        self.assertEqual(response.context["user"].username, "knownuser")
+        # Should stay logged in if the REMOTE_USER header disappears.
+        response = await self.async_client.get("/remote_user/")
+        self.assertFalse(response.context["user"].is_anonymous)
+        self.assertEqual(response.context["user"].username, "knownuser")
+
+    # RemovedInDjango70Warning.
+    async def test_deprecation_msg(self):
+        msg = (
+            "Async support of PersistentRemoteUserMiddleware is deprecated. Use "
+            "AsyncPersistentRemoteUserMiddleware instead."
+        )
+        with self.assertWarnsMessage(RemovedInDjango70Warning, msg):
+            await self.async_client.get("/remote_user/")
+
+
+class AsyncPersistentRemoteUserTest(AsyncRemoteUserTest):
+    middleware = "django.contrib.auth.middleware.AsyncPersistentRemoteUserMiddleware"
+    require_header = False
+
+    async def test_header_disappears(self):
         await User.objects.acreate(username="knownuser")
         # Known user authenticates
         response = await self.async_client.get(
@@ -518,6 +805,8 @@ class RemoteUserImproperlyConfigured(TestCase):
         ):
             self.client.get("/remote_user/")
 
+    # RemovedInDjango70Warning.
+    @ignore_warnings(category=RemovedInDjango70Warning)
     @override_settings(
         MIDDLEWARE=["django.contrib.auth.middleware.RemoteUserMiddleware"]
     )
@@ -527,11 +816,33 @@ class RemoteUserImproperlyConfigured(TestCase):
         ):
             await self.async_client.get("/remote_user/")
 
+    # RemovedInDjango70Warning.
+    @ignore_warnings(category=RemovedInDjango70Warning)
     @override_settings(
         MIDDLEWARE=["django.contrib.auth.middleware.PersistentRemoteUserMiddleware"]
     )
     async def test_improperly_configured_message_persistent_remote_user_async(self):
         with self.assertRaisesMessage(
             ImproperlyConfigured, self.msg % "PersistentRemoteUserMiddleware"
+        ):
+            await self.async_client.get("/remote_user/")
+
+    @override_settings(
+        MIDDLEWARE=["django.contrib.auth.middleware.AsyncRemoteUserMiddleware"]
+    )
+    async def test_improperly_configured_message_async_remote_user(self):
+        with self.assertRaisesMessage(
+            ImproperlyConfigured, self.msg % "AsyncRemoteUserMiddleware"
+        ):
+            await self.async_client.get("/remote_user/")
+
+    @override_settings(
+        MIDDLEWARE=[
+            "django.contrib.auth.middleware.AsyncPersistentRemoteUserMiddleware"
+        ]
+    )
+    async def test_improperly_configured_message_async_persistent_remote_user(self):
+        with self.assertRaisesMessage(
+            ImproperlyConfigured, self.msg % "AsyncPersistentRemoteUserMiddleware"
         ):
             await self.async_client.get("/remote_user/")


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37025

#### Branch description
Provide a concise overview of the issue or rationale behind the proposed changes.

This was proposed during this PR review: https://github.com/django/django/pull/21079

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

I have used AI tools for helping to create the docs. I have reviewed these but am still not comfortable with what the docs should be.

#### Checklist
- [X] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [X] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [X] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.