### PR TITLE
Removed integer pk assumption from file_uploads test.

### DIFF
--- a/tests/file_uploads/tests.py
+++ b/tests/file_uploads/tests.py
@@ -800,8 +800,7 @@ class FileUploadTests(TestCase):
             "multipart/form-data; boundary=%(boundary)s" % vars,
         )
         self.assertEqual(response.status_code, 200)
-        id = int(response.content)
-        obj = FileModel.objects.get(pk=id)
+        obj = FileModel.objects.get(pk=response.content.decode())
         # The name of the file uploaded and the file stored in the server-side
         # shouldn't differ.
         self.assertEqual(os.path.basename(obj.testfile.path), "MiXeD_cAsE.txt")


### PR DESCRIPTION
The test was incompatible with MongoDB's bson.ObjectId.