### PR TITLE
Fixed #37092, Refs #35870 -- Added missing deprecation warnings for USE_BLANK_CHOICE_DASH.

### DIFF
--- a/django/conf/__init__.py
+++ b/django/conf/__init__.py
@@ -25,6 +25,7 @@ ENVIRONMENT_VARIABLE = "DJANGO_SETTINGS_MODULE"
 DEFAULT_STORAGE_ALIAS = "default"
 STATICFILES_STORAGE_ALIAS = "staticfiles"
 
+# RemovedInDjango70Warning.
 USE_BLANK_CHOICE_DASH_DEPRECATED_MSG = (
     "The USE_BLANK_CHOICE_DASH setting is deprecated. If you wish to define "
     "your own default blank choice label, override "
@@ -148,6 +149,11 @@ class LazySettings(LazyObject):
             self.__dict__.pop(name, None)
 
         # RemovedInDjango70Warning.
+        if name == "USE_BLANK_CHOICE_DASH":
+            _show_settings_deprecation_warning(
+                USE_BLANK_CHOICE_DASH_DEPRECATED_MSG, RemovedInDjango70Warning
+            )
+        # RemovedInDjango70Warning.
         if name == "MAILERS":
             # When MAILERS is set, clear any cached values of
             # deprecated settings so that __getattr__() runs again for them.
@@ -254,6 +260,13 @@ class Settings:
                 self._explicit_settings.add(setting)
 
         # RemovedInDjango70Warning.
+        if "USE_BLANK_CHOICE_DASH" in self._explicit_settings:
+            warnings.warn(
+                USE_BLANK_CHOICE_DASH_DEPRECATED_MSG,
+                RemovedInDjango70Warning,
+                skip_file_prefixes=django_file_prefixes(),
+            )
+        # RemovedInDjango70Warning.
         _check_email_settings_conflicts(self._explicit_settings)
         for name in DEPRECATED_EMAIL_SETTINGS.intersection(self._explicit_settings):
             warnings.warn(
@@ -307,10 +320,8 @@ class UserSettingsHolder:
     def __setattr__(self, name, value):
         self._deleted.discard(name)
         if name == "USE_BLANK_CHOICE_DASH":
-            warnings.warn(
-                USE_BLANK_CHOICE_DASH_DEPRECATED_MSG,
-                RemovedInDjango70Warning,
-                skip_file_prefixes=django_file_prefixes(),
+            _show_settings_deprecation_warning(
+                USE_BLANK_CHOICE_DASH_DEPRECATED_MSG, RemovedInDjango70Warning
             )
         # RemovedInDjango70Warning.
         if name in DEPRECATED_EMAIL_SETTINGS:

--- a/tests/deprecation/test_use_blank_choice_dash.py
+++ b/tests/deprecation/test_use_blank_choice_dash.py
@@ -1,0 +1,41 @@
+import sys
+from types import ModuleType
+
+from django.conf import (
+    USE_BLANK_CHOICE_DASH_DEPRECATED_MSG,
+    LazySettings,
+    Settings,
+    settings,
+)
+from django.test import SimpleTestCase
+from django.utils.deprecation import RemovedInDjango70Warning
+
+
+# RemovedInDjango70Warning.
+class UseBlankChoiceDashDeprecationTests(SimpleTestCase):
+    msg = USE_BLANK_CHOICE_DASH_DEPRECATED_MSG
+
+    def test_override_settings_warning(self):
+        with self.assertRaisesMessage(RemovedInDjango70Warning, self.msg):
+            with self.settings(USE_BLANK_CHOICE_DASH=True):
+                pass
+
+    def test_settings_init_warning(self):
+        settings_module = ModuleType("fake_settings_module")
+        settings_module.USE_TZ = False
+        settings_module.USE_BLANK_CHOICE_DASH = True
+        sys.modules["fake_settings_module"] = settings_module
+        try:
+            with self.assertRaisesMessage(RemovedInDjango70Warning, self.msg):
+                Settings("fake_settings_module")
+        finally:
+            del sys.modules["fake_settings_module"]
+
+    def test_settings_assignment_warning(self):
+        settings = LazySettings()
+        with self.assertRaisesMessage(RemovedInDjango70Warning, self.msg):
+            settings.USE_BLANK_CHOICE_DASH = True
+
+    def test_access(self):
+        # Warning is not raised on access.
+        self.assertEqual(settings.USE_BLANK_CHOICE_DASH, False)


### PR DESCRIPTION
#### Trac ticket number
ticket-37092
ticket-35870

#### Branch description
Need to issue deprecation warnings in regular cases, not just uses of `override_settings()`.

Follow-up to 63c56cda133a85a158502891c40465bc0331d3d9.

Modeled on 5d80843ebc5376d00f98bf2a6aadbada4c29365c.

cc/ @annalauraw

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
