### PR TITLE
Made PR quality check require tickets for new contributors.

### DIFF
--- a/scripts/pr_quality/check_pr.py
+++ b/scripts/pr_quality/check_pr.py
@@ -470,10 +470,18 @@ def main(
             pr_number,
         )
         return
+    if commit_count == 0:
+        logger.info(
+            "PR #%s author has no commits -- setting size threshold to 0.",
+            pr_number,
+        )
+        threshold = 0
+    else:
+        threshold = LARGE_PR_THRESHOLD
 
     pr_title_result = SKIPPED
     total_changes = get_pr_total_changes(pr_number, repo, token)
-    ticket_result = check_trac_ticket(pr_body, total_changes)
+    ticket_result = check_trac_ticket(pr_body, total_changes, threshold)
     ticket_status_result = SKIPPED
     ticket_has_patch_result = SKIPPED
     ticket_id = extract_ticket_id(pr_body) if ticket_result is None else None

--- a/scripts/pr_quality/errors.py
+++ b/scripts/pr_quality/errors.py
@@ -154,6 +154,7 @@ MISSING_TRAC_TICKET = (
     "Patches submitted against unreviewed tickets are unlikely to be merged.\n"
     "3. Edit the **Trac ticket number** section of your PR description to include "
     "the ticket in the format `ticket-NNNNN` (e.g. `ticket-36991`).\n\n"
-    "For PRs with fewer than {threshold} lines changed (additions + deletions), you "
-    "may write `N/A` in the ticket field instead (e.g. `N/A - typo fix`).",
+    "Unless this is your first contribution, for PRs with fewer than {threshold} lines "
+    "changed (additions + deletions), you may write `N/A` in the ticket field instead "
+    "(e.g. `N/A - typo fix`).",
 )

--- a/scripts/pr_quality/tests/test_check_pr.py
+++ b/scripts/pr_quality/tests/test_check_pr.py
@@ -770,6 +770,15 @@ class TestIntegration(BaseTestCase):
         self.assertIsNone(result)
         mock_gh.assert_not_called()
 
+    def test_new_contributor_cannot_omit_ticket(self):
+        body = make_pr_body(ticket="", checked_items=0)
+        _, mock_summary, _ = self.call_main(pr_body=body, commit_count=0)
+        _, results, _ = mock_summary.call_args.args
+        result_map = {name: result for name, result, _ in results}
+        self.assertEqual(
+            result_map["Trac ticket referenced"].title, check_pr.MISSING_TRAC_TICKET[0]
+        )
+
     def test_fully_valid_pr_no_comment_posted(self):
         result, _, mock_gh = self.call_main(
             pr_body=VALID_PR_BODY, pr_title=VALID_PR_TITLE


### PR DESCRIPTION
#### Trac ticket number
n/a see forum discussion below

#### Branch description
Agents are already abusing the exception for small pull requests by mixing in unrelated typo fixes with their code changes for unreviewed tickets and removing mention of said ticket.

See description at https://forum.djangoproject.com/t/bot-checks-for-typo-prs-some-considerations/45028/14.

Small pull requests need just as much careful consideration as larger pull requests, and it's not a great heuristic for whether something is a typo fix only.

This will have the effect of discouraging typo fixes as an avenue for first contributions, but we can still accept them if we are informed through other channels, e.g. Trac or Discord. See a recent typo fix I cherry-picked without a PR in 4c3d0b99f1ee8b2f0b4aac5bfb3a786134152d41.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
