### PR TITLE
Fixed #28567 -- Made translate_url() resolve URLs using the language …

### DIFF
--- a/django/urls/base.py
+++ b/django/urls/base.py
@@ -2,9 +2,10 @@ from urllib.parse import unquote, urlencode, urlsplit, urlunsplit
 
 from asgiref.local import Local
 
+from django.conf import settings
 from django.http import QueryDict
 from django.utils.functional import lazy
-from django.utils.translation import override
+from django.utils.translation import get_language_from_path, override
 
 from .exceptions import NoReverseMatch, Resolver404
 from .resolvers import _get_cached_resolver, get_ns_resolver, get_resolver
@@ -185,9 +186,18 @@ def translate_url(url, lang_code):
     Return the original URL if no translated version is found.
     """
     parsed = urlsplit(url)
+    source_lang = get_language_from_path(parsed.path)
+    path = unquote(parsed.path)
     try:
-        # URL may be encoded.
-        match = resolve(unquote(parsed.path))
+        if source_lang is not None:
+            with override(source_lang):
+                match = resolve(path)
+        else:
+            try:
+                match = resolve(path)
+            except Resolver404:
+                with override(settings.LANGUAGE_CODE):
+                    match = resolve(path)
     except Resolver404:
         pass
     else:

--- a/tests/i18n/patterns/tests.py
+++ b/tests/i18n/patterns/tests.py
@@ -206,6 +206,16 @@ class URLTranslationTests(URLTestCaseBase):
 
         with translation.override("nl"):
             self.assertEqual(translate_url("/nl/gebruikers/", "en"), "/en/users/")
+            # Translated URL patterns without a language prefix are resolved
+            # using the active language (#28567).
+            self.assertEqual(translate_url("/vertaald/", "en"), "/translated/")
+            self.assertEqual(
+                translate_url("/vertaald-regex/", "en"), "/translated-regex/"
+            )
+            self.assertEqual(
+                translate_url("/vertaald/default-slug/", "en"),
+                "/translated/default-slug/",
+            )
             self.assertEqual(translation.get_language(), "nl")
 
     def test_reverse_translated_with_captured_kwargs(self):

--- a/tests/view_tests/tests/test_i18n.py
+++ b/tests/view_tests/tests/test_i18n.py
@@ -13,7 +13,7 @@ from django.test import (
 )
 from django.test.selenium import SeleniumTestCase
 from django.urls import reverse
-from django.utils.translation import get_language, override
+from django.utils.translation import deactivate_all, get_language, override
 from django.views.i18n import JavaScriptCatalog, get_formats
 
 from ..urls import locale_dir
@@ -245,6 +245,25 @@ class SetLanguageTests(TestCase):
             headers={"referer": "/nl/vertaald/"},
         )
         self.assertRedirects(response, "/en/translated/")
+
+    @modify_settings(
+        MIDDLEWARE={
+            "append": "django.middleware.locale.LocaleMiddleware",
+        }
+    )
+    def test_setlang_with_mismatched_cookie_and_next_url_prefix(self):
+        self.client.cookies[settings.LANGUAGE_COOKIE_NAME] = "de"
+        response = self.client.post(
+            "/i18n/setlang/",
+            data={"language": "nl", "next": "/en/translated/"},
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, "/nl/vertaald/")
+        self.assertEqual(
+            self.client.cookies[settings.LANGUAGE_COOKIE_NAME].value,
+            "nl",
+        )
+        deactivate_all()
 
 
 @override_settings(ROOT_URLCONF="view_tests.urls")


### PR DESCRIPTION
…from the URL prefix.

Edit: updated ticket info.

37086 Trac ticket number was the one i started with. However, was a duplicate to 28567 trac. 

ticket-28567

#### Branch description
`translate_url()` silently returned URLs unchanged when the language activated by `LocaleMiddleware` (typically from the cookie) differed from the language prefix already present in the URL being translated. The internal `resolve()` call would raise `Resolver404` because `LocalePrefixPattern.match()` uses `get_language()` rather than the URL's actual prefix, and `translate_url()` swallows that exception.

The fix moves source-language detection inside `translate_url()` itself: it derives the source language from the URL path via `get_language_from_path()` and wraps the `resolve()` call in `translation.override(source_lang)`. The function now produces correct results regardless of the caller's active language context.

The bug was reachable via `set_language` in any multilingual site where users navigate between language-prefixed URLs without the cookie being kept in sync — a common occurrence with manual URL editing or following external links.

Regression test added in `tests/view_tests/tests/test_i18n.py::SetLanguageTests::test_setlang_with_mismatched_cookie_and_next_url_prefix`.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Used Claude (Anthropic) for: triage analysis, architectural reasoning around the fix location, drafting the regression test, drafting the release note, and walking through the Django contribution workflow. All code, test logic, and the architectural decision were reviewed and verified manually — including running the targeted test suites (442 tests) and confirming the bug reproduction in a separate scratch project before working in the Django source.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
