### PR TITLE
Fixed #37074 -- Synced admin calendar today highlight with server time.

### DIFF
--- a/django/contrib/admin/static/admin/js/admin/DateTimeShortcuts.js
+++ b/django/contrib/admin/static/admin/js/admin/DateTimeShortcuts.js
@@ -52,17 +52,7 @@
         },
         // Return the current time while accounting for the server timezone.
         now: function () {
-            const serverOffset = document.body.dataset.adminUtcOffset;
-            if (serverOffset) {
-                const localNow = new Date();
-                const localOffset = localNow.getTimezoneOffset() * -60;
-                localNow.setTime(
-                    localNow.getTime() + 1000 * (serverOffset - localOffset),
-                );
-                return localNow;
-            } else {
-                return new Date();
-            }
+            return CalendarNamespace.serverToday();
         },
         // Add a warning when the time zone in the browser and backend do not match.
         addTimezoneWarning: function (inp) {

--- a/django/contrib/admin/static/admin/js/calendar.js
+++ b/django/contrib/admin/static/admin/js/calendar.js
@@ -103,9 +103,21 @@ depends on core.js for utility functions like removeChildren or quickElement
                 true,
             );
         },
+        // Return the current date adjusted for the server timezone.
+        serverToday: function () {
+            const today = new Date();
+            const serverOffset = document.body.dataset.adminUtcOffset;
+            if (serverOffset) {
+                const localOffset = today.getTimezoneOffset() * -60;
+                today.setTime(
+                    today.getTime() + 1000 * (serverOffset - localOffset),
+                );
+            }
+            return today;
+        },
         draw: function (month, year, div_id, callback, selected) {
             // month = 1-12, year = 1-9999
-            const today = new Date();
+            const today = CalendarNamespace.serverToday();
             const todayDay = today.getDate();
             const todayMonth = today.getMonth() + 1;
             const todayYear = today.getFullYear();
@@ -267,7 +279,7 @@ depends on core.js for utility functions like removeChildren or quickElement
         //     calendar is clicked
         this.div_id = div_id;
         this.callback = callback;
-        this.today = new Date();
+        this.today = CalendarNamespace.serverToday();
         this.currentMonth = this.today.getMonth() + 1;
         this.currentYear = this.today.getFullYear();
         if (typeof selected !== "undefined") {

--- a/js_tests/admin/DateTimeShortcuts.test.js
+++ b/js_tests/admin/DateTimeShortcuts.test.js
@@ -137,3 +137,34 @@ QUnit.test("today link has aria-label with current date", function (assert) {
     const expectedAriaLabel = `Today (${formattedDate})`;
     assert.equal(todayLink.attr("aria-label"), expectedAriaLabel);
 });
+
+QUnit.test("calendar today highlight with server offset", function (assert) {
+    const $ = django.jQuery;
+    const calDiv = $('<div id="test-calendar"></div>');
+    $("#qunit-fixture").append(calDiv);
+
+    // Simulate a server timezone that is 24 hours ahead of the browser.
+    const localOffset = new Date().getTimezoneOffset() * -60;
+    const serverOffset = localOffset + 86400;
+    $("body").attr("data-admin-utc-offset", serverOffset);
+
+    const expectedDate = new Date();
+    expectedDate.setTime(
+        expectedDate.getTime() + 1000 * (serverOffset - localOffset),
+    );
+
+    CalendarNamespace.draw(
+        expectedDate.getMonth() + 1,
+        expectedDate.getFullYear(),
+        "test-calendar",
+        function () {},
+    );
+
+    const todayCells = calDiv.find("td.today");
+    assert.equal(todayCells.length, 1, "Exactly one cell marked as today");
+    assert.equal(
+        todayCells.find("a").text(),
+        String(expectedDate.getDate()),
+        "Today cell matches server-adjusted date",
+    );
+});


### PR DESCRIPTION
#### Trac ticket number
ticket-37074

#### Branch description
This PR resolves a timezone discrepancy in the admin datetime widget where the highlighted "today" on the calendar popup did not match the date inserted by the "Today" shortcut button. Previously, the "Today" shortcut used the server's timezone, but the visual calendar grid calculated "today" using `new Date()`, which relies purely on the browser's local timezone. This update modifies `calendar.js` to look for the `data-admin-utc-offset` attribute on the `<body>` element. If present, it offsets the browser's local date calculation to match the server's timezone, perfectly synchronizing both features.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

I have used Antigravity to test and verify the changes made for the fix.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
