### PR TITLE
Fixed #37102 -- Fixed CountsDict bug: *kwargs → **kwargs in super().__init__() call.

### DIFF
--- a/django/utils/html.py
+++ b/django/utils/html.py
@@ -278,7 +278,7 @@ def smart_urlquote(url):
 
 class CountsDict(dict):
     def __init__(self, *args, word, **kwargs):
-        super().__init__(*args, *kwargs)
+        super().__init__(*args, **kwargs)
         self.word = word
 
     def __missing__(self, key):

--- a/tests/utils_tests/test_html.py
+++ b/tests/utils_tests/test_html.py
@@ -10,6 +10,7 @@ from django.test.utils import override_settings
 from django.utils.deprecation import RemovedInDjango70Warning
 from django.utils.functional import lazystr
 from django.utils.html import (
+    CountsDict,
     conditional_escape,
     escape,
     escapejs,
@@ -525,3 +526,31 @@ class TestUtilsHtml(SimpleTestCase):
         for value in tests:
             with self.subTest(value=value):
                 self.assertEqual(urlize(value), value)
+
+
+class TestCountsDict(SimpleTestCase):
+    def test_init_with_kwargs(self):
+        """CountsDict correctly passes kwargs to dict.__init__."""
+        d = CountsDict(word="hello", a=1, b=2)
+        self.assertEqual(d["a"], 1)
+        self.assertEqual(d["b"], 2)
+        self.assertEqual(d.word, "hello")
+
+    def test_init_with_no_kwargs(self):
+        """CountsDict works when only word is provided."""
+        d = CountsDict(word="test")
+        self.assertEqual(d.word, "test")
+
+    def test_missing_key_counts_in_word(self):
+        """__missing__ returns the count of key characters in word."""
+        d = CountsDict(word="hello")
+        self.assertEqual(d["l"], 2)
+        self.assertEqual(d["h"], 1)
+        self.assertEqual(d["z"], 0)
+
+    def test_missing_key_caches_result(self):
+        """__missing__ caches the computed count in the dict."""
+        d = CountsDict(word="banana")
+        self.assertNotIn("a", d)
+        self.assertEqual(d["a"], 3)
+        self.assertIn("a", d)


### PR DESCRIPTION
Fixed #37102.

## Summary

The `CountsDict` class in `django/utils/html.py` had a bug in its `__init__` method where `*kwargs` (positional unpacking) was used instead of `**kwargs` (keyword unpacking) when calling `super().__init__()`.

```python
# Before (bug):
super().__init__(*args, *kwargs)

# After (fix):
super().__init__(*args, **kwargs)
```

While this never triggers in current usage (`CountsDict` is only called with `word=middle`), it would fail if any keyword arguments were passed.

## Changes

- Fixed `*kwargs` → `**kwargs` in `django/utils/html.py` line 281
- Added `TestCountsDict` regression tests in `tests/utils_tests/test_html.py` (4 tests)

All existing tests continue to pass.