### PR TITLE
Fixed #37075 -- Allowed overriding the PostgreSQL pool's "check" callable.

### DIFF
--- a/django/db/backends/postgresql/base.py
+++ b/django/db/backends/postgresql/base.py
@@ -216,11 +216,15 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             # Ensure we run in autocommit, Django properly sets it later on.
             connect_kwargs["autocommit"] = True
             enable_checks = self.settings_dict["CONN_HEALTH_CHECKS"]
+            # Copy to avoid mutating the user's settings dict.
+            pool_options = {**pool_options}
+            pool_options.setdefault(
+                "check", ConnectionPool.check_connection if enable_checks else None
+            )
             pool = ConnectionPool(
                 kwargs=connect_kwargs,
                 open=False,  # Do not open the pool during startup.
                 configure=self._configure_connection,
-                check=ConnectionPool.check_connection if enable_checks else None,
                 **pool_options,
             )
             # setdefault() ensures that multiple threads don't set this in

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -224,6 +224,14 @@ CSRF
 
 * ...
 
+Database backends
+~~~~~~~~~~~~~~~~~
+
+* A ``"check"`` callable provided in ``OPTIONS["pool"]`` now takes precedence
+  over Django's default for the PostgreSQL backend. This enables custom pool
+  liveness probes, such as a ``pg_is_in_recovery()`` check to discard
+  connections silently rerouted to a reader after an Aurora writer flip.
+
 Decorators
 ~~~~~~~~~~
 

--- a/tests/backends/postgresql/tests.py
+++ b/tests/backends/postgresql/tests.py
@@ -326,6 +326,33 @@ class Tests(TestCase):
             new_connection.close_pool()
 
     @unittest.skipUnless(is_psycopg3, "psycopg3 specific test")
+    def test_pool_check_can_be_overridden(self):
+        def custom_check(conn):
+            pass
+
+        new_connection = no_pool_connection(alias="default_pool")
+        new_connection.settings_dict["OPTIONS"]["pool"] = {"check": custom_check}
+
+        for enable_checks in (True, False):
+            with self.subTest(CONN_HEALTH_CHECKS=enable_checks):
+                new_connection.settings_dict["CONN_HEALTH_CHECKS"] = enable_checks
+                try:
+                    self.assertIs(new_connection.pool._check, custom_check)
+                finally:
+                    new_connection.close_pool()
+
+    @unittest.skipUnless(is_psycopg3, "psycopg3 specific test")
+    def test_pool_options_not_mutated(self):
+        pool_options = {"min_size": 0, "max_size": 2}
+        new_connection = no_pool_connection(alias="default_pool")
+        new_connection.settings_dict["OPTIONS"]["pool"] = pool_options
+        try:
+            self.assertIsNotNone(new_connection.pool)
+        finally:
+            new_connection.close_pool()
+        self.assertEqual(pool_options, {"min_size": 0, "max_size": 2})
+
+    @unittest.skipUnless(is_psycopg3, "psycopg3 specific test")
     def test_cannot_open_new_connection_in_atomic_block(self):
         new_connection = no_pool_connection(alias="default_pool")
         new_connection.settings_dict["OPTIONS"]["pool"] = True


### PR DESCRIPTION
Trac ticket: https://code.djangoproject.com/ticket/37075

Setting `"check"` in `OPTIONS["pool"]` previously raised `TypeError: psycopg_pool.pool.ConnectionPool() got multiple values for keyword argument 'check'` because the PostgreSQL backend passed `check=` to `ConnectionPool()` and unpacked `**pool_options` on top, regardless of `CONN_HEALTH_CHECKS`. The user's callable now takes precedence via `setdefault()`; `pool_options` is copied first to avoid mutating the user's settings dict (per review feedback on the ticket).

The driving use case is AWS Aurora PostgreSQL writer-flip handling: after a writer failover existing TCP connections survive but become read-only, and a `pg_is_in_recovery()` check chained into pool validation is the standard way to discard them — see [AWS's Fast failover with Aurora PostgreSQL guide](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.BestPractices.FastFailover.html).

The same shape would also let `configure` be overridden, but that's intentionally out of scope here — Django's `_configure_connection` installs framework-level invariants and any override design needs more thought (chaining, ordering). This PR only changes `check`.

Two regression tests added:

- `test_pool_check_can_be_overridden` — asserts a user-provided `check` becomes `pool._check` for both `CONN_HEALTH_CHECKS=True` and `False`.
- `test_pool_options_not_mutated` — asserts `OPTIONS["pool"]` is unchanged after pool init.

Release note added under "Database backends" in `docs/releases/6.1.txt`.