### PR TITLE
Refs #37060 -- Shortened app label in AlterField test for Oracle.

### DIFF
--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -3097,7 +3097,7 @@ class OperationTests(OperationTestBase):
     def test_alter_field_reloads_state_on_transitive_attname_to_field_type_change(
         self,
     ):
-        app_label = "test_alflrstfattnamettc"
+        app_label = "test_alflrstatftc"
         project_state = self.apply_operations(
             app_label,
             ProjectState(),


### PR DESCRIPTION
#### Trac ticket number
ticket-37060

#### Branch description
Fixes Oracle test failure: https://github.com/django/django/pull/21156#issuecomment-4401960752

This avoids having to run `connection.ops.truncate_name()` when deriving the table name, e.g. for calls like:

```py
f"{app_label}_primary"
```

Which were failing here, as the f-string'd name was not the actual, truncated table name:

```py
                    for c in connection.introspection.get_table_description(
                        cursor, f"{app_label}_primary"
                    )
```

Follow-up to 21c51c2623a966ba1ad8fd10e36bc8bbec93b70e.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

ChatGPT (GPT5.3) to help debug the failure.