### PR TITLE
Fixed #37079 -- Fixed specialization of header lookups in RemoteUserMiddleware.

### DIFF
--- a/django/contrib/auth/middleware.py
+++ b/django/contrib/auth/middleware.py
@@ -8,6 +8,7 @@ from django.contrib.auth import REDIRECT_FIELD_NAME, load_backend
 from django.contrib.auth.backends import RemoteUserBackend
 from django.contrib.auth.views import redirect_to_login
 from django.core.exceptions import ImproperlyConfigured
+from django.core.handlers.asgi import ASGIRequest
 from django.shortcuts import resolve_url
 from django.utils.deprecation import MiddlewareMixin
 from django.utils.functional import SimpleLazyObject
@@ -141,7 +142,7 @@ class RemoteUserMiddleware:
                 f" before the {self.__class__.__name__} class."
             )
         try:
-            username = request.META[self.header]
+            username = self._get_username(request)
         except KeyError:
             # If specified header doesn't exist then remove any existing
             # authenticated remote-user, or return (leaving request.user set to
@@ -183,7 +184,7 @@ class RemoteUserMiddleware:
                 f" before the {self.__class__.__name__} class."
             )
         try:
-            username = request.META["HTTP_" + self.header]
+            username = self._get_username(request)
         except KeyError:
             # If specified header doesn't exist then remove any existing
             # authenticated remote-user, or return (leaving request.user set to
@@ -235,6 +236,11 @@ class RemoteUserMiddleware:
         except AttributeError:  # Backend has no clean_username method.
             pass
         return username
+
+    def _get_username(self, request):
+        if isinstance(request, ASGIRequest):
+            return request.META["HTTP_" + self.header]
+        return request.META[self.header]
 
     def _remove_invalid_user(self, request):
         """

--- a/django/contrib/auth/middleware.py
+++ b/django/contrib/auth/middleware.py
@@ -142,7 +142,7 @@ class RemoteUserMiddleware:
                 f" before the {self.__class__.__name__} class."
             )
         try:
-            username = self._get_username(request)
+            username = self.get_username(request)
         except KeyError:
             # If specified header doesn't exist then remove any existing
             # authenticated remote-user, or return (leaving request.user set to
@@ -184,7 +184,7 @@ class RemoteUserMiddleware:
                 f" before the {self.__class__.__name__} class."
             )
         try:
-            username = self._get_username(request)
+            username = self.get_username(request)
         except KeyError:
             # If specified header doesn't exist then remove any existing
             # authenticated remote-user, or return (leaving request.user set to
@@ -237,7 +237,7 @@ class RemoteUserMiddleware:
             pass
         return username
 
-    def _get_username(self, request):
+    def get_username(self, request):
         if isinstance(request, ASGIRequest):
             return request.META["HTTP_" + self.header]
         return request.META[self.header]

--- a/tests/auth_tests/test_remote_user.py
+++ b/tests/auth_tests/test_remote_user.py
@@ -1,5 +1,7 @@
 from datetime import UTC, datetime
 
+import asgiref.sync
+
 from django.conf import settings
 from django.contrib.auth import aauthenticate, authenticate
 from django.contrib.auth.backends import RemoteUserBackend
@@ -14,6 +16,15 @@ from django.test import (
     modify_settings,
     override_settings,
 )
+from django.utils.decorators import sync_only_middleware
+
+
+@sync_only_middleware
+def sync_middleware(get_response):
+    def middleware(request):
+        return get_response(request)
+
+    return middleware
 
 
 @override_settings(ROOT_URLCONF="auth_tests.urls")
@@ -470,6 +481,20 @@ class RemoteUserCustomTest(RemoteUserTest):
         self.assertEqual(newuser.email, "user@example.com")
 
 
+class ASGISyncPathRemoteUserTest(RemoteUserTest):
+    """Later sync-only middleware forces sync execution even under ASGI."""
+
+    middleware = [
+        RemoteUserTest.middleware,
+        "auth_tests.test_remote_user.sync_middleware",
+    ]
+
+    def setUp(self):
+        method = getattr(self, self._testMethodName)
+        if not isinstance(method, asgiref.sync.AsyncToSync):
+            self.skipTest("This test covers async-only functionality")
+
+
 class CustomHeaderMiddleware(RemoteUserMiddleware):
     """
     Middleware that overrides custom HTTP auth user header.
@@ -484,6 +509,11 @@ class CustomHeaderRemoteUserTest(RemoteUserTest):
     header.
     """
 
+    middleware = "auth_tests.test_remote_user.CustomHeaderMiddleware"
+    header = "HTTP_AUTHUSER"
+
+
+class CustomHeaderASGISyncPathRemoteUserTest(ASGISyncPathRemoteUserTest):
     middleware = "auth_tests.test_remote_user.CustomHeaderMiddleware"
     header = "HTTP_AUTHUSER"
 


### PR DESCRIPTION
#### Trac ticket number
ticket-37079

#### Branch description
We need to switch on whether the request is a WSGI or ASGI request to know whether to prepend `HTTP_`: we cannot assume sync exceution means we are running under WSGI, as there could be other sync middleware forcing sync execution under ASGI.

Thanks @Arfey for the report.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
