### PR TITLE
Fixed #37088 -- Included attributes in media object equality.

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -72,14 +72,19 @@ class MediaAsset:
         self.attributes = attributes
 
     def __eq__(self, other):
-        # Compare the path only, to ensure performant comparison in
-        # Media.merge.
-        return (self.__class__ is other.__class__ and self.path == other.path) or (
-            isinstance(other, str) and self._path == other
-        )
+        # Compare path and attrs to ensure performant comparison
+        # in Media.merge.
+        return (
+            self.__class__ is other.__class__
+            and self._path == other._path
+            and self.attributes == other.attributes
+        ) or (isinstance(other, str) and self._path == other)
 
     def __hash__(self):
-        # Hash the path only, to ensure performant comparison in Media.merge.
+        # Compare path and attrs to ensure performant comparison
+        # in Media.merge.
+        if self.attributes:
+            return hash(self._path) ^ hash(frozenset(self.attributes.items()))
         return hash(self._path)
 
     def __str__(self):
@@ -142,8 +147,22 @@ class Media:
                 css = {}
             if js is None:
                 js = []
-        self._css_lists = [css]
-        self._js_lists = [js]
+        self._css_lists = [self._normalize_css(css)]
+        self._js_lists = [self._normalize_js(js)]
+
+    @staticmethod
+    def _normalize_js(js):
+        return [Script(path) if isinstance(path, str) else path for path in js]
+
+    @staticmethod
+    def _normalize_css(css):
+        return {
+            medium: [
+                Stylesheet(path, media=medium) if isinstance(path, str) else path
+                for path in paths
+            ]
+            for medium, paths in css.items()
+        }
 
     def __repr__(self):
         return "Media(css=%r, js=%r)" % (self._css, self._js)
@@ -177,11 +196,7 @@ class Media:
             (
                 path.render(attrs=attrs)
                 if isinstance(path, MediaAsset)
-                else (
-                    path.__html__()
-                    if hasattr(path, "__html__")
-                    else Script(path).render(attrs=attrs)
-                )
+                else path.__html__()
             )
             for path in self._js
         ]
@@ -195,11 +210,7 @@ class Media:
                 (
                     path.render(attrs=attrs)
                     if isinstance(path, MediaAsset)
-                    else (
-                        path.__html__()
-                        if hasattr(path, "__html__")
-                        else Stylesheet(path, media=medium).render(attrs=attrs)
-                    )
+                    else path.__html__()
                 )
                 for path in self._css[medium]
             ]

--- a/tests/forms_tests/tests/test_media.py
+++ b/tests/forms_tests/tests/test_media.py
@@ -17,20 +17,24 @@ class MediaAssetTestCase(SimpleTestCase):
     def test_eq(self):
         self.assertEqual(MediaAsset("path/to/css"), MediaAsset("path/to/css"))
         self.assertEqual(MediaAsset("path/to/css"), "path/to/css")
-        self.assertEqual(
+        self.assertNotEqual(
             MediaAsset("path/to/css", media="all"), MediaAsset("path/to/css")
         )
 
         self.assertNotEqual(MediaAsset("path/to/css"), MediaAsset("path/to/other.css"))
         self.assertNotEqual(MediaAsset("path/to/css"), "path/to/other.css")
         self.assertNotEqual(
-            MediaAsset("path/to/css", media="all"), Stylesheet("path/to/css")
+            MediaAsset("path/to/css", rel="stylesheet"), Stylesheet("path/to/css")
         )
 
     def test_hash(self):
         self.assertEqual(hash(MediaAsset("path/to/css")), hash("path/to/css"))
         self.assertEqual(
             hash(MediaAsset("path/to/css")), hash(MediaAsset("path/to/css"))
+        )
+        self.assertNotEqual(
+            hash(MediaAsset("path/to/css", rel="stylesheet")),
+            hash(MediaAsset("path/to/css")),
         )
 
     def test_str(self):
@@ -171,9 +175,10 @@ class FormsMediaTestCase(SimpleTestCase):
         )
         self.assertEqual(
             repr(m),
-            "Media(css={'all': ['path/to/css1', '/path/to/css2']}, "
-            "js=['/path/to/js1', 'http://media.other.com/path/to/js2', "
-            "'https://secure.other.com/path/to/js3'])",
+            "Media(css={'all': [Stylesheet('path/to/css1'),"
+            " Stylesheet('/path/to/css2')]}, js=[Script('/path/to/js1'),"
+            " Script('http://media.other.com/path/to/js2'),"
+            " Script('https://secure.other.com/path/to/js3')])",
         )
 
         class Foo:
@@ -807,7 +812,8 @@ class FormsMediaTestCase(SimpleTestCase):
         self.assertEqual(merged._js_lists, [["a", "b", "c"], ["a", "c", "b"]])
         msg = (
             "Detected duplicate Media files in an opposite order: "
-            "['a', 'b', 'c'], ['a', 'c', 'b']"
+            "[Script('a'), Script('b'), Script('c')],"
+            " [Script('a'), Script('c'), Script('b')]"
         )
         with self.assertWarnsMessage(RuntimeWarning, msg):
             merged._js
@@ -840,7 +846,8 @@ class FormsMediaTestCase(SimpleTestCase):
         )
         msg = (
             "Detected duplicate Media files in an opposite order: "
-            "['b.css', 'c.css'], ['c.css', 'b.css']"
+            "[Stylesheet('b.css'), Stylesheet('c.css')],"
+            " [Stylesheet('c.css'), Stylesheet('b.css')]"
         )
         with self.assertWarnsMessage(RuntimeWarning, msg):
             merged._css
@@ -977,6 +984,7 @@ class FormsMediaObjectTestCase(SimpleTestCase):
             '<link href="/path/to/css3" media="all" rel="stylesheet">\n'
             '<script src="/path/to/js1"></script>\n'
             '<script src="http://media.other.com/path/to/js2"></script>\n'
+            '<script src="/path/to/js4"></script>\n'
             '<script src="https://secure.other.com/path/to/js3"></script>\n'
             '<script src="/path/to/js4" integrity="9d947b87fdeb25030d56d01f7aa75800">'
             "</script>",


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37088

#### Branch description
Since in the majority of cases the `MediaAsset.attributes` will be empty or small, there's only a tiny performance penalty.

However, the accidental use of the `path` property caused a 1_000x performacne degredation (N=1_000_000).

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
> AI wrote the benchmarking script (not part of the commit).

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.

## To my fellow reviewer

1. I had to cast strings to media assets early to be able to deduplicate CSS assets based on their media query. It uses hash identity, not equality.

2. I found a substantial performance bug while working on this. `MediaAsset.__eq__` called `path` not `_path` which calls the entire staticfiles stack.