### PR TITLE
Fixed #37080 -- Treat generic deprecation warnings as errors.

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -28,7 +28,7 @@ else:
     from django.test.runner import get_max_test_processes, parallel_type
     from django.test.selenium import SeleniumTestCase, SeleniumTestCaseBase
     from django.test.utils import NullTimeKeeper, TimeKeeper, get_runner
-    from django.utils.deprecation import RemovedInDjango70Warning
+    from django.utils.deprecation import (RemovedInNextVersionWarning, RemovedAfterNextVersionWarning)
     from django.utils.functional import classproperty
     from django.utils.log import DEFAULT_LOGGING
     from django.utils.version import PYPY
@@ -43,7 +43,8 @@ else:
     warnings.filterwarnings("ignore", r"\(1003, *", category=MySQLdb.Warning)
 
 # Make deprecation warnings errors to ensure no usage of deprecated features.
-warnings.simplefilter("error", RemovedInDjango70Warning)
+warnings.simplefilter("error", RemovedInNextVersionWarning)
+warnings.simplefilter("error", RemovedAfterNextVersionWarning)
 # Make resource and runtime warning errors to ensure no usage of error prone
 # patterns.
 warnings.simplefilter("error", ResourceWarning)

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -28,7 +28,10 @@ else:
     from django.test.runner import get_max_test_processes, parallel_type
     from django.test.selenium import SeleniumTestCase, SeleniumTestCaseBase
     from django.test.utils import NullTimeKeeper, TimeKeeper, get_runner
-    from django.utils.deprecation import (RemovedInNextVersionWarning, RemovedAfterNextVersionWarning)
+    from django.utils.deprecation import (
+        RemovedInNextVersionWarning,
+        RemovedAfterNextVersionWarning,
+    )
     from django.utils.functional import classproperty
     from django.utils.log import DEFAULT_LOGGING
     from django.utils.version import PYPY


### PR DESCRIPTION
#### Trac ticket number
ticket-37080

#### Summary
This change updates runtests.py to use generic deprecation warnings so both RemovedInNextVersionWarning and RemovedAfterNextVersionWarning are always treated as errors.

#### Testing
Ran the test_runner module and the full Django test suite locally. All tests passed.

#### AI Assistance Disclosure
[x] AI tools were used, I have disclosed which ones, and fully reviewed and verified their output.

AI assistance used: ChatGPT helped interpret the ticket and review the approach. The final implementation was done manually.

#### Checklist
[x] This PR follows the contribution guidelines.
[x] This PR does not disclose a security vulnerability.
[x] This PR targets the main branch.
[x] The commit message includes the ticket number.
[x] I have checked the "Has patch" ticket flag in the Trac system.