### PR TITLE
Fixed #32980 -- Cached related managers with binding checks.

### DIFF
--- a/django/contrib/contenttypes/fields.py
+++ b/django/contrib/contenttypes/fields.py
@@ -606,6 +606,21 @@ class ReverseGenericManyToOneDescriptor(ReverseManyToOneDescriptor):
             self.rel,
         )
 
+    @cached_property
+    def related_manager_cache_key(self):
+        # GenericRel defaults to related_name="+" unless related_query_name is
+        # provided, so use the field name to avoid collisions between multiple
+        # GenericRelations on the same model.
+        return self.field.cache_name
+
+    def related_manager_binding(self, instance):
+        model = (
+            instance._meta.concrete_model
+            if self.field.for_concrete_model
+            else instance.__class__
+        )
+        return model, instance.pk, instance._state.db
+
 
 def create_generic_related_manager(superclass, rel):
     """

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -459,12 +459,27 @@ class ModelBase(type):
         return cls._meta.default_manager
 
 
-class ModelStateFieldsCacheDescriptor:
+class ModelStateCacheDescriptor:
+    """
+    Upon first access, replace itself with an empty dictionary on the instance.
+    """
+
+    def __set_name__(self, owner, name):
+        self.attribute_name = name
+
     def __get__(self, instance, cls=None):
         if instance is None:
             return self
-        res = instance.fields_cache = {}
+        res = instance.__dict__[self.attribute_name] = {}
         return res
+
+
+class ModelStateFieldsCacheDescriptor(ModelStateCacheDescriptor):
+    pass
+
+
+class ModelStateRelatedManagersCacheDescriptor(ModelStateCacheDescriptor):
+    pass
 
 
 class ModelStateFetchModeDescriptor:
@@ -485,6 +500,7 @@ class ModelState:
     # on the actual save.
     adding = True
     fields_cache = ModelStateFieldsCacheDescriptor()
+    related_managers_cache = ModelStateRelatedManagersCacheDescriptor()
     fetch_mode = ModelStateFetchModeDescriptor()
     peers = ()
 
@@ -492,10 +508,18 @@ class ModelState:
         state = self.__dict__.copy()
         # Weak references can't be pickled.
         state.pop("peers", None)
+        if "fields_cache" in state:
+            state["fields_cache"] = self.fields_cache.copy()
+        # Manager instances stored in related_managers_cache won't necessarily
+        # be deserializable if they were dynamically created via inner scopes,
+        # e.g. create_forward_many_to_many_manager().
+        if "related_managers_cache" in state:
+            state["related_managers_cache"] = {}
         return state
 
     def __del__(self):
         self.fields_cache.clear()
+        self.related_managers_cache.clear()
 
 
 class Model(AltersData, metaclass=ModelBase):
@@ -661,6 +685,8 @@ class Model(AltersData, metaclass=ModelBase):
         state = self.__dict__.copy()
         state["_state"] = copy.copy(state["_state"])
         state["_state"].fields_cache = state["_state"].fields_cache.copy()
+        if "related_managers_cache" in self._state.__dict__:
+            state["_state"].related_managers_cache = {}
         # memoryview cannot be pickled, so cast it to bytes and store
         # separately.
         _memoryview_attrs = []

--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -681,6 +681,17 @@ class ReverseManyToOneDescriptor:
             self.rel,
         )
 
+    @cached_property
+    def related_manager_cache_key(self):
+        return self.rel.cache_name
+
+    def related_manager_binding(self, instance):
+        return (
+            self.field.get_foreign_related_value(instance),
+            instance._get_pk_val(),
+            instance._state.db,
+        )
+
     def __get__(self, instance, cls=None):
         """
         Get the related objects through the reverse relation.
@@ -694,7 +705,18 @@ class ReverseManyToOneDescriptor:
         if instance is None:
             return self
 
-        return self.related_manager_cls(instance)
+        cache = instance._state.related_managers_cache
+        cache_key = self.related_manager_cache_key
+        binding = self.related_manager_binding(instance)
+        manager = cache.get(cache_key)
+        if (
+            manager is None
+            or getattr(manager, "_related_manager_binding", None) != binding
+        ):
+            manager = self.related_manager_cls(instance)
+            manager._related_manager_binding = binding
+            cache[cache_key] = manager
+        return manager
 
     def _get_set_deprecation_msg_params(self):
         return (
@@ -1060,6 +1082,23 @@ class ManyToManyDescriptor(ReverseManyToOneDescriptor):
             related_model._default_manager.__class__,
             self.rel,
             reverse=self.reverse,
+        )
+
+    @cached_property
+    def related_manager_cache_key(self):
+        return self.rel.cache_name if self.reverse else self.field.cache_name
+
+    def related_manager_binding(self, instance):
+        source_field_name = (
+            self.field.m2m_reverse_field_name()
+            if self.reverse
+            else self.field.m2m_field_name()
+        )
+        source_field = self.through._meta.get_field(source_field_name)
+        return (
+            source_field.get_foreign_related_value(instance),
+            instance._get_pk_val(),
+            instance._state.db,
         )
 
     def _get_set_deprecation_msg_params(self):

--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -686,8 +686,16 @@ class ReverseManyToOneDescriptor:
         return self.rel.cache_name
 
     def related_manager_binding(self, instance):
+        get_related_value = getattr(self.field, "get_foreign_related_value", None)
+        if get_related_value is None:
+            get_related_value = self.rel.get_instance_value_for_fields
+            related_value = get_related_value(
+                instance, self.field.foreign_related_fields
+            )
+        else:
+            related_value = get_related_value(instance)
         return (
-            self.field.get_foreign_related_value(instance),
+            related_value,
             instance._get_pk_val(),
             instance._state.db,
         )

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -351,6 +351,10 @@ Models
   ``OR``, ``XOR``, respectively. These aggregates were previously included only
   in ``contrib.postgres``.
 
+* Related managers for ``ForeignKey``, ``ManyToManyField``, and
+  ``GenericRelation`` are now cached on model instances, with caches refreshed
+  when the instance values that bind the manager change.
+
 * :class:`django.db.models.BinaryField` now validates Base64 input strictly.
   Invalid Base64 strings now raise ``ValidationError`` instead of being
   silently accepted.

--- a/tests/custom_managers/tests.py
+++ b/tests/custom_managers/tests.py
@@ -1,3 +1,5 @@
+import pickle
+
 from django.db import models
 from django.test import TestCase
 
@@ -128,6 +130,14 @@ class CustomManagerTests(TestCase):
         self.assertIsInstance(self.droopy.books, PublishedBookManager)
         self.assertIsInstance(self.b2.authors, PersonManager)
 
+    def test_fk_related_manager_reused(self):
+        self.assertIs(self.b1.favorite_books, self.b1.favorite_books)
+        self.assertIn("favorite_books", self.b1._state.related_managers_cache)
+        self.assertIsNot(
+            self.b1.favorite_books(manager="fun_people"),
+            self.b1.favorite_books(manager="fun_people"),
+        )
+
     def test_no_objects(self):
         """
         The default manager, "objects", doesn't exist, because a custom one
@@ -245,6 +255,28 @@ class CustomManagerTests(TestCase):
             ordered=False,
         )
 
+    def test_gfk_related_manager_reused(self):
+        self.assertIs(
+            self.b1.fun_people_favorite_things,
+            self.b1.fun_people_favorite_things,
+        )
+        self.assertIn(
+            "fun_people_favorite_things",
+            self.b1._state.related_managers_cache,
+        )
+        self.assertIsNot(
+            self.b1.favorite_things(manager="fun_people"),
+            self.b1.favorite_things(manager="fun_people"),
+        )
+
+    def test_gfk_related_manager_rebuilt_after_pk_change(self):
+        book = Book.published_objects.create(
+            title="How to program", author="Rodney Dangerfield", is_published=True
+        )
+        manager = book.favorite_things
+        book.pk = None
+        self.assertIsNot(book.favorite_things, manager)
+
     def test_m2m_related_manager(self):
         bugs = Person.objects.create(first_name="Bugs", last_name="Bunny", fun=True)
         self.b1.authors.add(bugs)
@@ -290,6 +322,26 @@ class CustomManagerTests(TestCase):
             lambda c: c.first_name,
             ordered=False,
         )
+
+    def test_m2m_related_forward_manager_reused(self):
+        self.assertIs(self.b1.authors, self.b1.authors)
+        self.assertIn("authors", self.b1._state.related_managers_cache)
+        self.assertIsNot(
+            self.b1.authors(manager="fun_people"),
+            self.b1.authors(manager="fun_people"),
+        )
+
+    def test_m2m_related_reverse_manager_reused(self):
+        bugs = Person.objects.create(first_name="Bugs", last_name="Bunny")
+        self.b1.authors.add(bugs)
+        self.assertIs(bugs.books, bugs.books)
+        self.assertIn("books", bugs._state.related_managers_cache)
+
+    def test_related_managers_cache_not_pickled(self):
+        self.b1.authors
+        self.assertIn("authors", self.b1._state.related_managers_cache)
+        reloaded = pickle.loads(pickle.dumps(self.b1))
+        self.assertEqual(reloaded._state.related_managers_cache, {})
 
     def test_removal_through_default_fk_related_manager(self, bulk=True):
         bugs = FunPerson.objects.create(

--- a/tests/m2m_regress/tests.py
+++ b/tests/m2m_regress/tests.py
@@ -39,6 +39,14 @@ class M2MRegressionTests(TestCase):
         self.assertSequenceEqual(e1.topics.all(), [t1])
         self.assertSequenceEqual(e1.related.all(), [t2])
 
+    def test_m2m_managers_reused(self):
+        s1 = SelfRefer.objects.create(name="s1")
+        e1 = Entry.objects.create(name="e1")
+        self.assertIs(s1.references, s1.references)
+        self.assertIs(s1.related, s1.related)
+        self.assertIs(e1.topics, e1.topics)
+        self.assertIs(e1.related, e1.related)
+
     def test_internal_related_name_not_in_error_msg(self):
         # The secret internal related names for self-referential many-to-many
         # fields shouldn't appear in the list when an error is made.
@@ -76,10 +84,12 @@ class M2MRegressionTests(TestCase):
         Entry.objects.create(name="e1")
         entry = Entry.objects.first()
         entry.topics.set([t1])
+        old_manager = entry.topics
         old_topics = entry.topics.all()
         entry.pk = None
         entry._state.adding = True
         entry.save()
+        self.assertIsNot(entry.topics, old_manager)
         entry.topics.set(old_topics)
         entry = Entry.objects.get(pk=entry.pk)
         self.assertCountEqual(entry.topics.all(), old_topics)

--- a/tests/many_to_many/tests.py
+++ b/tests/many_to_many/tests.py
@@ -106,6 +106,8 @@ class ManyToManyTests(TestCase):
         user_1 = User.objects.create(username="Jean")
         user_2 = User.objects.create(username="Joe")
         self.a3.authors.add(user_1.username)
+        user_1_articles = user_1.article_set
+        self.assertIs(user_1_articles, user_1.article_set)
         self.assertSequenceEqual(user_1.article_set.all(), [self.a3])
         # Change the username on a different instance of the same user.
         user_1_from_db = User.objects.get(pk=user_1.pk)
@@ -119,6 +121,7 @@ class ManyToManyTests(TestCase):
         # Refresh the instance with an evaluated related manager.
         user_1.refresh_from_db()
         self.assertEqual(user_1.username, "Paul")
+        self.assertIsNot(user_1.article_set, user_1_articles)
         self.assertSequenceEqual(user_1.article_set.all(), [self.a4])
 
     def test_add_remove_invalid_type(self):

--- a/tests/model_regress/test_state.py
+++ b/tests/model_regress/test_state.py
@@ -1,6 +1,10 @@
 import gc
 
-from django.db.models.base import ModelState, ModelStateFieldsCacheDescriptor
+from django.db.models.base import (
+    ModelState,
+    ModelStateFieldsCacheDescriptor,
+    ModelStateRelatedManagersCacheDescriptor,
+)
 from django.test import SimpleTestCase
 from django.test.utils import garbage_collect
 
@@ -10,6 +14,12 @@ from .models import Worker, WorkerProfile
 class ModelStateTests(SimpleTestCase):
     def test_fields_cache_descriptor(self):
         self.assertIsInstance(ModelState.fields_cache, ModelStateFieldsCacheDescriptor)
+
+    def test_related_managers_cache_descriptor(self):
+        self.assertIsInstance(
+            ModelState.related_managers_cache,
+            ModelStateRelatedManagersCacheDescriptor,
+        )
 
     def test_one_to_one_field_cycle_collection(self):
         self.addCleanup(gc.set_debug, gc.get_debug())


### PR DESCRIPTION
#### Trac ticket number

ticket-32980

#### Branch description
Reintroduces per-instance caching for related managers while recording the instance values that bind each manager. Cached managers are reused while those values are stable and rebuilt when the binding changes, avoiding stale-manager regressions from #33984.

This covers reverse `ForeignKey`, `ManyToManyField`, and `GenericRelation` managers, and adds tests for manager reuse, copy-with-M2M, `refresh_from_db()`, generic relation primary-key changes, and pickling.

#### Benchmarks
Benchmarked locally on Python 3.14.4 using SQLite against the PR merge-base:

| Case | Base | This PR | Result |
| --- | ---: | ---: | ---: |
| `user.groups` | `3.165 us` | `835.3 ns` | `3.79x faster` |
| `user.user_permissions` | `3.175 us` | `825.9 ns` | `3.84x faster` |
| 1000-user `prefetch_related("groups")` loop | `16.328 ms` | `15.497 ms` | `1.05x faster` |

Repeated related-manager access now reuses the same manager instance, e.g. `user.groups is user.groups` changes from `False` to `True`.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Used OpenAI Codex assistance to investigate the previous implementation and revert, draft the patch and tests, and run verification. I manually reviewed the final diff and test results before submission.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
