### PR TITLE
Fixed #37075 -- Allowed overriding the PostgreSQL pool's "check" callable.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -891,6 +891,7 @@ answer newbie questions, and generally made Django that much better:
     Ramon Saraiva <ramonsaraiva@gmail.com>
     Ram Rachum <ram@rachum.com>
     Randy Barlow <randy@electronsweatshop.com>
+    Raoni Timo <raoni@relume.io>
     Raphaël Barrois <raphael.barrois@m4x.org>
     Raphael Michel <mail@raphaelmichel.de>
     Raúl Cumplido <raulcumplido@gmail.com>

--- a/django/db/backends/postgresql/base.py
+++ b/django/db/backends/postgresql/base.py
@@ -216,11 +216,15 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             # Ensure we run in autocommit, Django properly sets it later on.
             connect_kwargs["autocommit"] = True
             enable_checks = self.settings_dict["CONN_HEALTH_CHECKS"]
+            # Copy to avoid mutating the user's settings dict.
+            pool_options = {**pool_options}
+            pool_options.setdefault(
+                "check", ConnectionPool.check_connection if enable_checks else None
+            )
             pool = ConnectionPool(
                 kwargs=connect_kwargs,
                 open=False,  # Do not open the pool during startup.
                 configure=self._configure_connection,
-                check=ConnectionPool.check_connection if enable_checks else None,
                 **pool_options,
             )
             # setdefault() ensures that multiple threads don't set this in

--- a/tests/backends/postgresql/tests.py
+++ b/tests/backends/postgresql/tests.py
@@ -326,6 +326,33 @@ class Tests(TestCase):
             new_connection.close_pool()
 
     @unittest.skipUnless(is_psycopg3, "psycopg3 specific test")
+    def test_pool_check_can_be_overridden(self):
+        def custom_check(conn):
+            pass
+
+        new_connection = no_pool_connection(alias="default_pool")
+        new_connection.settings_dict["OPTIONS"]["pool"] = {"check": custom_check}
+
+        for enable_checks in (True, False):
+            with self.subTest(CONN_HEALTH_CHECKS=enable_checks):
+                new_connection.settings_dict["CONN_HEALTH_CHECKS"] = enable_checks
+                try:
+                    self.assertIs(new_connection.pool._check, custom_check)
+                finally:
+                    new_connection.close_pool()
+
+    @unittest.skipUnless(is_psycopg3, "psycopg3 specific test")
+    def test_pool_options_not_mutated(self):
+        pool_options = {"min_size": 0, "max_size": 2}
+        new_connection = no_pool_connection(alias="default_pool")
+        new_connection.settings_dict["OPTIONS"]["pool"] = pool_options
+        try:
+            self.assertIsNotNone(new_connection.pool)
+        finally:
+            new_connection.close_pool()
+        self.assertEqual(pool_options, {"min_size": 0, "max_size": 2})
+
+    @unittest.skipUnless(is_psycopg3, "psycopg3 specific test")
     def test_cannot_open_new_connection_in_atomic_block(self):
         new_connection = no_pool_connection(alias="default_pool")
         new_connection.settings_dict["OPTIONS"]["pool"] = True


### PR DESCRIPTION
#### Trac ticket number

ticket-37075

#### Branch description

Setting `"check"` in `OPTIONS["pool"]` previously raised `TypeError: psycopg_pool.pool.ConnectionPool() got multiple values for keyword argument 'check'` because the PostgreSQL backend passed `check=` to `ConnectionPool()` and unpacked `**pool_options` on top, regardless of `CONN_HEALTH_CHECKS`. The user's callable now takes precedence via `setdefault()`; `pool_options` is copied first to avoid mutating the user's settings dict (per review feedback on the ticket).

The driving use case is AWS Aurora PostgreSQL writer-flip handling: after a writer failover existing TCP connections survive but become read-only, and a `pg_is_in_recovery()` check chained into pool validation is the standard way to discard them — see [AWS's Fast failover with Aurora PostgreSQL guide](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.BestPractices.FastFailover.html).

The same shape would also let `configure` be overridden, but that's intentionally out of scope here — Django's `_configure_connection` installs framework-level invariants and any override design needs more thought (chaining, ordering). This PR only changes `check`.

Two regression tests added:

- `test_pool_check_can_be_overridden` — asserts a user-provided `check` becomes `pool._check` for both `CONN_HEALTH_CHECKS=True` and `False`.
- `test_pool_options_not_mutated` — asserts `OPTIONS["pool"]` is unchanged after pool init.

Release note added under "Database backends" in `docs/releases/6.1.txt`.

The bug also exists in 5.2 LTS; the patch applies cleanly there. Backport at the merger's discretion.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude Code (Opus 4.7) was used to draft the patch, the regression tests, the release note, and this PR description. I have reviewed and verified all output before submitting — including independently reading the upstream Django and psycopg-pool source to confirm the duplicate-kwarg analysis.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.