### PR TITLE
Fixed #37080 -- Treat generic deprecation warnings as errors.

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -28,7 +28,7 @@ else:
     from django.test.runner import get_max_test_processes, parallel_type
     from django.test.selenium import SeleniumTestCase, SeleniumTestCaseBase
     from django.test.utils import NullTimeKeeper, TimeKeeper, get_runner
-    from django.utils.deprecation import RemovedInDjango70Warning
+    from django.utils.deprecation import (RemovedInNextVersionWarning, RemovedAfterNextVersionWarning)
     from django.utils.functional import classproperty
     from django.utils.log import DEFAULT_LOGGING
     from django.utils.version import PYPY
@@ -43,7 +43,8 @@ else:
     warnings.filterwarnings("ignore", r"\(1003, *", category=MySQLdb.Warning)
 
 # Make deprecation warnings errors to ensure no usage of deprecated features.
-warnings.simplefilter("error", RemovedInDjango70Warning)
+warnings.simplefilter("error", RemovedInNextVersionWarning)
+warnings.simplefilter("error", RemovedAfterNextVersionWarning)
 # Make resource and runtime warning errors to ensure no usage of error prone
 # patterns.
 warnings.simplefilter("error", ResourceWarning)


### PR DESCRIPTION
#### Trac ticket number

ticket-37080

#### Branch description

This PR updates `runtests.py` to use the generic deprecation warning classes instead of a version-specific warning. This makes Django’s own test runner consistently treat both `RemovedInNextVersionWarning` and `RemovedAfterNextVersionWarning` as errors.

#### AI Assistance Disclosure

- [ ] **No AI tools were used** in preparing this PR.
- [x] **AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

AI assistance used: ChatGPT helped interpret the ticket, navigate Django’s contribution workflow, and review the proposed change. I manually implemented the change and verified it by running the relevant and full Django test suites.

#### Checklist

- [x] This PR follows the contribution guidelines.
- [x] This PR does not disclose a security vulnerability.
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.