### PR TITLE
Fixed #36337 - Update autocomplete select2 id when form is deleted in formset

### DIFF
--- a/django/contrib/admin/static/admin/js/autocomplete.js
+++ b/django/contrib/admin/static/admin/js/autocomplete.js
@@ -30,4 +30,7 @@
     document.addEventListener("formset:added", (event) => {
         $(event.target).find(".admin-autocomplete").djangoAdminSelect2();
     });
+    document.addEventListener("formset:id_modified", (event) => {
+        $(event.target).find(".admin-autocomplete").djangoAdminSelect2();
+    });
 }

--- a/django/contrib/admin/static/admin/js/inlines.js
+++ b/django/contrib/admin/static/admin/js/inlines.js
@@ -119,7 +119,7 @@
             if (options.added) {
                 options.added(row);
             }
-        row.get(0).dispatchEvent(
+            row.get(0).dispatchEvent(
                 new CustomEvent("formset:added", {
                     bubbles: true,
                     detail: {
@@ -214,14 +214,16 @@
             for (i = 0, formCount = forms.length; i < formCount; i++) {
                 updateElementIndex($(forms).get(i), options.prefix, i);
                 $(forms.get(i)).find("*").each(updateElementCallback);
-                $(forms).get(i).dispatchEvent(
-                new CustomEvent("formset:id_modified", {
-                    bubbles: true,
-                    detail: {
-                        formsetName: options.prefix,
-                    },
-                }),
-            );
+                $(forms)
+                    .get(i)
+                    .dispatchEvent(
+                        new CustomEvent("formset:id_modified", {
+                            bubbles: true,
+                            detail: {
+                                formsetName: options.prefix,
+                            },
+                        }),
+                    );
             }
         };
 

--- a/django/contrib/admin/static/admin/js/inlines.js
+++ b/django/contrib/admin/static/admin/js/inlines.js
@@ -119,7 +119,7 @@
             if (options.added) {
                 options.added(row);
             }
-            row.get(0).dispatchEvent(
+        row.get(0).dispatchEvent(
                 new CustomEvent("formset:added", {
                     bubbles: true,
                     detail: {
@@ -214,6 +214,14 @@
             for (i = 0, formCount = forms.length; i < formCount; i++) {
                 updateElementIndex($(forms).get(i), options.prefix, i);
                 $(forms.get(i)).find("*").each(updateElementCallback);
+                $(forms).get(i).dispatchEvent(
+                new CustomEvent("formset:id_modified", {
+                    bubbles: true,
+                    detail: {
+                        formsetName: options.prefix,
+                    },
+                }),
+            );
             }
         };
 

--- a/js_tests/admin/autocomplete.test.js
+++ b/js_tests/admin/autocomplete.test.js
@@ -1,0 +1,50 @@
+QUnit.module("admin.inlines.autocomplete: tabular formset autocomplete id consistency", {
+    beforeEach: function () {
+        const $ = django.jQuery;
+        $("#qunit-fixture").append($("#tabular-formset-with-autocomplete").text());
+        this.table = $("table.inline");
+        this.inlineRows = this.table.find("tr.form-row");
+
+        $(".admin-autocomplete").not("[name*=__prefix__]").djangoAdminSelect2();
+        this.inlineRows.tabularFormset("table.inline tr.form-row", {
+            prefix: "auto",
+            deleteText: "Remove",
+        });
+    },
+});
+
+QUnit.test(
+    "after row deletion, select2 aria-owns matches renumbered select id",
+    function (assert) {
+        const $ = django.jQuery;
+        assert.equal(
+            $("#auto-2").find("select.admin-autocomplete").attr("id"),
+            "id_auto-2-fk",
+            "precondition: third row select has id auto-2-fk"
+        );
+
+        // Delete the n-1 row
+        const deleteLink = this.table.find("#auto-1 .inline-deletelink");
+        deleteLink.trigger($.Event("click", { target: deleteLink }));
+
+        // Ensure that the n row is renumbered to n-1 and that the select2 aria-owns attribute is updated accordingly.
+        const renumberedSelect = $("#auto-1").find("select.admin-autocomplete");
+        assert.equal(
+            renumberedSelect.attr("id"),
+            "id_auto-1-fk",
+            "select id is renumbered after deletion"
+        );
+
+        renumberedSelect.select2("open");
+        const $selection = renumberedSelect
+            .next(".select2-container")
+            .find(".select2-selection");
+        const ariaOwns = $selection.attr("aria-owns");
+        assert.ok(ariaOwns, "aria-owns attribute is present when open");
+        assert.ok(
+            ariaOwns.indexOf("auto-1-fk") !== -1,
+            "aria-owns references the renumbered id (auto-1), not the old id (auto-2)"
+        );
+        renumberedSelect.select2("close");
+    }
+);

--- a/js_tests/admin/autocomplete.test.js
+++ b/js_tests/admin/autocomplete.test.js
@@ -1,17 +1,24 @@
-QUnit.module("admin.inlines.autocomplete: tabular formset autocomplete id consistency", {
-    beforeEach: function () {
-        const $ = django.jQuery;
-        $("#qunit-fixture").append($("#tabular-formset-with-autocomplete").text());
-        this.table = $("table.inline");
-        this.inlineRows = this.table.find("tr.form-row");
+QUnit.module(
+    "admin.inlines.autocomplete: tabular formset autocomplete id consistency",
+    {
+        beforeEach: function () {
+            const $ = django.jQuery;
+            $("#qunit-fixture").append(
+                $("#tabular-formset-with-autocomplete").text(),
+            );
+            this.table = $("table.inline");
+            this.inlineRows = this.table.find("tr.form-row");
 
-        $(".admin-autocomplete").not("[name*=__prefix__]").djangoAdminSelect2();
-        this.inlineRows.tabularFormset("table.inline tr.form-row", {
-            prefix: "auto",
-            deleteText: "Remove",
-        });
+            $(".admin-autocomplete")
+                .not("[name*=__prefix__]")
+                .djangoAdminSelect2();
+            this.inlineRows.tabularFormset("table.inline tr.form-row", {
+                prefix: "auto",
+                deleteText: "Remove",
+            });
+        },
     },
-});
+);
 
 QUnit.test(
     "after row deletion, select2 aria-owns matches renumbered select id",
@@ -20,7 +27,7 @@ QUnit.test(
         assert.equal(
             $("#auto-2").find("select.admin-autocomplete").attr("id"),
             "id_auto-2-fk",
-            "precondition: third row select has id auto-2-fk"
+            "precondition: third row select has id auto-2-fk",
         );
 
         // Delete the n-1 row
@@ -32,7 +39,7 @@ QUnit.test(
         assert.equal(
             renumberedSelect.attr("id"),
             "id_auto-1-fk",
-            "select id is renumbered after deletion"
+            "select id is renumbered after deletion",
         );
 
         renumberedSelect.select2("open");
@@ -43,8 +50,8 @@ QUnit.test(
         assert.ok(ariaOwns, "aria-owns attribute is present when open");
         assert.ok(
             ariaOwns.indexOf("auto-1-fk") !== -1,
-            "aria-owns references the renumbered id (auto-1), not the old id (auto-2)"
+            "aria-owns references the renumbered id (auto-1), not the old id (auto-2)",
         );
         renumberedSelect.select2("close");
-    }
+    },
 );

--- a/js_tests/tests.html
+++ b/js_tests/tests.html
@@ -83,6 +83,44 @@
             </div>
         </div>
     </script>
+    <script type="text/html" id="tabular-formset-with-autocomplete">
+      <input id="id_auto-TOTAL_FORMS" value="3">
+      <input id="id_auto-MAX_NUM_FORMS" value="">
+      <table class="inline">
+          <tr id="auto-0" class="form-row has_original">
+              <td class="field-test_field">
+                  <select id="id_auto-0-fk" class="admin-autocomplete"
+                      data-app-label="myapp" data-model-name="mymodel"
+                      data-field-name="fk"></select>
+              </td>
+              <td class="delete"><input type="checkbox" /></td>
+          </tr>
+          <tr id="auto-1" class="form-row">
+              <td class="field-test_field">
+                  <select id="id_auto-1-fk" class="admin-autocomplete"
+                      data-app-label="myapp" data-model-name="mymodel"
+                      data-field-name="fk"></select>
+              </td>
+              <td class="delete"></td>
+          </tr>
+          <tr id="auto-2" class="form-row">
+              <td class="field-test_field">
+                  <select id="id_auto-2-fk" class="admin-autocomplete"
+                      data-app-label="myapp" data-model-name="mymodel"
+                      data-field-name="fk"></select>
+              </td>
+              <td class="delete"></td>
+          </tr>
+          <tr id="auto-empty" class="form-row empty-form">
+              <td class="field-test_field">
+                  <select id="id_auto-__prefix__-fk" class="admin-autocomplete"
+                      data-app-label="myapp" data-model-name="mymodel"
+                      data-field-name="fk"></select>
+              </td>
+              <td class="delete"></td>
+          </tr>
+      </table>
+  </script>
     <script type="text/html" id="nav-sidebar-filter">
       <nav class="sticky" id="nav-sidebar">
         <input type="search" id="nav-filter"
@@ -114,6 +152,7 @@
 
     <script src='../django/contrib/admin/static/admin/js/vendor/xregexp/xregexp.min.js'></script>
     <script src='../django/contrib/admin/static/admin/js/vendor/jquery/jquery.min.js'></script>
+    <script src='../django/contrib/admin/static/admin/js/vendor/select2/select2.full.js'></script>
     <script src='../django/contrib/admin/static/admin/js/jquery.init.js'></script>
     <script src='./admin/jsi18n-mocks.test.js'></script>
 
@@ -138,6 +177,9 @@
 
     <script src='../django/contrib/admin/static/admin/js/SelectFilter2.js' data-cover></script>
     <script src='./admin/SelectFilter2.test.js'></script>
+
+    <script src='../django/contrib/admin/static/admin/js/autocomplete.js'></script>
+    <script src='./admin/autocomplete.test.js'></script>
 
     <script src='../django/contrib/admin/static/admin/js/inlines.js' data-cover></script>
     <script src='./admin/inlines.test.js'></script>


### PR DESCRIPTION


#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-36337

#### Branch description
When an inline form (in a formset) was deleted, the ID used by the `select2` autcomplete library was not updated, even though django-admin recomputes the IDs of the form. This would then lead to a rendering bug if a new form was then added to the formset, since the ID would belong to the autocomplete in both the `n` and `n-1` form. This fix recomputes the `select2` autocomplete IDs when a form is deleted from a formset

| Before | After |
|---|---|
| <img width="350" alt="DjangoFormBugBefore" src="https://github.com/user-attachments/assets/61551941-a6c5-4bed-9879-eeb11c82b7e2" /> | <img width="350" alt="DjangoFormBugAfter" src="https://github.com/user-attachments/assets/1655b6de-b2ae-42b0-a669-582e8090f98f" /> |



#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude Code has been used for research purposes to research unit test styling and ensure tests are not duplicates.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
