### PR TITLE
Fixed #37103 -- Made HttpRequest.body handle malformed CONTENT_LENGTH.

### DIFF
--- a/django/http/request.py
+++ b/django/http/request.py
@@ -404,10 +404,16 @@ class HttpRequest:
                     "You cannot access body after reading from request's data stream"
                 )
 
+            # Make Content-Length fall back to 0 if malformed (e.g. ASGIRequest
+            # comma-joins duplicate Content-Length headers).
+            try:
+                content_length = int(self.META.get("CONTENT_LENGTH") or 0)
+            except (ValueError, TypeError):
+                content_length = 0
             # Limit the maximum request data size that will be handled
             # in-memory. Reject early when Content-Length is present and
             # already exceeds the limit, avoiding reading the body at all.
-            self._check_data_too_big(int(self.META.get("CONTENT_LENGTH") or 0))
+            self._check_data_too_big(content_length)
 
             # Content-Length can be absent or understated (e.g.
             # `Transfer-Encoding: chunked` on ASGI), so for seekable

--- a/tests/asgi/tests.py
+++ b/tests/asgi/tests.py
@@ -804,6 +804,24 @@ class ASGITest(SimpleTestCase):
                 self.assertEqual(request.META["HTTP_COOKIE"], "a=abc; b=def; c=ghi")
                 self.assertEqual(request.COOKIES, {"a": "abc", "b": "def", "c": "ghi"})
 
+    def test_malformed_content_length(self):
+        body = b"hello world body"
+        cases = [
+            {"content_length_headers": [b"10", b"20"], "CONTENT_LENGTH": "10,20"},
+            {"content_length_headers": [b"abc"], "CONTENT_LENGTH": "abc"},
+        ]
+        for case in cases:
+            with self.subTest(CONTENT_LENGTH=case["CONTENT_LENGTH"]):
+                scope = self.async_request_factory._base_scope(method="POST", path="/")
+                headers = [(b"content-type", b"text/plain")]
+                for content_length in case["content_length_headers"]:
+                    headers.append((b"content-length", content_length))
+                scope["headers"] = headers
+                request = ASGIRequest(scope, BytesIO(body))
+                self.assertEqual(dict(request.POST), {})
+                self.assertEqual(request.body, body)
+                self.assertEqual(request.META["CONTENT_LENGTH"], case["CONTENT_LENGTH"])
+
 
 class MaxMemorySizeASGITests(SimpleTestCase):
     def make_request(
@@ -826,6 +844,22 @@ class MaxMemorySizeASGITests(SimpleTestCase):
 
     def test_body_size_exceeded_without_content_length(self):
         request = self.make_request(b"x" * 10)
+        with (
+            self.settings(DATA_UPLOAD_MAX_MEMORY_SIZE=5),
+            self.assertRaisesMessage(RequestDataTooBig, TOO_MUCH_DATA_MSG),
+        ):
+            request.body
+
+    def test_body_size_exceeded_with_malformed_content_length(self):
+        body = b"x" * 10
+        scope = AsyncRequestFactory()._base_scope(method="POST", path="/")
+        scope["headers"] = [
+            (b"content-type", b"application/octet-stream"),
+            (b"content-length", b"10"),
+            (b"content-length", b"20"),
+        ]
+        request = ASGIRequest(scope, BytesIO(body))
+        self.assertEqual(request.META["CONTENT_LENGTH"], "10,20")
         with (
             self.settings(DATA_UPLOAD_MAX_MEMORY_SIZE=5),
             self.assertRaisesMessage(RequestDataTooBig, TOO_MUCH_DATA_MSG),


### PR DESCRIPTION
#### Trac ticket number

ticket-37103

#### Branch description

`HttpRequest.body` raised an unhandled `ValueError` when `META["CONTENT_LENGTH"]` was malformed, while `WSGIRequest`, `MultiPartParser`, and `django.core.servers.basehttp` already fall back to `0` for invalid values.

This wraps the `int(CONTENT_LENGTH)` call in `HttpRequest.body` with the same `try`/`except (ValueError, TypeError)` pattern and adds an ASGI regression test for a non-numeric `CONTENT_LENGTH` value such as the comma-joined value produced from duplicate `Content-Length` headers.

Tests run:

- `tests/runtests.py asgi -v 2 --parallel 1`
- `tests/runtests.py requests_tests -v 1 --parallel 1`

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

OpenAI Codex was used to help investigate the issue, prepare the patch, and draft this PR description. I reviewed and verified the code changes and test results before submitting.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
