### PR TITLE
Fixed #24638 -- Added QuerySet.comment() to inject SQL comments.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -986,6 +986,7 @@ answer newbie questions, and generally made Django that much better:
     Shannon -jj Behrens <https://www.jjinux.com/>
     Shawn Milochik <shawn@milochik.com>
     Shreya Bamne <shreya.bamne@gmail.com>
+    Sid <dcsid10@gmail.com>
     Silvan Spross <silvan.spross@gmail.com>
     Simeon Visser <http://simeonvisser.com>
     Simon Blanchard

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1988,10 +1988,10 @@ class QuerySet(AltersData):
         """Add an SQL comment to the query."""
         if not isinstance(message, str):
             raise TypeError("QuerySet.comment() argument must be a string.")
-        if "/*" in message or "*/" in message:
+        if "/*" in message or "*/" in message or "\x00" in message:
             raise ValueError(
-                "QuerySet.comment() cannot include '/*' or '*/'; strip or "
-                "escape these delimiters before calling comment()."
+                "QuerySet.comment() cannot include '/*', '*/', or null bytes; "
+                "remove them before calling comment()."
             )
         clone = self._chain()
         clone.query.comments = (*clone.query.comments, message)

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -49,7 +49,7 @@ MAX_GET_RESULTS = 21
 REPR_OUTPUT_SIZE = 20
 
 DEFAULT_FETCH_MODE = FETCH_ONE
-sql_comment_re = _lazy_re_compile(r"^[\w ._-]+$")
+sql_comment_re = _lazy_re_compile(r"[\w ._-]+")
 
 
 class BaseIterable:

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1706,6 +1706,9 @@ class QuerySet(AltersData):
         clone.query.default_ordering = True
         self._clear_ordering_in_combined_queries(clone.query, other_qs)
         clone.query.clear_limits()
+        # Comments belong to the combined leg (`self.query`). Clear them on
+        # the outer combinator wrapper so they aren't emitted twice.
+        clone.query.comments = ()
         clone.query.combinator = combinator
         clone.query.combinator_all = all
         return clone
@@ -1979,6 +1982,19 @@ class QuerySet(AltersData):
         """Set the fetch mode for the QuerySet."""
         clone = self._chain()
         clone._fetch_mode = fetch_mode
+        return clone
+
+    def comment(self, message):
+        """Add an SQL comment to the query."""
+        if not isinstance(message, str):
+            raise TypeError("QuerySet.comment() argument must be a string.")
+        if "/*" in message or "*/" in message:
+            raise ValueError(
+                "QuerySet.comment() cannot include '/*' or '*/'; strip or "
+                "escape these delimiters before calling comment()."
+            )
+        clone = self._chain()
+        clone.query.comments = (*clone.query.comments, message)
         return clone
 
     ###################################

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -39,6 +39,7 @@ from django.db.models.utils import (
 from django.utils import timezone
 from django.utils.deprecation import RemovedInDjango70Warning
 from django.utils.functional import cached_property
+from django.utils.regex_helper import _lazy_re_compile
 from django.utils.warnings import django_file_prefixes
 
 # The maximum number of results to fetch in a get() query.
@@ -48,6 +49,7 @@ MAX_GET_RESULTS = 21
 REPR_OUTPUT_SIZE = 20
 
 DEFAULT_FETCH_MODE = FETCH_ONE
+SQL_COMMENT_RE = _lazy_re_compile(r"^[\w ._-]+$")
 
 
 class BaseIterable:
@@ -1988,10 +1990,10 @@ class QuerySet(AltersData):
         """Add an SQL comment to the query."""
         if not isinstance(message, str):
             raise TypeError("QuerySet.comment() argument must be a string.")
-        if "/*" in message or "*/" in message or "\x00" in message:
+        if not SQL_COMMENT_RE.fullmatch(message):
             raise ValueError(
-                "QuerySet.comment() cannot include '/*', '*/', or null bytes; "
-                "remove them before calling comment()."
+                "QuerySet.comment() argument must contain only letters, numbers, "
+                "spaces, periods, underscores, and hyphens."
             )
         clone = self._chain()
         clone.query.comments = (*clone.query.comments, message)

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -49,7 +49,7 @@ MAX_GET_RESULTS = 21
 REPR_OUTPUT_SIZE = 20
 
 DEFAULT_FETCH_MODE = FETCH_ONE
-SQL_COMMENT_RE = _lazy_re_compile(r"^[\w ._-]+$")
+sql_comment_re = _lazy_re_compile(r"^[\w ._-]+$")
 
 
 class BaseIterable:
@@ -1990,7 +1990,7 @@ class QuerySet(AltersData):
         """Add an SQL comment to the query."""
         if not isinstance(message, str):
             raise TypeError("QuerySet.comment() argument must be a string.")
-        if not SQL_COMMENT_RE.fullmatch(message):
+        if not sql_comment_re.fullmatch(message):
             raise ValueError(
                 "QuerySet.comment() argument must contain only letters, numbers, "
                 "spaces, periods, underscores, and hyphens."

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -1690,9 +1690,9 @@ class SQLCompiler:
         Return SQL comments for ``Query.comments`` as a single space-separated
         string of ``/* ... */`` blocks.
 
-        Validation in ``QuerySet.comment()`` already rejects strings containing
-        ``/*``, ``*/``, or null bytes, so the values here cannot break out of
-        the comment or be truncated by database adapters.
+        Validation in ``QuerySet.comment()`` restricts comments to word
+        characters, spaces, periods, underscores, and hyphens, so the values
+        here cannot contain SQL comment delimiters or control characters.
         """
         return " ".join("/* %s */" % comment for comment in self.query.comments)
 

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -1691,7 +1691,8 @@ class SQLCompiler:
         string of ``/* ... */`` blocks.
 
         Validation in ``QuerySet.comment()`` already rejects strings containing
-        ``/*`` or ``*/``, so the values here cannot break out of the comment.
+        ``/*``, ``*/``, or null bytes, so the values here cannot break out of
+        the comment or be truncated by database adapters.
         """
         return " ".join("/* %s */" % comment for comment in self.query.comments)
 

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -626,7 +626,10 @@ class SQLCompiler:
         sql_parts, args_parts = zip(
             *((braces.format(sql), args) for sql, args in parts)
         )
-        result = [" {} ".format(combinator_sql).join(sql_parts)]
+        combined_sql = " {} ".format(combinator_sql).join(sql_parts)
+        if self.query.comments:
+            combined_sql = "%s %s" % (self.comments_sql(), combined_sql)
+        result = [combined_sql]
         params = []
         for part in args_parts:
             params.extend(part)
@@ -820,6 +823,9 @@ class SQLCompiler:
                     )
                     result += distinct_result
                     params += distinct_params
+
+                if self.query.comments:
+                    result.append(self.comments_sql())
 
                 out_cols = []
                 for _, (s_sql, s_params), alias in self.select + extra_select:
@@ -1679,6 +1685,16 @@ class SQLCompiler:
                 else:
                     yield value
 
+    def comments_sql(self):
+        """
+        Return SQL comments for ``Query.comments`` as a single space-separated
+        string of ``/* ... */`` blocks.
+
+        Validation in ``QuerySet.comment()`` already rejects strings containing
+        ``/*`` or ``*/``, so the values here cannot break out of the comment.
+        """
+        return " ".join("/* %s */" % comment for comment in self.query.comments)
+
 
 class SQLInsertCompiler(SQLCompiler):
     returning_fields = None
@@ -2090,10 +2106,10 @@ class SQLUpdateCompiler(SQLCompiler):
                 values.append(f"{quoted_name} = %s")
                 update_params.append(val)
         table = self.query.base_table
-        result = [
-            "UPDATE %s SET" % qn(table),
-            ", ".join(values),
-        ]
+        result = ["UPDATE"]
+        if self.query.comments:
+            result.append(self.comments_sql())
+        result += [qn(table), "SET", ", ".join(values)]
         try:
             where, params = self.compile(self.query.where)
         except FullResultSet:

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -303,6 +303,8 @@ class Query(BaseExpression):
 
     explain_info = None
 
+    comments = ()
+
     def __init__(self, model, alias_cols=True):
         self.model = model
         self.alias_refcount = {}

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -1927,6 +1927,47 @@ For example:
     # queries the database with the 'backup' alias
     >>> Entry.objects.using("backup")
 
+``comment()``
+~~~~~~~~~~~~~
+
+.. versionadded:: 6.2
+
+.. method:: comment(message)
+
+Returns a new ``QuerySet`` that injects ``message`` into the resulting SQL as
+an ``/* … */`` comment, after ``SELECT`` (and ``DISTINCT`` if present) or
+after ``UPDATE``.
+
+For example::
+
+    Entry.objects.comment("hello").all()
+
+… roughly produces:
+
+.. code-block:: sql
+
+    SELECT /* hello */ "blog_entry"."id", … FROM "blog_entry"
+
+Calls can be chained; each call appends a separate block::
+
+    Entry.objects.comment("first").comment("second").update(headline="x")
+
+… produces:
+
+.. code-block:: sql
+
+    UPDATE /* first */ /* second */ "blog_entry" SET "headline" = …
+
+``comment()`` raises :exc:`ValueError` if ``message`` contains ``/*`` or
+``*/`` to prevent SQL comment injection, and :exc:`TypeError` if ``message``
+is not a string.
+
+``comment()`` only affects ``SELECT`` and ``UPDATE`` statements; ``DELETE``,
+``INSERT``, and statements issued by migrations are not annotated. When
+called on a combined ``QuerySet`` (produced by :meth:`union`,
+:meth:`intersection`, or :meth:`difference`), the comment is emitted as a
+leading ``/* … */`` block before the combined SQL.
+
 ``select_for_update()``
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -1935,28 +1935,28 @@ For example:
 .. method:: comment(message)
 
 Returns a new ``QuerySet`` that injects ``message`` into the resulting SQL as
-an ``/* … */`` comment, after ``SELECT`` (and ``DISTINCT`` if present) or
+an ``/* ... */`` comment, after ``SELECT`` (and ``DISTINCT`` if present) or
 after ``UPDATE``.
 
 For example::
 
     Entry.objects.comment("hello").all()
 
-… roughly produces:
+roughly produces:
 
 .. code-block:: sql
 
-    SELECT /* hello */ "blog_entry"."id", … FROM "blog_entry"
+    SELECT /* hello */ "blog_entry"."id" FROM "blog_entry"
 
 Calls can be chained; each call appends a separate block::
 
     Entry.objects.comment("first").comment("second").update(headline="x")
 
-… produces:
+produces:
 
 .. code-block:: sql
 
-    UPDATE /* first */ /* second */ "blog_entry" SET "headline" = …
+    UPDATE /* first */ /* second */ "blog_entry" SET "headline" = 'x'
 
 ``comment()`` raises :exc:`ValueError` if ``message`` contains ``/*`` or
 ``*/`` to prevent SQL comment injection, and :exc:`TypeError` if ``message``
@@ -1966,7 +1966,7 @@ is not a string.
 ``INSERT``, and statements issued by migrations are not annotated. When
 called on a combined ``QuerySet`` (produced by :meth:`union`,
 :meth:`intersection`, or :meth:`difference`), the comment is emitted as a
-leading ``/* … */`` block before the combined SQL.
+leading ``/* ... */`` block before the combined SQL.
 
 ``select_for_update()``
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -1958,9 +1958,10 @@ produces:
 
     UPDATE /* first */ /* second */ "blog_entry" SET "headline" = 'x'
 
-``comment()`` raises :exc:`ValueError` if ``message`` contains ``/*``,
-``*/``, or null bytes to prevent SQL comment injection and avoid database
-adapter parsing issues, and :exc:`TypeError` if ``message`` is not a string.
+``message`` must be a non-empty string containing only letters, numbers,
+spaces, periods, underscores, and hyphens. ``comment()`` raises
+:exc:`ValueError` if ``message`` contains any other characters, and
+:exc:`TypeError` if ``message`` is not a string.
 
 ``comment()`` only affects ``SELECT`` and ``UPDATE`` statements; ``DELETE``,
 ``INSERT``, and statements issued by migrations are not annotated. When

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -1958,9 +1958,9 @@ produces:
 
     UPDATE /* first */ /* second */ "blog_entry" SET "headline" = 'x'
 
-``comment()`` raises :exc:`ValueError` if ``message`` contains ``/*`` or
-``*/`` to prevent SQL comment injection, and :exc:`TypeError` if ``message``
-is not a string.
+``comment()`` raises :exc:`ValueError` if ``message`` contains ``/*``,
+``*/``, or null bytes to prevent SQL comment injection and avoid database
+adapter parsing issues, and :exc:`TypeError` if ``message`` is not a string.
 
 ``comment()`` only affects ``SELECT`` and ``UPDATE`` statements; ``DELETE``,
 ``INSERT``, and statements issued by migrations are not annotated. When

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -187,7 +187,8 @@ Migrations
 Models
 ~~~~~~
 
-* ...
+* The new :meth:`.QuerySet.comment` method allows injecting an SQL comment
+  into the generated ``SELECT`` or ``UPDATE`` statement.
 
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -816,6 +816,7 @@ class ManagerTest(SimpleTestCase):
         "aupdate",
         "aupdate_or_create",
         "fetch_mode",
+        "comment",
     ]
 
     def test_manager_methods(self):

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -4740,8 +4740,98 @@ class QuerySetCommentTests(TestCase):
         with CaptureQueriesContext(connection) as ctx:
             list(qs)
         sql = ctx.captured_queries[0]["sql"]
-        self.assertIn("/* outer combinator */", sql)
+        self.assertEqual(sql.count("/* outer combinator */"), 1)
         self.assertLess(sql.index("/* outer combinator */"), sql.index("UNION"))
+
+    @skipUnlessDBFeature("supports_select_intersection")
+    def test_comment_inside_intersection_leg(self):
+        qs = NamedCategory.objects.comment("first leg").intersection(
+            NamedCategory.objects.all()
+        )
+        with CaptureQueriesContext(connection) as ctx:
+            list(qs)
+        sql = ctx.captured_queries[0]["sql"]
+        self.assertEqual(sql.count("/* first leg */"), 1)
+
+    @skipUnlessDBFeature("supports_select_intersection")
+    def test_comment_around_intersection(self):
+        qs = NamedCategory.objects.intersection(NamedCategory.objects.all()).comment(
+            "outer combinator"
+        )
+        with CaptureQueriesContext(connection) as ctx:
+            list(qs)
+        sql = ctx.captured_queries[0]["sql"]
+        self.assertEqual(sql.count("/* outer combinator */"), 1)
+        self.assertLess(sql.index("/* outer combinator */"), sql.index("INTERSECT"))
+
+    @skipUnlessDBFeature("supports_select_difference")
+    def test_comment_inside_difference_leg(self):
+        qs = NamedCategory.objects.comment("first leg").difference(
+            NamedCategory.objects.all()
+        )
+        with CaptureQueriesContext(connection) as ctx:
+            list(qs)
+        sql = ctx.captured_queries[0]["sql"]
+        self.assertEqual(sql.count("/* first leg */"), 1)
+
+    @skipUnlessDBFeature("supports_select_difference")
+    def test_comment_around_difference(self):
+        qs = NamedCategory.objects.difference(NamedCategory.objects.all()).comment(
+            "outer combinator"
+        )
+        with CaptureQueriesContext(connection) as ctx:
+            list(qs)
+        sql = ctx.captured_queries[0]["sql"]
+        self.assertEqual(sql.count("/* outer combinator */"), 1)
+        self.assertLess(sql.index("/* outer combinator */"), sql.index("EXCEPT"))
+
+    def test_comment_leg_and_wrapper_combined(self):
+        qs = (
+            NamedCategory.objects.comment("leg")
+            .union(NamedCategory.objects.all())
+            .comment("outer")
+        )
+        with CaptureQueriesContext(connection) as ctx:
+            list(qs)
+        sql = ctx.captured_queries[0]["sql"]
+        self.assertEqual(sql.count("/* leg */"), 1)
+        self.assertEqual(sql.count("/* outer */"), 1)
+        # The outer comment leads the statement; the leg comment follows it.
+        self.assertLess(sql.index("/* outer */"), sql.index("/* leg */"))
+
+    def test_update_multiple_comments(self):
+        NamedCategory.objects.create(name="initial")
+        with CaptureQueriesContext(connection) as ctx:
+            NamedCategory.objects.comment("first").comment("second").update(
+                name="renamed"
+            )
+        update_sql = next(
+            q["sql"] for q in ctx.captured_queries if q["sql"].startswith("UPDATE")
+        )
+        self.assertIn("UPDATE /* first */ /* second */ ", update_sql)
+
+    def test_delete_statements_not_annotated(self):
+        NamedCategory.objects.create(name="doomed")
+        with CaptureQueriesContext(connection) as ctx:
+            NamedCategory.objects.comment("cleanup").filter(name="doomed").delete()
+        delete_sqls = [
+            q["sql"] for q in ctx.captured_queries if q["sql"].startswith("DELETE")
+        ]
+        self.assertTrue(delete_sqls)
+        for sql in delete_sqls:
+            self.assertNotIn("/* cleanup */", sql)
+
+    def test_insert_statements_not_annotated(self):
+        with CaptureQueriesContext(connection) as ctx:
+            DumbCategory.objects.comment("seed").bulk_create(
+                [DumbCategory(), DumbCategory()]
+            )
+        insert_sqls = [
+            q["sql"] for q in ctx.captured_queries if q["sql"].startswith("INSERT")
+        ]
+        self.assertTrue(insert_sqls)
+        for sql in insert_sqls:
+            self.assertNotIn("/* seed */", sql)
 
     def test_rejects_non_string(self):
         msg = "QuerySet.comment() argument must be a string."

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -4756,8 +4756,8 @@ class QuerySetCommentTests(TestCase):
 
     def test_rejects_comment_delimiters(self):
         msg = (
-            "QuerySet.comment() cannot include '/*' or '*/'; strip or "
-            "escape these delimiters before calling comment()."
+            "QuerySet.comment() cannot include '/*', '*/', or null bytes; "
+            "remove them before calling comment()."
         )
         for bad in [
             "foo /* bar",
@@ -4767,6 +4767,14 @@ class QuerySetCommentTests(TestCase):
         ]:
             with self.subTest(bad=bad), self.assertRaisesMessage(ValueError, msg):
                 NamedCategory.objects.comment(bad)
+
+    def test_rejects_null_byte(self):
+        msg = (
+            "QuerySet.comment() cannot include '/*', '*/', or null bytes; "
+            "remove them before calling comment()."
+        )
+        with self.assertRaisesMessage(ValueError, msg):
+            NamedCategory.objects.comment("\x00")
 
 
 class QuerySetCloningTests(TestCase):

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -4641,6 +4641,134 @@ class Ticket23622Tests(TestCase):
         self.assertSequenceEqual(Ticket23605A.objects.filter(qx), [a2])
 
 
+class QuerySetCommentTests(TestCase):
+    """Tests for QuerySet.comment() (Trac #24638)."""
+
+    def test_select_single_comment(self):
+        with CaptureQueriesContext(connection) as ctx:
+            list(NamedCategory.objects.comment("blog/views.py:50"))
+        self.assertIn("SELECT /* blog/views.py:50 */ ", ctx.captured_queries[0]["sql"])
+
+    def test_select_multiple_comments_preserve_order(self):
+        with CaptureQueriesContext(connection) as ctx:
+            list(
+                NamedCategory.objects.comment("first")
+                .comment("second")
+                .comment("third")
+            )
+        self.assertIn(
+            "SELECT /* first */ /* second */ /* third */ ",
+            ctx.captured_queries[0]["sql"],
+        )
+
+    def test_select_empty_comment_allowed(self):
+        with CaptureQueriesContext(connection) as ctx:
+            list(NamedCategory.objects.comment("").comment("non-empty"))
+        self.assertIn("SELECT /*  */ /* non-empty */ ", ctx.captured_queries[0]["sql"])
+
+    def test_select_with_distinct(self):
+        with CaptureQueriesContext(connection) as ctx:
+            list(NamedCategory.objects.distinct().comment("after distinct"))
+        sql = ctx.captured_queries[0]["sql"]
+        self.assertIn("DISTINCT", sql)
+        self.assertIn("/* after distinct */", sql)
+        # The comment must come after DISTINCT.
+        self.assertLess(sql.index("DISTINCT"), sql.index("/* after distinct */"))
+
+    def test_select_with_filter_preserves_comment(self):
+        with CaptureQueriesContext(connection) as ctx:
+            list(NamedCategory.objects.comment("traceparent=00-x").filter(name="x"))
+        self.assertIn("/* traceparent=00-x */", ctx.captured_queries[0]["sql"])
+
+    def test_select_subquery(self):
+        with CaptureQueriesContext(connection) as ctx:
+            list(
+                NamedCategory.objects.annotate(
+                    foo=(
+                        Tag.objects.filter(category=OuterRef("id"))
+                        .comment("inner subquery")
+                        .values("name")[:1]
+                    )
+                ).comment("outer query")
+            )
+        sql = ctx.captured_queries[0]["sql"]
+        self.assertIn("/* inner subquery */", sql)
+        self.assertIn("/* outer query */", sql)
+
+    def test_aggregate_subquery(self):
+        with CaptureQueriesContext(connection) as ctx:
+            Tag.objects.comment("tag-aggregate").values("parent").annotate(
+                tag_per_parent=Count("pk")
+            ).aggregate(Max("tag_per_parent"))
+        sql = ctx.captured_queries[0]["sql"]
+        self.assertIn("/* tag-aggregate */", sql)
+
+    def test_update(self):
+        NamedCategory.objects.create(name="initial")
+        with CaptureQueriesContext(connection) as ctx:
+            NamedCategory.objects.comment("update from worker-3").update(name="renamed")
+        update_sql = next(
+            q["sql"] for q in ctx.captured_queries if q["sql"].startswith("UPDATE")
+        )
+        self.assertIn("UPDATE /* update from worker-3 */ ", update_sql)
+
+    def test_clone_preserves_comment(self):
+        base = NamedCategory.objects.comment("shared")
+        derived = base.filter(name="x").comment("extra")
+        with CaptureQueriesContext(connection) as ctx:
+            list(base)
+            list(derived)
+        self.assertIn("/* shared */", ctx.captured_queries[0]["sql"])
+        self.assertNotIn("/* extra */", ctx.captured_queries[0]["sql"])
+        derived_sql = ctx.captured_queries[1]["sql"]
+        self.assertIn("/* shared */", derived_sql)
+        self.assertIn("/* extra */", derived_sql)
+
+    def test_unicode_comment(self):
+        with CaptureQueriesContext(connection) as ctx:
+            list(NamedCategory.objects.comment("источник=cron"))
+        self.assertIn("/* источник=cron */", ctx.captured_queries[0]["sql"])
+
+    def test_comment_inside_union_leg(self):
+        qs = NamedCategory.objects.comment("first leg").union(
+            NamedCategory.objects.all()
+        )
+        with CaptureQueriesContext(connection) as ctx:
+            list(qs)
+        sql = ctx.captured_queries[0]["sql"]
+        self.assertEqual(sql.count("/* first leg */"), 1)
+
+    def test_comment_around_union(self):
+        qs = NamedCategory.objects.union(NamedCategory.objects.all()).comment(
+            "outer combinator"
+        )
+        with CaptureQueriesContext(connection) as ctx:
+            list(qs)
+        sql = ctx.captured_queries[0]["sql"]
+        self.assertIn("/* outer combinator */", sql)
+        self.assertLess(sql.index("/* outer combinator */"), sql.index("UNION"))
+
+    def test_rejects_non_string(self):
+        msg = "QuerySet.comment() argument must be a string."
+        for bad in [None, 42, b"bytes", ["list"], object()]:
+            with self.subTest(bad=bad), self.assertRaisesMessage(TypeError, msg):
+                NamedCategory.objects.comment(bad)
+
+    def test_rejects_comment_delimiters(self):
+        msg = (
+            "QuerySet.comment() cannot include '/*' or '*/'; strip or "
+            "escape these delimiters before calling comment()."
+        )
+        for bad in [
+            "foo /* bar",
+            "foo */ bar",
+            "*/-- DROP TABLE x;--/*",
+            "/* nested */",
+        ]:
+            with self.subTest(bad=bad), self.assertRaisesMessage(ValueError, msg):
+                NamedCategory.objects.comment(bad)
+
+
 class QuerySetCloningTests(TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -4677,8 +4677,8 @@ class QuerySetCommentTests(TestCase):
 
     def test_select_with_filter_preserves_comment(self):
         with CaptureQueriesContext(connection) as ctx:
-            list(NamedCategory.objects.comment("traceparent=00-x").filter(name="x"))
-        self.assertIn("/* traceparent=00-x */", ctx.captured_queries[0]["sql"])
+            list(NamedCategory.objects.comment("request-id=123").filter(name="x"))
+        self.assertIn("/* request-id=123 */", ctx.captured_queries[0]["sql"])
 
     def test_select_subquery(self):
         with CaptureQueriesContext(connection) as ctx:

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -4646,8 +4646,8 @@ class QuerySetCommentTests(TestCase):
 
     def test_select_single_comment(self):
         with CaptureQueriesContext(connection) as ctx:
-            list(NamedCategory.objects.comment("blog/views.py:50"))
-        self.assertIn("SELECT /* blog/views.py:50 */ ", ctx.captured_queries[0]["sql"])
+            list(NamedCategory.objects.comment("blog.views.py 50"))
+        self.assertIn("SELECT /* blog.views.py 50 */ ", ctx.captured_queries[0]["sql"])
 
     def test_select_multiple_comments_preserve_order(self):
         with CaptureQueriesContext(connection) as ctx:
@@ -4661,11 +4661,6 @@ class QuerySetCommentTests(TestCase):
             ctx.captured_queries[0]["sql"],
         )
 
-    def test_select_empty_comment_allowed(self):
-        with CaptureQueriesContext(connection) as ctx:
-            list(NamedCategory.objects.comment("").comment("non-empty"))
-        self.assertIn("SELECT /*  */ /* non-empty */ ", ctx.captured_queries[0]["sql"])
-
     def test_select_with_distinct(self):
         with CaptureQueriesContext(connection) as ctx:
             list(NamedCategory.objects.distinct().comment("after distinct"))
@@ -4677,8 +4672,8 @@ class QuerySetCommentTests(TestCase):
 
     def test_select_with_filter_preserves_comment(self):
         with CaptureQueriesContext(connection) as ctx:
-            list(NamedCategory.objects.comment("request-id=123").filter(name="x"))
-        self.assertIn("/* request-id=123 */", ctx.captured_queries[0]["sql"])
+            list(NamedCategory.objects.comment("request-id 123").filter(name="x"))
+        self.assertIn("/* request-id 123 */", ctx.captured_queries[0]["sql"])
 
     def test_select_subquery(self):
         with CaptureQueriesContext(connection) as ctx:
@@ -4726,8 +4721,8 @@ class QuerySetCommentTests(TestCase):
 
     def test_unicode_comment(self):
         with CaptureQueriesContext(connection) as ctx:
-            list(NamedCategory.objects.comment("источник=cron"))
-        self.assertIn("/* источник=cron */", ctx.captured_queries[0]["sql"])
+            list(NamedCategory.objects.comment("источник cron"))
+        self.assertIn("/* источник cron */", ctx.captured_queries[0]["sql"])
 
     def test_comment_inside_union_leg(self):
         qs = NamedCategory.objects.comment("first leg").union(
@@ -4754,27 +4749,28 @@ class QuerySetCommentTests(TestCase):
             with self.subTest(bad=bad), self.assertRaisesMessage(TypeError, msg):
                 NamedCategory.objects.comment(bad)
 
-    def test_rejects_comment_delimiters(self):
+    def test_rejects_disallowed_comment_characters(self):
         msg = (
-            "QuerySet.comment() cannot include '/*', '*/', or null bytes; "
-            "remove them before calling comment()."
+            "QuerySet.comment() argument must contain only letters, numbers, "
+            "spaces, periods, underscores, and hyphens."
         )
         for bad in [
+            "",
+            "blog/views.py:50",
+            "request-id=123",
             "foo /* bar",
             "foo */ bar",
             "*/-- DROP TABLE x;--/*",
             "/* nested */",
+            "quote '",
+            'quote "',
+            "semi;colon",
+            "hash#tag",
+            "comma,value",
+            *(f"name{chr(c)}" for c in chain(range(32), range(0x7F, 0xA0))),
         ]:
             with self.subTest(bad=bad), self.assertRaisesMessage(ValueError, msg):
                 NamedCategory.objects.comment(bad)
-
-    def test_rejects_null_byte(self):
-        msg = (
-            "QuerySet.comment() cannot include '/*', '*/', or null bytes; "
-            "remove them before calling comment()."
-        )
-        with self.assertRaisesMessage(ValueError, msg):
-            NamedCategory.objects.comment("\x00")
 
 
 class QuerySetCloningTests(TestCase):


### PR DESCRIPTION
#### Trac ticket number

ticket-24638

#### Branch description

Adds `QuerySet.comment(message)` for placing SQL block comments in generated `SELECT` and `UPDATE` statements. Comments are preserved across queryset cloning/chaining, appear in the expected position for combined queries, and reject SQL comment delimiters to prevent breaking out of the generated comment block.

#### AI Assistance Disclosure (REQUIRED)

<!-- Please select exactly ONE of the following: -->

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Used Claude Opus 4.7 to help draft the implementation and tests. Used Codex for a follow-up review of the patch, CI status, and Trac/PR metadata. I then manually reviewed the final diff, tests, documentation, and PR description.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes. <!-- N/A: no UI changes. -->

