### PR TITLE
Fixed #31295 -- Avoid Select widget triggering additional query when …

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -3,6 +3,7 @@ Helper functions for creating Form classes from Django models
 and database field objects.
 """
 
+from collections import deque
 from itertools import chain
 
 from django.core.exceptions import (
@@ -1438,16 +1439,30 @@ class ModelChoiceIterator(BaseChoiceIterator):
     def __init__(self, field):
         self.field = field
         self.queryset = field.queryset
+        self._deque = deque()
+
+        def generator():
+            if self.field.empty_label is not None:
+                yield ("", self.field.empty_label)
+            queryset = self.queryset
+            # Can't use iterator() when queryset uses prefetch_related()
+            if not queryset._prefetch_related_lookups:
+                queryset = queryset.iterator()
+            for obj in iter(queryset):
+                yield self.choice(obj)
+            # Reset the generator after it's exhausted so that it can
+            # be used again.
+            self.generator = generator()
+
+        self.generator = generator()
 
     def __iter__(self):
-        if self.field.empty_label is not None:
-            yield ("", self.field.empty_label)
-        queryset = self.queryset
-        # Can't use iterator() when queryset uses prefetch_related()
-        if not queryset._prefetch_related_lookups:
-            queryset = queryset.iterator()
-        for obj in queryset:
-            yield self.choice(obj)
+        return self
+
+    def __next__(self):
+        if self._deque:
+            return self._deque.popleft()
+        return next(self.generator)
 
     def __len__(self):
         # count() adds a query but uses less memory since the QuerySet results
@@ -1456,13 +1471,21 @@ class ModelChoiceIterator(BaseChoiceIterator):
         return self.queryset.count() + (1 if self.field.empty_label is not None else 0)
 
     def __bool__(self):
-        return self.field.empty_label is not None or self.queryset.exists()
+        return (
+            self.field.empty_label is not None or self._deque or self.queryset.exists()
+        )
 
     def choice(self, obj):
         return (
             ModelChoiceIteratorValue(self.field.prepare_value(obj), obj),
             self.field.label_from_instance(obj),
         )
+
+    def peek(self):
+        value = next(self.generator, None)
+        if value is not None:
+            self._deque.append(value)
+        return value
 
 
 class ModelChoiceField(ChoiceField):

--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -851,7 +851,11 @@ class Select(ChoiceWidget):
         if self.allow_multiple_selected:
             return use_required_attribute
 
-        first_choice = next(iter(self.choices), None)
+        first_choice = (
+            self.choices.peek()
+            if hasattr(self.choices, "peek")
+            else next(iter(self.choices), None)
+        )
         return (
             use_required_attribute
             and first_choice is not None

--- a/tests/model_forms/test_modelchoicefield.py
+++ b/tests/model_forms/test_modelchoicefield.py
@@ -169,6 +169,17 @@ class ModelChoiceFieldTests(TestCase):
         Category.objects.all().delete()
         self.assertIs(bool(f.choices), False)
 
+    def test_empty_label_one_query(self):
+        class MyForm(forms.Form):
+            f = forms.ModelChoiceField(Category.objects.all(), empty_label=None)
+
+        form = MyForm()
+        with self.assertNumQueries(1):
+            form.as_ul()
+        # Make sure the query re-runs when re-rendering the form.
+        with self.assertNumQueries(1):
+            form.as_ul()
+
     def test_choices_bool_empty_label(self):
         f = forms.ModelChoiceField(Category.objects.all(), empty_label="--------")
         Category.objects.all().delete()


### PR DESCRIPTION
…using ModelChoiceIterator.

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-31295

#### Branch description
This patch allows "peeking" at the choices of a ModelChoiceIterator without any additional queries, which fixes the double query issue for a ModelChoiceField when `empty_label` is set to None.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [X] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [X] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [X] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [X] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
- [X] I have attached screenshots in both light and dark modes for any UI changes.
