### PR TITLE
Fixed #37080 -- Use generic deprecation warnings in runtests.

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -28,7 +28,10 @@ else:
     from django.test.runner import get_max_test_processes, parallel_type
     from django.test.selenium import SeleniumTestCase, SeleniumTestCaseBase
     from django.test.utils import NullTimeKeeper, TimeKeeper, get_runner
-    from django.utils.deprecation import RemovedInDjango70Warning
+    from django.utils.deprecation import (
+        RemovedAfterNextVersionWarning,
+        RemovedInNextVersionWarning,
+    )
     from django.utils.functional import classproperty
     from django.utils.log import DEFAULT_LOGGING
     from django.utils.version import PYPY
@@ -43,7 +46,8 @@ else:
     warnings.filterwarnings("ignore", r"\(1003, *", category=MySQLdb.Warning)
 
 # Make deprecation warnings errors to ensure no usage of deprecated features.
-warnings.simplefilter("error", RemovedInDjango70Warning)
+warnings.simplefilter("error", RemovedInNextVersionWarning)
+warnings.simplefilter("error", RemovedAfterNextVersionWarning)
 # Make resource and runtime warning errors to ensure no usage of error prone
 # patterns.
 warnings.simplefilter("error", ResourceWarning)


### PR DESCRIPTION
#### Trac ticket number
ticket-37080

#### Branch description
This change updates runtests.py to use generic deprecation warnings instead of version-specific ones. This ensures consistent behavior and that both RemovedInNextVersionWarning and RemovedAfterNextVersionWarning are always treated as errors.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

AI assistance used: ChatGPT was used to understand the issue and review the approach. The implementation and testing were done manually.

#### Checklist
- [x] This PR follows the contribution guidelines.
- [x] This PR **does not** disclose a security vulnerability.
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.