### PR TITLE
Fixed #26066 -- Improved handling of wide admin changelist tables.

### DIFF
--- a/django/contrib/admin/static/admin/css/changelists.css
+++ b/django/contrib/admin/static/admin/css/changelists.css
@@ -50,6 +50,10 @@
     width: 100%;
 }
 
+#changelist-form .results table {
+    overflow-wrap: break-word;
+}
+
 #changelist .toplinks {
     border-bottom: 1px solid var(--hairline-color);
 }
@@ -85,7 +89,6 @@
 
 #changelist table thead th {
     padding: 0;
-    white-space: nowrap;
     vertical-align: middle;
 }
 

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -125,6 +125,10 @@ Minor features
 * :attr:`~django.contrib.admin.ModelAdmin.list_display` now uses boolean icons
   for boolean fields on related models.
 
+* The admin change list page now handles wide tables more gracefully. Table
+  column headers can now wrap instead of forcing horizontal overflow, and long
+  cell content is broken to prevent overflow.
+
 :mod:`django.contrib.admindocs`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
#### Trac ticket number
ticket-26066

#### Branch description
The admin change list page's table overflows horizontally with the scrollbar hidden at the bottom of a potentially very long table, requiring the user to scroll all the way down before they can scroll sideways.

This fix makes two CSS improvements to `django/contrib/admin/static/admin/css/changelists.css`:
1. Removes `white-space: nowrap` from `#changelist table thead th` so headers can wrap to multiple lines, preventing many overflow scenarios.
2. Adds `overflow-wrap: break-word` to `.results table` so long unbroken strings (URLs, codes, etc.) wrap instead of forcing the table wider.

The existing `overflow-x: auto` is preserved as a fallback for extreme cases.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

AI tools used: Claude Code (opencode) was used to assist with code changes and PR preparation. All changes have been reviewed and verified.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
