### PR TITLE
Fixed #37078 -- Deprecated SHA-1 default for salted_hmac() and base64_hmac() algorithm

### DIFF
--- a/django/core/signing.py
+++ b/django/core/signing.py
@@ -38,10 +38,12 @@ import base64
 import datetime
 import json
 import time
+import warnings
 import zlib
 
 from django.conf import settings
 from django.utils.crypto import constant_time_compare, salted_hmac
+from django.utils.deprecation import RemovedInDjango70Warning, django_file_prefixes
 from django.utils.encoding import force_bytes
 from django.utils.module_loading import import_string
 from django.utils.regex_helper import _lazy_re_compile
@@ -96,7 +98,17 @@ def b64_decode(s):
     return base64.urlsafe_b64decode(s + pad)
 
 
-def base64_hmac(salt, value, key, algorithm="sha1"):
+# RemovedInDjango70Warning: algorithm="sha256"
+def base64_hmac(salt, value, key, algorithm=None):
+    if algorithm is None:
+        warnings.warn(
+            "The default argument for algorithm in base64_hmac() will change "
+            "from 'sha1' to 'sha256' in Django 7.0. Pass an explicit "
+            "algorithm to silence this warning.",
+            category=RemovedInDjango70Warning,
+            skip_file_prefixes=django_file_prefixes(),
+        )
+        algorithm = "sha1"
     return b64_encode(
         salted_hmac(salt, value, key, algorithm=algorithm).digest()
     ).decode()

--- a/django/utils/crypto.py
+++ b/django/utils/crypto.py
@@ -5,8 +5,10 @@ Django's standard crypto functions and utilities.
 import hashlib
 import hmac
 import secrets
+import warnings
 
 from django.conf import settings
+from django.utils.deprecation import RemovedInDjango70Warning, django_file_prefixes
 from django.utils.encoding import force_bytes
 
 
@@ -16,14 +18,27 @@ class InvalidAlgorithm(ValueError):
     pass
 
 
-def salted_hmac(key_salt, value, secret=None, *, algorithm="sha1"):
+# RemovedInDjango70Warning: algorithm="sha256"
+def salted_hmac(key_salt, value, secret=None, *, algorithm=None):
     """
     Return the HMAC of 'value', using a key generated from key_salt and a
     secret (which defaults to settings.SECRET_KEY). Default algorithm is SHA1,
     but any algorithm name supported by hashlib can be passed.
 
+    Removed in Django70Warning: The default algorithm will change to SHA256
+    in Django 7.0, so provide an explicit algorithm to silence the warning.
+
     A different key_salt should be passed in for every application of HMAC.
     """
+    if algorithm is None:
+        warnings.warn(
+            "The default argument for algorithm in salted_hmac() will change "
+            "from 'sha1' to 'sha256' in Django 7.0. Pass an explicit "
+            "algorithm to silence this warning.",
+            category=RemovedInDjango70Warning,
+            skip_file_prefixes=django_file_prefixes(),
+        )
+        algorithm = "sha1"
     if secret is None:
         secret = settings.SECRET_KEY
 

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -80,6 +80,11 @@ details on these changes.
 * Support for double-dot variable lookup, like ``{{ book..title }}``,
   is removed.
 
+* The default value of the ``algorithm`` argument for
+  ``django.utils.crypto.salted_hmac()`` and
+  ``django.core.signing.base64_hmac()`` will change from ``"sha1"`` to
+  ``"sha256"``.
+
 .. _deprecation-removed-in-6.1:
 
 6.1

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -589,6 +589,12 @@ Miscellaneous
   deprecated. This syntax maps to a lookup of the empty string, which is
   normally a mistake.
 
+* The default value of the ``algorithm`` argument for
+  ``django.utils.crypto.salted_hmac()`` and
+  ``django.core.signing.base64_hmac()`` is deprecated and will change from
+  ``"sha1"`` to ``"sha256"`` in Django 7.0. Pass an explicit ``algorithm``
+  to silence the deprecation warning.
+
 Features removed in 6.1
 =======================
 

--- a/tests/signing/tests.py
+++ b/tests/signing/tests.py
@@ -4,6 +4,7 @@ from django.core import signing
 from django.test import SimpleTestCase, override_settings
 from django.test.utils import freeze_time
 from django.utils.crypto import InvalidAlgorithm
+from django.utils.deprecation import RemovedInDjango70Warning
 
 
 class TestSigner(SimpleTestCase):
@@ -42,6 +43,15 @@ class TestSigner(SimpleTestCase):
             signing.Signer(key="predictable-secret", salt="one").signature("hello"),
             signing.Signer(key="predictable-secret", salt="two").signature("hello"),
         )
+
+    def test_base64_hmac_default_algorithm_deprecation(self):
+        msg = (
+            "The default argument for algorithm in base64_hmac() will change "
+            "from 'sha1' to 'sha256' in Django 7.0. Pass an explicit "
+            "algorithm to silence this warning."
+        )
+        with self.assertWarnsMessage(RemovedInDjango70Warning, msg):
+            signing.base64_hmac("salt", "value", "key")
 
     def test_custom_algorithm(self):
         signer = signing.Signer(key="predictable-secret", algorithm="sha512")

--- a/tests/utils_tests/test_crypto.py
+++ b/tests/utils_tests/test_crypto.py
@@ -8,6 +8,7 @@ from django.utils.crypto import (
     pbkdf2,
     salted_hmac,
 )
+from django.utils.deprecation import RemovedInDjango70Warning
 
 
 class TestUtilsCryptoMisc(SimpleTestCase):
@@ -24,20 +25,30 @@ class TestUtilsCryptoMisc(SimpleTestCase):
 
     def test_salted_hmac(self):
         tests = [
-            ((b"salt", b"value"), {}, "b51a2e619c43b1ca4f91d15c57455521d71d61eb"),
-            (("salt", "value"), {}, "b51a2e619c43b1ca4f91d15c57455521d71d61eb"),
+            (
+                (b"salt", b"value"),
+                {"algorithm": "sha1"},
+                "b51a2e619c43b1ca4f91d15c57455521d71d61eb",
+            ),
             (
                 ("salt", "value"),
-                {"secret": "abcdefg"},
+                {"algorithm": "sha1"},
+                "b51a2e619c43b1ca4f91d15c57455521d71d61eb",
+            ),
+            (
+                ("salt", "value"),
+                {"secret": "abcdefg", "algorithm": "sha1"},
                 "8bbee04ccddfa24772d1423a0ba43bd0c0e24b76",
             ),
             (
                 ("salt", "value"),
-                {"secret": "x" * hashlib.sha1().block_size},
+                {"secret": "x" * hashlib.sha1().block_size, "algorithm": "sha1"},
                 "bd3749347b412b1b0a9ea65220e55767ac8e96b0",
             ),
             (
                 ("salt", "value"),
+                # RemovedInDjango70Warning: Remove the explicit algorithm to
+                # test the new default value.
                 {"algorithm": "sha256"},
                 "ee0bf789e4e009371a5372c90f73fcf17695a8439c9108b0480f14e347b3f9ec",
             ),
@@ -55,6 +66,15 @@ class TestUtilsCryptoMisc(SimpleTestCase):
         for args, kwargs, digest in tests:
             with self.subTest(args=args, kwargs=kwargs):
                 self.assertEqual(salted_hmac(*args, **kwargs).hexdigest(), digest)
+
+    def test_salted_hmac_default_algorithm_deprecation(self):
+        msg = (
+            "The default argument for algorithm in salted_hmac() will change "
+            "from 'sha1' to 'sha256' in Django 7.0. Pass an explicit "
+            "algorithm to silence this warning."
+        )
+        with self.assertWarnsMessage(RemovedInDjango70Warning, msg):
+            salted_hmac("salt", "value")
 
     def test_invalid_algorithm(self):
         msg = "'whatever' is not an algorithm accepted by the hashlib module."


### PR DESCRIPTION
#### Trac ticket number

ticket-37078

#### Branch description

Deprecated the default value of the algorithm argument in
`django.utils.crypto.salted_hmac()` and `django.core.signing.base64_hmac()`,
which will change from 'sha1' to 'sha256' in Django 7.0.

#### AI Assistance Disclosure (REQUIRED)
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Used Grok 4.3 (xAI) <noreply@x.ai> for issue detection and fix suggestions.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
