### PR TITLE
Fixed #36649 -- Added |= operator support to MultiValueDict and QueryDict

### DIFF
--- a/django/http/request.py
+++ b/django/http/request.py
@@ -741,6 +741,10 @@ class QueryDict(MultiValueDict):
             )
         return "&".join(output)
 
+    def __ior__(self, other):
+        self._assert_mutable()
+        return super().__ior__(other)
+
 
 class MediaType:
     def __init__(self, media_type_raw_line):

--- a/django/utils/datastructures.py
+++ b/django/utils/datastructures.py
@@ -218,6 +218,10 @@ class MultiValueDict(dict):
         """Return current object as a dict with singular values."""
         return {key: self[key] for key in self}
 
+    def __ior__(self, other):
+        self.update(other)
+        return self
+
 
 class ImmutableList(tuple):
     """

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -573,6 +573,13 @@ The ``QueryDict``\ s at ``request.POST`` and ``request.GET`` will be immutable
 when accessed in a normal request/response cycle. To get a mutable version you
 need to use :meth:`QueryDict.copy`.
 
+.. versionadded:: 6.1
+
+  Support for |the |= update operator|__ was added to mutable ``QueryDict``\s.
+
+  .. |the |= update operator| replace:: the ``|=`` update operator
+  __ https://docs.python.org/3/library/stdtypes.html#dict.update
+
 Methods
 -------
 

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -426,6 +426,9 @@ Requests and Responses
   the :func:`~django.shortcuts.redirect` shortcut, now accept a ``max_length``
   parameter to override the default maximum URL length limit.
 
+* Mutable :class:`.QueryDict`\s now support the ``|=`` update operator for
+  updating with the contents of a mapping or key/value iterable.
+
 Security
 ~~~~~~~~
 

--- a/tests/httpwrappers/tests.py
+++ b/tests/httpwrappers/tests.py
@@ -301,6 +301,39 @@ class QueryDictTests(SimpleTestCase):
         with self.assertRaises(TypeError):
             QueryDict.fromkeys(0)
 
+    def test_update_operator_immutable(self):
+        q = QueryDict("color=red&q=tacos")
+        msg = "This QueryDict instance is immutable"
+        with self.assertRaisesMessage(AttributeError, msg):
+            q |= {"color": "yellow"}
+        with self.assertRaisesMessage(AttributeError, msg):
+            q |= {}
+        self.assertEqual(q, QueryDict("color=red&q=tacos"))
+
+    def test_update_operator_dict(self):
+        q = QueryDict("color=red&q=tacos", mutable=True)
+        q |= {"color": "yellow"}
+        self.assertIs(q._mutable, True)
+        self.assertEqual(q, QueryDict("color=red&color=yellow&q=tacos"))
+
+    def test_update_operator_querydict(self):
+        q = QueryDict("color=red&q=tacos", mutable=True)
+        q2 = QueryDict("color=yellow")
+        q |= q2
+        self.assertEqual(q, QueryDict("color=red&color=yellow&q=tacos"))
+
+    def test_update_operator_querydict_list(self):
+        q = QueryDict("color=red&q=tacos", mutable=True)
+        q2 = QueryDict("color=yellow&color=blue")
+        q |= q2
+        self.assertEqual(q, QueryDict("color=red&color=yellow&color=blue&q=tacos"))
+
+    def test_update_operator_nondict(self):
+        q = QueryDict("color=red&q=tacos", mutable=True)
+        msg = "'int' object is not iterable"
+        with self.assertRaisesMessage(TypeError, msg):
+            q |= 42
+
 
 class HttpResponseTests(SimpleTestCase):
     def test_headers_type(self):

--- a/tests/utils_tests/test_datastructures.py
+++ b/tests/utils_tests/test_datastructures.py
@@ -248,6 +248,29 @@ class MultiValueDictTests(SimpleTestCase):
             with self.subTest(value), self.assertRaises(ValueError):
                 MultiValueDict().update(value)
 
+    def test_update_operator_dict(self):
+        d = MultiValueDict({"name": ["Adrian", "Simon"]})
+        d |= {"name": "Holovaty", "position": "Developer"}
+        self.assertEqual(
+            list(d.lists()),
+            [("name", ["Adrian", "Simon", "Holovaty"]), ("position", ["Developer"])],
+        )
+
+    def test_update_operator_multivaluedict(self):
+        d = MultiValueDict({"name": ["Adrian", "Simon"]})
+        d2 = MultiValueDict({"name": ["Holovaty"], "position": ["Developer"]})
+        d |= d2
+        self.assertEqual(
+            list(d.lists()),
+            [("name", ["Adrian", "Simon", "Holovaty"]), ("position", ["Developer"])],
+        )
+
+    def test_update_operator_nondict(self):
+        d = MultiValueDict({"name": ["Adrian", "Simon"]})
+        msg = "'int' object is not iterable"
+        with self.assertRaisesMessage(TypeError, msg):
+            d |= 42
+
 
 class ImmutableListTests(SimpleTestCase):
     def test_sort(self):


### PR DESCRIPTION

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-36649

#### Branch description
Per [forum discussion](https://forum.djangoproject.com/t/add-merge-and-update-operator-support-to-multivaluedict-querydict/43123), add [PEP 584](https://peps.python.org/pep-0584/) |= (merge operator) support to these classes.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [X] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [X] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [X] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [X] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
- [X] I have attached screenshots in both light and dark modes for any UI changes.
