### PR TITLE
Fixed error view template.render() consistency and RawPostDataException typo

### DIFF
--- a/django/http/request.py
+++ b/django/http/request.py
@@ -45,7 +45,7 @@ class RawPostDataException(Exception):
     """
     You cannot access raw_post_data from a request that has
     multipart/* POST data if it has been accessed via POST,
-    FILES, etc..
+    FILES, etc.
     """
 
     pass

--- a/django/views/defaults.py
+++ b/django/views/defaults.py
@@ -96,7 +96,7 @@ def server_error(request, template_name=ERROR_500_TEMPLATE_NAME):
         return HttpResponseServerError(
             ERROR_PAGE_TEMPLATE % {"title": "Server Error (500)", "details": ""},
         )
-    return HttpResponseServerError(template.render())
+    return HttpResponseServerError(template.render(request=request))
 
 
 @requires_csrf_token


### PR DESCRIPTION
#### Trac ticket number

N/A - small fixes

#### Branch description

Two small fixes:

1. **Fixed `server_error()` template.render() call** — `server_error()` was calling `template.render()` with no arguments, while `bad_request()` was calling `template.render(request=request)`. Made `server_error()` consistent by also passing `request=request`.

2. **Fixed typo in `RawPostDataException` docstring** — "etc.." → "etc." (double period).

#### AI Assistance Disclosure (REQUIRED)

- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

AI tools (Claude) were used to identify the inconsistencies and prepare this PR. All changes were manually reviewed and verified.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the \`main\` branch.
- [x] The commit message is written in past tense and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.