### PR TITLE
Fixed #37078 -- Changed default algorithm in salted_hmac() and base64_hmac() from SHA-1 to SHA-256

### DIFF
--- a/django/core/signing.py
+++ b/django/core/signing.py
@@ -96,7 +96,7 @@ def b64_decode(s):
     return base64.urlsafe_b64decode(s + pad)
 
 
-def base64_hmac(salt, value, key, algorithm="sha1"):
+def base64_hmac(salt, value, key, algorithm="sha256"):
     return b64_encode(
         salted_hmac(salt, value, key, algorithm=algorithm).digest()
     ).decode()

--- a/django/utils/crypto.py
+++ b/django/utils/crypto.py
@@ -16,7 +16,7 @@ class InvalidAlgorithm(ValueError):
     pass
 
 
-def salted_hmac(key_salt, value, secret=None, *, algorithm="sha1"):
+def salted_hmac(key_salt, value, secret=None, *, algorithm="sha256"):
     """
     Return the HMAC of 'value', using a key generated from key_salt and a
     secret (which defaults to settings.SECRET_KEY). Default algorithm is SHA1,

--- a/tests/utils_tests/test_crypto.py
+++ b/tests/utils_tests/test_crypto.py
@@ -24,16 +24,34 @@ class TestUtilsCryptoMisc(SimpleTestCase):
 
     def test_salted_hmac(self):
         tests = [
-            ((b"salt", b"value"), {}, "b51a2e619c43b1ca4f91d15c57455521d71d61eb"),
-            (("salt", "value"), {}, "b51a2e619c43b1ca4f91d15c57455521d71d61eb"),
+            (
+                (b"salt", b"value"),
+                {},
+                "ee0bf789e4e009371a5372c90f73fcf17695a8439c9108b0480f14e347b3f9ec",
+            ),
             (
                 ("salt", "value"),
-                {"secret": "abcdefg"},
+                {},
+                "ee0bf789e4e009371a5372c90f73fcf17695a8439c9108b0480f14e347b3f9ec",
+            ),
+            (
+                (b"salt", b"value"),
+                {"algorithm": "sha1"},
+                "b51a2e619c43b1ca4f91d15c57455521d71d61eb",
+            ),
+            (
+                ("salt", "value"),
+                {"algorithm": "sha1"},
+                "b51a2e619c43b1ca4f91d15c57455521d71d61eb",
+            ),
+            (
+                ("salt", "value"),
+                {"secret": "abcdefg", "algorithm": "sha1"},
                 "8bbee04ccddfa24772d1423a0ba43bd0c0e24b76",
             ),
             (
                 ("salt", "value"),
-                {"secret": "x" * hashlib.sha1().block_size},
+                {"secret": "x" * hashlib.sha1().block_size, "algorithm": "sha1"},
                 "bd3749347b412b1b0a9ea65220e55767ac8e96b0",
             ),
             (


### PR DESCRIPTION
#### Trac ticket number
ticket-37078

#### Branch description
`salted_hmac()` in `django/utils/crypto.py` and `base64_hmac()` in `django/core/signing.py` both defaulted to `algorithm="sha1"`. SHA-1 is deprecated by NIST (SP 800-131A Rev. 2) and fails compliance requirements such as FIPS 140-2 and PCI DSS that mandate SHA-256 or stronger for HMAC operations.

This default was inconsistent with Django's own internal usage — every security-sensitive caller already passed `algorithm="sha256"` explicitly:

- `Signer.__init__` (`signing.py:193`) defaults to `"sha256"`
- `PasswordResetTokenGenerator` (`tokens.py:20`) defaults to `"sha256"`
- `AbstractBaseUser._get_session_auth_hash` (`base_user.py:148`) passes `algorithm="sha256"`

Third-party code calling `salted_hmac()` without specifying an algorithm was silently getting SHA-1, creating a false sense of security.

#### AI Assistance Disclosure (REQUIRED)
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Used Grok 4.3 (xAI) for issue detection and fix suggestions.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
