### PR TITLE
Fixed #36300 -- Restored the semantic where RemoteUserMiddleware.header corresponds to request.META under ASGI.

### DIFF
--- a/django/contrib/auth/middleware.py
+++ b/django/contrib/auth/middleware.py
@@ -238,7 +238,10 @@ class RemoteUserMiddleware:
         return username
 
     def get_username(self, request):
-        if isinstance(request, ASGIRequest):
+        if (
+            isinstance(request, ASGIRequest)
+            and self.header == RemoteUserMiddleware.header
+        ):
             return request.META["HTTP_" + self.header]
         return request.META[self.header]
 

--- a/docs/howto/auth-remote-user.txt
+++ b/docs/howto/auth-remote-user.txt
@@ -2,24 +2,24 @@
 How to authenticate using ``REMOTE_USER``
 =========================================
 
-This document describes how to make use of external authentication sources
-(where the web server sets the ``REMOTE_USER`` environment variable) in your
-Django applications. This type of authentication solution is typically seen on
-intranet sites, with single sign-on solutions such as IIS and Integrated
-Windows Authentication or Apache and `mod_authnz_ldap`_, `CAS`_, `WebAuth`_,
-`mod_auth_sspi`_, etc.
+This document describes how to make use of external authentication sources in
+your Django applications. This type of authentication solution is typically
+seen on intranet sites, with single sign-on solutions such as IIS and
+Integrated Windows Authentication or Apache and `mod_authnz_ldap`_, `CAS`_,
+`WebAuth`_, `mod_auth_sspi`_, etc.
 
 .. _mod_authnz_ldap: https://httpd.apache.org/docs/current/mod/mod_authnz_ldap.html
 .. _CAS: https://www.apereo.org/projects/cas
 .. _WebAuth: https://uit.stanford.edu/service/authentication
 .. _mod_auth_sspi: https://sourceforge.net/projects/mod-auth-sspi
 
-When the web server takes care of authentication it typically sets the
-``REMOTE_USER`` environment variable for use in the underlying application. In
-Django, ``REMOTE_USER`` is made available in the :attr:`request.META
-<django.http.HttpRequest.META>` attribute. Django can be configured to make
-use of the ``REMOTE_USER`` value using the ``RemoteUserMiddleware``
-or ``PersistentRemoteUserMiddleware``, and
+When the web server takes care of authentication it typically provides the
+authenticated user as ``REMOTE_USER``. In Django, this value is made available
+in :attr:`request.META <django.http.HttpRequest.META>` (as ``REMOTE_USER`` when
+supplied as an environment variable, as in WSGI, or ``HTTP_REMOTE_USER`` when
+supplied via an HTTP header, as in ASGI). Django can be configured to make use
+of the ``REMOTE_USER`` value using the ``RemoteUserMiddleware`` or
+``PersistentRemoteUserMiddleware``, and
 :class:`~django.contrib.auth.backends.RemoteUserBackend` classes found in
 :mod:`django.contrib.auth`.
 
@@ -47,7 +47,8 @@ with :class:`~django.contrib.auth.backends.RemoteUserBackend` in the
     ]
 
 With this setup, ``RemoteUserMiddleware`` will detect the username in
-``request.META['REMOTE_USER']`` and will authenticate and auto-login that user
+``request.META['REMOTE_USER']`` (or ``request.META['HTTP_REMOTE_USER']`` under
+ASGI) and will authenticate and auto-login that user
 using the :class:`~django.contrib.auth.backends.RemoteUserBackend`.
 
 Be aware that this particular setup disables authentication with the default
@@ -103,9 +104,7 @@ instead of :class:`django.contrib.auth.middleware.RemoteUserMiddleware`::
     client can supply the header. You must be sure that your web server or
     reverse proxy always sets or strips that header based on the appropriate
     authentication checks, never permitting an end user to submit a fake (or
-    "spoofed") header value. In particular, ASGI deployments cannot be exposed
-    directly to the internet (that is, without a reverse proxy) when using this
-    middleware.
+    "spoofed") header value.
 
     Since the HTTP headers ``X-Auth-User`` and ``X-Auth_User`` (for example)
     both normalize to the ``HTTP_X_AUTH_USER`` key in ``request.META``, you
@@ -115,10 +114,12 @@ instead of :class:`django.contrib.auth.middleware.RemoteUserMiddleware`::
     Under WSGI, this warning doesn't apply to ``RemoteUserMiddleware`` in its
     default configuration with ``header = "REMOTE_USER"``, since a key that
     doesn't start with ``HTTP_`` in ``request.META`` can only be set by your
-    WSGI server, not directly from an HTTP request header. This warning *does*
-    apply by default on ASGI, because in the async path, the middleware
-    prepends ``HTTP_`` to the defined header name before looking it up in
-    ``request.META``.
+    WSGI server, not directly from an HTTP request header.
+
+    This warning applies under ASGI in all configurations, because there is
+    no equivalent for a WSGI server's ability to place a trusted value in the
+    environ. ASGI deployments *must* use a reverse proxy as described above
+    when using this middleware.
 
 If you need more control, you can create your own authentication backend
 that inherits from :class:`~django.contrib.auth.backends.RemoteUserBackend` and

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -463,6 +463,15 @@ backends.
 * The undocumented ``InclusionAdminNode.__init__()`` now takes the template tag
   ``name`` as the first positional argument.
 
+:mod:`django.contrib.auth`
+--------------------------
+
+* Under ASGI, :class:`~django.contrib.auth.middleware.RemoteUserMiddleware` no
+  longer prefixes ``HTTP_`` when looking up custom values in ``request.META``.
+  For example, to send ``-H "AuthUser": ...``, the ``header`` attribute should
+  be ``HTTP_AUTHUSER``. This restores the behavior prior to Django 5.2. (The
+  default value of ``REMOTE_USER`` is not affected.)
+
 :mod:`django.contrib.gis`
 -------------------------
 

--- a/tests/auth_tests/test_remote_user.py
+++ b/tests/auth_tests/test_remote_user.py
@@ -31,8 +31,15 @@ def sync_middleware(get_response):
 class RemoteUserTest(TestCase):
     middleware = "django.contrib.auth.middleware.RemoteUserMiddleware"
     backend = "django.contrib.auth.backends.RemoteUserBackend"
+
+    # ASGI tests always provide this value via `headers`.
+    # WSGI tests provide this value directly into the environ via `**extra`.
+    # When subclassing to provide a custom header, implement a property to
+    # strip the prefix, and always pass via `headers`, since the only case
+    # where it should be passed via the environ is under WSGI, and only when
+    # the value is exactly "REMOTE_USER".
     header = "REMOTE_USER"
-    email_header = "REMOTE_EMAIL"
+    email_header = "HTTP_REMOTE_EMAIL"
 
     # Usernames to be passed in REMOTE_USER for the test_known_user test case.
     known_user = "knownuser"
@@ -77,7 +84,9 @@ class RemoteUserTest(TestCase):
         self.assertTrue(response.context["user"].is_anonymous)
         self.assertEqual(await User.objects.acount(), num_users)
 
-        response = await self.async_client.get("/remote_user/", **{self.header: ""})
+        response = await self.async_client.get(
+            "/remote_user/", headers={self.header: ""}
+        )
         self.assertTrue(response.context["user"].is_anonymous)
         self.assertEqual(await User.objects.acount(), num_users)
 
@@ -154,7 +163,7 @@ class RemoteUserTest(TestCase):
         """See test_unknown_user."""
         num_users = await User.objects.acount()
         response = await self.async_client.get(
-            "/remote_user/", **{self.header: "newuser"}
+            "/remote_user/", headers={self.header: "newuser"}
         )
         self.assertEqual(response.context["user"].username, "newuser")
         self.assertEqual(await User.objects.acount(), num_users + 1)
@@ -162,7 +171,7 @@ class RemoteUserTest(TestCase):
 
         # Another request with same user should not create any new users.
         response = await self.async_client.get(
-            "/remote_user/", **{self.header: "newuser"}
+            "/remote_user/", headers={self.header: "newuser"}
         )
         self.assertEqual(await User.objects.acount(), num_users + 1)
 
@@ -188,14 +197,14 @@ class RemoteUserTest(TestCase):
         await User.objects.acreate(username="knownuser2")
         num_users = await User.objects.acount()
         response = await self.async_client.get(
-            "/remote_user/", **{self.header: self.known_user}
+            "/remote_user/", headers={self.header: self.known_user}
         )
         self.assertEqual(response.context["user"].username, "knownuser")
         self.assertEqual(await User.objects.acount(), num_users)
         # A different user passed in the headers causes the new user
         # to be logged in.
         response = await self.async_client.get(
-            "/remote_user/", **{self.header: self.known_user2}
+            "/remote_user/", headers={self.header: self.known_user2}
         )
         self.assertEqual(response.context["user"].username, "knownuser2")
         self.assertEqual(await User.objects.acount(), num_users)
@@ -233,7 +242,7 @@ class RemoteUserTest(TestCase):
         await user.asave()
 
         response = await self.async_client.get(
-            "/remote_user/", **{self.header: self.known_user}
+            "/remote_user/", headers={self.header: self.known_user}
         )
         self.assertNotEqual(default_login, response.context["user"].last_login)
 
@@ -241,7 +250,7 @@ class RemoteUserTest(TestCase):
         user.last_login = default_login
         await user.asave()
         response = await self.async_client.get(
-            "/remote_user/", **{self.header: self.known_user}
+            "/remote_user/", headers={self.header: self.known_user}
         )
         self.assertEqual(default_login, response.context["user"].last_login)
 
@@ -271,7 +280,7 @@ class RemoteUserTest(TestCase):
         await User.objects.acreate(username="knownuser")
         # Known user authenticates
         response = await self.async_client.get(
-            "/remote_user/", **{self.header: self.known_user}
+            "/remote_user/", headers={self.header: self.known_user}
         )
         self.assertEqual(response.context["user"].username, "knownuser")
         # During the session, the REMOTE_USER header disappears. Should trigger
@@ -307,12 +316,12 @@ class RemoteUserTest(TestCase):
         await User.objects.acreate(username="knownuser")
         # Known user authenticates
         response = await self.async_client.get(
-            "/remote_user/", **{self.header: self.known_user}
+            "/remote_user/", headers={self.header: self.known_user}
         )
         self.assertEqual(response.context["user"].username, "knownuser")
         # During the session, the REMOTE_USER changes to a different user.
         response = await self.async_client.get(
-            "/remote_user/", **{self.header: "newnewuser"}
+            "/remote_user/", headers={self.header: "newnewuser"}
         )
         # The current user is not the prior remote_user.
         # In backends that create a new user, username is "newnewuser"
@@ -327,7 +336,7 @@ class RemoteUserTest(TestCase):
     async def test_inactive_user_async(self):
         await User.objects.acreate(username="knownuser", is_active=False)
         response = await self.async_client.get(
-            "/remote_user/", **{self.header: "knownuser"}
+            "/remote_user/", headers={self.header: "knownuser"}
         )
         self.assertTrue(response.context["user"].is_anonymous)
 
@@ -355,7 +364,7 @@ class RemoteUserNoCreateTest(RemoteUserTest):
     async def test_unknown_user_async(self):
         num_users = await User.objects.acount()
         response = await self.async_client.get(
-            "/remote_user/", **{self.header: "newuser"}
+            "/remote_user/", headers={self.header: "newuser"}
         )
         self.assertTrue(response.context["user"].is_anonymous)
         self.assertEqual(await User.objects.acount(), num_users)
@@ -374,7 +383,7 @@ class AllowAllUsersRemoteUserBackendTest(RemoteUserTest):
     async def test_inactive_user_async(self):
         user = await User.objects.acreate(username="knownuser", is_active=False)
         response = await self.async_client.get(
-            "/remote_user/", **{self.header: self.known_user}
+            "/remote_user/", headers={self.header: self.known_user}
         )
         self.assertEqual(response.context["user"].username, user.username)
 
@@ -402,7 +411,7 @@ class CustomRemoteUserBackend(RemoteUserBackend):
         return user
 
     async def aconfigure_user(self, request, user, created=True):
-        user.email = request.META.get("HTTP_" + RemoteUserTest.email_header, "")
+        user.email = request.META.get(RemoteUserTest.email_header, "")
         if not created:
             user.last_name = user.username
         await user.asave()
@@ -468,9 +477,9 @@ class RemoteUserCustomTest(RemoteUserTest):
         num_users = await User.objects.acount()
         response = await self.async_client.get(
             "/remote_user/",
-            **{
+            headers={
                 self.header: "newuser",
-                self.email_header: "user@example.com",
+                self.email_header.removeprefix("HTTP_"): "user@example.com",
             },
         )
         self.assertEqual(response.context["user"].username, "newuser")
@@ -503,19 +512,51 @@ class CustomHeaderMiddleware(RemoteUserMiddleware):
     header = "HTTP_AUTHUSER"
 
 
-class CustomHeaderRemoteUserTest(RemoteUserTest):
+class CustomHeaderMixin:
+    middleware = "auth_tests.test_remote_user.CustomHeaderMiddleware"
+    auth_header = CustomHeaderMiddleware.header
+
+    @property
+    def header(self):
+        """Return the unprefixed header the server or proxy should provide."""
+        return self.auth_header.removeprefix("HTTP_")
+
+    def setUp(self):
+        """Force any **kwargs to be passed via `headers`."""
+        super().setUp()
+        original_get = self.client.get
+        original_async_get = self.async_client.get
+
+        def get(self, *args, headers={}, **kwargs):
+            headers = {**headers}
+            headers.update(kwargs)
+            return original_get(self, *args, headers=headers)
+
+        async def aget(self, *args, headers={}, **kwargs):
+            headers = {**headers}
+            headers.update(kwargs)
+            return await original_async_get(self, *args, headers=headers)
+
+        self.client.get = get
+        self.async_client.get = aget
+        self.addCleanup(setattr, self.client, "get", original_get)
+        self.addCleanup(setattr, self.async_client, "get", original_async_get)
+
+
+class CustomHeaderRemoteUserTest(CustomHeaderMixin, RemoteUserTest):
     """
     Tests a custom RemoteUserMiddleware subclass with custom HTTP auth user
     header.
     """
 
-    middleware = "auth_tests.test_remote_user.CustomHeaderMiddleware"
-    header = "HTTP_AUTHUSER"
 
-
-class CustomHeaderASGISyncPathRemoteUserTest(ASGISyncPathRemoteUserTest):
-    middleware = "auth_tests.test_remote_user.CustomHeaderMiddleware"
-    header = "HTTP_AUTHUSER"
+class CustomHeaderASGISyncPathRemoteUserTest(
+    CustomHeaderMixin, ASGISyncPathRemoteUserTest
+):
+    """
+    Tests sync execution under ASGI of a custom RemoteUserMiddleware subclass
+    with custom HTTP auth user header.
+    """
 
 
 class PersistentRemoteUserTest(RemoteUserTest):
@@ -546,7 +587,7 @@ class PersistentRemoteUserTest(RemoteUserTest):
         await User.objects.acreate(username="knownuser")
         # Known user authenticates
         response = await self.async_client.get(
-            "/remote_user/", **{self.header: self.known_user}
+            "/remote_user/", headers={self.header: self.known_user}
         )
         self.assertEqual(response.context["user"].username, "knownuser")
         # Should stay logged in if the REMOTE_USER header disappears.


### PR DESCRIPTION
#### Trac ticket number
ticket-36300

#### Branch description
This restores the behavior for custom headers under ASGI prior to 5.2. In 5.2, anyone trying to follow the [documented example](https://docs.djangoproject.com/en/dev/howto/auth-remote-user/#:~:text=HTTP_AUTHUSER%22) of setting `header = "HTTP_AUTHUSER"` would have had to send `-X "HTTP_AUTHUSER"` at the proxy under ASGI, which can't be right.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
