### PR TITLE
Prevent malformed directive delimiters in CSP policy generation

### DIFF
--- a/django/utils/csp.py
+++ b/django/utils/csp.py
@@ -6,6 +6,11 @@ from django.utils.html import format_html
 
 # Template context key for the CSP nonce.
 CONTEXT_KEY = "csp_nonce"
+POLICY_DELIMITERS = frozenset(";\r\n")
+
+
+def _contains_policy_delimiter(value):
+    return any(char in value for char in POLICY_DELIMITERS)
 
 
 class CSP(StrEnum):
@@ -98,6 +103,11 @@ def build_policy(config, nonce=None):
     policy = []
 
     for directive, values in config.items():
+        if not isinstance(directive, str) or _contains_policy_delimiter(directive):
+            raise ValueError(
+                "CSP directive names must be strings without policy delimiters."
+            )
+
         if values in (None, False):
             continue
 
@@ -120,6 +130,14 @@ def build_policy(config, nonce=None):
 
             if not values:
                 continue
+
+            if any(
+                not isinstance(value, str) or _contains_policy_delimiter(value)
+                for value in values
+            ):
+                raise ValueError(
+                    "CSP directive values must be strings without policy delimiters."
+                )
 
             rendered_value = " ".join(values)
 

--- a/tests/utils_tests/test_csp.py
+++ b/tests/utils_tests/test_csp.py
@@ -135,6 +135,20 @@ class CSPBuildPolicyTest(SimpleTestCase):
         policy = {"default-src": []}
         self.assertPolicyEqual(build_policy(policy), "")
 
+    def test_config_rejects_directive_policy_delimiters(self):
+        for directive in ["default-src; script-src", "default-src\r", "default-src\n"]:
+            with self.subTest(directive=directive):
+                msg = "CSP directive names must be strings without policy delimiters."
+                with self.assertRaisesMessage(ValueError, msg):
+                    build_policy({directive: [CSP.SELF]})
+
+    def test_config_rejects_directive_value_policy_delimiters(self):
+        for value in ["'self'; script-src 'none'", "'self'\r", "'self'\n"]:
+            with self.subTest(value=value):
+                msg = "CSP directive values must be strings without policy delimiters."
+                with self.assertRaisesMessage(ValueError, msg):
+                    build_policy({"default-src": [value]})
+
 
 class LazyNonceTests(SimpleTestCase):
     def test_generates_on_usage(self):


### PR DESCRIPTION
Prevent malformed CSP directive serialization by rejecting directive names and values containing policy delimiters.

Previously, delimiter-containing input could be rendered directly into the generated CSP policy string, allowing malformed configuration to alter directive boundaries during serialization.

This change adds validation for `;`, `\r`, and `\n` in CSP directive names and values before building the final policy string.

Added regression tests covering malformed directive names and directive values.