### PR TITLE
Fixed #36825 -- Included CSP nonce in templates if available.

### DIFF
--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -1,5 +1,3 @@
-@import url("widgets.css");
-
 /* FORM ROWS */
 
 .form-row {

--- a/django/contrib/admin/templates/admin/auth/user/add_form.html
+++ b/django/contrib/admin/templates/admin/auth/user/add_form.html
@@ -8,5 +8,5 @@
 {% endblock %}
 {% block extrahead %}
   {{ block.super }}
-  <link rel="stylesheet" href="{% static 'admin/css/unusable_password_field.css' %}">
+  <link rel="stylesheet" href="{% static 'admin/css/unusable_password_field.css' %}" {% csp_nonce_attr %}>
 {% endblock %}

--- a/django/contrib/admin/templates/admin/auth/user/change_password.html
+++ b/django/contrib/admin/templates/admin/auth/user/change_password.html
@@ -5,8 +5,9 @@
 {% block title %}{% if form.errors %}{% translate "Error:" %} {% endif %}{{ block.super }}{% endblock %}
 {% block extrastyle %}
   {{ block.super }}
-  <link rel="stylesheet" href="{% static "admin/css/forms.css" %}">
-  <link rel="stylesheet" href="{% static 'admin/css/unusable_password_field.css' %}">
+  <link rel="stylesheet" href="{% static "admin/css/widgets.css" %}" {% csp_nonce_attr %}>
+  <link rel="stylesheet" href="{% static "admin/css/forms.css" %}" {% csp_nonce_attr %}>
+  <link rel="stylesheet" href="{% static 'admin/css/unusable_password_field.css' %}" {% csp_nonce_attr %}>
 {% endblock %}
 {% block bodyclass %}{{ block.super }} {{ opts.app_label }}-{{ opts.model_name }} change-form{% endblock %}
 {% if not is_popup %}

--- a/django/contrib/admin/templates/admin/base.html
+++ b/django/contrib/admin/templates/admin/base.html
@@ -4,22 +4,22 @@
 <head>
 <title>{% block title %}{% endblock %}</title>
 <meta name="color-scheme" content="light dark" />
-<link rel="stylesheet" href="{% block stylesheet %}{% static "admin/css/base.css" %}{% endblock %}">
+<link rel="stylesheet" href="{% block stylesheet %}{% static "admin/css/base.css" %}{% endblock %}" {% csp_nonce_attr %}>
 {% block dark-mode-vars %}
-  <link rel="stylesheet" href="{% static "admin/css/dark_mode.css" %}">
-  <script src="{% static "admin/js/theme.js" %}"></script>
+  <link rel="stylesheet" href="{% static "admin/css/dark_mode.css" %}" {% csp_nonce_attr %}>
+  <script src="{% static "admin/js/theme.js" %}" {% csp_nonce_attr %}></script>
 {% endblock %}
 {% if not is_popup and is_nav_sidebar_enabled %}
-  <link rel="stylesheet" href="{% static "admin/css/nav_sidebar.css" %}">
-  <script src="{% static 'admin/js/nav_sidebar.js' %}" defer></script>
+  <link rel="stylesheet" href="{% static "admin/css/nav_sidebar.css" %}" {% csp_nonce_attr %}>
+  <script src="{% static 'admin/js/nav_sidebar.js' %}" defer {% csp_nonce_attr %}></script>
 {% endif %}
 {% block extrastyle %}{% endblock %}
-{% if LANGUAGE_BIDI %}<link rel="stylesheet" href="{% block stylesheet_rtl %}{% static "admin/css/rtl.css" %}{% endblock %}">{% endif %}
+{% if LANGUAGE_BIDI %}<link rel="stylesheet" href="{% block stylesheet_rtl %}{% static "admin/css/rtl.css" %}{% endblock %}" {% csp_nonce_attr %}>{% endif %}
 {% block extrahead %}{% endblock %}
 {% block responsive %}
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="{% static "admin/css/responsive.css" %}">
-    {% if LANGUAGE_BIDI %}<link rel="stylesheet" href="{% static "admin/css/responsive_rtl.css" %}">{% endif %}
+    <link rel="stylesheet" href="{% static "admin/css/responsive.css" %}" {% csp_nonce_attr %}>
+    {% if LANGUAGE_BIDI %}<link rel="stylesheet" href="{% static "admin/css/responsive_rtl.css" %}" {% csp_nonce_attr %}>{% endif %}
 {% endblock %}
 {% block blockbots %}<meta name="robots" content="NONE,NOARCHIVE">{% endblock %}
 </head>

--- a/django/contrib/admin/templates/admin/change_form.html
+++ b/django/contrib/admin/templates/admin/change_form.html
@@ -3,11 +3,15 @@
 
 {% block title %}{% if errors %}{% translate "Error:" %} {% endif %}{{ block.super }}{% endblock %}
 {% block extrahead %}{{ block.super }}
-<script src="{% url 'admin:jsi18n' %}"></script>
-{{ media }}
+<script src="{% url 'admin:jsi18n' %}" {% csp_nonce_attr %}></script>
+{% csp_nonce_attr media %}
 {% endblock %}
 
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static "admin/css/forms.css" %}">{% endblock %}
+{% block extrastyle %}
+  {{ block.super }}
+  <link rel="stylesheet" href="{% static "admin/css/widgets.css" %}" {% csp_nonce_attr %}>
+  <link rel="stylesheet" href="{% static "admin/css/forms.css" %}" {% csp_nonce_attr %}>
+{% endblock %}
 
 {% block coltype %}colM{% endblock %}
 
@@ -76,6 +80,7 @@
             {% if adminform and add %}
                 data-model-name="{{ opts.model_name }}"
             {% endif %}
+            {% csp_nonce_attr %}
             async>
     </script>
 {% endblock %}

--- a/django/contrib/admin/templates/admin/change_list.html
+++ b/django/contrib/admin/templates/admin/change_list.html
@@ -4,16 +4,17 @@
 {% block title %}{% if cl.formset and cl.formset.errors %}{% translate "Error:" %} {% endif %}{{ block.super }}{% endblock %}
 {% block extrastyle %}
   {{ block.super }}
-  <link rel="stylesheet" href="{% static "admin/css/changelists.css" %}">
+  <link rel="stylesheet" href="{% static "admin/css/changelists.css" %}" {% csp_nonce_attr %}>
   {% if cl.formset %}
-    <link rel="stylesheet" href="{% static "admin/css/forms.css" %}">
+    <link rel="stylesheet" href="{% static "admin/css/widgets.css" %}" {% csp_nonce_attr %}>
+    <link rel="stylesheet" href="{% static "admin/css/forms.css" %}" {% csp_nonce_attr %}>
   {% endif %}
   {% if cl.formset or action_form %}
-    <script src="{% url 'admin:jsi18n' %}"></script>
+    <script src="{% url 'admin:jsi18n' %}" {% csp_nonce_attr %}></script>
   {% endif %}
-  {{ media.css }}
+  {% csp_nonce_attr media.css %}
   {% if not actions_on_top and not actions_on_bottom %}
-    <style>
+    <style {% csp_nonce_attr %}>
       #changelist table thead th:first-child {width: inherit}
     </style>
   {% endif %}
@@ -21,8 +22,8 @@
 
 {% block extrahead %}
 {{ block.super }}
-{{ media.js }}
-<script src="{% static 'admin/js/filters.js' %}" defer></script>
+{% csp_nonce_attr media.js %}
+<script src="{% static 'admin/js/filters.js' %}" defer {% csp_nonce_attr %}></script>
 {% endblock %}
 
 {% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} change-list{% endblock %}

--- a/django/contrib/admin/templates/admin/delete_confirmation.html
+++ b/django/contrib/admin/templates/admin/delete_confirmation.html
@@ -3,8 +3,8 @@
 
 {% block extrahead %}
     {{ block.super }}
-    {{ media }}
-    <script src="{% static 'admin/js/cancel.js' %}" async></script>
+    {% csp_nonce_attr media %}
+    <script src="{% static 'admin/js/cancel.js' %}" async {% csp_nonce_attr %}></script>
 {% endblock %}
 
 {% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} delete-confirmation{% endblock %}

--- a/django/contrib/admin/templates/admin/delete_selected_confirmation.html
+++ b/django/contrib/admin/templates/admin/delete_selected_confirmation.html
@@ -3,8 +3,8 @@
 
 {% block extrahead %}
     {{ block.super }}
-    {{ media }}
-    <script src="{% static 'admin/js/cancel.js' %}" async></script>
+    {% csp_nonce_attr media %}
+    <script src="{% static 'admin/js/cancel.js' %}" async {% csp_nonce_attr %}></script>
 {% endblock %}
 
 {% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} delete-confirmation delete-selected-confirmation{% endblock %}

--- a/django/contrib/admin/templates/admin/index.html
+++ b/django/contrib/admin/templates/admin/index.html
@@ -1,7 +1,7 @@
 {% extends "admin/base_site.html" %}
 {% load i18n static admin_filters %}
 
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static "admin/css/dashboard.css" %}">{% endblock %}
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static "admin/css/dashboard.css" %}" {% csp_nonce_attr %}>{% endblock %}
 
 {% block coltype %}colMS{% endblock %}
 

--- a/django/contrib/admin/templates/admin/login.html
+++ b/django/contrib/admin/templates/admin/login.html
@@ -2,8 +2,8 @@
 {% load i18n static %}
 
 {% block title %}{% if form.errors %}{% translate "Error:" %} {% endif %}{{ block.super }}{% endblock %}
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static "admin/css/login.css" %}">
-{{ form.media }}
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static "admin/css/login.css" %}" {% csp_nonce_attr %}>
+{% csp_nonce_attr form.media %}
 {% endblock %}
 
 {% block bodyclass %}{{ block.super }} login{% endblock %}

--- a/django/contrib/admin/templates/admin/popup_response.html
+++ b/django/contrib/admin/templates/admin/popup_response.html
@@ -4,7 +4,8 @@
   <body>
     <script id="django-admin-popup-response-constants"
             src="{% static "admin/js/popup_response.js" %}"
-            data-popup-response="{{ popup_response_data }}">
+            data-popup-response="{{ popup_response_data }}"
+            {% csp_nonce_attr %}>
     </script>
   </body>
 </html>

--- a/django/contrib/admin/templates/admin/prepopulated_fields_js.html
+++ b/django/contrib/admin/templates/admin/prepopulated_fields_js.html
@@ -1,5 +1,6 @@
 {% load static %}
 <script id="django-admin-prepopulated-fields-constants"
         src="{% static "admin/js/prepopulate_init.js" %}"
-        data-prepopulated-fields="{{ prepopulated_fields_json }}">
+        data-prepopulated-fields="{{ prepopulated_fields_json }}"
+        {% csp_nonce_attr %}>
 </script>

--- a/django/contrib/admin/templates/registration/password_change_form.html
+++ b/django/contrib/admin/templates/registration/password_change_form.html
@@ -2,7 +2,11 @@
 {% load i18n static %}
 
 {% block title %}{% if form.errors %}{% translate "Error:" %} {% endif %}{{ block.super }}{% endblock %}
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static "admin/css/forms.css" %}">{% endblock %}
+{% block extrastyle %}
+  {{ block.super }}
+  <link rel="stylesheet" href="{% static "admin/css/widgets.css" %}" {% csp_nonce_attr %}>
+  <link rel="stylesheet" href="{% static "admin/css/forms.css" %}" {% csp_nonce_attr %}>
+{% endblock %}
 {% block userlinks %}
   {% url 'django-admindocs-docroot' as docsroot %}{% if docsroot %}<a href="{{ docsroot }}">{% translate 'Documentation' %}</a> / {% endif %} {% translate 'Change password' %} /
   <form id="logout-form" method="post" action="{% url 'admin:logout' %}">

--- a/django/contrib/admin/templates/registration/password_reset_confirm.html
+++ b/django/contrib/admin/templates/registration/password_reset_confirm.html
@@ -2,7 +2,11 @@
 {% load i18n static %}
 
 {% block title %}{% if form.new_password1.errors or form.new_password2.errors %}{% translate "Error:" %} {% endif %}{{ block.super }}{% endblock %}
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static "admin/css/forms.css" %}">{% endblock %}
+{% block extrastyle %}
+  {{ block.super }}
+  <link rel="stylesheet" href="{% static "admin/css/widgets.css" %}" {% csp_nonce_attr %}>
+  <link rel="stylesheet" href="{% static "admin/css/forms.css" %}" {% csp_nonce_attr %}>
+{% endblock %}
 {% block breadcrumbs %}
 <ol class="breadcrumbs">
 <li><a href="{% url 'admin:index' %}">{% translate 'Home' %}</a></li>

--- a/django/contrib/admin/templates/registration/password_reset_form.html
+++ b/django/contrib/admin/templates/registration/password_reset_form.html
@@ -2,7 +2,11 @@
 {% load i18n static %}
 
 {% block title %}{% if form.email.errors %}{% translate "Error:" %} {% endif %}{{ block.super }}{% endblock %}
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static "admin/css/forms.css" %}">{% endblock %}
+{% block extrastyle %}
+  {{ block.super }}
+  <link rel="stylesheet" href="{% static "admin/css/widgets.css" %}" {% csp_nonce_attr %}>
+  <link rel="stylesheet" href="{% static "admin/css/forms.css" %}" {% csp_nonce_attr %}>
+{% endblock %}
 {% block breadcrumbs %}
 <ol class="breadcrumbs">
 <li><a href="{% url 'admin:index' %}">{% translate 'Home' %}</a></li>

--- a/django/contrib/admindocs/templates/admin_doc/model_detail.html
+++ b/django/contrib/admindocs/templates/admin_doc/model_detail.html
@@ -3,7 +3,7 @@
 
 {% block extrahead %}
 {{ block.super }}
-<style>
+<style {% csp_nonce_attr %}>
 .module table { width:100%; }
 .module table p { padding: 0; margin: 0; }
 </style>

--- a/django/views/csrf.py
+++ b/django/views/csrf.py
@@ -24,6 +24,7 @@ def csrf_failure(request, reason="", template_name=CSRF_FAILURE_TEMPLATE_NAME):
     Default view used when request fails CSRF protection
     """
     from django.middleware.csrf import REASON_NO_CSRF_COOKIE, REASON_NO_REFERER
+    from django.template.context_processors import csp
 
     c = {
         "title": _("Forbidden"),
@@ -64,7 +65,7 @@ def csrf_failure(request, reason="", template_name=CSRF_FAILURE_TEMPLATE_NAME):
         "DEBUG": settings.DEBUG,
         "docs_version": get_docs_version(),
         "more": _("More information is available with DEBUG=True."),
-    }
+    } | csp(request)
     try:
         t = loader.get_template(template_name)
         body = t.render(request=request)

--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -673,6 +673,8 @@ def technical_404_response(request, exception):
     return HttpResponseNotFound(t.render(c))
 
 
+@csp_override({})
+@csp_report_only_override({})
 def default_urlconf(request):
     """Create an empty URLconf 404 error response."""
     with builtin_template_path("default_urlconf.html").open(encoding="utf-8") as fh:

--- a/django/views/templates/csrf_403.html
+++ b/django/views/templates/csrf_403.html
@@ -5,7 +5,7 @@
   <meta name="color-scheme" content="light dark" />
   <meta name="robots" content="NONE,NOARCHIVE">
   <title>403 Forbidden</title>
-  <style>
+  <style {% csp_nonce_attr %}>
     html * { padding:0; margin:0; }
     body * { padding:10px 20px; }
     body * * { padding:0; }

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -282,6 +282,11 @@ CSP
   with ``CSP.NONCE`` in a CSP policy but
   ``django.template.context_processors.csp`` is not configured.
 
+* CSP nonce attributes are now added on ``<script>``, ``<style>``, and
+  ``<link>`` elements in admin templates and all built-in templates when the
+  :func:`~django.template.context_processors.csp` context processor is
+  configured. See :ref:`csp-nonce-config` for setup instructions.
+
 CSRF
 ~~~~
 

--- a/tests/admin_views/test_csp.py
+++ b/tests/admin_views/test_csp.py
@@ -1,0 +1,111 @@
+from django.contrib.auth.models import User
+from django.test import TestCase, modify_settings, override_settings
+from django.urls import reverse
+
+
+@override_settings(
+    ROOT_URLCONF="admin_views.urls",
+    TEMPLATES=[
+        {
+            "BACKEND": "django.template.backends.django.DjangoTemplates",
+            "APP_DIRS": True,
+            "OPTIONS": {
+                "context_processors": [
+                    "django.template.context_processors.request",
+                    "django.contrib.auth.context_processors.auth",
+                    "django.template.context_processors.csp",
+                ],
+            },
+        }
+    ],
+)
+@modify_settings(
+    MIDDLEWARE={"append": "django.middleware.csp.ContentSecurityPolicyMiddleware"}
+)
+class AdminCspNonceTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.superuser = User.objects.create_superuser(
+            username="super", password="secret", email="super@example.com"
+        )
+
+    def setUp(self):
+        self.client.force_login(self.superuser)
+
+    @override_settings(
+        TEMPLATES=[
+            {
+                "BACKEND": "django.template.backends.django.DjangoTemplates",
+                "APP_DIRS": True,
+                "OPTIONS": {
+                    "context_processors": [
+                        "django.template.context_processors.request",
+                        "django.contrib.auth.context_processors.auth",
+                    ],
+                },
+            }
+        ],
+    )
+    def test_no_nonce_without_csp_context_processor(self):
+        response = self.client.get(reverse("admin:index"))
+        self.assertNotContains(response, 'nonce="')
+
+    def test_index_base_scripts_have_nonce(self):
+        response = self.client.get(reverse("admin:index"))
+        content = response.content.decode()
+        self.assertRegex(content, r'<script src="[^"]*theme\.js"[^>]*nonce="[^"]+"')
+        self.assertRegex(
+            content, r'<script src="[^"]*nav_sidebar\.js"[^>]*nonce="[^"]+"'
+        )
+
+    def test_index_base_links_have_nonce(self):
+        response = self.client.get(reverse("admin:index"))
+        content = response.content.decode()
+        self.assertRegex(content, r'<link[^>]+base\.css"[^>]*nonce="[^"]+"')
+        self.assertRegex(content, r'<link[^>]+dashboard\.css"[^>]*nonce="[^"]+"')
+
+    def test_change_form_scripts_have_nonce(self):
+        response = self.client.get(
+            reverse("admin:auth_user_change", args=[self.superuser.pk])
+        )
+        content = response.content.decode()
+        self.assertRegex(
+            content, r'<script[^>]*src="[^"]*change_form\.js"[^>]*nonce="[^"]+"'
+        )
+
+    def test_change_form_links_have_nonce(self):
+        response = self.client.get(
+            reverse("admin:auth_user_change", args=[self.superuser.pk])
+        )
+        self.assertRegex(
+            response.content.decode(), r'<link[^>]+forms\.css"[^>]*nonce="[^"]+"'
+        )
+
+    def test_change_list_scripts_have_nonce(self):
+        response = self.client.get(reverse("admin:auth_user_changelist"))
+        self.assertRegex(
+            response.content.decode(),
+            r'<script src="[^"]*filters\.js"[^>]*nonce="[^"]+"',
+        )
+
+    def test_change_list_links_have_nonce(self):
+        response = self.client.get(reverse("admin:auth_user_changelist"))
+        self.assertRegex(
+            response.content.decode(), r'<link[^>]+changelists\.css"[^>]*nonce="[^"]+"'
+        )
+
+    def test_delete_confirmation_script_has_nonce(self):
+        response = self.client.get(
+            reverse("admin:auth_user_delete", args=[self.superuser.pk])
+        )
+        self.assertRegex(
+            response.content.decode(),
+            r'<script src="[^"]*cancel\.js"[^>]*nonce="[^"]+"',
+        )
+
+    def test_login_link_has_nonce(self):
+        self.client.logout()
+        response = self.client.get(reverse("admin:login"))
+        self.assertRegex(
+            response.content.decode(), r'<link[^>]+login\.css"[^>]*nonce="[^"]+"'
+        )

--- a/tests/view_tests/tests/test_csrf.py
+++ b/tests/view_tests/tests/test_csrf.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 from django.template import TemplateDoesNotExist
 from django.test import Client, RequestFactory, SimpleTestCase, override_settings
+from django.utils.csp import CSP
 from django.utils.translation import override
 from django.views.csrf import CSRF_FAILURE_TEMPLATE_NAME, csrf_failure
 
@@ -112,6 +113,37 @@ class CsrfViewTests(SimpleTestCase):
         """A custom CSRF_FAILURE_TEMPLATE_NAME is used."""
         response = self.client.post("/")
         self.assertContains(response, "Test template for CSRF failure", status_code=403)
+        self.assertIs(response.wsgi_request, response.context.request)
+
+    @override_settings(
+        TEMPLATES=[
+            {
+                "BACKEND": "django.template.backends.django.DjangoTemplates",
+                "OPTIONS": {
+                    "loaders": [
+                        (
+                            "django.template.loaders.locmem.Loader",
+                            {CSRF_FAILURE_TEMPLATE_NAME: ("{% csp_nonce_attr %}")},
+                        ),
+                    ],
+                    "context_processors": [
+                        "django.template.context_processors.csp",
+                    ],
+                },
+            }
+        ],
+        MIDDLEWARE=[
+            "django.middleware.csrf.CsrfViewMiddleware",
+            "django.middleware.csp.ContentSecurityPolicyMiddleware",
+        ],
+        SECURE_CSP={
+            "default-src": [CSP.NONCE],
+        },
+    )
+    def test_custom_template_with_csp_nonce(self):
+        """A custom CSRF_FAILURE_TEMPLATE_NAME with a CSP nonce is used."""
+        response = self.client.post("/")
+        self.assertContains(response, "nonce=", status_code=403)
         self.assertIs(response.wsgi_request, response.context.request)
 
     def test_custom_template_does_not_exist(self):


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-36825

#### Branch description

Error pages, admin, and registration templates were updated to use `{% csp_nonce %}` on their explicit `<script>`, `<link>`, and `<style>` HTML elements.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
