### PR TITLE
Refs #36439 -- Added sync_to_async() to dummy password hasher path.

### DIFF
--- a/django/contrib/auth/__init__.py
+++ b/django/contrib/auth/__init__.py
@@ -1,5 +1,7 @@
 import re
 
+from asgiref.sync import sync_to_async
+
 from django.apps import apps as django_apps
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured, PermissionDenied
@@ -407,6 +409,6 @@ def check_password_with_timing_attack_mitigation(user, password):
 async def acheck_password_with_timing_attack_mitigation(user, password):
     """See check_user_with_timing_attack_mitigation."""
     if user is None:
-        get_user_model()().set_password(password)
+        await sync_to_async(get_user_model()().set_password)(password)
     else:
         return await user.acheck_password(password)

--- a/tests/auth_tests/test_auth_backends.py
+++ b/tests/auth_tests/test_auth_backends.py
@@ -498,6 +498,22 @@ class BaseModelBackendTest:
         await aauthenticate(username="no_such_user", password="test")
         self.assertEqual(CountingMD5PasswordHasher.calls, 1)
 
+    async def test_aauthentication_timing_async_bridge(self):
+        with patch(
+            "django.contrib.auth.hashers.sync_to_async",
+            return_value=mock.AsyncMock(return_value=(True, False)),
+        ) as mocked_adapter:
+            username = getattr(self.user, self.UserModel.USERNAME_FIELD)
+            await aauthenticate(username=username, password="test")
+            mocked_adapter.assert_called_once()
+
+        with patch(
+            "django.contrib.auth.sync_to_async", return_value=mock.AsyncMock()
+        ) as mocked_adapter:
+            username = getattr(self.user, self.UserModel.USERNAME_FIELD)
+            await aauthenticate(username="no_such_user", password="test")
+            mocked_adapter.assert_called_once()
+
     @override_settings(
         PASSWORD_HASHERS=["auth_tests.test_auth_backends.CountingMD5PasswordHasher"]
     )


### PR DESCRIPTION
#### Trac ticket number
ticket-36439

Follow-up to 748ca0a146175c4868ece87f5e845a75416c30e3.

#### Branch description
Since the existing user path eventually calls `sync_to_async()` in acheck_password, aim for parity with the nonexistent/inactive user branch by adding `sync_to_async()`.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
