### PR TITLE
Fixed #36784 -- Added csp_nonce_attr template tag for CSP nonce inclusion.

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -82,14 +82,27 @@ class MediaAsset:
         return hash(self._path)
 
     def __str__(self):
-        return format_html(
-            self.element_template,
-            path=self.path,
-            attributes=flatatt(self.attributes),
-        )
+        return self.render()
 
     def __repr__(self):
         return f"{type(self).__qualname__}({self._path!r})"
+
+    def render(self, *, attrs=None):
+        if (
+            attrs
+            and self.attributes
+            and (conflicts := attrs.keys() & self.attributes.keys())
+        ):
+            conflicts = ", ".join(sorted(conflicts))
+            raise ValueError(
+                f"{self.__class__.__qualname__} has conflicting attributes: "
+                f"{conflicts}"
+            )
+        return format_html(
+            self.element_template,
+            path=self.path,
+            attributes=flatatt({**(attrs or {}), **self.attributes}),
+        )
 
     @property
     def path(self):
@@ -142,38 +155,47 @@ class Media:
     def _js(self):
         return self.merge(*self._js_lists)
 
-    def render(self):
+    def render(self, *, attrs=None):
         return mark_safe(
             "\n".join(
                 chain.from_iterable(
-                    getattr(self, "render_" + name)() for name in MEDIA_TYPES
+                    getattr(self, "render_" + name)(attrs=attrs) for name in MEDIA_TYPES
                 )
             )
         )
 
-    def render_js(self):
+    def render_js(self, *, attrs=None):
         return [
             (
-                path.__html__()
-                if hasattr(path, "__html__")
-                else format_html('<script src="{}"></script>', self.absolute_path(path))
+                path.render(attrs=attrs)
+                if isinstance(path, MediaAsset)
+                else (
+                    path.__html__()
+                    if hasattr(path, "__html__")
+                    else Script(path).render(attrs=attrs)
+                )
             )
             for path in self._js
         ]
 
-    def render_css(self):
+    def render_css(self, *, attrs=None):
         # To keep rendering order consistent, we can't just iterate over
         # items(). We need to sort the keys, and iterate over the sorted list.
         media = sorted(self._css)
         return chain.from_iterable(
             [
                 (
-                    path.__html__()
-                    if hasattr(path, "__html__")
-                    else format_html(
-                        '<link href="{}" media="{}" rel="stylesheet">',
-                        self.absolute_path(path),
-                        medium,
+                    path.render(attrs=attrs)
+                    if isinstance(path, MediaAsset)
+                    else (
+                        path.__html__()
+                        if hasattr(path, "__html__")
+                        else format_html(
+                            '<link href="{}" media="{}"{} rel="stylesheet">',
+                            self.absolute_path(path),
+                            medium,
+                            flatatt(attrs) if attrs else "",
+                        )
                     )
                 )
                 for path in self._css[medium]

--- a/django/template/context_processors.py
+++ b/django/template/context_processors.py
@@ -12,6 +12,7 @@ import itertools
 from django.conf import settings
 from django.middleware.csp import get_nonce
 from django.middleware.csrf import get_token
+from django.utils.csp import CONTEXT_KEY as CSP_CONTEXT_KEY
 from django.utils.functional import SimpleLazyObject, lazy
 
 
@@ -94,4 +95,4 @@ def csp(request):
     """
     Add the CSP nonce to the context.
     """
-    return {"csp_nonce": get_nonce(request)}
+    return {CSP_CONTEXT_KEY: get_nonce(request)}

--- a/django/template/defaulttags.py
+++ b/django/template/defaulttags.py
@@ -11,7 +11,7 @@ from itertools import groupby
 
 from django.conf import settings
 from django.http import QueryDict
-from django.utils import timezone
+from django.utils import csp, timezone
 from django.utils.datastructures import DeferredSubDict
 from django.utils.html import conditional_escape, escape, format_html
 from django.utils.lorem_ipsum import paragraphs, words
@@ -1685,3 +1685,8 @@ def do_with(parser, token):
     nodelist = parser.parse(("endwith",))
     parser.delete_first_token()
     return WithNode(None, None, nodelist, extra_context=extra_context)
+
+
+@register.simple_tag(takes_context=True)
+def csp_nonce_attr(context, media=None):
+    return csp.nonce_attr(context, media)

--- a/django/utils/csp.py
+++ b/django/utils/csp.py
@@ -2,6 +2,10 @@ import secrets
 from enum import StrEnum
 
 from django.utils.functional import SimpleLazyObject, empty
+from django.utils.html import format_html
+
+# Template context key for the CSP nonce.
+CONTEXT_KEY = "csp_nonce"
 
 
 class CSP(StrEnum):
@@ -63,10 +67,10 @@ class LazyNonce(SimpleLazyObject):
 
     Example Django template usage with context processors enabled:
 
-        <script{% if csp_nonce %} nonce="{{ csp_nonce }}"...{% endif %}>
+        <script {% csp_nonce_attr %}></script>
 
-    The `{% if %}` block will only render if the nonce has been evaluated
-    elsewhere.
+    ``{% csp_nonce_attr %}`` will only render the nonce attribute if the nonce
+    has been evaluated (i.e. accessed) elsewhere in the request/response cycle.
 
     """
 
@@ -75,6 +79,15 @@ class LazyNonce(SimpleLazyObject):
 
     def __bool__(self):
         return self._wrapped is not empty
+
+
+def nonce_attr(context, media=None):
+    nonce = context.get(CONTEXT_KEY)
+    if media:
+        return media.render(attrs={"nonce": nonce} if nonce is not None else None)
+    if nonce is None:
+        return ""
+    return format_html('nonce="{}"', nonce)
 
 
 def generate_nonce():

--- a/docs/howto/csp.txt
+++ b/docs/howto/csp.txt
@@ -73,8 +73,10 @@ To use nonces in your CSP policy, beside the basic config, you need to:
         },
     ]
 
-3. In your templates, add the ``nonce`` attribute to the relevant inline
-   ``<style>`` or ``<script>`` tags, using the ``csp_nonce`` context variable:
+3. In your templates, add the nonce to elements that require it:
+
+   For inline ``<style>`` or ``<script>`` tags, use the ``csp_nonce`` context
+   variable directly:
 
    .. code-block:: html+django
 
@@ -85,6 +87,26 @@ To use nonces in your CSP policy, beside the basic config, you need to:
       <script nonce="{{ csp_nonce }}">
         // This inline JavaScript will be allowed.
       </script>
+
+   For external ``<script src="...">`` and ``<link rel="stylesheet">``
+   elements, use the :ttag:`csp_nonce_attr` template tag:
+
+   .. code-block:: html+django
+
+      <script src="/path/to/script.js" {% csp_nonce_attr %}></script>
+      <link rel="stylesheet" href="/path/to/style.css" {% csp_nonce_attr %}>
+
+   To render a :class:`~django.forms.Media` object's assets with the nonce
+   applied to each element, pass the object to the :ttag:`csp_nonce_attr` tag:
+
+   .. code-block:: html+django
+
+      {% csp_nonce_attr form.media %}
+
+   .. versionchanged:: 6.1
+
+       The :ttag:`csp_nonce_attr` template tag was added, including support for
+       rendering :class:`~django.forms.Media` objects.
 
 .. admonition:: Caching and Nonce Reuse
 

--- a/docs/ref/csp.txt
+++ b/docs/ref/csp.txt
@@ -260,16 +260,43 @@ expression into the CSP header.
 
 To use this nonce in templates, the
 :func:`~django.template.context_processors.csp` context processor needs to be
-enabled. It adds a ``csp_nonce`` variable to the template context, allowing
-inline elements to include a matching ``nonce="{{ csp_nonce }}"`` attribute in
-inline scripts or styles.
+enabled. It adds a ``csp_nonce`` variable to the template context.
+
+.. versionchanged:: 6.1
+
+    The :ttag:`csp_nonce_attr` template tag was added, including support for
+    rendering :class:`~django.forms.Media` objects.
+
+For inline ``<script>`` and ``<style>`` elements, include the nonce directly
+using the context variable:
+
+.. code-block:: html+django
+
+    <script nonce="{{ csp_nonce }}">
+      // This inline JavaScript will be allowed.
+    </script>
+
+For external ``<script src="...">`` and ``<link rel="stylesheet">`` elements,
+use the :ttag:`csp_nonce_attr` template tag:
+
+.. code-block:: html+django
+
+    <script src="/path/to/script.js" {% csp_nonce_attr %}></script>
+    <link rel="stylesheet" href="/path/to/style.css" {% csp_nonce_attr %}>
+
+To render a :class:`~django.forms.Media` object's assets with the nonce
+applied, pass the object to the :ttag:`csp_nonce_attr` template tag:
+
+.. code-block:: html+django
+
+    {% csp_nonce_attr form.media %}
 
 The browser will only execute inline elements that include a ``nonce=<value>``
 attribute matching the one specified in the ``Content-Security-Policy`` (or
 ``Content-Security-Policy-Report-Only``) header. This mechanism provides
 fine-grained control over which inline code is allowed to run.
 
-If a template includes ``{{ csp_nonce }}`` but the policy does not include
+If a template includes the CSP nonce but the policy does not include
 :attr:`~django.utils.csp.CSP.NONCE`, the HTML will include a nonce attribute,
 but the header will lack the required source expression. In this case, the
 browser will block the inline script or style (or report it for report-only
@@ -291,7 +318,8 @@ the nonce and weakens security.
 
 To ensure nonce-based policies remain effective:
 
-* Avoid caching full responses that include ``{{ csp_nonce }}``.
+* Avoid caching full responses that include ``{{ csp_nonce }}`` or
+  :ttag:`csp_nonce_attr`.
 * If caching is necessary, use a strategy that injects a fresh nonce on each
   request, or consider refactoring your application to avoid inline scripts and
   styles altogether.

--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -101,6 +101,36 @@ Sample usage:
 This tag is used for CSRF protection, as described in the documentation for
 :doc:`Cross Site Request Forgeries </ref/csrf>`.
 
+.. templatetag:: csp_nonce_attr
+
+``csp_nonce_attr``
+------------------
+
+.. versionadded:: 6.1
+
+When called without arguments, renders a ``nonce="<value>"`` HTML attribute
+when the :func:`~django.template.context_processors.csp` context processor is
+configured, and an empty string otherwise. Use it in ``<script>`` or
+``<link>`` elements to allow them under a nonce-based Content Security Policy:
+
+.. code-block:: html+django
+
+    <script src="/path/to/script.js" {% csp_nonce_attr %}></script>
+    <link rel="stylesheet" href="/path/to/style.css" {% csp_nonce_attr %}>
+
+When called with a :class:`~django.forms.Media` object as the argument,
+renders its assets with the CSP nonce applied to each ``<script>`` and
+``<link>`` element:
+
+.. code-block:: html+django
+
+    {% csp_nonce_attr form.media %}
+
+In both forms, if the context processor is not configured, assets are rendered
+without a nonce attribute.
+
+See :ref:`csp-nonce` for full configuration details.
+
 .. templatetag:: cycle
 
 ``cycle``

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -217,7 +217,11 @@ Cache
 CSP
 ~~~
 
-* ...
+* The new :ttag:`csp_nonce_attr` template tag renders the CSP nonce attribute
+  on ``<script>`` and ``<link>`` elements, or renders a
+  :class:`~django.forms.Media` object's assets with the nonce applied, when the
+  :func:`~django.template.context_processors.csp` context processor is
+  configured. See :ref:`csp-nonce` for details.
 
 CSRF
 ~~~~

--- a/docs/topics/forms/media.txt
+++ b/docs/topics/forms/media.txt
@@ -322,6 +322,10 @@ HTML:
 ``Media`` objects
 =================
 
+.. class:: Media
+
+    Represents a collection of media assets required by a widget or form.
+
 When you interrogate the ``media`` attribute of a widget or form, the
 value that is returned is a ``forms.Media`` object. As we have already
 seen, the string representation of a ``Media`` object is the HTML

--- a/tests/forms_tests/tests/test_media.py
+++ b/tests/forms_tests/tests/test_media.py
@@ -72,6 +72,18 @@ class MediaAssetTestCase(SimpleTestCase):
         asset = MediaAsset("//absolute/path/to/css")
         self.assertEqual(asset.path, "//absolute/path/to/css")
 
+    def test_render_attrs_conflict(self):
+        asset = MediaAsset("/path/to/asset", nonce="static")
+        msg = "MediaAsset has conflicting attributes: nonce"
+        with self.assertRaisesMessage(ValueError, msg):
+            asset.render(attrs={"nonce": "dynamic"})
+
+    def test_render_attrs_multiple_conflicts(self):
+        asset = MediaAsset("/path/to/asset", integrity="sha256-abc", nonce="static")
+        msg = "MediaAsset has conflicting attributes: integrity, nonce"
+        with self.assertRaisesMessage(ValueError, msg):
+            asset.render(attrs={"integrity": "sha256-xyz", "nonce": "dynamic"})
+
 
 @override_settings(STATIC_URL="http://media.example.com/static/")
 class ScriptTestCase(SimpleTestCase):
@@ -89,6 +101,35 @@ class ScriptTestCase(SimpleTestCase):
             str(Script("path/to/js", **{"async": True, "deferred": False})),
             '<script src="http://media.example.com/static/path/to/js" async></script>',
         )
+
+    def test_render_with_attrs(self):
+        script = Script("/path/to/js", integrity="sha256-abc")
+        self.assertHTMLEqual(
+            script.render(attrs={"nonce": "abc123"}),
+            '<script src="/path/to/js" integrity="sha256-abc" nonce="abc123"></script>',
+        )
+
+    def test_render_attrs_conflict(self):
+        script = Script("/path/to/js", nonce="static")
+        msg = "Script has conflicting attributes: nonce"
+        with self.assertRaisesMessage(ValueError, msg):
+            script.render(attrs={"nonce": "dynamic"})
+
+
+@override_settings(STATIC_URL="http://media.example.com/static/")
+class CSSTestCase(SimpleTestCase):
+    def test_render_with_attrs(self):
+        asset = CSS("/path/to/css")
+        self.assertHTMLEqual(
+            asset.render(attrs={"nonce": "abc123"}),
+            '<link href="/path/to/css" nonce="abc123" rel="stylesheet">',
+        )
+
+    def test_render_attrs_conflict(self):
+        asset = CSS("/path/to/css", nonce="static")
+        msg = "CSS has conflicting attributes: nonce"
+        with self.assertRaisesMessage(ValueError, msg):
+            asset.render(attrs={"nonce": "dynamic"})
 
 
 @override_settings(
@@ -798,6 +839,43 @@ class FormsMediaTestCase(SimpleTestCase):
         merged = media + empty_media
         self.assertEqual(merged._css_lists, [{"screen": ["a.css"]}])
         self.assertEqual(merged._js_lists, [["a"]])
+
+    def test_render_js_with_attrs(self):
+        media = Media(js=[Script("/path/to/js", integrity="sha256-abc")])
+        self.assertHTMLEqual(
+            media.render(attrs={"nonce": "abc123"}),
+            '<script src="/path/to/js" integrity="sha256-abc" nonce="abc123"></script>',
+        )
+
+    def test_render_css_with_attrs(self):
+        media = Media(css={"all": [CSS("/path/to/css", media="print")]})
+        self.assertHTMLEqual(
+            media.render(attrs={"nonce": "abc123"}),
+            '<link href="/path/to/css" media="print" nonce="abc123" rel="stylesheet">',
+        )
+
+    def test_render_css_string_path_with_attrs(self):
+        media = Media(css={"all": ["/path/to/css"]})
+        self.assertHTMLEqual(
+            media.render(attrs={"nonce": "abc123"}),
+            '<link href="/path/to/css" media="all" nonce="abc123" rel="stylesheet">',
+        )
+
+    def test_render_attrs_conflict(self):
+        cases = [
+            (
+                Media(js=[Script("/path/to/js", nonce="static")]),
+                "Script has conflicting attributes: nonce",
+            ),
+            (
+                Media(css={"all": [CSS("/path/to/css", nonce="static")]}),
+                "CSS has conflicting attributes: nonce",
+            ),
+        ]
+        for media, msg in cases:
+            with self.subTest(msg=msg):
+                with self.assertRaisesMessage(ValueError, msg):
+                    media.render(attrs={"nonce": "dynamic"})
 
 
 @override_settings(

--- a/tests/template_tests/syntax_tests/test_csp_nonce_attr.py
+++ b/tests/template_tests/syntax_tests/test_csp_nonce_attr.py
@@ -1,0 +1,89 @@
+from django.forms import Media
+from django.forms.widgets import Script
+from django.template import Context, Template
+from django.test import SimpleTestCase, override_settings
+
+
+@override_settings(STATIC_URL="/static/")
+class CspNonceTagTests(SimpleTestCase):
+    def test_with_nonce_in_context(self):
+        t = Template("<script {% csp_nonce_attr %}></script>")
+        result = t.render(Context({"csp_nonce": "abc123"}))
+        self.assertEqual(result, '<script nonce="abc123"></script>')
+
+    def test_without_csp_nonce_in_context(self):
+        t = Template("<script {% csp_nonce_attr %}></script>")
+        result = t.render(Context())
+        self.assertEqual(result, "<script ></script>")
+
+    def test_with_csp_nonce_none(self):
+        t = Template("<script {% csp_nonce_attr %}></script>")
+        result = t.render(Context({"csp_nonce": None}))
+        self.assertEqual(result, "<script ></script>")
+
+    def test_nonce_is_escaped(self):
+        t = Template("<script {% csp_nonce_attr %}></script>")
+        result = t.render(Context({"csp_nonce": '<script>"'}))
+        self.assertIn("&lt;", result)
+        self.assertNotIn("<script>", result)
+
+
+@override_settings(STATIC_URL="/static/")
+class CspNonceTagWithMediaTests(SimpleTestCase):
+    def test_with_nonce_in_context(self):
+        media = Media(js=["/path/to/js"])
+        t = Template("{% csp_nonce_attr media %}")
+        result = t.render(Context({"media": media, "csp_nonce": "abc123"}))
+        self.assertHTMLEqual(
+            result,
+            '<script src="/path/to/js" nonce="abc123"></script>',
+        )
+
+    def test_without_csp_nonce_in_context(self):
+        media = Media(js=["/path/to/js"])
+        t = Template("{% csp_nonce_attr media %}")
+        result = t.render(Context({"media": media}))
+        self.assertHTMLEqual(result, '<script src="/path/to/js"></script>')
+
+    def test_with_csp_nonce_none(self):
+        media = Media(js=["/path/to/js"])
+        t = Template("{% csp_nonce_attr media %}")
+        result = t.render(Context({"media": media, "csp_nonce": None}))
+        self.assertHTMLEqual(result, '<script src="/path/to/js"></script>')
+
+    def test_css_and_js(self):
+        media = Media(
+            css={"all": ["/path/to/css"]},
+            js=["/path/to/js"],
+        )
+        t = Template("{% csp_nonce_attr media %}")
+        result = t.render(Context({"media": media, "csp_nonce": "abc123"}))
+        self.assertHTMLEqual(
+            result,
+            '<link href="/path/to/css" media="all" nonce="abc123" rel="stylesheet">\n'
+            '<script src="/path/to/js" nonce="abc123"></script>',
+        )
+
+    def test_with_script_object(self):
+        media = Media(js=[Script("/path/to/js", integrity="sha256-abc")])
+        t = Template("{% csp_nonce_attr media %}")
+        result = t.render(Context({"media": media, "csp_nonce": "abc123"}))
+        self.assertHTMLEqual(
+            result,
+            '<script src="/path/to/js" integrity="sha256-abc"'
+            ' nonce="abc123"></script>',
+        )
+
+    def test_output_is_safe(self):
+        media = Media(js=["/path/to/js"])
+        t = Template("{% csp_nonce_attr media %}")
+        result = t.render(Context({"media": media, "csp_nonce": "abc123"}))
+        self.assertIn("<script", result)
+        self.assertNotIn("&lt;", result)
+
+    def test_script_with_conflicting_nonce_raises(self):
+        media = Media(js=[Script("/path/to/js", nonce="static")])
+        t = Template("{% csp_nonce_attr media %}")
+        msg = "Script has conflicting attributes: nonce"
+        with self.assertRaisesMessage(ValueError, msg):
+            t.render(Context({"media": media, "csp_nonce": "abc123"}))


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-36784

#### Branch description

New default tag `{% csp_nonce_attr %}` was added for explicit CSP nonce inclusion into `<script>` and `<link>` elements.

`{% csp_nonce_attr %}` renders `nonce="<value>"` when `csp_nonce` is present in the template context, and renders nothing otherwise. `{% csp_nonce_attr media %}` renders a `Media` object's assets with the nonce attr applied to each tag.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [X] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude Sonnet 4.6 was used for some mechanical work (renames) and for doing a general review of code, consistency, and accuracy.

#### Checklist
- [X] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [X] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [X] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
