### PR TITLE
Fixed #37065 -- Support async view dispatch in method_decorator

### DIFF
--- a/django/utils/decorators.py
+++ b/django/utils/decorators.py
@@ -1,6 +1,6 @@
 "Functions that help with dynamically creating decorators for views."
 
-from functools import partial, update_wrapper, wraps
+from functools import update_wrapper, wraps
 from inspect import iscoroutinefunction, markcoroutinefunction
 
 
@@ -41,7 +41,12 @@ def _multi_decorate(decorators, method):
         # 'self' argument, but it's a closure over self so it can call
         # 'func'. Also, wrap method.__get__() in a function because new
         # attributes can't be set on bound method objects, only on functions.
-        bound_method = wraps(method)(partial(method.__get__(self, type(self))))
+        @wraps(method)
+        def bound_method(*args2, **kwargs2):
+            return method.__get__(self, type(self))(*args2, **kwargs2)
+
+        if getattr(self, "view_is_async", False):
+            markcoroutinefunction(bound_method)
         for dec in decorators:
             bound_method = dec(bound_method)
         return bound_method(*args, **kwargs)

--- a/tests/decorators/tests.py
+++ b/tests/decorators/tests.py
@@ -10,7 +10,7 @@ from django.contrib.auth.decorators import (
     user_passes_test,
 )
 from django.http import HttpResponse
-from django.test import SimpleTestCase
+from django.test import RequestFactory, SimpleTestCase
 from django.utils.decorators import method_decorator
 from django.utils.functional import keep_lazy, keep_lazy_text, lazy
 from django.utils.safestring import mark_safe
@@ -23,6 +23,7 @@ from django.views.decorators.http import (
     require_safe,
 )
 from django.views.decorators.vary import vary_on_cookie, vary_on_headers
+from django.views.generic import View
 
 
 def fully_decorated(request):
@@ -696,3 +697,48 @@ class AsyncMethodDecoratorTests(SimpleTestCase):
         method = Test().method
         self.assertIs(iscoroutinefunction(method), True)
         self.assertEqual(await method(), "returned: tests")
+
+    async def test_async_view_never_cache_applied(self):
+        """
+        @method_decorator applied to View class synchronous dispatch should
+        function correctly for async view i.e. with async def get().
+        """
+        factory = RequestFactory()
+        request = factory.get("/dummy-url/")
+
+        @method_decorator(never_cache, name="dispatch")
+        class AsyncView(View):
+            async def get(self, request, *args, **kwargs):
+                return HttpResponse("Async GET response")
+
+        async_view = AsyncView.as_view()
+        response = await async_view(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Cache-Control", response)
+        self.assertIn("no-cache", response["Cache-Control"])
+        self.assertEqual(response.content, b"Async GET response")
+
+    async def test_sync_view_never_cache_applied(self):
+        """
+        @method_decorator applied to View class synchronous dispatch should
+        function correctly for sync view i.e. with def get().
+        """
+        factory = RequestFactory()
+        request = factory.get("/dummy-url/")
+
+        @method_decorator(never_cache, name="dispatch")
+        class SyncView(View):
+            def get(self, request, *args, **kwargs):
+                return HttpResponse("Sync GET response")
+
+        sync_view = SyncView.as_view()
+        response = sync_view(request)
+
+        self.assertEqual(iscoroutinefunction(sync_view), False)
+        self.assertEqual(iscoroutinefunction(View.dispatch), False)
+        self.assertEqual(iscoroutinefunction(SyncView.as_view()), False)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Cache-Control", response)
+        self.assertIn("no-cache", response["Cache-Control"])
+        self.assertEqual(response.content, b"Sync GET response")


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37065

#### Branch description
`@method_decorator` previously failed on async views when applied with name='dispatch'. The coroutine check was only performed on the dispatch method itself, not on the underlying handler methods (e.g., async def get).

This change updates `_multi_decorate` to use the `view_is_async` class attribute to mark the method being decorated as a coroutine (here `dispatch`), ensuring the return value is properly awaited before being processed in the respective decorators.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
