### PR TITLE
Refs #34976 -- Added success message to startproject and startapp commands.

### DIFF
--- a/django/core/management/templates.py
+++ b/django/core/management/templates.py
@@ -233,6 +233,13 @@ class TemplateCommand(BaseCommand):
 
         run_formatters([top_dir], **formatter_paths, stderr=self.stderr)
 
+        if self.verbosity >= 1:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f'Success! Created {self.app_or_project} "{name}" at "{top_dir}".'
+                )
+            )
+
     def handle_template(self, template, subdir):
         """
         Determine where the app or project templates are.

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -2589,9 +2589,9 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         "Make sure the startproject management command creates a project"
         args = ["startproject", "testproject"]
         testproject_dir = os.path.join(self.test_dir, "testproject")
-
         out, err = self.run_django_admin(args)
         self.assertNoOutput(err)
+        self.assertIn("Success! Created project", out)
         self.assertTrue(os.path.isdir(testproject_dir))
 
         # running again..
@@ -2912,7 +2912,7 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         ]
         testproject_dir = os.path.join(self.test_dir, "project_dir2")
         out, err = self.run_django_admin(args)
-        self.assertNoOutput(out)
+        self.assertIn("Success! Created project", out)
         self.assertNoOutput(err)
         self.assertTrue(os.path.exists(testproject_dir))
 
@@ -3151,7 +3151,7 @@ class StartApp(AdminScriptTestCase):
         ]
         testapp_dir = os.path.join(self.test_dir, "my_app")
         out, err = self.run_django_admin(args)
-        self.assertNoOutput(out)
+        self.assertIn("Success! Created app", out)
         self.assertNoOutput(err)
         self.assertTrue(os.path.exists(testapp_dir))
 
@@ -3163,7 +3163,7 @@ class StartApp(AdminScriptTestCase):
         ]
         testapp_dir = os.path.join(self.test_dir, "apps", "my_app")
         out, err = self.run_django_admin(args)
-        self.assertNoOutput(out)
+        self.assertIn("Success! Created app", out)
         self.assertNoOutput(err)
         self.assertTrue(os.path.exists(testapp_dir))
 
@@ -3175,7 +3175,7 @@ class StartApp(AdminScriptTestCase):
         nested_args = ["startapp", "child", "parent/child"]
         child_app_dir = os.path.join(self.test_dir, "parent", "child")
         out, err = self.run_django_admin(nested_args)
-        self.assertNoOutput(out)
+        self.assertIn("Success! Created app", out)
         self.assertNoOutput(err)
         self.assertTrue(os.path.exists(child_app_dir))
 


### PR DESCRIPTION
#### Trac ticket number

<!-- Replace XXXXX with the corresponding Trac ticket number. -->

<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-34976

#### Branch description

The `startproject` and `startapp` commands currently provide no output on success, which can confuse beginners who may not realize the command worked. This patch adds a success message after successful creation while respecting the `--verbosity` flag.

When `verbosity >= 1` (default):

* `startproject` outputs: `Success! Created project "mysite" at "/path/to/mysite".`
* `startapp` outputs: `Success! Created app "myapp" at "/path/to/myapp".`

When `--verbosity 0` is used, no output is shown, preserving the existing behavior.

#### AI Assistance Disclosure (REQUIRED)

<!-- Please select exactly ONE of the following: -->

* [x] **No AI tools were used** in preparing this PR.

#### Checklist

* [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
* [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
* [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
* [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
* [x] I have not requested, and will not request, an automated AI review for this PR.
* [x] I have checked the "Has patch" ticket flag in the Trac system.
* [x] I have added or updated relevant tests.
* [x] I have added or updated relevant docs, including release notes if applicable.
* [ ] I have attached screenshots in both light and dark modes for any UI changes.