### PR TITLE
Fixed #37090 -- Fixed clearing of unnecessary orderings in nested unions on Oracle.

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1312,8 +1312,7 @@ class Query(BaseExpression):
             and not connection.features.ignores_unnecessary_order_by_in_subqueries
         ):
             self.clear_ordering(force=False)
-            for query in self.combined_queries:
-                query.clear_ordering(force=False)
+            self.clear_ordering_in_combined_queries()
         sql, params = self.get_compiler(connection=connection).as_sql()
         if self.subquery:
             sql = "(%s)" % sql
@@ -2402,6 +2401,11 @@ class Query(BaseExpression):
         self.extra_order_by = ()
         if clear_default:
             self.default_ordering = False
+
+    def clear_ordering_in_combined_queries(self):
+        for query in self.combined_queries:
+            query.clear_ordering(force=False)
+            query.clear_ordering_in_combined_queries()
 
     def set_group_by(self, allow_aliases=True):
         """

--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -580,6 +580,20 @@ class QuerySetSetOperationTests(TestCase):
             ordered=False,
         )
 
+    @skipUnlessDBFeature("supports_slicing_ordering_in_compound")
+    def test_union_in_with_ordering_union(self):
+        qs1 = Number.objects.filter(num__gt=7).order_by("id")
+        qs2 = Number.objects.filter(num__lt=2).order_by("-id")
+        qs3 = Number.objects.filter(num=5).order_by("id")
+        union = qs1.union(qs2).order_by("id")
+        self.assertNumbersEqual(
+            Number.objects.exclude(
+                id__in=union.union(qs3).order_by("-id").values("id")
+            ),
+            [2, 3, 4, 6, 7],
+            ordered=False,
+        )
+
     @skipUnlessDBFeature(
         "supports_slicing_ordering_in_compound", "allow_sliced_subqueries_with_in"
     )


### PR DESCRIPTION
#### Trac ticket number
ticket-37090

#### Branch description
Thanks @dcsid for the patch. (Broken out from #21102)

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

I did not use AI tools, but @dcsid's disclosure from #21102 likely applies.