### PR TITLE
Fixed #37103 -- Made HttpRequest.body tolerate malformed CONTENT_LENGTH.

### DIFF
--- a/django/http/request.py
+++ b/django/http/request.py
@@ -407,7 +407,14 @@ class HttpRequest:
             # Limit the maximum request data size that will be handled
             # in-memory. Reject early when Content-Length is present and
             # already exceeds the limit, avoiding reading the body at all.
-            self._check_data_too_big(int(self.META.get("CONTENT_LENGTH") or 0))
+            # CONTENT_LENGTH may be malformed (e.g. ASGIRequest comma-joins
+            # duplicate Content-Length headers into a non-numeric value);
+            # fall back to 0 like WSGIRequest and MultiPartParser do.
+            try:
+                content_length = int(self.META.get("CONTENT_LENGTH") or 0)
+            except (ValueError, TypeError):
+                content_length = 0
+            self._check_data_too_big(content_length)
 
             # Content-Length can be absent or understated (e.g.
             # `Transfer-Encoding: chunked` on ASGI), so for seekable

--- a/tests/asgi/tests.py
+++ b/tests/asgi/tests.py
@@ -804,6 +804,27 @@ class ASGITest(SimpleTestCase):
                 self.assertEqual(request.META["HTTP_COOKIE"], "a=abc; b=def; c=ghi")
                 self.assertEqual(request.COOKIES, {"a": "abc", "b": "def", "c": "ghi"})
 
+    def test_body_access_handles_malformed_content_length(self):
+        """
+        A non-numeric ``CONTENT_LENGTH`` in META (e.g. the value produced
+        when ``ASGIRequest`` comma-joins duplicate ``Content-Length``
+        headers) must not surface as an unhandled ``ValueError`` from
+        ``request.body``; it should fall back to the same defined behavior
+        as ``request.POST``, which already handles it via
+        ``MultiPartParser``.
+        """
+        body = b"hello world body"
+        scope = self.async_request_factory._base_scope(
+            method="POST", path="/"
+        )
+        scope["headers"] = [
+            (b"content-type", b"text/plain"),
+            (b"content-length", b"10,20"),
+        ]
+        request = ASGIRequest(scope, BytesIO(body))
+        self.assertEqual(dict(request.POST), {})
+        self.assertEqual(request.body, body)
+
 
 class MaxMemorySizeASGITests(SimpleTestCase):
     def make_request(


### PR DESCRIPTION
#### Trac ticket number

ticket-37103

#### Branch description

`HttpRequest.body` raised an unhandled `ValueError` when `META["CONTENT_LENGTH"]` was malformed, while `WSGIRequest`, `MultiPartParser`, and `django.core.servers.basehttp` already fall back to `0` for invalid values.

This wraps the `int(CONTENT_LENGTH)` call in `HttpRequest.body` with the same `try`/`except (ValueError, TypeError)` pattern and adds an ASGI regression test for a non-numeric `CONTENT_LENGTH` value such as the comma-joined value produced from duplicate `Content-Length` headers.

Tests run:

- `tests/runtests.py asgi -v 2 --parallel 1`
- `tests/runtests.py requests_tests -v 1 --parallel 1`

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

OpenAI Codex was used to help investigate the issue, prepare the patch, and draft this PR description. I reviewed and verified the code changes and test results before submitting.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
