### PR TITLE
Fixed #36864 - Add support for module and submodule loading in import_string

### DIFF
--- a/django/utils/module_loading.py
+++ b/django/utils/module_loading.py
@@ -5,7 +5,7 @@ from importlib import import_module
 from importlib.util import find_spec as importlib_find
 
 
-def cached_import(module_path, class_name):
+def cached_import(module_path):
     # Check whether module is loaded and fully initialized.
     if not (
         (module := sys.modules.get(module_path))
@@ -13,26 +13,37 @@ def cached_import(module_path, class_name):
         and getattr(spec, "_initializing", False) is False
     ):
         module = import_module(module_path)
-    return getattr(module, class_name)
+    return module
 
 
 def import_string(dotted_path):
     """
-    Import a dotted module path and return the attribute/class designated by
-    the last name in the path. Raise ImportError if the import failed.
+    Import a dotted module path and return the module or attribute/class
+    designated by the path. Raise ImportError if the import failed.
     """
     try:
-        module_path, class_name = dotted_path.rsplit(".", 1)
-    except ValueError as err:
-        raise ImportError("%s doesn't look like a module path" % dotted_path) from err
+        module = cached_import(dotted_path)
+    except ImportError as err:
+        # Attempt to load an attribute from a module
+        try:
+            module_path, class_name = dotted_path.rsplit(".", 1)
+        except ValueError:
+            # The supplied path contained no dots, so must be a module,
+            # and we've already failed to load.
+            raise err
 
-    try:
-        return cached_import(module_path, class_name)
-    except AttributeError as err:
-        raise ImportError(
-            'Module "%s" does not define a "%s" attribute/class'
-            % (module_path, class_name)
-        ) from err
+        module = cached_import(module_path)
+
+        try:
+            class_or_attr = getattr(module, class_name)
+        except AttributeError as err:
+            raise ImportError(
+                'Module "%s" does not define a "%s" attribute/class'
+                % (module_path, class_name)
+            ) from err
+
+        return class_or_attr
+    return module
 
 
 def autodiscover_modules(*args, **kwargs):

--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -824,8 +824,8 @@ Functions for working with Python modules.
 
 .. function:: import_string(dotted_path)
 
-    Imports a dotted module path and returns the attribute/class designated by
-    the last name in the path. Raises ``ImportError`` if the import failed. For
+    Imports a dotted module path and returns the module or attribute/class
+    designated by the path. Raises ``ImportError`` if the import failed. For
     example::
 
         from django.utils.module_loading import import_string

--- a/tests/auth_tests/test_models.py
+++ b/tests/auth_tests/test_models.py
@@ -464,7 +464,7 @@ class UserWithPermTestCase(TestCase):
             )
 
     def test_invalid_backend_submodule(self):
-        with self.assertRaises(ImportError):
+        with self.assertRaises(TypeError):
             User.objects.with_perm(
                 "auth.test",
                 backend="json.tool",

--- a/tests/auth_tests/test_validators.py
+++ b/tests/auth_tests/test_validators.py
@@ -53,11 +53,8 @@ class PasswordValidationTest(SimpleTestCase):
 
     def test_get_password_validators_custom_invalid(self):
         validator_config = [{"NAME": "json.tool"}]
-        msg = (
-            "The module in NAME could not be imported: json.tool. "
-            "Check your AUTH_PASSWORD_VALIDATORS setting."
-        )
-        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+        msg = "'module' object is not callable"
+        with self.assertRaisesMessage(TypeError, msg):
             get_password_validators(validator_config)
 
     def test_validate_password(self):

--- a/tests/utils_tests/test_module_loading.py
+++ b/tests/utils_tests/test_module_loading.py
@@ -134,11 +134,24 @@ class ModuleImportTests(SimpleTestCase):
         self.assertEqual(cls, import_string)
 
         # Test exceptions raised
-        with self.assertRaises(ImportError):
-            import_string("no_dots_in_path")
         msg = 'Module "utils_tests" does not define a "unexistent" attribute'
         with self.assertRaisesMessage(ImportError, msg):
             import_string("utils_tests.unexistent")
+
+    def test_import_string_unloaded_modules(self):
+        """Regression test for issue #36864"""
+        module_dotpath = "utils_tests"
+        submodule_dotpath = "utils_tests.test_module.good_module"
+        attr_dotpath = "utils_tests.test_module.good_module.content"
+
+        import_string(module_dotpath)
+        import_string(submodule_dotpath)
+
+        with self.assertRaisesMessage(ValueError, "Empty module name"):
+            import_string("")
+
+        self.addCleanup(sys.modules.pop, submodule_dotpath, None)
+        self.addCleanup(sys.modules.pop, module_dotpath, None)
 
 
 @modify_settings(INSTALLED_APPS={"append": "utils_tests.test_module"})


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-36864

#### Branch description
Adds support for importing modules from the `utils.module_loading.import_string` function.

It may be worth noting that the signature for `cached_import` has changed to only take a module path and load it, rather than also attempting the `getattr` call as well since it seems that all of the caching functionality was centered around module loading. This function does not appear in the documentation, so I believe it is not public.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
