### PR TITLE
Fixed #13680 -- Reported unrecognized fixture format without an extension.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1120,6 +1120,7 @@ answer newbie questions, and generally made Django that much better:
     ye7cakf02@sneakemail.com
     ymasuda@ethercube.com
     Yoong Kang Lim <yoongkang.lim@gmail.com>
+    Youngjae Kwon <gczzga@gmail.com>
     Yury V. Zaytsev <yury@shurup.com>
     Yusuke Miyazaki <miyazaki.dev@gmail.com>
     Yves Weissig <yves@weissig.me>

--- a/django/core/management/commands/loaddata.py
+++ b/django/core/management/commands/loaddata.py
@@ -348,6 +348,15 @@ class Command(BaseCommand):
             fixture_files.extend(fixture_files_in_dir)
 
         if not fixture_files:
+            if ser_fmt is None:
+                # If a file matches the basename but uses an unrecognized
+                # extension, parse_name() raises a clearer error than the
+                # generic "No fixture named ..." below. Refs #13680.
+                for fixture_dir in fixture_dirs:
+                    for candidate in glob.iglob(
+                        glob.escape(os.path.join(fixture_dir, fixture_name)) + ".*"
+                    ):
+                        self.parse_name(os.path.basename(candidate))
             raise CommandError("No fixture named '%s' found." % fixture_name)
 
         return fixture_files

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -290,6 +290,10 @@ Management Commands
   :data:`~django.db.models.signals.m2m_changed` signals with ``raw=True`` when
   loading fixtures.
 
+* The :djadmin:`loaddata` command now reports the unrecognized
+  serialization format when a fixture file is loaded by name without
+  the file extension.
+
 Migrations
 ~~~~~~~~~~
 

--- a/tests/fixtures_regress/fixtures/compressed_unknown.invalid.gz
+++ b/tests/fixtures_regress/fixtures/compressed_unknown.invalid.gz
@@ -1,0 +1,1 @@
+This data shouldn't load, as it's of an unknown file format.

--- a/tests/fixtures_regress/fixtures/mixed_format.invalid
+++ b/tests/fixtures_regress/fixtures/mixed_format.invalid
@@ -1,0 +1,1 @@
+This data shouldn't load, as it's of an unknown file format.

--- a/tests/fixtures_regress/fixtures/mixed_format.json
+++ b/tests/fixtures_regress/fixtures/mixed_format.json
@@ -1,0 +1,9 @@
+[
+    {
+        "pk": "100",
+        "model": "fixtures_regress.absolute",
+        "fields": {
+            "name": "Mixed format JSON"
+        }
+    }
+]

--- a/tests/fixtures_regress/fixtures/unknown_format.invalid
+++ b/tests/fixtures_regress/fixtures/unknown_format.invalid
@@ -1,0 +1,1 @@
+This data shouldn't load, as it's of an unknown file format.

--- a/tests/fixtures_regress/tests.py
+++ b/tests/fixtures_regress/tests.py
@@ -265,6 +265,48 @@ class TestFixtures(TestCase):
                 verbosity=0,
             )
 
+    def test_unknown_format_no_ext(self):
+        """
+        Loading a fixture in an unknown format without its file extension
+        raises the same error as when the extension is specified
+        explicitly (#13680).
+        """
+        msg = (
+            "Problem installing fixture 'unknown_format': invalid is not a "
+            "known serialization format."
+        )
+        with self.assertRaisesMessage(management.CommandError, msg):
+            management.call_command(
+                "loaddata",
+                "unknown_format",
+                verbosity=0,
+            )
+
+    def test_unknown_format_no_ext_with_known_format(self):
+        """
+        A fixture in a known format is loaded normally even when a sibling
+        file with the same basename uses an unknown extension (#13680).
+        """
+        management.call_command("loaddata", "mixed_format", verbosity=0)
+        self.assertEqual(Absolute.objects.filter(name="Mixed format JSON").count(), 1)
+
+    def test_unknown_format_no_ext_compressed(self):
+        """
+        Loading a fixture by name when only a compressed file with an
+        unknown serialization format extension exists raises a helpful
+        error identifying the unknown format (#13680).
+        """
+        msg = (
+            "Problem installing fixture 'compressed_unknown': invalid is "
+            "not a known serialization format."
+        )
+        with self.assertRaisesMessage(management.CommandError, msg):
+            management.call_command(
+                "loaddata",
+                "compressed_unknown",
+                verbosity=0,
+            )
+
     @override_settings(SERIALIZATION_MODULES={"unkn": "unexistent.path"})
     def test_unimportable_serializer(self):
         """


### PR DESCRIPTION
#### Trac ticket number

ticket-13680

#### Branch description

Loading a fixture by name without specifying its extension previously raised
a generic "No fixture named X found." error, even when a file with that
basename existed on disk with an unrecognized serialization format extension.
The message gave no hint that the format was the problem (e.g. PyYAML not
installed for ".yaml" files).

This change reuses the existing `parse_name()` path: when no fixture matches
the known formats, the directories are scanned again for files sharing the
basename and `parse_name()` is invoked on each match, which raises the same
`"<ext> is not a known serialization format."` error already produced when
the user specifies the extension explicitly.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

I used Claude Code (Opus 4.7) for exploration, drafting tests, and writing the patch.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.