### PR TITLE
Fixed #37102 -- Fixed CountsDict bug: *kwargs → **kwargs in super().__init__() call.

### DIFF
--- a/django/utils/html.py
+++ b/django/utils/html.py
@@ -278,7 +278,7 @@ def smart_urlquote(url):
 
 class CountsDict(dict):
     def __init__(self, *args, word, **kwargs):
-        super().__init__(*args, *kwargs)
+        super().__init__(*args, **kwargs)
         self.word = word
 
     def __missing__(self, key):

--- a/tests/utils_tests/test_html.py
+++ b/tests/utils_tests/test_html.py
@@ -10,6 +10,7 @@ from django.test.utils import override_settings
 from django.utils.deprecation import RemovedInDjango70Warning
 from django.utils.functional import lazystr
 from django.utils.html import (
+    CountsDict,
     conditional_escape,
     escape,
     escapejs,
@@ -525,3 +526,31 @@ class TestUtilsHtml(SimpleTestCase):
         for value in tests:
             with self.subTest(value=value):
                 self.assertEqual(urlize(value), value)
+
+
+class TestCountsDict(SimpleTestCase):
+    def test_init_with_kwargs(self):
+        """CountsDict correctly passes kwargs to dict.__init__."""
+        d = CountsDict(word="hello", a=1, b=2)
+        self.assertEqual(d["a"], 1)
+        self.assertEqual(d["b"], 2)
+        self.assertEqual(d.word, "hello")
+
+    def test_init_with_no_kwargs(self):
+        """CountsDict works when only word is provided."""
+        d = CountsDict(word="test")
+        self.assertEqual(d.word, "test")
+
+    def test_missing_key_counts_in_word(self):
+        """__missing__ returns the count of key characters in word."""
+        d = CountsDict(word="hello")
+        self.assertEqual(d["l"], 2)
+        self.assertEqual(d["h"], 1)
+        self.assertEqual(d["z"], 0)
+
+    def test_missing_key_caches_result(self):
+        """__missing__ caches the computed count in the dict."""
+        d = CountsDict(word="banana")
+        self.assertNotIn("a", d)
+        self.assertEqual(d["a"], 3)
+        self.assertIn("a", d)


### PR DESCRIPTION
#### Trac ticket number

ticket-37102

#### Branch description

The \`CountsDict\` class in \`django/utils/html.py\` had a bug in its \`__init__\` method where \`*kwargs\` (positional unpacking) was used instead of \`**kwargs\` (keyword unpacking) when calling \`super().__init__()\`.

While this never triggers in current usage (\`CountsDict\` is only called with \`word=middle\`), it would fail if any keyword arguments were passed to the constructor.

The fix is a single-character change: \`*kwargs\` → \`**kwargs\` on line 281. Added \`TestCountsDict\` regression tests in \`tests/utils_tests/test_html.py\` (4 tests covering kwargs passthrough, no-args usage, \`__missing__\` counting, and result caching).

#### AI Assistance Disclosure (REQUIRED)

- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the \`main\` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.