### PR TITLE
Refs #37068 -- Avoided table rebuild on SQLite for altering NOT NULL.

### DIFF
--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -172,3 +172,9 @@ class DatabaseFeatures(BaseDatabaseFeatures):
 
     can_introspect_json_field = property(operator.attrgetter("supports_json_field"))
     has_json_object_function = property(operator.attrgetter("supports_json_field"))
+
+    supports_alter_column_nullability = Database.sqlite_version_info >= (
+        3,
+        53,
+        1,
+    )

--- a/django/db/backends/sqlite3/schema.py
+++ b/django/db/backends/sqlite3/schema.py
@@ -386,6 +386,34 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                     model._meta.db_table, old_field, new_field, new_type
                 )
             )
+        # On SQLite 3.53.1+, use newly supported "ALTER TABLE ... ALTER COLUMN
+        # ... {SET|DROP} NOT NULL" if only nullability has changed.
+        if (
+            self.connection.features.supports_alter_column_nullability
+            and old_field.column == new_field.column
+            and old_type == new_type
+            and old_field.null != new_field.null
+            and old_field.default == new_field.default
+            and old_field.db_default == new_field.db_default
+            and old_db_params.get("check") == new_db_params.get("check")
+            and old_db_params.get("collation") == new_db_params.get("collation")
+            and old_field.unique == new_field.unique
+            and old_field.db_index == new_field.db_index
+            # Exclude fields with custom constraints because they would be
+            # dropped and recreated by the base _alter_field() method.
+            and not (old_field.remote_field and old_field.db_constraint)
+            and not (new_field.remote_field and new_field.db_constraint)
+        ):
+            return super()._alter_field(
+                model,
+                old_field,
+                new_field,
+                old_type,
+                new_type,
+                old_db_params,
+                new_db_params,
+                strict,
+            )
         # Alter by remaking table
         self._remake_table(model, alter_fields=[(old_field, new_field)])
         # Rebuild tables with FKs pointing to this field.

--- a/tests/backends/sqlite/tests.py
+++ b/tests/backends/sqlite/tests.py
@@ -16,9 +16,23 @@ from django.db import (
     connections,
     transaction,
 )
-from django.db.models import Aggregate, Avg, StdDev, Sum, Variance
+from django.db.models import (
+    Aggregate,
+    Avg,
+    IntegerField,
+    Model,
+    StdDev,
+    Sum,
+    Variance,
+)
 from django.db.utils import ConnectionHandler
-from django.test import SimpleTestCase, TestCase, TransactionTestCase, override_settings
+from django.test import (
+    SimpleTestCase,
+    TestCase,
+    TransactionTestCase,
+    override_settings,
+    skipUnlessDBFeature,
+)
 from django.test.utils import CaptureQueriesContext, isolate_apps
 
 from ..models import Item, Object, Square
@@ -181,6 +195,58 @@ class SchemaTests(TransactionTestCase):
         with self.assertRaisesMessage(NotSupportedError, msg):
             with transaction.atomic(), connection.schema_editor(atomic=True):
                 pass
+
+    @skipUnlessDBFeature("supports_alter_column_nullability")
+    def test_alter_field_set_not_null_without_remake(self):
+        class Human(Model):
+            age = IntegerField(null=True)
+
+        old_field = Human._meta.get_field("age")
+        new_field = IntegerField(null=False)
+        new_field.set_attributes_from_name("age")
+
+        with connection.schema_editor() as editor:
+            editor.create_model(Human)
+            try:
+                with mock.patch.object(editor, "_remake_table") as remake:
+                    editor._alter_field(
+                        Human,
+                        old_field,
+                        new_field,
+                        old_field.db_type(connection),
+                        new_field.db_type(connection),
+                        old_field.db_parameters(connection),
+                        new_field.db_parameters(connection),
+                    )
+                    remake.assert_not_called()
+            finally:
+                editor.delete_model(Human)
+
+    @skipUnlessDBFeature("supports_alter_column_nullability")
+    def test_alter_field_drop_not_null_without_remake(self):
+        class Human(Model):
+            age = IntegerField()
+
+        old_field = Human._meta.get_field("age")
+        new_field = IntegerField(null=True)
+        new_field.set_attributes_from_name("age")
+
+        with connection.schema_editor() as editor:
+            editor.create_model(Human)
+            try:
+                with mock.patch.object(editor, "_remake_table") as remake:
+                    editor._alter_field(
+                        Human,
+                        old_field,
+                        new_field,
+                        old_field.db_type(connection),
+                        new_field.db_type(connection),
+                        old_field.db_parameters(connection),
+                        new_field.db_parameters(connection),
+                    )
+                    remake.assert_not_called()
+            finally:
+                editor.delete_model(Human)
 
     def test_constraint_checks_disabled_atomic_allowed(self):
         """


### PR DESCRIPTION
#### Trac ticket number

ticket-37068

#### Branch description

Deal with "part two" of the ticket, avoiding table rebuilds on SQLite 3.53.1+ when only a field's nullability changes.

I used the same `pysqlite3` strategy as in #21181 (part one) to test on SQLite 3.53.1.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

I used a bit of Claude.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
