### PR TITLE
Fixed #37096 -- Fixed test_invalid_choice_db_option on Python 3.14.5+.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -598,6 +598,7 @@ answer newbie questions, and generally made Django that much better:
     Karderio <karderio@gmail.com>
     Karen Tracey <kmtracey@gmail.com>
     Karol Sikora <elektrrrus@gmail.com>
+    Kasey Steinhauer <kstein257@gmail.com>
     Kasun Herath <kasunh01@gmail.com>
     Katherine “Kati” Michel <kthrnmichel@gmail.com>
     Kathryn Killebrew <kathryn.killebrew@gmail.com>

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -2450,7 +2450,8 @@ class CommandDBOptionChoiceTests(SimpleTestCase):
         if PY314:
             expected_error = (
                 r"Error: argument --database: invalid choice: 'deflaut', "
-                r"maybe you meant 'default'\? \(choose from default, other\)"
+                r"maybe you meant 'default'\? "
+                r"\(choose from '?default'?, '?other'?\)"
             )
         else:
             expected_error = (


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

[ticket-37096](https://code.djangoproject.com/ticket/37096)

#### Branch description
On Python 3.14.5+, `CommandDBOptionChoiceTests.test_invalid_choice_db_option` fails because [cpython#130750](https://github.com/python/cpython/issues/130750) (3.14 backport via [cpython#149385](https://github.com/python/cpython/pull/149385)) restored quoting of choice values in `argparse` "invalid choice" error messages — going from `(choose from default, other)` to `(choose from 'default', 'other')`. The `PY314` regex (added for #36321) expected the unquoted form.

This mirrors the pre-3.14 branch's `'?default'?, '?other'?` pattern so the regex tolerates both forms. Verified on Python 3.14.5: full suite passes (19,257 tests).


#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
