### PR TITLE
Fixed #36888 -- Made QuerySet.acreate() call asave().

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -694,11 +694,7 @@ class QuerySet(AltersData):
     async def aget(self, *args, **kwargs):
         return await sync_to_async(self.get)(*args, **kwargs)
 
-    def create(self, **kwargs):
-        """
-        Create a new object with the given kwargs, saving it to the database
-        and returning the created object.
-        """
+    def _prepare_for_create(self, **kwargs):
         reverse_one_to_one_fields = frozenset(kwargs).intersection(
             self.model._meta._reverse_one_to_one_field_names
         )
@@ -710,6 +706,14 @@ class QuerySet(AltersData):
 
         obj = self.model(**kwargs)
         self._for_write = True
+        return obj
+
+    def create(self, **kwargs):
+        """
+        Create a new object with the given kwargs, saving it to the database
+        and returning the created object.
+        """
+        obj = self._prepare_for_create(**kwargs)
         obj.save(force_insert=True, using=self.db)
         obj._state.fetch_mode = self._fetch_mode
         return obj
@@ -717,7 +721,10 @@ class QuerySet(AltersData):
     create.alters_data = True
 
     async def acreate(self, **kwargs):
-        return await sync_to_async(self.create)(**kwargs)
+        obj = await sync_to_async(self._prepare_for_create)(**kwargs)
+        await obj.asave(force_insert=True, using=self.db)
+        obj._state.fetch_mode = self._fetch_mode
+        return obj
 
     acreate.alters_data = True
 

--- a/tests/async/models.py
+++ b/tests/async/models.py
@@ -13,3 +13,11 @@ class SimpleModel(models.Model):
 
 class ManyToManyModel(models.Model):
     simples = models.ManyToManyField("SimpleModel")
+
+
+class IncrementASaveModel(models.Model):
+    field = models.IntegerField()
+
+    async def asave(self, *args, **kwargs):
+        self.field += 1
+        await super().asave(*args, **kwargs)

--- a/tests/async/test_async_queryset.py
+++ b/tests/async/test_async_queryset.py
@@ -1,6 +1,7 @@
 import json
 import xml.etree.ElementTree
 from datetime import datetime
+from unittest.mock import patch
 
 from asgiref.sync import async_to_sync, sync_to_async
 
@@ -8,7 +9,7 @@ from django.db import NotSupportedError, connection
 from django.db.models import Prefetch, Sum
 from django.test import TestCase, skipIfDBFeature, skipUnlessDBFeature
 
-from .models import RelatedModel, SimpleModel
+from .models import IncrementASaveModel, RelatedModel, SimpleModel
 
 
 class AsyncQuerySetTest(TestCase):
@@ -92,6 +93,15 @@ class AsyncQuerySetTest(TestCase):
     async def test_acreate(self):
         await SimpleModel.objects.acreate(field=4)
         self.assertEqual(await SimpleModel.objects.acount(), 4)
+
+    async def test_acreate_calls_asave(self):
+        with patch("django.db.models.base.Model.asave") as mock_asave:
+            await SimpleModel.objects.acreate(field=4)
+            mock_asave.assert_called()
+
+    async def test_acreate_runs_overridden_asave(self):
+        obj = await IncrementASaveModel.objects.acreate(field=4)
+        self.assertEqual(obj.field, 5)
 
     async def test_aget_or_create(self):
         instance, created = await SimpleModel.objects.aget_or_create(field=4)


### PR DESCRIPTION
#### Trac ticket number

ticket-36888

#### Branch description

When you use the async Django ORM and override ``asave()`` to add custom logic, ``QuerySet.acreate()`` does not actually run that override — it falls through to ``sync_to_async(self.create)``, which calls the sync ``save()`` instead.

```python
class SimpleModel(models.Model):
    field = models.IntegerField()

    async def asave(self, *args, **kwargs):
        self.field += 1
        await super().asave(*args, **kwargs)

obj = await SimpleModel.objects.acreate(field=4)
obj.field  # returns 4 — the asave override never ran
```

After this change ``obj.field`` is ``5`` as expected.

#### Approach

Mirrors the existing PR #20602 (open since January 2026, no review activity). Extracts the kwarg validation + model instantiation from ``create()`` into a private ``_prepare_for_create()`` helper, then makes ``acreate()`` call ``await obj.asave(...)`` directly. The helper still runs sync (it has to — model ``__init__`` can trigger descriptors like ``GenericForeignKeyDescriptor.__set__`` that hit the database), wrapped in ``sync_to_async``. This is the same workaround [@jericho1050 suggested in #20896](https://github.com/django/django/pull/20896) for the GFK case.

#### Considering the prior thread

[@Arfey raised a valid concern](https://github.com/django/django/pull/20602#issuecomment-4114581147) on #20602 that the broader async ORM story is incomplete — there is no real perf benefit over the sync path today, async transactions are unfinished, and admin/forms still call ``save()`` rather than ``asave()`` so user code in overridden ``asave()`` won't run there either. Those points are accurate and worth addressing separately, but this fix stands on its own: when a user *does* opt into the async path and *does* override ``asave()``, ``acreate()`` silently bypassing that override is a clear correctness bug (not a performance one). Closing this gap doesn't make the broader async ORM situation worse, and it removes one footgun for projects that build on top of Django's async surface (e.g. https://github.com/Arfey/django-async-backend/issues/21).

#### Supersedes

#20602 (same fix, same tests, same author CI failure already addressed in that PR's current diff). Happy to defer to that PR if @Materson wants to revive it; opening this so the fix isn't blocked on a stale branch.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Drafted with Claude (Anthropic). Reviewed and verified locally — ``async.test_async_queryset`` (27 tests including the two new ones), full ``async`` suite (69 tests), and ``basic`` and ``queries.test_query`` regression suites all pass.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability.
- [x] This PR targets the ``main`` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.