### PR TITLE
[RD-Bench V2] Fix: django__django-10999

### DIFF
--- a/django/utils/dateparse.py
+++ b/django/utils/dateparse.py
@@ -29,7 +29,7 @@ datetime_re = re.compile(
 standard_duration_re = re.compile(
     r'^'
     r'(?:(?P<days>-?\d+) (days?, )?)?'
-    r'((?:(?P<hours>-?\d+):)(?=\d+:\d+))?'
+    r'((?:(?P<hours>-?\d+):)(?=-?\d+:-?\d+))?'
     r'(?:(?P<minutes>-?\d+):)?'
     r'(?P<seconds>-?\d+)'
     r'(?:\.(?P<microseconds>\d{1,6})\d{0,6})?'

--- a/rdbench.patch
+++ b/rdbench.patch
@@ -1,0 +1,13 @@
+<diff>
+--- a/django/utils/dateparse.py
++++ b/django/utils/dateparse.py
+@@ -18,7 +18,7 @@ date_re = re.compile(
+ standard_duration_re = re.compile(
+     r'^'
+     r'(?:(?P<days>-?\d+) (days?, )?)?'
+-    r'((?:(?P<hours>-?\d+):)(?=\d+:\d+))?'
++    r'((?:(?P<hours>-?\d+):)(?=-?\d+:-?\d+))?'
+     r'(?:(?P<minutes>-?\d+):)?'
+     r'(?P<seconds>-?\d+)'
+     r'(?:\.(?P<microseconds>\d{1,6})\d{0,6})?'
+</diff>


### PR DESCRIPTION
**RD-Bench V2 automated PR**

Task ID: `django__django-10999`
Base commit: `36300ef336e3f130a0dadc1143163ff3d23dc843`

**Issue:**
Fix parse_duration() for some negative durations
Description
	
The ​https://docs.djangoproject.com/en/2.1/_modules/django/utils/dateparse/ defines:
standard_duration_re = re.compile(
	r'^'
	r'(?:(?P<days>-?\d+) (days?, )?)?'
	r'((?:(?P<hours>-?\d+):)(?=\d+:\d+))?'
	r'(?:(?P<minutes>-?\d+):)?'
	r'(?P<seconds>-?\d+)'
	r'(?:\.(?P<microseconds>\d{1,6})\d{0,6})?'
	r'$'
)
that doesn't match to negative durations, because of the <hours> definition final (lookahead) part does not have '-?' in it. The fo

**Patch context:**
The patch modifies the regular expression used in the parse_duration function to correctly handle negative durations. Previously, the regex did not account for negative values in the hours component due to a missing '-?' in the lookahead assertion. This change ensures that negative durations are parsed correctly, improving the function's robustness and accuracy.