### PR TITLE
Fixed #37097 -- Made Query.clear_ordering() clear ordering on combined queries also.

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1703,8 +1703,8 @@ class QuerySet(AltersData):
         # Clear limits and ordering so they can be reapplied
         clone.query.clear_ordering(force=True)
         clone.query.default_ordering = True
+        self._clear_ordering_in_combined_queries(clone.query, other_qs)
         clone.query.clear_limits()
-        clone.query.combined_queries = (self.query, *(qs.query for qs in other_qs))
         clone.query.combinator = combinator
         clone.query.combinator_all = all
         return clone
@@ -2334,6 +2334,14 @@ class QuerySet(AltersData):
                 f"Cannot use QuerySet.{method}() on an unordered queryset performing "
                 f"aggregation. Add an ordering with order_by()."
             )
+
+    def _clear_ordering_in_combined_queries(self, cloned_query, other_qs):
+        combined_queries = [self.query]
+        for qs in other_qs:
+            query = qs.query.clone()
+            query.clear_ordering(force=False, clear_default=False)
+            combined_queries.append(query)
+        cloned_query.combined_queries = tuple(combined_queries)
 
 
 class InstanceCheckMeta(type):

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -590,6 +590,10 @@ class SQLCompiler:
                     raise DatabaseError(
                         "LIMIT/OFFSET not allowed in subqueries of compound statements."
                     )
+                if compiler.get_order_by():
+                    raise DatabaseError(
+                        "ORDER BY not allowed in subqueries of compound statements."
+                    )
         parts = []
         empty_compiler = None
         for compiler in compilers:

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -640,15 +640,6 @@ class SQLCompiler:
         if selected is not None and compiler.query.selected is None:
             compiler.query = compiler.query.clone()
             compiler.query.set_values(selected)
-        if (
-            (
-                features.requires_compound_order_by_subquery
-                and not features.ignores_unnecessary_order_by_in_subqueries
-            )
-            or not features.supports_parentheses_in_compound
-        ) and compiler.get_order_by():
-            compiler.query = compiler.query.clone()
-            compiler.query.clear_ordering(force=False)
         part_sql, part_args = compiler.as_sql(with_col_aliases=True)
         if compiler.query.combinator:
             # Wrap in a subquery if wrapping in parentheses isn't

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -2402,6 +2402,8 @@ class Query(BaseExpression):
         self.extra_order_by = ()
         if clear_default:
             self.default_ordering = False
+        for query in self.combined_queries:
+            query.clear_ordering(force=False, clear_default=clear_default)
 
     def set_group_by(self, allow_aliases=True):
         """

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -2402,6 +2402,9 @@ class Query(BaseExpression):
         self.extra_order_by = ()
         if clear_default:
             self.default_ordering = False
+        # Ordering is cleared on combined queries with clear_default=False
+        # when union() and analogues are called, so percolate any possible
+        # clear_default=True.
         for query in self.combined_queries:
             query.clear_ordering(force=False, clear_default=clear_default)
 

--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -625,7 +625,11 @@ class QuerySetSetOperationTests(TestCase):
     def test_count_union_with_select_related_in_values(self):
         e1 = ExtraInfo.objects.create(value=1, info="e1")
         a1 = Author.objects.create(name="a1", num=1, extra=e1)
-        qs = Author.objects.select_related("extra").values("pk", "name", "extra__value")
+        qs = (
+            Author.objects.select_related("extra")
+            .order_by()
+            .values("pk", "name", "extra__value")
+        )
         self.assertCountEqual(
             qs.union(qs), [{"pk": a1.id, "name": "a1", "extra__value": 1}]
         )
@@ -706,9 +710,11 @@ class QuerySetSetOperationTests(TestCase):
         msg = "LIMIT/OFFSET not allowed in subqueries of compound statements"
         with self.assertRaisesMessage(DatabaseError, msg):
             list(qs1.union(qs2[:10]))
-        # Unioning ordered queries is permitted.
-        list(qs1.order_by("id").union(qs2))
-        list(qs1.union(qs2).order_by("id").union(qs3))
+        msg = "ORDER BY not allowed in subqueries of compound statements."
+        with self.assertRaisesMessage(DatabaseError, msg):
+            list(qs1.order_by("id").union(qs2))
+        with self.assertRaisesMessage(DatabaseError, msg):
+            list(qs1.union(qs2).order_by("id").union(qs3))
 
     @skipIfDBFeature("supports_select_intersection")
     def test_unsupported_intersection_raises_db_error(self):

--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -578,6 +578,23 @@ class QuerySetSetOperationTests(TestCase):
             ordered=False,
         )
 
+    def test_double_union_in_with_default_ordering(self):
+        e1 = ExtraInfo.objects.create(value=7, info="e1")
+        Author.objects.bulk_create(
+            [Author(num=i, name=f"a{i}", extra=e1) for i in range(1, 8)]
+        )
+        qs1 = Author.objects.filter(num__lt=2)
+        qs2 = Author.objects.filter(num__gt=6)
+        qs3 = Author.objects.filter(num=4)
+        double_union = qs1.union(qs2).union(qs3)
+        # Target a column (num) other than the ordering column (name). Before,
+        # on Postgres: "each UNION query must have the same number of columns".
+        self.assertQuerySetEqual(
+            Author.objects.filter(num__in=double_union.values("num")).order_by("-name"),
+            ["a7", "a4", "a1"],
+            transform=lambda au: au.name,
+        )
+
     @skipUnlessDBFeature(
         "supports_slicing_ordering_in_compound", "allow_sliced_subqueries_with_in"
     )


### PR DESCRIPTION
#### Trac ticket number
ticket-37097

#### Branch description
We remove ordering on combined queries (the inner queries of a union/intersection/difference) when using the `__in` lookup, since at least d8c90d4c22cb218f1c170eba086c53d3dff7fbc0, but we weren't doing this recursively.

Thanks @shaib for the report, @charettes for the implementation idea, and @dcsid for the initial patch.

087bb9e8f3478d53f12b1737af865992af17c5f2 drove more traffic into this by applying default orderings after `union()`. So even though the same error would have been reachable with an explicit `order_by()`, e.g. `union().order_by().union().order_by()`, we can consider it a regression.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
