### PR TITLE
Fixed #31295 -- Avoided Select widget triggering additional query when …

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -3,6 +3,7 @@ Helper functions for creating Form classes from Django models
 and database field objects.
 """
 
+from collections import deque
 from itertools import chain
 
 from django.core.exceptions import (
@@ -1438,16 +1439,19 @@ class ModelChoiceIterator(BaseChoiceIterator):
     def __init__(self, field):
         self.field = field
         self.queryset = field.queryset
+        self._deque = deque()
+        self._generator = self.generator()
 
-    def __iter__(self):
+    def generator(self):
         if self.field.empty_label is not None:
             yield ("", self.field.empty_label)
-        queryset = self.queryset
-        # Can't use iterator() when queryset uses prefetch_related()
-        if not queryset._prefetch_related_lookups:
-            queryset = queryset.iterator()
-        for obj in queryset:
+        for obj in self.queryset.iterator(chunk_size=100):
             yield self.choice(obj)
+
+    def __iter__(self):
+        yield from chain(self._deque, self._generator)
+        self._deque = deque()
+        self._generator = self.generator()
 
     def __len__(self):
         # count() adds a query but uses less memory since the QuerySet results
@@ -1456,13 +1460,21 @@ class ModelChoiceIterator(BaseChoiceIterator):
         return self.queryset.count() + (1 if self.field.empty_label is not None else 0)
 
     def __bool__(self):
-        return self.field.empty_label is not None or self.queryset.exists()
+        return (
+            self.field.empty_label is not None or self._deque or self.queryset.exists()
+        )
 
     def choice(self, obj):
         return (
             ModelChoiceIteratorValue(self.field.prepare_value(obj), obj),
             self.field.label_from_instance(obj),
         )
+
+    def peek(self):
+        value = next(self._generator, None)
+        if value is not None:
+            self._deque.append(value)
+        return value
 
 
 class ModelChoiceField(ChoiceField):

--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -851,7 +851,11 @@ class Select(ChoiceWidget):
         if self.allow_multiple_selected:
             return use_required_attribute
 
-        first_choice = next(iter(self.choices), None)
+        first_choice = (
+            self.choices.peek()
+            if hasattr(self.choices, "peek")
+            else next(iter(self.choices), None)
+        )
         return (
             use_required_attribute
             and first_choice is not None

--- a/docs/ref/forms/fields.txt
+++ b/docs/ref/forms/fields.txt
@@ -1619,11 +1619,15 @@ customize the yielded 2-tuple choices.
 
     ``ModelChoiceIterator`` has the following method:
 
-    .. method:: __iter__()
+    .. method:: generator()
 
         Yields 2-tuple choices, in the ``(value, label)`` format used by
         :attr:`ChoiceField.choices`. The first ``value`` element is a
         :class:`ModelChoiceIteratorValue` instance.
+
+    .. versionchanged:: 6.1
+
+        ``generator`` yields choices instead of ``__iter__``.
 
 ``ModelChoiceIteratorValue``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -264,6 +264,12 @@ Forms
   field's choices. This allows per-request refreshing when called in a form's
   ``__init__()``.
 
+* :class:`~django.forms.ModelChoiceIterator` now yields choices via
+  its :meth:`~django.forms.ModelChoiceIterator.generator` method.
+  Users who have previously overridden the ``__iter__()`` method of
+  :class:`~django.forms.ModelChoiceIterator` should override
+  :meth:`~django.forms.ModelChoiceIterator.generator` instead.
+
 Generic Views
 ~~~~~~~~~~~~~
 

--- a/tests/model_forms/test_modelchoicefield.py
+++ b/tests/model_forms/test_modelchoicefield.py
@@ -169,6 +169,22 @@ class ModelChoiceFieldTests(TestCase):
         Category.objects.all().delete()
         self.assertIs(bool(f.choices), False)
 
+    def test_empty_label_one_query(self):
+        class MyForm(forms.Form):
+            f = forms.ModelChoiceField(Category.objects.all(), empty_label=None)
+
+        form = MyForm()
+        with self.assertNumQueries(1):
+            form.as_ul()
+        # Ensure the query re-runs when re-rendering the form.
+        with self.assertNumQueries(1):
+            form.as_ul()
+
+        # Ensure the iterator stops after yielding its choices.
+        choice_iterator = iter(form.fields["f"].choices)
+        self.assertEqual(len(list(choice_iterator)), 3)
+        self.assertEqual(len(list(choice_iterator)), 0)
+
     def test_choices_bool_empty_label(self):
         f = forms.ModelChoiceField(Category.objects.all(), empty_label="--------")
         Category.objects.all().delete()


### PR DESCRIPTION
…using ModelChoiceIterator.

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-31295

#### Branch description
This patch allows "peeking" at the choices of a ModelChoiceIterator without any additional queries, which fixes the double query issue for a ModelChoiceField when `empty_label` is set to None.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [X] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [X] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [X] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [X] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [X] I have attached screenshots in both light and dark modes for any UI changes.
