### PR TITLE
Fixed #37025 -- Avoided masking header discrepancies in RemoteUserTest.

### DIFF
--- a/django/contrib/auth/middleware.py
+++ b/django/contrib/auth/middleware.py
@@ -183,6 +183,9 @@ class RemoteUserMiddleware:
                 f" before the {self.__class__.__name__} class."
             )
         try:
+            # BUG: on ASGI, as of Django 5.2, the value of the .header
+            # attribute is what must be sent by the client.
+            # https://code.djangoproject.com/ticket/36300
             username = request.META["HTTP_" + self.header]
         except KeyError:
             # If specified header doesn't exist then remove any existing

--- a/tests/auth_tests/test_remote_user.py
+++ b/tests/auth_tests/test_remote_user.py
@@ -1,5 +1,7 @@
 from datetime import UTC, datetime
 
+import asgiref.sync
+
 from django.conf import settings
 from django.contrib.auth import aauthenticate, authenticate
 from django.contrib.auth.backends import RemoteUserBackend
@@ -20,6 +22,13 @@ from django.test import (
 class RemoteUserTest(TestCase):
     middleware = "django.contrib.auth.middleware.RemoteUserMiddleware"
     backend = "django.contrib.auth.backends.RemoteUserBackend"
+
+    # ASGI tests provide this value via `headers`.
+    # WSGI tests provide this value directly into the environ via `**extra`.
+    # When subclassing to provide a custom header, implement a property to
+    # strip the prefix, and always pass via `headers`, since the only case
+    # where it should be passed via the environ is under WSGI, and only when
+    # the value is exactly "REMOTE_USER".
     header = "REMOTE_USER"
     email_header = "REMOTE_EMAIL"
 
@@ -66,7 +75,9 @@ class RemoteUserTest(TestCase):
         self.assertTrue(response.context["user"].is_anonymous)
         self.assertEqual(await User.objects.acount(), num_users)
 
-        response = await self.async_client.get("/remote_user/", **{self.header: ""})
+        response = await self.async_client.get(
+            "/remote_user/", headers={self.header: ""}
+        )
         self.assertTrue(response.context["user"].is_anonymous)
         self.assertEqual(await User.objects.acount(), num_users)
 
@@ -143,7 +154,7 @@ class RemoteUserTest(TestCase):
         """See test_unknown_user."""
         num_users = await User.objects.acount()
         response = await self.async_client.get(
-            "/remote_user/", **{self.header: "newuser"}
+            "/remote_user/", headers={self.header: "newuser"}
         )
         self.assertEqual(response.context["user"].username, "newuser")
         self.assertEqual(await User.objects.acount(), num_users + 1)
@@ -151,7 +162,7 @@ class RemoteUserTest(TestCase):
 
         # Another request with same user should not create any new users.
         response = await self.async_client.get(
-            "/remote_user/", **{self.header: "newuser"}
+            "/remote_user/", headers={self.header: "newuser"}
         )
         self.assertEqual(await User.objects.acount(), num_users + 1)
 
@@ -177,14 +188,14 @@ class RemoteUserTest(TestCase):
         await User.objects.acreate(username="knownuser2")
         num_users = await User.objects.acount()
         response = await self.async_client.get(
-            "/remote_user/", **{self.header: self.known_user}
+            "/remote_user/", headers={self.header: self.known_user}
         )
         self.assertEqual(response.context["user"].username, "knownuser")
         self.assertEqual(await User.objects.acount(), num_users)
         # A different user passed in the headers causes the new user
         # to be logged in.
         response = await self.async_client.get(
-            "/remote_user/", **{self.header: self.known_user2}
+            "/remote_user/", headers={self.header: self.known_user2}
         )
         self.assertEqual(response.context["user"].username, "knownuser2")
         self.assertEqual(await User.objects.acount(), num_users)
@@ -222,7 +233,7 @@ class RemoteUserTest(TestCase):
         await user.asave()
 
         response = await self.async_client.get(
-            "/remote_user/", **{self.header: self.known_user}
+            "/remote_user/", headers={self.header: self.known_user}
         )
         self.assertNotEqual(default_login, response.context["user"].last_login)
 
@@ -230,7 +241,7 @@ class RemoteUserTest(TestCase):
         user.last_login = default_login
         await user.asave()
         response = await self.async_client.get(
-            "/remote_user/", **{self.header: self.known_user}
+            "/remote_user/", headers={self.header: self.known_user}
         )
         self.assertEqual(default_login, response.context["user"].last_login)
 
@@ -260,7 +271,7 @@ class RemoteUserTest(TestCase):
         await User.objects.acreate(username="knownuser")
         # Known user authenticates
         response = await self.async_client.get(
-            "/remote_user/", **{self.header: self.known_user}
+            "/remote_user/", headers={self.header: self.known_user}
         )
         self.assertEqual(response.context["user"].username, "knownuser")
         # During the session, the REMOTE_USER header disappears. Should trigger
@@ -296,12 +307,12 @@ class RemoteUserTest(TestCase):
         await User.objects.acreate(username="knownuser")
         # Known user authenticates
         response = await self.async_client.get(
-            "/remote_user/", **{self.header: self.known_user}
+            "/remote_user/", headers={self.header: self.known_user}
         )
         self.assertEqual(response.context["user"].username, "knownuser")
         # During the session, the REMOTE_USER changes to a different user.
         response = await self.async_client.get(
-            "/remote_user/", **{self.header: "newnewuser"}
+            "/remote_user/", headers={self.header: "newnewuser"}
         )
         # The current user is not the prior remote_user.
         # In backends that create a new user, username is "newnewuser"
@@ -316,7 +327,7 @@ class RemoteUserTest(TestCase):
     async def test_inactive_user_async(self):
         await User.objects.acreate(username="knownuser", is_active=False)
         response = await self.async_client.get(
-            "/remote_user/", **{self.header: "knownuser"}
+            "/remote_user/", headers={self.header: "knownuser"}
         )
         self.assertTrue(response.context["user"].is_anonymous)
 
@@ -344,7 +355,7 @@ class RemoteUserNoCreateTest(RemoteUserTest):
     async def test_unknown_user_async(self):
         num_users = await User.objects.acount()
         response = await self.async_client.get(
-            "/remote_user/", **{self.header: "newuser"}
+            "/remote_user/", headers={self.header: "newuser"}
         )
         self.assertTrue(response.context["user"].is_anonymous)
         self.assertEqual(await User.objects.acount(), num_users)
@@ -363,7 +374,7 @@ class AllowAllUsersRemoteUserBackendTest(RemoteUserTest):
     async def test_inactive_user_async(self):
         user = await User.objects.acreate(username="knownuser", is_active=False)
         response = await self.async_client.get(
-            "/remote_user/", **{self.header: self.known_user}
+            "/remote_user/", headers={self.header: self.known_user}
         )
         self.assertEqual(response.context["user"].username, user.username)
 
@@ -457,7 +468,7 @@ class RemoteUserCustomTest(RemoteUserTest):
         num_users = await User.objects.acount()
         response = await self.async_client.get(
             "/remote_user/",
-            **{
+            headers={
                 self.header: "newuser",
                 self.email_header: "user@example.com",
             },
@@ -485,7 +496,39 @@ class CustomHeaderRemoteUserTest(RemoteUserTest):
     """
 
     middleware = "auth_tests.test_remote_user.CustomHeaderMiddleware"
-    header = "HTTP_AUTHUSER"
+    auth_header = "HTTP_AUTHUSER"
+
+    @property
+    def header(self):
+        """Return the unprefixed header the server or proxy should provide."""
+        method = getattr(self, self._testMethodName)
+        if isinstance(method, asgiref.sync.AsyncToSync):
+            # BUG: on ASGI, as of Django 5.2, the value of the .header
+            # attribute is what must be sent by the proxy.
+            # https://code.djangoproject.com/ticket/36300
+            return self.auth_header
+        return self.auth_header.removeprefix("HTTP_")
+
+    def setUp(self):
+        """Force any **kwargs to be passed via `headers`."""
+        super().setUp()
+        original_get = self.client.get
+        original_async_get = self.async_client.get
+
+        def get(self, *args, headers={}, **kwargs):
+            headers = {**headers}
+            headers.update(kwargs)
+            return original_get(self, *args, headers=headers)
+
+        async def aget(self, *args, headers={}, **kwargs):
+            headers = {**headers}
+            headers.update(kwargs)
+            return await original_async_get(self, *args, headers=headers)
+
+        self.client.get = get
+        self.async_client.get = aget
+        self.addCleanup(setattr, self.client, "get", original_get)
+        self.addCleanup(setattr, self.async_client, "get", original_async_get)
 
 
 class PersistentRemoteUserTest(RemoteUserTest):
@@ -516,7 +559,7 @@ class PersistentRemoteUserTest(RemoteUserTest):
         await User.objects.acreate(username="knownuser")
         # Known user authenticates
         response = await self.async_client.get(
-            "/remote_user/", **{self.header: self.known_user}
+            "/remote_user/", headers={self.header: self.known_user}
         )
         self.assertEqual(response.context["user"].username, "knownuser")
         # Should stay logged in if the REMOTE_USER header disappears.


### PR DESCRIPTION
#### Trac ticket number
ticket-37025
ticket-36300

#### Branch description
Because these tests always passed both WSGI environ variables and HTTP headers via `**extra`, this masked a behavior difference between WSGI and ASGI.

What should happen: but for a single exception--the default REMOTE_USER case on WSGI--everything should be passed via `headers`. Only the default REMOTE_USER case on WSGI should be passed via ``**extra``.

Since that was not done, a regression made it into Django 5.2 (50f89ae850f6b4e35819fe725a08c7e579bfd099) where `.header` no longer corresponded to the request.META key under ASGI. To cope, an ASGI user would have started sending HTTP headers that match the `.header` attribute, which may or may not have been edited to remove the HTTP_ prefix. (Note: the default `REMOTE_USER` case did not work under ASGI, so the change in Django 5.2 had the effect of fixing the default case but changing the semantic of the custom case.)

This was raised in ticket-36300 but closed for lack of follow-up. I plan to fix this unintentional behavior change next.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
