### PR TITLE
Fixed #37065 -- Doc'd method_decorator usage on dispatch for async views

### DIFF
--- a/docs/topics/async.txt
+++ b/docs/topics/async.txt
@@ -117,6 +117,26 @@ For example::
     @never_cache
     async def my_async_view(request): ...
 
+:func:`~django.utils.decorators.method_decorator` can be used with asynchronous
+methods, including ``async def`` view handlers. Note, though, that if
+decorating :meth:`~django.views.generic.base.View.dispatch` on a ``View`` with
+asynchronous handlers, you will need to override ``dispatch`` to make it
+``async def`` as well::
+
+    class MyClass(View):
+        @method_decorator(never_cache)
+        async def dispatch(self, *args, **kwargs):
+            return super().dispatch(*args, **kwargs)
+
+        async def get(self, request): ...
+
+        async def post(self, request): ...
+
+Here, because we are decorating ``dispatch``, rather than the individual
+handler methods, we need to make ``dispatch`` asynchronous so that
+``method_decorator`` can correctly mark the resulting method as a coroutine
+function.
+
 Queries & the ORM
 -----------------
 


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->



ticket-37065

#### Branch description

Added a documentation example for using `method_decorator` on `dispatch` for View subclasses with async handlers. 

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
