### PR TITLE
Fixed #37076, #37072 -- Reworked SimpleTestCase.assertWarnsMessage().

### DIFF
--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -5,7 +5,9 @@ import pickle
 import posixpath
 import sys
 import threading
+import types
 import unittest
+import warnings
 from collections import Counter
 from contextlib import contextmanager
 from copy import copy, deepcopy
@@ -55,7 +57,7 @@ from django.test.utils import (
     modify_settings,
     override_settings,
 )
-from django.utils.functional import classproperty
+from django.utils.functional import classproperty, partition
 from django.views.static import serve
 
 logger = logging.getLogger("django.test")
@@ -885,19 +887,61 @@ class SimpleTestCase(unittest.TestCase):
             **kwargs,
         )
 
+    @contextmanager
+    def _assertWarnsMessageContext(self, expected_warning, expected_message):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.filterwarnings("always")
+            result = types.SimpleNamespace(warnings=caught)
+            yield result
+
+        def is_match(warning):
+            return issubclass(
+                warning.category, expected_warning
+            ) and expected_message in str(warning.message)
+
+        non_matching, matching = partition(is_match, caught)
+
+        if matching:
+            result.filename = matching[0].filename
+            result.lineno = matching[0].lineno
+            result.warning = matching[0]
+        else:
+            msg = (
+                f"No {expected_warning.__name__!r} warning was triggered with "
+                f"a message containing {expected_message!r}."
+            )
+            if non_matching:
+                msg += " But these warnings were triggered:\n"
+                msg += "\n".join(repr(w.message) for w in non_matching)
+            raise self.failureException(msg)
+
+        # Re-emit all caught warnings that didn't match.
+        for w in non_matching:
+            warnings.warn_explicit(
+                message=w.message,
+                category=w.category,
+                filename=w.filename,
+                lineno=w.lineno,
+            )
+
     def assertWarnsMessage(self, expected_warning, expected_message, *args, **kwargs):
-        """
-        Same as assertRaisesMessage but for assertWarns() instead of
-        assertRaises().
-        """
-        return self._assertFooMessage(
-            self.assertWarns,
-            "warning",
-            expected_warning,
-            expected_message,
-            *args,
-            **kwargs,
-        )
+        # PY315: Replace entire implementation with:
+        #   return self.assertWarnsRegex(
+        #       expected_warning, re.escape(expected_message), *args, **kwargs
+        #   )
+
+        # When no callable passed behaves as a context manager.
+        if not args:
+            if kwargs:
+                raise TypeError(
+                    "assertWarnsMessage() does not accept keyword arguments when used "
+                    "as a context manager."
+                )
+            return self._assertWarnsMessageContext(expected_warning, expected_message)
+
+        func, *func_args = args
+        with self._assertWarnsMessageContext(expected_warning, expected_message):
+            return func(*func_args, **kwargs)
 
     def assertFieldOutput(
         self,

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -234,6 +234,16 @@ Tests
   :setting:`AUTHENTICATION_BACKENDS` not implementing ``(a)get_user()``, e.g.
   permission-only backends.
 
+* :meth:`~django.test.SimpleTestCase.assertWarnsMessage` now checks all
+  warnings matching the ``expected_category`` for the ``expected_message`` and
+  no longer suppresses other warnings in the category. Previously, the first
+  warning triggered in the category had to contain the message or the assertion
+  would fail, and all other warnings in the category were silently ignored
+  (regardless of message).
+
+  Tests that had unintentionally relied on :meth:`.assertWarnsMessage`
+  suppressing all warnings in the ``expected_category`` may need to be updated.
+
 URLs
 ~~~~
 

--- a/tests/admin_views/test_actions.py
+++ b/tests/admin_views/test_actions.py
@@ -877,6 +877,17 @@ class AdminDetailActionsTest(TestCase):
             "deprecated. Update the signature to get_actions(self, request, "
             "action_location=ActionLocation.CHANGE_LIST)."
         )
+        expected_warnings = {
+            get_actions_overridden_msg,
+            "Overriding get_action_choices() without the 'action_location' "
+            "parameter is deprecated. Update the signature to "
+            "get_action_choices(self, request, default_choices=None, "
+            "action_location=ActionLocation.CHANGE_LIST).",
+            "Unpacking an action tuple is deprecated. "
+            "Use Action attributes instead.",
+            "Using indexes on an action tuple is deprecated. "
+            "Use Action attributes instead.",
+        }
         with self.assertWarnsMessage(
             RemovedInDjango70Warning, get_actions_overridden_msg
         ) as warning:
@@ -890,17 +901,6 @@ class AdminDetailActionsTest(TestCase):
             response = self.client.get(changelist_url)
 
             message_warnings = [str(warning.message) for warning in warning_list]
-            expected_warnings = {
-                get_actions_overridden_msg,
-                "Overriding get_action_choices() without the 'action_location' "
-                "parameter is deprecated. Update the signature to "
-                "get_action_choices(self, request, default_choices=None, "
-                "action_location=ActionLocation.CHANGE_LIST).",
-                "Unpacking an action tuple is deprecated. "
-                "Use Action attributes instead.",
-                "Using indexes on an action tuple is deprecated. "
-                "Use Action attributes instead.",
-            }
             self.assertEqual(set(message_warnings), expected_warnings)
             self.assertEqual(
                 {warning.filename for warning in warning_list}, {admin_filename}
@@ -912,18 +912,15 @@ class AdminDetailActionsTest(TestCase):
             "action": "delete_selected",
             "index": 0,
         }
-        get_actions_overridden_msg = (
-            "Overriding get_actions() without the 'action_location' parameter is "
-            "deprecated. Update the signature to get_actions(self, request, "
-            "action_location=ActionLocation.CHANGE_LIST)."
-        )
-        with self.assertWarnsMessage(
-            RemovedInDjango70Warning, get_actions_overridden_msg
-        ) as warning:
-            response = self.client.post(
-                reverse("admin:admin_views_modelaction_changelist"), action_data
+        with warnings.catch_warnings(record=True) as warning_list:
+            warnings.simplefilter("always", RemovedInDjango70Warning)
+            response = self.client.post(changelist_url, action_data)
+
+            message_warnings = [str(warning.message) for warning in warning_list]
+            self.assertEqual(set(message_warnings), expected_warnings)
+            self.assertEqual(
+                {warning.filename for warning in warning_list}, {admin_filename}
             )
-        self.assertEqual(warning.filename, admin_filename)
         self.assertContains(
             response, "Are you sure you want to delete the selected model action?"
         )

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -2931,6 +2931,13 @@ class DeprecatedInternalsTests(SimpleTestCase):
 
 
 # RemovedInDjango70Warning.
+@ignore_warnings(
+    category=RemovedInDjango70Warning,
+    message=(
+        "The 'connection' argument is deprecated. Switch to the 'using' "
+        "argument with a MAILERS alias."
+    ),
+)
 class MailDeprecatedPositionalArgsTests(SimpleTestCase):
 
     def get_connection(self, *args, **kwargs):

--- a/tests/postgres_tests/test_aggregates.py
+++ b/tests/postgres_tests/test_aggregates.py
@@ -13,7 +13,7 @@ from django.db.models import (
 )
 from django.db.models.fields.json import KeyTransform
 from django.db.models.functions import Cast, Concat, LPad, Substr
-from django.test.utils import Approximate
+from django.test.utils import Approximate, ignore_warnings
 from django.utils import timezone
 from django.utils.deprecation import RemovedInDjango70Warning
 
@@ -570,7 +570,13 @@ class TestGeneralAggregate(PostgreSQLTestCase):
             "preserve the previous behavior."
         )
 
-        with self.assertWarnsMessage(RemovedInDjango70Warning, msg) as ctx:
+        with (
+            ignore_warnings(
+                category=RemovedInDjango70Warning,
+                message="The PostgreSQL specific StringAgg function is deprecated",
+            ),
+            self.assertWarnsMessage(RemovedInDjango70Warning, msg) as ctx,
+        ):
             values = AggregateTestModel.objects.aggregate(
                 stringagg=StringAgg("char_field", delimiter="'")
             )

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -53,7 +53,11 @@ from django.test.utils import (
     teardown_test_environment,
 )
 from django.urls import NoReverseMatch, path, reverse, reverse_lazy
-from django.utils.deprecation import RemovedInDjango70Warning
+from django.utils.deprecation import (
+    RemovedAfterNextVersionWarning,
+    RemovedInDjango70Warning,
+    RemovedInNextVersionWarning,
+)
 from django.utils.html import VOID_ELEMENTS
 
 from .models import Car, Person, PossessedCar
@@ -1336,17 +1340,60 @@ class AssertWarnsMessageTests(SimpleTestCase):
         with self.assertWarnsMessage(UserWarning, "Expected message"):
             warnings.warn("Expected message", UserWarning)
 
+    def test_context_manager_message_kwarg(self):
+        # PY315: Remove the outer assertRaisesMessage(msg_kwargs_unsupported).
+        # (When assertWarnsMessage() wraps assertWarnsRegex(), the `msg`
+        # keyword argument will become supported for context manager usage.)
+        msg_kwargs_unsupported = (
+            "assertWarnsMessage() does not accept keyword arguments when used as a "
+            "context manager."
+        )
+        with self.assertRaisesMessage(TypeError, msg_kwargs_unsupported):
+            msg = "Custom assertWarnsMessage() failure message"
+            with (
+                self.assertRaisesMessage(AssertionError, msg),
+                self.assertWarnsMessage(UserWarning, "Expected Message", msg=msg),
+            ):
+                pass
+
     def test_context_manager_failure(self):
-        msg = "Expected message' not found in 'Unexpected message'"
-        with self.assertRaisesMessage(AssertionError, msg):
-            with self.assertWarnsMessage(UserWarning, "Expected message"):
-                warnings.warn("Unexpected message", UserWarning)
+        msg = (
+            "No 'UserWarning' warning was triggered with a message "
+            "containing 'Expected message'."
+        )
+        with (
+            self.assertRaisesMessage(AssertionError, msg),
+            self.assertWarnsMessage(UserWarning, "Expected message"),
+        ):
+            warnings.warn("Unexpected message", UserWarning)
+            warnings.warn("Expected message", RuntimeWarning)
+
+    def test_failure_message_includes_nonmatching_categories(self):
+        msg = (
+            "No 'UserWarning' warning was triggered with a message containing "
+            "'Expected message'. But these warnings were triggered:\n"
+            "UserWarning('Unexpected message')\n"
+            "RuntimeWarning('Expected message')"
+        )
+        with (
+            self.assertRaisesMessage(AssertionError, msg),
+            self.assertWarnsMessage(UserWarning, "Expected message"),
+        ):
+            warnings.warn("Unexpected message", UserWarning)
+            warnings.warn("Expected message", RuntimeWarning)
 
     def test_callable(self):
         def func():
-            warnings.warn("Expected message", UserWarning)
+            # Wrong message and wrong category warnings.
+            warnings.warn("Unexpected message", UserWarning)
+            warnings.warn("Expected message", RuntimeWarning)
 
-        self.assertWarnsMessage(UserWarning, "Expected message", func)
+        msg = (
+            "No 'UserWarning' warning was triggered with a message "
+            "containing 'Expected message'."
+        )
+        with self.assertRaisesMessage(AssertionError, msg):
+            self.assertWarnsMessage(UserWarning, "Expected message", func)
 
     def test_special_re_chars(self):
         def func1():
@@ -1354,6 +1401,60 @@ class AssertWarnsMessageTests(SimpleTestCase):
 
         with self.assertWarnsMessage(UserWarning, "[.*x+]y?"):
             func1()
+
+    def test_matches_regardless_the_order(self):
+        # RemovedInNextVersionWarning is always converted to error.
+        with (
+            self.assertRaisesMessage(RemovedInNextVersionWarning, "Unexpected"),
+            self.assertWarnsMessage(RemovedInNextVersionWarning, "Expected"),
+        ):
+
+            warnings.warn("Unexpected", RemovedInNextVersionWarning)
+            warnings.warn("Expected", RemovedInNextVersionWarning)
+
+        # With warning that does not trigger an error.
+        with self.assertWarnsMessage(DeprecationWarning, "Expected"):
+            warnings.warn("Unexpected", DeprecationWarning)
+            warnings.warn("Expected", DeprecationWarning)
+
+    def test_does_not_ignore_entire_category(self):
+        with (
+            self.assertRaisesMessage(RemovedAfterNextVersionWarning, "Unexpected"),
+            self.assertWarnsMessage(RemovedAfterNextVersionWarning, "Expected"),
+        ):
+            warnings.warn("Expected", RemovedAfterNextVersionWarning)
+            warnings.warn("Unexpected", RemovedAfterNextVersionWarning)
+
+    def test_does_not_ignore_entire_category_regardless_the_order(self):
+        with (
+            self.assertRaisesMessage(RemovedAfterNextVersionWarning, "Unexpected"),
+            self.assertWarnsMessage(RemovedAfterNextVersionWarning, "Expected"),
+        ):
+            warnings.warn("Unexpected", RemovedAfterNextVersionWarning)
+            warnings.warn("Expected", RemovedAfterNextVersionWarning)
+
+    def test_non_matching_warnings_are_reemitted(self):
+        # Same category, wrong message.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with self.assertWarnsMessage(RemovedInNextVersionWarning, "Expected"):
+                warnings.warn("Unexpected", RemovedInNextVersionWarning)
+                warnings.warn("Expected", RemovedInNextVersionWarning)
+
+        self.assertEqual(len(caught), 1)
+        self.assertEqual(str(caught[0].message), "Unexpected")
+        self.assertIs(caught[0].category, RemovedInNextVersionWarning)
+
+        # Different category warnings.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with self.assertWarnsMessage(RemovedInNextVersionWarning, "Expected"):
+                warnings.warn("Unexpected", DeprecationWarning)
+                warnings.warn("Expected", RemovedInNextVersionWarning)
+
+        self.assertEqual(len(caught), 1)
+        self.assertEqual(str(caught[0].message), "Unexpected")
+        self.assertIs(caught[0].category, DeprecationWarning)
 
 
 class AssertFieldOutputTests(SimpleTestCase):


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37076
ticket-37072

#### Branch description

Before assertWarnsMessage shared the same
function _assertFooMessage() with
assertRaisesMessage() which as explained
in one of the tickets is not right.

Fully reworked assertWarnsMessage.
Now it makes tuple of matching warnings
and non matching, if any of the warnings
match it returns the result and re emits
others.
If no match it raises an assertion error.

Added test to check that warning match regardless the order.
(#37076)
  
Added test to check that the function raises error for
the second category that was ignored before (#37072).

Added test to check that warnings match regardless the order
and raise an error when using RemovedAfterNextVersionWarning,
since runtests.py by default raises an error for this warning.
(mix of both bugs).

Added test to check that warnings get properly re-emitted.

Updated one of the psycopg2 tests, since it was raising
two RemovedInDjango70Warnings which one of them was
converted to error.

Added the fix to 6.1 releases.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
Claude Sonnet 4.6. Was used for analyzing in general how the catch warnings and filters work and etc.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
