### PR TITLE
Refs #15727 -- Moved security.E026 out of list of deploy=True checks.

### DIFF
--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -592,8 +592,6 @@ The following checks are run if you use the :option:`check --deploy` option:
   ``'django-insecure-'`` indicating that it was generated automatically by
   Django. Please generate a long and random value, otherwise many of Django's
   security-critical features will be vulnerable to attack.
-* **security.E026**: The CSP setting ``<SETTING_NAME>`` must be a dictionary
-  (got ``<value>`` instead).
 
 The following checks verify that your security-related settings are correctly
 configured:
@@ -604,6 +602,8 @@ configured:
   correct number of arguments.
 * **security.E102**: The CSRF failure view ``'path.to.view'`` could not be
   imported.
+* **security.E026**: The CSP setting ``<SETTING_NAME>`` must be a dictionary
+  (got ``<value>`` instead).
 
 Signals
 -------


### PR DESCRIPTION
Thanks @robhudson for the catch.

See no `deploy=True` here:
https://github.com/django/django/blob/5686ce41958b21f0ae5bfa290e8d4420a6349c1b/django/core/checks/security/base.py#L291-L292