### PR TITLE
Fixed #32969 -- Fixed pickling for classes related to HTTP handling 

### DIFF
--- a/django/core/handlers/asgi.py
+++ b/django/core/handlers/asgi.py
@@ -5,6 +5,7 @@ import tempfile
 import traceback
 from collections import defaultdict
 from contextlib import aclosing, closing
+from io import BytesIO
 
 from asgiref.sync import ThreadSensitiveContext, sync_to_async
 
@@ -145,6 +146,21 @@ class ASGIRequest(HttpRequest):
     def close(self):
         super().close()
         self._stream.close()
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["stream"] = self._stream.read()
+        del state["_stream"]
+        return state
+
+    def __setstate__(self, state):
+        stream = state.pop("stream")
+        self.__dict__.update(state)
+        try:
+            content_length = int(self.scope.get("CONTENT_LENGTH"))
+        except (ValueError, TypeError):
+            content_length = 0
+        self._stream = base.LimitedStream(BytesIO(stream), content_length)
 
 
 class ASGIHandler(base.BaseHandler):
@@ -365,3 +381,7 @@ class ASGIHandler(base.BaseHandler):
                 (position + cls.chunk_size) >= len(data),
             )
             position += cls.chunk_size
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self.load_middleware(is_async=True)

--- a/django/core/handlers/base.py
+++ b/django/core/handlers/base.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import types
 from inspect import iscoroutinefunction
+from io import IOBase
 
 from asgiref.sync import async_to_sync, sync_to_async
 
@@ -16,6 +17,47 @@ from django.utils.module_loading import import_string
 from .exception import convert_exception_to_response
 
 logger = logging.getLogger("django.request")
+
+
+class LimitedStream(IOBase):
+    """
+    Wrap another stream to disallow reading it past a number of bytes.
+
+    Based on the implementation from werkzeug.wsgi.LimitedStream. See:
+    https://github.com/pallets/werkzeug/blob/dbf78f67/src/werkzeug/wsgi.py#L828
+    """
+
+    def __init__(self, stream, limit):
+        self._read = stream.read
+        self._readline = stream.readline
+        self._pos = 0
+        self.limit = limit
+
+    def read(self, size=-1, /):
+        _pos = self._pos
+        limit = self.limit
+        if _pos >= limit:
+            return b""
+        if size == -1 or size is None:
+            size = limit - _pos
+        else:
+            size = min(size, limit - _pos)
+        data = self._read(size)
+        self._pos += len(data)
+        return data
+
+    def readline(self, size=-1, /):
+        _pos = self._pos
+        limit = self.limit
+        if _pos >= limit:
+            return b""
+        if size == -1 or size is None:
+            size = limit - _pos
+        else:
+            size = min(size, limit - _pos)
+        line = self._readline(size)
+        self._pos += len(line)
+        return line
 
 
 class BaseHandler:
@@ -365,6 +407,14 @@ class BaseHandler:
             if response:
                 return response
         return None
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        del state["_view_middleware"]
+        del state["_template_response_middleware"]
+        del state["_exception_middleware"]
+        del state["_middleware_chain"]
+        return state
 
 
 def reset_urlconf(sender, **kwargs):

--- a/django/core/handlers/wsgi.py
+++ b/django/core/handlers/wsgi.py
@@ -1,4 +1,4 @@
-from io import IOBase
+from io import BytesIO
 
 from django.conf import settings
 from django.core import signals
@@ -10,47 +10,6 @@ from django.utils.functional import cached_property
 from django.utils.regex_helper import _lazy_re_compile
 
 _slashes_re = _lazy_re_compile(rb"/+")
-
-
-class LimitedStream(IOBase):
-    """
-    Wrap another stream to disallow reading it past a number of bytes.
-
-    Based on the implementation from werkzeug.wsgi.LimitedStream. See:
-    https://github.com/pallets/werkzeug/blob/dbf78f67/src/werkzeug/wsgi.py#L828
-    """
-
-    def __init__(self, stream, limit):
-        self._read = stream.read
-        self._readline = stream.readline
-        self._pos = 0
-        self.limit = limit
-
-    def read(self, size=-1, /):
-        _pos = self._pos
-        limit = self.limit
-        if _pos >= limit:
-            return b""
-        if size == -1 or size is None:
-            size = limit - _pos
-        else:
-            size = min(size, limit - _pos)
-        data = self._read(size)
-        self._pos += len(data)
-        return data
-
-    def readline(self, size=-1, /):
-        _pos = self._pos
-        limit = self.limit
-        if _pos >= limit:
-            return b""
-        if size == -1 or size is None:
-            size = limit - _pos
-        else:
-            size = min(size, limit - _pos)
-        line = self._readline(size)
-        self._pos += len(line)
-        return line
 
 
 class WSGIRequest(HttpRequest):
@@ -75,7 +34,7 @@ class WSGIRequest(HttpRequest):
             content_length = int(environ.get("CONTENT_LENGTH"))
         except (ValueError, TypeError):
             content_length = 0
-        self._stream = LimitedStream(self.environ["wsgi.input"], content_length)
+        self._stream = base.LimitedStream(self.environ["wsgi.input"], content_length)
         self._read_started = False
         self.resolver_match = None
 
@@ -108,6 +67,28 @@ class WSGIRequest(HttpRequest):
         return self._files
 
     POST = property(_get_post, _set_post)
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        errb = b""
+        if self.environ.get("wsgi.errors"):
+            errb = self.environ["wsgi.errors"].getvalue()
+        state["environ"]["wsgi.input"] = self._stream.read()
+        state["environ"]["wsgi.errors"] = errb
+        del state["META"]
+        del state["_stream"]
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self.environ["wsgi.input"] = BytesIO(self.environ["wsgi.input"])
+        self.environ["wsgi.errors"] = BytesIO(self.environ["wsgi.errors"])
+        self.META = self.environ
+        try:
+            content_length = int(self.environ.get("CONTENT_LENGTH"))
+        except (ValueError, TypeError):
+            content_length = 0
+        self._stream = base.LimitedStream(self.environ["wsgi.input"], content_length)
 
 
 class WSGIHandler(base.BaseHandler):
@@ -142,6 +123,10 @@ class WSGIHandler(base.BaseHandler):
                 response.file_to_stream, response.block_size
             )
         return response
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self.load_middleware(is_async=False)
 
 
 def get_path_info(environ):

--- a/django/core/servers/basehttp.py
+++ b/django/core/servers/basehttp.py
@@ -15,7 +15,7 @@ from collections import deque
 from wsgiref import simple_server
 
 from django.core.exceptions import ImproperlyConfigured
-from django.core.handlers.wsgi import LimitedStream
+from django.core.handlers.base import LimitedStream
 from django.core.wsgi import get_wsgi_application
 from django.db import connections
 from django.utils.log import log_message

--- a/django/template/base.py
+++ b/django/template/base.py
@@ -290,6 +290,24 @@ class Template:
             "end": end,
         }
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["engine"] = str(self.engine)
+        state["origin"] = self.origin.name
+        state["loader"] = str(self.origin.loader)
+        del state["nodelist"]
+        return state
+
+    def __setstate(self, state):
+        from .engine import _engine_list
+
+        self.__dict__.update(state)
+        self.engine = _engine_list(using=state["engine"])
+        self.origin = Origin(
+            state["origin"], template_name=state["name"], loader=state["loader"]
+        )
+        self.nodelist = self.compile_nodelist()
+
 
 class PartialTemplate:
     """

--- a/django/test/client.py
+++ b/django/test/client.py
@@ -14,8 +14,8 @@ from asgiref.sync import sync_to_async
 
 from django.conf import settings
 from django.core.handlers.asgi import ASGIRequest
-from django.core.handlers.base import BaseHandler
-from django.core.handlers.wsgi import LimitedStream, WSGIRequest
+from django.core.handlers.base import BaseHandler, LimitedStream
+from django.core.handlers.wsgi import WSGIRequest
 from django.core.serializers.json import DjangoJSONEncoder
 from django.core.signals import got_request_exception, request_finished, request_started
 from django.db import close_old_connections
@@ -209,6 +209,10 @@ class ClientHandler(BaseHandler):
 
         return response
 
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self.load_middleware()
+
 
 class AsyncClientHandler(BaseHandler):
     """An async version of ClientHandler."""
@@ -260,6 +264,10 @@ class AsyncClientHandler(BaseHandler):
             await sync_to_async(response.close, thread_sensitive=False)()
             request_finished.connect(close_old_connections)
         return response
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self.load_middleware(is_async=True)
 
 
 def store_rendered_templates(store, signal, sender, template, context, **kwargs):

--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -11,7 +11,6 @@ import inspect
 import re
 import string
 from importlib import import_module
-from pickle import PicklingError
 from urllib.parse import quote
 
 from asgiref.local import Local
@@ -101,8 +100,14 @@ class ResolverMatch:
             )
         )
 
-    def __reduce_ex__(self, protocol):
-        raise PicklingError(f"Cannot pickle {self.__class__.__qualname__}.")
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        del state["func"]
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self.func = get_callable(state["_func_path"])
 
 
 def get_resolver(urlconf=None):
@@ -498,6 +503,16 @@ class URLPattern:
         elif not hasattr(callback, "__name__"):
             return callback.__module__ + "." + callback.__class__.__name__
         return callback.__module__ + "." + callback.__qualname__
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["lookup_str"] = self.lookup_str
+        del state["callback"]
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self.callback = get_callable(state["lookup_str"])
 
 
 class URLResolver:

--- a/tests/requests_tests/tests.py
+++ b/tests/requests_tests/tests.py
@@ -7,7 +7,8 @@ from urllib.parse import urlencode
 from django.core.exceptions import BadRequest, DisallowedHost
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.core.files.uploadhandler import MemoryFileUploadHandler
-from django.core.handlers.wsgi import LimitedStream, WSGIRequest
+from django.core.handlers.base import LimitedStream
+from django.core.handlers.wsgi import WSGIRequest
 from django.http import (
     HttpHeaders,
     HttpRequest,

--- a/tests/test_client/tests.py
+++ b/tests/test_client/tests.py
@@ -22,6 +22,7 @@ rather than the HTML rendered to the end-user.
 
 import copy
 import itertools
+import pickle
 import tempfile
 from unittest import mock
 
@@ -100,6 +101,86 @@ class ClientTest(TestCase):
         self.assertIs(response_copy.client, response.client)
         self.assertIs(response_copy.resolver_match, response.resolver_match)
         self.assertIs(response_copy.asgi_request, response.asgi_request)
+
+    def test_pickle_response(self):
+        response = self.client.get("/cbv_view/")
+        pickled = pickle.dumps(response)
+        new_response = pickle.loads(pickled)
+        self.assertIsNot(new_response, response)
+        self.assertIsNot(new_response.resolver_match, response.resolver_match)
+        self.assertIsNot(new_response.wsgi_request, response.wsgi_request)
+        for key in [
+            "headers",
+            "cookies",
+            "closed",
+            "_reason_phrase",
+            "_is_rendered",
+            "exc_info",
+        ]:
+            with self.subTest(key=key):
+                self.assertEqual(new_response.__dict__[key], response.__dict__[key])
+        for key in [
+            "path",
+            "method",
+            "content_type",
+            "content_params",
+            "_read_started",
+            "COOKIES",
+        ]:
+            with self.subTest(key=key):
+                self.assertEqual(
+                    new_response.wsgi_request.__dict__[key],
+                    response.wsgi_request.__dict__[key],
+                )
+        for key in ["defaults", "cookies", "exc_info", "extra", "headers"]:
+            with self.subTest(key=key):
+                self.assertEqual(
+                    new_response.client.__dict__[key], response.client.__dict__[key]
+                )
+        self.assertEqual(
+            repr(response.resolver_match.__dict__["_wrapped"]),
+            repr(new_response.resolver_match),
+        )
+
+    async def test_pickle_response_async(self):
+        response = await self.async_client.get("/cbv_view/")
+        pickled = pickle.dumps(response)
+        new_response = pickle.loads(pickled)
+        self.assertIsNot(new_response, response)
+        self.assertIsNot(new_response.resolver_match, response.resolver_match)
+        self.assertIsNot(new_response.asgi_request, response.asgi_request)
+        for key in [
+            "headers",
+            "cookies",
+            "closed",
+            "_reason_phrase",
+            "_is_rendered",
+            "exc_info",
+        ]:
+            with self.subTest(key=key):
+                self.assertEqual(new_response.__dict__[key], response.__dict__[key])
+        for key in [
+            "path",
+            "method",
+            "content_type",
+            "content_params",
+            "_read_started",
+            "COOKIES",
+        ]:
+            with self.subTest(key=key):
+                self.assertEqual(
+                    new_response.asgi_request.__dict__[key],
+                    response.asgi_request.__dict__[key],
+                )
+        for key in ["defaults", "cookies", "exc_info", "extra", "headers"]:
+            with self.subTest(key=key):
+                self.assertEqual(
+                    new_response.client.__dict__[key], response.client.__dict__[key]
+                )
+        self.assertEqual(
+            repr(response.resolver_match.__dict__["_wrapped"]),
+            repr(new_response.resolver_match),
+        )
 
     def test_query_string_encoding(self):
         # WSGI requires latin-1 encoded strings.

--- a/tests/urlpatterns_reverse/tests.py
+++ b/tests/urlpatterns_reverse/tests.py
@@ -2,6 +2,7 @@
 Unit tests for reverse URL lookups.
 """
 
+import copy
 import pickle
 import sys
 import threading
@@ -1689,9 +1690,20 @@ class ResolverMatchTests(SimpleTestCase):
 
     @override_settings(ROOT_URLCONF="urlpatterns.path_urls")
     def test_pickling(self):
-        msg = "Cannot pickle ResolverMatch."
-        with self.assertRaisesMessage(pickle.PicklingError, msg):
-            pickle.dumps(resolve("/users/"))
+        resolver_match = resolve("/users/")
+        pickled = pickle.dumps(resolver_match)
+        new_match = pickle.loads(pickled)
+        self.assertEqual(resolver_match.func, new_match.func)
+        self.assertEqual(resolver_match.route, new_match.route)
+        self.assertEqual(len(resolver_match.tried), len(new_match.tried))
+
+    @override_settings(ROOT_URLCONF="urlpatterns.path_urls")
+    def test_copy(self):
+        resolver_match = resolve("/users/")
+        new_match = copy.copy(resolver_match)
+        self.assertEqual(resolver_match.__dict__, new_match.__dict__)
+        self.assertEqual(resolver_match.route, new_match.route)
+        self.assertEqual(len(resolver_match.tried), len(new_match.tried))
 
 
 @override_settings(ROOT_URLCONF="urlpatterns_reverse.erroneous_urls")


### PR DESCRIPTION
#### Trac ticket number
ticket-32969

#### Branch description
Several classes associated with HTTP handling have attributes that reference objects that can't be pickled.  Previous fixes have tried removing the attributes that won't pickle, but since the attributes weren't replaced with `__setstate__`, copied or unpickled objects were missing them. 

This PR adds  `__getstate__` and `__setstate__` methods to these classes, allowing instances to serialize and deserialize properly. I see that this approach was discussed on #14664, and rejected as incorrect because urlconf could have changed after the `ResolverMatch` instance was pickled. However, the unpicklable objects are only present in responses created by the test client, and the reason for their inclusion is documented.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [X] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [X] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [X] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [X] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
- [X] I have attached screenshots in both light and dark modes for any UI changes.
