### PR TITLE
Fixed #27833 -- Batched prefetch_related() queries to respect database parameter limits

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -2847,16 +2847,34 @@ def prefetch_one_level(instances, prefetcher, lookup, level):
 
     # The 'values to be matched' must be hashable as they will be used
     # in a dictionary.
-    (
-        rel_qs,
-        rel_obj_attr,
-        instance_attr,
-        single,
-        cache_name,
-        is_descriptor,
-    ) = prefetcher.get_prefetch_querysets(
-        instances, lookup.get_current_querysets(level)
+
+    # Some databases (e.g. SQLite) limit the number of query parameters. If
+    # there are more instances than the database can handle in a single query,
+    # split them into batches.
+    connection = connections[instances[0]._state.db]
+    batch_size = connection.ops.bulk_batch_size([instances[0]._meta.pk], instances)
+    batches = (
+        instances[i : i + batch_size] for i in range(0, len(instances), batch_size)
     )
+
+    # Call get_prefetch_querysets() once per batch, collecting the querysets.
+    # We assume it returns the same rel_obj_attr, instance_attr, single,
+    # cache_name, and is_descriptor for all batches (homogeneous instances),
+    # so we keep the values from the last batch.
+    all_related_querysets = []
+    for batch in batches:
+        (
+            rel_qs,
+            rel_obj_attr,
+            instance_attr,
+            single,
+            cache_name,
+            is_descriptor,
+        ) = prefetcher.get_prefetch_querysets(
+            batch, lookup.get_current_querysets(level)
+        )
+        all_related_querysets.append(rel_qs)
+
     # We have to handle the possibility that the QuerySet we just got back
     # contains some prefetch_related lookups. We don't want to trigger the
     # prefetch_related functionality by evaluating the query. Rather, we need
@@ -2865,19 +2883,34 @@ def prefetch_one_level(instances, prefetcher, lookup, level):
     # later (happens in nested prefetch_related).
     additional_lookups = [
         copy.copy(additional_lookup)
-        for additional_lookup in getattr(rel_qs, "_prefetch_related_lookups", ())
+        for additional_lookup in getattr(
+            all_related_querysets[0], "_prefetch_related_lookups", ()
+        )
     ]
     if additional_lookups:
         # Don't need to clone because the manager should have given us a fresh
         # instance, so we access an internal instead of using public interface
         # for performance reasons.
-        rel_qs._prefetch_related_lookups = ()
+        for rel_qs in all_related_querysets:
+            rel_qs._prefetch_related_lookups = ()
 
-    all_related_objects = list(rel_qs)
-
+    # Stream objects from all batch querysets into rel_obj_cache in a single
+    # pass, deduplicating as we go. The same related object may appear in
+    # results from multiple batches (e.g. a shared FK target), so we track
+    # seen (rel_attr_val, pk) pairs to avoid duplicates in the final lists.
+    # all_related_objects is built here (deduplicated) for use as the next
+    # level's instance list in nested prefetches.
     rel_obj_cache = {}
-    for rel_obj in all_related_objects:
+    seen_related_pks = set()
+    all_related_objects = []
+    for rel_obj in chain.from_iterable(all_related_querysets):
         rel_attr_val = rel_obj_attr(rel_obj)
+        obj_pk = rel_obj.pk
+        key = (rel_attr_val, obj_pk)
+        if key in seen_related_pks:
+            continue
+        seen_related_pks.add(key)
+        all_related_objects.append(rel_obj)
         rel_obj_cache.setdefault(rel_attr_val, []).append(rel_obj)
 
     to_attr, as_attr = lookup.get_current_to_attr(level)

--- a/tests/prefetch_related/tests.py
+++ b/tests/prefetch_related/tests.py
@@ -2305,3 +2305,89 @@ class PrefetchRelatedMTICacheTests(TestCase):
         self.assertSequenceEqual(
             gp.authorwithage.authorwithagechild.favorite_authors.all(), []
         )
+
+
+class LargePrefetchBatchingTests(TestCase):
+    """
+    prefetch_related() splits queries into batches when the number of instances
+    exceeds the database's maximum query parameter limit (e.g. SQLite). These
+    tests mock a small batch size to exercise the batching code path without
+    requiring thousands of objects.
+    """
+
+    # A batch size small enough that test_size requires multiple batches.
+    mock_batch_size = 5
+    test_size = 11  # requires ceil(11/5) = 3 batches
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.book1 = Book.objects.create(title="Poems")
+        cls.book2 = Book.objects.create(title="Sense and Sensibility")
+        cls.authors = [
+            Author.objects.create(name=f"Author {i}", first_book=cls.book1)
+            for i in range(cls.test_size)
+        ]
+        cls.reader = Reader.objects.create(name="Amy")
+        # first and last authors share book1 via M2M to exercise cross-batch
+        # result merging.
+        cls.authors[0].books.add(cls.book1)
+        cls.authors[-1].books.add(cls.book2)
+        cls.reader.books_read.add(cls.book1, cls.book2)
+
+    def _mock_batch_size(self):
+        """Return a mock forcing bulk_batch_size to return mock_batch_size."""
+        return mock.patch(
+            "django.db.backends.base.operations.BaseDatabaseOperations.bulk_batch_size",
+            return_value=self.mock_batch_size,
+        )
+
+    def test_fk_batching(self):
+        """Forward FK prefetch works correctly across multiple batches."""
+        with self._mock_batch_size():
+            authors = list(Author.objects.prefetch_related("first_book"))
+        self.assertEqual(len(authors), self.test_size)
+        with self.assertNumQueries(0):
+            for author in authors:
+                self.assertEqual(author.first_book, self.book1)
+
+    def test_m2m_batching(self):
+        """M2M prefetch works correctly across multiple batches."""
+        with self._mock_batch_size():
+            authors = list(Author.objects.prefetch_related("books"))
+        self.assertEqual(len(authors), self.test_size)
+        with self.assertNumQueries(0):
+            self.assertSequenceEqual(authors[0].books.all(), [self.book1])
+            self.assertSequenceEqual(authors[-1].books.all(), [self.book2])
+            # Authors with no M2M relation get an empty list.
+            for author in authors[1:-1]:
+                self.assertSequenceEqual(author.books.all(), [])
+
+    def test_nested_prefetch_batching(self):
+        """Nested prefetch (books__read_by) works correctly across batches."""
+        with self._mock_batch_size():
+            authors = list(Author.objects.prefetch_related("books__read_by"))
+        with self.assertNumQueries(0):
+            self.assertSequenceEqual(
+                authors[0].books.all()[0].read_by.all(), [self.reader]
+            )
+            self.assertSequenceEqual(
+                authors[-1].books.all()[0].read_by.all(), [self.reader]
+            )
+
+    def test_no_duplicate_related_objects(self):
+        """
+        When multiple source instances in different batches share the same
+        related object (e.g. the same book is first_book for many authors),
+        that related object must appear exactly once in the prefetch results
+        for each source instance -- not once per batch it appears in.
+        """
+        # All authors share book1 as first_book. With batching, book1 would be
+        # fetched in every batch, producing duplicates without deduplication.
+        with self._mock_batch_size():
+            authors = list(Author.objects.prefetch_related("first_book"))
+        with self.assertNumQueries(0):
+            for author in authors:
+                # first_book is a to-one relation; it should be a single
+                # object, not a list. Accessing it should not raise and
+                # should be book1.
+                self.assertEqual(author.first_book, self.book1)


### PR DESCRIPTION


#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-27833

#### Branch description

Some databases (e.g. SQLite) limit the number of query parameters allowed in a single SQL query. prefetch_related() previously issued a single query with one parameter per source instance, causing failures when the instance count exceeded that limit.

prefetch_one_level() now splits instances into batches sized by connection.ops.bulk_batch_size(), consistent with bulk_create() and bulk_update(). Results from all batches are merged before populating the prefetch cache.

Duplicate related objects that appear across multiple batches (due to shared FK targets) are deduplicated by tracking seen (rel_attr_val, pk) pairs before building rel_obj_cache.

#### AI Assistance Disclosure (REQUIRED)

<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [X] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

OpenCode with GitHub Copilot and Claude Sonnet 4.6

#### Checklist
- [X] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [X] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [X] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
- [X] I have attached screenshots in both light and dark modes for any UI changes.
