### PR TITLE
Pinned selenium version to "<4.44.0" due to change in get_attribute("class") behavior.

### DIFF
--- a/tests/requirements/py3.txt
+++ b/tests/requirements/py3.txt
@@ -14,7 +14,7 @@ pymemcache >= 3.4.0
 pywatchman; sys_platform != 'win32'
 PyYAML >= 6.0.2
 redis >= 5.1.0
-selenium >= 4.23.0
+selenium >= 4.23.0,<4.44.0
 sqlparse >= 0.5.0
 tblib >= 3.0.0
 tzdata


### PR DESCRIPTION
Before selenium 4.44.0, target_element.get_attribute("class") returned "" when there was no class attribute. This now returns None.

Reported to selenium here: https://github.com/SeleniumHQ/selenium/issues/17448
