### PR TITLE
Fixed #25230 -- Optimized redundant distinct().count() queries.

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -654,7 +654,41 @@ class Query(BaseExpression):
         Perform a COUNT() query using the current filter constraints.
         """
         obj = self.clone()
+        if obj.distinct and obj._distinct_is_redundant_for_count():
+            obj.distinct = False
         return obj.get_aggregation(using, {"__count": Count("*")})["__count"]
+
+    def _distinct_is_redundant_for_count(self):
+        """
+        Return whether distinct() can be elided for count().
+
+        This deliberately handles only base-table row counts where selected
+        results are guaranteed unique by the non-null model primary key. More
+        complex cases, such as joins and annotations, still need the existing
+        DISTINCT subquery to preserve result semantics.
+        """
+        if (
+            self.distinct_fields
+            or self.is_sliced
+            or self.combinator
+            or self.group_by is not None
+            or self.annotations
+            or self.extra
+            or self.extra_tables
+            or self.extra_order_by
+            or self.select_related
+            or self._filtered_relations
+            or self.contains_subquery
+            or self.where.contains_aggregate
+            or self.where.contains_over_clause
+            or self.model._meta.is_composite_pk
+            or self.count_active_tables() > 1
+        ):
+            return False
+        if self.default_cols:
+            return True
+        pk = self.model._meta.pk
+        return any(isinstance(expr, Col) and expr.target == pk for expr in self.select)
 
     def has_filters(self):
         return self.where

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -324,6 +324,10 @@ Models
   Invalid Base64 strings now raise ``ValidationError`` instead of being
   silently accepted.
 
+* :meth:`.QuerySet.count` now avoids a redundant ``DISTINCT`` subquery for
+  base-table :meth:`.QuerySet.distinct` queries where row uniqueness is already
+  guaranteed by the model primary key.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -1418,6 +1418,63 @@ class Queries2Tests(TestCase):
             [self.num8],
         )
 
+    def assertDistinctCountElided(self, queryset, expected):
+        with CaptureQueriesContext(connection) as captured_queries:
+            self.assertEqual(queryset.count(), expected)
+        sql = captured_queries[0]["sql"].lower()
+        self.assertIn("count(*)", sql)
+        self.assertNotIn("select distinct", sql)
+
+    def assertDistinctCountPreserved(self, queryset, expected):
+        with CaptureQueriesContext(connection) as captured_queries:
+            self.assertEqual(queryset.count(), expected)
+        self.assertIn("select distinct", captured_queries[0]["sql"].lower())
+
+    def test_distinct_count_elides_redundant_distinct_for_base_table(self):
+        self.assertDistinctCountElided(Number.objects.distinct(), 3)
+
+    def test_distinct_count_elides_redundant_distinct_when_pk_selected(self):
+        self.assertDistinctCountElided(Number.objects.values("id", "num").distinct(), 3)
+
+    def test_distinct_count_keeps_distinct_when_pk_not_selected(self):
+        Number.objects.create(num=4)
+        self.assertDistinctCountPreserved(Number.objects.values("num").distinct(), 3)
+
+    def test_distinct_count_keeps_distinct_for_multivalued_joins(self):
+        tag1 = Tag.objects.create(name="t1")
+        tag2 = Tag.objects.create(name="t2")
+        note = Note.objects.create(note="n1", misc="m1")
+        extra = ExtraInfo.objects.create(info="e1", note=note)
+        author = Author.objects.create(name="a1", num=1, extra=extra)
+        item = Item.objects.create(
+            name="i1",
+            created=datetime.datetime(2026, 1, 1),
+            creator=author,
+            note=note,
+        )
+        item.tags.add(tag1, tag2)
+
+        self.assertDistinctCountPreserved(
+            Item.objects.filter(tags__in=[tag1, tag2]).distinct(),
+            1,
+        )
+
+    def test_distinct_count_keeps_distinct_for_reverse_fk_joins(self):
+        report = Report.objects.create(name="r1")
+        ReportComment.objects.create(report=report)
+        ReportComment.objects.create(report=report)
+
+        self.assertDistinctCountPreserved(
+            Report.objects.filter(reportcomment__isnull=False).distinct(),
+            1,
+        )
+
+    def test_distinct_count_keeps_distinct_for_annotations(self):
+        self.assertDistinctCountPreserved(
+            Number.objects.annotate(negated_num=-F("num")).distinct(),
+            3,
+        )
+
     def test_ticket12239(self):
         # Custom lookups are registered to round float values correctly on gte
         # and lt IntegerField queries.


### PR DESCRIPTION
#### Trac ticket number

ticket-25230

#### Branch description

Optimizes `QuerySet.distinct().count()` by removing redundant `DISTINCT` only for base-table counts where the model primary key already guarantees row uniqueness.

Scope handled:

- default model-column selections with no joins.
- `values()` / `values_list()` selections that include the model primary key, with no joins.

Scope intentionally unchanged: joins, reverse-FK/multivalued joins, `distinct(*fields)` / `DISTINCT ON`, slicing, grouping, aggregation, annotations, combinators, extra selections/tables/orderings, filtered relations, subqueries, window/aggregate filters, `select_related()`, and composite primary keys.

Local benchmark on a 300,000-row wide table, 5 timed runs per query:

| Backend | Before median | After median | Speedup |
| --- | ---: | ---: | ---: |
| SQLite | 0.050347s | 0.000678s | 74.3x |
| PostgreSQL 16 | 0.057094s | 0.019508s | 2.9x |
| MySQL 8.4 | 0.350377s | 0.010414s | 33.6x |

The optimized SQL changes from a wide `SELECT DISTINCT ...` subquery to a plain `COUNT(*)`. This is intended as a conservative version of the earlier approach in PR #16630.

Tests cover optimized base-table counts, optimized explicit-PK selections, and preserving `DISTINCT` for non-PK selections, multivalued joins, reverse-FK filters, and annotations.

Checks run locally:

- `tests/runtests.py queries --parallel 1 --verbosity 1`
- `tests/runtests.py aggregation --parallel 1 --verbosity 1`
- `black --check django/db/models/sql/query.py tests/queries/tests.py`
- `isort --check-only django/db/models/sql/query.py tests/queries/tests.py`
- `flake8 django/db/models/sql/query.py tests/queries/tests.py`
- `git diff --check`

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Used ChatGPT/Codex to help inspect prior discussion, draft code/tests, and review the patch. I manually reviewed the final diff and verified it locally with the tests and benchmarks listed above.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes. <!-- N/A: no UI changes. -->


