### PR TITLE
Fixed #29303 -- Avoided mutating original view in non_atomic_requests().

### DIFF
--- a/django/db/transaction.py
+++ b/django/db/transaction.py
@@ -1,4 +1,5 @@
 from contextlib import ContextDecorator, contextmanager
+from functools import wraps
 
 from django.db import (
     DEFAULT_DB_ALIAS,
@@ -325,10 +326,16 @@ def atomic(using=None, savepoint=True, durable=False):
 
 def _non_atomic_requests(view, using):
     try:
-        view._non_atomic_requests.add(using)
+        databases = view._non_atomic_requests | {using}
     except AttributeError:
-        view._non_atomic_requests = {using}
-    return view
+        databases = {using}
+
+    @wraps(view)
+    def wrapper(*args, **kwargs):
+        return view(*args, **kwargs)
+
+    wrapper._non_atomic_requests = databases
+    return wrapper
 
 
 def non_atomic_requests(using=None):

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -118,7 +118,9 @@ CSRF
 Decorators
 ~~~~~~~~~~
 
-* ...
+* :func:`~django.db.transaction.non_atomic_requests` no longer mutates the
+  original view function's ``_non_atomic_requests`` attribute when applied
+  multiple times (:ticket:`29303`).
 
 Email
 ~~~~~

--- a/tests/transaction_hooks/tests.py
+++ b/tests/transaction_hooks/tests.py
@@ -1,4 +1,5 @@
 from django.db import connection, transaction
+from django.http import HttpResponse
 from django.test import TransactionTestCase, skipUnlessDBFeature
 
 from .models import Thing
@@ -281,3 +282,18 @@ class TestConnectionOnCommit(TransactionTestCase):
         msg = "on_commit()'s callback must be a callable."
         with self.assertRaisesMessage(TypeError, msg):
             transaction.on_commit(None)
+
+    def test_non_atomic_requests_does_not_mutate_original(self):
+        """non_atomic_requests should return a new wrapper, not mutate the original."""
+
+        def my_view(request):
+            return HttpResponse("")
+
+        wrapped_once = transaction.non_atomic_requests(using="default")(my_view)
+        wrapped_twice = transaction.non_atomic_requests(using="other")(wrapped_once)
+
+        # wrapped_twice باید object جدید باشه
+        self.assertIsNot(wrapped_twice, wrapped_once)
+        # wrapped_once نباید دست خورده باشه
+        self.assertEqual(wrapped_once._non_atomic_requests, {"default"})
+        self.assertEqual(wrapped_twice._non_atomic_requests, {"default", "other"})


### PR DESCRIPTION
When `non_atomic_requests()` was applied multiple times to the same view
function, it mutated the `_non_atomic_requests` attribute of the original
function instead of returning a new wrapper. This has been fixed by
returning a `functools.wraps`-based wrapper so the original view is left
untouched.

#### Trac ticket number
ticket-29303

#### Branch description
Fixes a bug where `non_atomic_requests()` mutated the `_non_atomic_requests`
attribute of the original view function instead of returning a new wrapper.
This patch returns a `functools.wraps`-based wrapper so the original view
is left untouched, adds a regression test, and includes a release note.

#### AI Assistance Disclosure (REQUIRED)
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
