### PR TITLE
Fixed #34976 -- Added success message to startproject and startapp commands

### DIFF
--- a/django/core/management/templates.py
+++ b/django/core/management/templates.py
@@ -234,6 +234,13 @@ class TemplateCommand(BaseCommand):
 
         run_formatters([top_dir], **formatter_paths, stderr=self.stderr)
 
+        if self.verbosity >= 1:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f'Success! Created {self.app_or_project} "{name}" at "{top_dir}".'
+                )
+            )
+
     def handle_template(self, template, subdir):
         """
         Determine where the app or project templates are.

--- a/django/core/management/templates.py
+++ b/django/core/management/templates.py
@@ -233,6 +233,13 @@ class TemplateCommand(BaseCommand):
 
         run_formatters([top_dir], **formatter_paths, stderr=self.stderr)
 
+        if self.verbosity >= 1:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f'Success! Created {self.app_or_project} "{name}" at "{top_dir}".'
+                )
+            )
+
     def handle_template(self, template, subdir):
         """
         Determine where the app or project templates are.

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -750,6 +750,7 @@ class DjangoAdminSettingsDirectory(AdminScriptTestCase):
         args = ["startapp", "settings_test"]
         app_path = os.path.join(self.test_dir, "settings_test")
         out, err = self.run_django_admin(args, "test_project.settings")
+        self.assertIn("Success! Created app", out)
         self.assertNoOutput(err)
         self.assertTrue(os.path.exists(app_path))
         with open(os.path.join(app_path, "apps.py")) as f:
@@ -766,6 +767,7 @@ class DjangoAdminSettingsDirectory(AdminScriptTestCase):
         args = ["startapp", "--template", template_path, "custom_settings_test"]
         app_path = os.path.join(self.test_dir, "custom_settings_test")
         out, err = self.run_django_admin(args, "test_project.settings")
+        self.assertIn("Success! Created app", out)
         self.assertNoOutput(err)
         self.assertTrue(os.path.exists(app_path))
         self.assertTrue(os.path.exists(os.path.join(app_path, "api.py")))
@@ -775,6 +777,7 @@ class DjangoAdminSettingsDirectory(AdminScriptTestCase):
         args = ["startapp", "こんにちは"]
         app_path = os.path.join(self.test_dir, "こんにちは")
         out, err = self.run_django_admin(args, "test_project.settings")
+        self.assertIn("Success! Created app", out)
         self.assertNoOutput(err)
         self.assertTrue(os.path.exists(app_path))
         with open(os.path.join(app_path, "apps.py"), encoding="utf8") as f:
@@ -2589,9 +2592,9 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         "Make sure the startproject management command creates a project"
         args = ["startproject", "testproject"]
         testproject_dir = os.path.join(self.test_dir, "testproject")
-
         out, err = self.run_django_admin(args)
         self.assertNoOutput(err)
+        self.assertIn("Success! Created project", out)
         self.assertTrue(os.path.isdir(testproject_dir))
 
         # running again..
@@ -2671,6 +2674,7 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         os.mkdir(testproject_dir)
 
         out, err = self.run_django_admin(args)
+        self.assertIn("Success! Created project", out)
         self.assertNoOutput(err)
         self.assertTrue(os.path.exists(os.path.join(testproject_dir, "manage.py")))
 
@@ -2693,6 +2697,7 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         testproject_dir = os.path.join(self.test_dir, "customtestproject")
 
         out, err = self.run_django_admin(args)
+        self.assertIn("Success! Created project", out)
         self.assertNoOutput(err)
         self.assertTrue(os.path.isdir(testproject_dir))
         self.assertTrue(os.path.exists(os.path.join(testproject_dir, "additional_dir")))
@@ -2721,6 +2726,7 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         testproject_dir = os.path.join(self.test_dir, "customtestproject")
 
         out, err = self.run_django_admin(args)
+        self.assertIn("Success! Created project", out)
         self.assertNoOutput(err)
         self.assertTrue(os.path.isdir(testproject_dir))
         self.assertTrue(os.path.exists(os.path.join(testproject_dir, "additional_dir")))
@@ -2735,6 +2741,7 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         testproject_dir = os.path.join(self.test_dir, "tarballtestproject")
 
         out, err = self.run_django_admin(args)
+        self.assertIn("Success! Created project", out)
         self.assertNoOutput(err)
         self.assertTrue(os.path.isdir(testproject_dir))
         self.assertTrue(os.path.exists(os.path.join(testproject_dir, "run.py")))
@@ -2756,6 +2763,7 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         os.mkdir(testproject_dir)
 
         out, err = self.run_django_admin(args)
+        self.assertIn("Success! Created project", out)
         self.assertNoOutput(err)
         self.assertTrue(os.path.isdir(testproject_dir))
         self.assertTrue(os.path.exists(os.path.join(testproject_dir, "run.py")))
@@ -2771,6 +2779,7 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         testproject_dir = os.path.join(self.test_dir, "urltestproject")
 
         out, err = self.run_django_admin(args)
+        self.assertIn("Success! Created project", out)
         self.assertNoOutput(err)
         self.assertTrue(os.path.isdir(testproject_dir))
         self.assertTrue(os.path.exists(os.path.join(testproject_dir, "run.py")))
@@ -2817,6 +2826,7 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         testproject_dir = os.path.join(self.test_dir, "urltestproject")
 
         out, err = self.run_django_admin(args)
+        self.assertIn("Success! Created project", out)
         self.assertNoOutput(err)
         self.assertTrue(os.path.isdir(testproject_dir))
         self.assertTrue(os.path.exists(os.path.join(testproject_dir, "run.py")))
@@ -2840,6 +2850,7 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         testproject_dir = os.path.join(self.test_dir, "customtestproject")
 
         out, err = self.run_django_admin(args)
+        self.assertIn("Success! Created project", out)
         self.assertNoOutput(err)
         self.assertTrue(os.path.isdir(testproject_dir))
         self.assertTrue(os.path.exists(os.path.join(testproject_dir, "additional_dir")))
@@ -2864,6 +2875,7 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         testproject_dir = os.path.join(self.test_dir, "project_dir")
         os.mkdir(testproject_dir)
         out, err = self.run_django_admin(args)
+        self.assertIn("Success! Created project", out)
         self.assertNoOutput(err)
         test_manage_py = os.path.join(testproject_dir, "manage.py")
         with open(test_manage_py) as fp:
@@ -2912,7 +2924,7 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         ]
         testproject_dir = os.path.join(self.test_dir, "project_dir2")
         out, err = self.run_django_admin(args)
-        self.assertNoOutput(out)
+        self.assertIn("Success! Created project", out)
         self.assertNoOutput(err)
         self.assertTrue(os.path.exists(testproject_dir))
 
@@ -3116,9 +3128,10 @@ class StartApp(AdminScriptTestCase):
     def test_trailing_slash_in_target_app_directory_name(self):
         app_dir = os.path.join(self.test_dir, "apps", "app1")
         os.makedirs(app_dir)
-        _, err = self.run_django_admin(
+        out, err = self.run_django_admin(
             ["startapp", "app", os.path.join("apps", "app1", "")]
         )
+        self.assertIn("Success! Created app", out)
         self.assertNoOutput(err)
         self.assertIs(os.path.exists(os.path.join(app_dir, "apps.py")), True)
 
@@ -3135,6 +3148,7 @@ class StartApp(AdminScriptTestCase):
 
     def test_template(self):
         out, err = self.run_django_admin(["startapp", "new_app"])
+        self.assertIn("Success! Created app", out)
         self.assertNoOutput(err)
         app_path = os.path.join(self.test_dir, "new_app")
         self.assertIs(os.path.exists(app_path), True)
@@ -3151,7 +3165,7 @@ class StartApp(AdminScriptTestCase):
         ]
         testapp_dir = os.path.join(self.test_dir, "my_app")
         out, err = self.run_django_admin(args)
-        self.assertNoOutput(out)
+        self.assertIn("Success! Created app", out)
         self.assertNoOutput(err)
         self.assertTrue(os.path.exists(testapp_dir))
 
@@ -3163,7 +3177,7 @@ class StartApp(AdminScriptTestCase):
         ]
         testapp_dir = os.path.join(self.test_dir, "apps", "my_app")
         out, err = self.run_django_admin(args)
-        self.assertNoOutput(out)
+        self.assertIn("Success! Created app", out)
         self.assertNoOutput(err)
         self.assertTrue(os.path.exists(testapp_dir))
 
@@ -3175,7 +3189,7 @@ class StartApp(AdminScriptTestCase):
         nested_args = ["startapp", "child", "parent/child"]
         child_app_dir = os.path.join(self.test_dir, "parent", "child")
         out, err = self.run_django_admin(nested_args)
-        self.assertNoOutput(out)
+        self.assertIn("Success! Created app", out)
         self.assertNoOutput(err)
         self.assertTrue(os.path.exists(child_app_dir))
 

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -763,6 +763,7 @@ class DjangoAdminSettingsDirectory(AdminScriptTestCase):
         args = ["startapp", "settings_test"]
         app_path = os.path.join(self.test_dir, "settings_test")
         out, err = self.run_django_admin(args, "test_project.settings")
+        self.assertIn("Success! Created app", out)
         self.assertNoOutput(err)
         self.assertTrue(os.path.exists(app_path))
         with open(os.path.join(app_path, "apps.py")) as f:
@@ -779,6 +780,7 @@ class DjangoAdminSettingsDirectory(AdminScriptTestCase):
         args = ["startapp", "--template", template_path, "custom_settings_test"]
         app_path = os.path.join(self.test_dir, "custom_settings_test")
         out, err = self.run_django_admin(args, "test_project.settings")
+        self.assertIn("Success! Created app", out)
         self.assertNoOutput(err)
         self.assertTrue(os.path.exists(app_path))
         self.assertTrue(os.path.exists(os.path.join(app_path, "api.py")))
@@ -788,6 +790,7 @@ class DjangoAdminSettingsDirectory(AdminScriptTestCase):
         args = ["startapp", "こんにちは"]
         app_path = os.path.join(self.test_dir, "こんにちは")
         out, err = self.run_django_admin(args, "test_project.settings")
+        self.assertIn("Success! Created app", out)
         self.assertNoOutput(err)
         self.assertTrue(os.path.exists(app_path))
         with open(os.path.join(app_path, "apps.py"), encoding="utf8") as f:
@@ -2619,6 +2622,7 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
 
         out, err = self.run_django_admin(args)
         self.assertNoOutput(err)
+        self.assertIn("Success! Created project", out)
         self.assertTrue(os.path.isdir(testproject_dir))
 
         # running again..
@@ -2698,6 +2702,7 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         os.mkdir(testproject_dir)
 
         out, err = self.run_django_admin(args)
+        self.assertIn("Success! Created project", out)
         self.assertNoOutput(err)
         self.assertTrue(os.path.exists(os.path.join(testproject_dir, "manage.py")))
 
@@ -2720,6 +2725,7 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         testproject_dir = os.path.join(self.test_dir, "customtestproject")
 
         out, err = self.run_django_admin(args)
+        self.assertIn("Success! Created project", out)
         self.assertNoOutput(err)
         self.assertTrue(os.path.isdir(testproject_dir))
         self.assertTrue(os.path.exists(os.path.join(testproject_dir, "additional_dir")))
@@ -2748,6 +2754,7 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         testproject_dir = os.path.join(self.test_dir, "customtestproject")
 
         out, err = self.run_django_admin(args)
+        self.assertIn("Success! Created project", out)
         self.assertNoOutput(err)
         self.assertTrue(os.path.isdir(testproject_dir))
         self.assertTrue(os.path.exists(os.path.join(testproject_dir, "additional_dir")))
@@ -2762,6 +2769,7 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         testproject_dir = os.path.join(self.test_dir, "tarballtestproject")
 
         out, err = self.run_django_admin(args)
+        self.assertIn("Success! Created project", out)
         self.assertNoOutput(err)
         self.assertTrue(os.path.isdir(testproject_dir))
         self.assertTrue(os.path.exists(os.path.join(testproject_dir, "run.py")))
@@ -2783,6 +2791,7 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         os.mkdir(testproject_dir)
 
         out, err = self.run_django_admin(args)
+        self.assertIn("Success! Created project", out)
         self.assertNoOutput(err)
         self.assertTrue(os.path.isdir(testproject_dir))
         self.assertTrue(os.path.exists(os.path.join(testproject_dir, "run.py")))
@@ -2798,6 +2807,7 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         testproject_dir = os.path.join(self.test_dir, "urltestproject")
 
         out, err = self.run_django_admin(args)
+        self.assertIn("Success! Created project", out)
         self.assertNoOutput(err)
         self.assertTrue(os.path.isdir(testproject_dir))
         self.assertTrue(os.path.exists(os.path.join(testproject_dir, "run.py")))
@@ -2859,6 +2869,7 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         testproject_dir = os.path.join(self.test_dir, "urltestproject")
 
         out, err = self.run_django_admin(args)
+        self.assertIn("Success! Created project", out)
         self.assertNoOutput(err)
         self.assertTrue(os.path.isdir(testproject_dir))
         self.assertTrue(os.path.exists(os.path.join(testproject_dir, "run.py")))
@@ -2882,6 +2893,7 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         testproject_dir = os.path.join(self.test_dir, "customtestproject")
 
         out, err = self.run_django_admin(args)
+        self.assertIn("Success! Created project", out)
         self.assertNoOutput(err)
         self.assertTrue(os.path.isdir(testproject_dir))
         self.assertTrue(os.path.exists(os.path.join(testproject_dir, "additional_dir")))
@@ -2906,6 +2918,7 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         testproject_dir = os.path.join(self.test_dir, "project_dir")
         os.mkdir(testproject_dir)
         out, err = self.run_django_admin(args)
+        self.assertIn("Success! Created project", out)
         self.assertNoOutput(err)
         test_manage_py = os.path.join(testproject_dir, "manage.py")
         with open(test_manage_py) as fp:
@@ -2954,7 +2967,7 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         ]
         testproject_dir = os.path.join(self.test_dir, "project_dir2")
         out, err = self.run_django_admin(args)
-        self.assertNoOutput(out)
+        self.assertIn("Success! Created project", out)
         self.assertNoOutput(err)
         self.assertTrue(os.path.exists(testproject_dir))
 
@@ -3158,9 +3171,10 @@ class StartApp(AdminScriptTestCase):
     def test_trailing_slash_in_target_app_directory_name(self):
         app_dir = os.path.join(self.test_dir, "apps", "app1")
         os.makedirs(app_dir)
-        _, err = self.run_django_admin(
+        out, err = self.run_django_admin(
             ["startapp", "app", os.path.join("apps", "app1", "")]
         )
+        self.assertIn("Success! Created app", out)
         self.assertNoOutput(err)
         self.assertIs(os.path.exists(os.path.join(app_dir, "apps.py")), True)
 
@@ -3177,6 +3191,7 @@ class StartApp(AdminScriptTestCase):
 
     def test_template(self):
         out, err = self.run_django_admin(["startapp", "new_app"])
+        self.assertIn("Success! Created app", out)
         self.assertNoOutput(err)
         app_path = os.path.join(self.test_dir, "new_app")
         self.assertIs(os.path.exists(app_path), True)
@@ -3193,7 +3208,7 @@ class StartApp(AdminScriptTestCase):
         ]
         testapp_dir = os.path.join(self.test_dir, "my_app")
         out, err = self.run_django_admin(args)
-        self.assertNoOutput(out)
+        self.assertIn("Success! Created app", out)
         self.assertNoOutput(err)
         self.assertTrue(os.path.exists(testapp_dir))
 
@@ -3205,7 +3220,7 @@ class StartApp(AdminScriptTestCase):
         ]
         testapp_dir = os.path.join(self.test_dir, "apps", "my_app")
         out, err = self.run_django_admin(args)
-        self.assertNoOutput(out)
+        self.assertIn("Success! Created app", out)
         self.assertNoOutput(err)
         self.assertTrue(os.path.exists(testapp_dir))
 
@@ -3217,7 +3232,7 @@ class StartApp(AdminScriptTestCase):
         nested_args = ["startapp", "child", "parent/child"]
         child_app_dir = os.path.join(self.test_dir, "parent", "child")
         out, err = self.run_django_admin(nested_args)
-        self.assertNoOutput(out)
+        self.assertIn("Success! Created app", out)
         self.assertNoOutput(err)
         self.assertTrue(os.path.exists(child_app_dir))
 


### PR DESCRIPTION
#### Trac ticket number

ticket-34976

#### Branch description

The `startproject` and `startapp` commands currently provide no output on success, which can confuse beginners who may not realize the command worked. This patch adds a success message after successful creation while respecting the `--verbosity` flag.

When `verbosity >= 1` (default):

- `startproject` outputs: `Success! Created project "mysite" at "/path/to/mysite".`
- `startapp` outputs: `Success! Created app "myapp" at "/path/to/myapp".`

When `--verbosity 0` is used, no output is shown, preserving the existing behavior.

#### AI Assistance Disclosure (REQUIRED)

- [x] **No AI tools were used** in preparing this PR.
- [ ]  **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.