### PR TITLE
Fixed #36864 -- Added support for module and submodule loading in import_string.

### DIFF
--- a/django/contrib/auth/password_validation.py
+++ b/django/contrib/auth/password_validation.py
@@ -33,6 +33,13 @@ def get_password_validators(validator_config):
                 "AUTH_PASSWORD_VALIDATORS setting."
             )
             raise ImproperlyConfigured(msg % validator["NAME"])
+        else:
+            if not callable(klass):
+                msg = (
+                    "The configured validator in NAME is not callable: %s. "
+                    "Check your AUTH_PASSWORD_VALIDATORS setting."
+                )
+                raise ImproperlyConfigured(msg % validator["NAME"])
         validators.append(klass(**validator.get("OPTIONS", {})))
 
     return validators

--- a/django/db/backends/base/creation.py
+++ b/django/db/backends/base/creation.py
@@ -372,21 +372,8 @@ class BaseDatabaseCreation:
         test_app = test_name.split(".")[0]
         # Importing a test app that isn't installed raises RuntimeError.
         if test_app in settings.INSTALLED_APPS:
-            try:
-                test_frame = import_string(module_or_class_name)
-            except ImportError:
-                # import_string() can raise ImportError if a submodule's parent
-                # module hasn't already been imported during test discovery.
-                # This can happen in at least two cases:
-                # 1. When running a subset of tests in a module, the test
-                #    runner won't import tests in that module's other
-                #    submodules.
-                # 2. When the parallel test runner spawns workers with an empty
-                #    import cache.
-                test_to_mark = import_string(test_name)
-                test_frame = sys.modules.get(test_to_mark.__module__)
-            else:
-                test_to_mark = getattr(test_frame, name_to_mark)
+            test_frame = import_string(module_or_class_name)
+            test_to_mark = getattr(test_frame, name_to_mark)
             if skip_reason:
                 setattr(test_frame, name_to_mark, skip(skip_reason)(test_to_mark))
             else:

--- a/django/utils/module_loading.py
+++ b/django/utils/module_loading.py
@@ -5,7 +5,7 @@ from importlib import import_module
 from importlib.util import find_spec as importlib_find
 
 
-def cached_import(module_path, class_name):
+def cached_import(module_path):
     # Check whether module is loaded and fully initialized.
     if not (
         (module := sys.modules.get(module_path))
@@ -13,26 +13,39 @@ def cached_import(module_path, class_name):
         and getattr(spec, "_initializing", False) is False
     ):
         module = import_module(module_path)
-    return getattr(module, class_name)
+    return module
 
 
 def import_string(dotted_path):
     """
-    Import a dotted module path and return the attribute/class designated by
-    the last name in the path. Raise ImportError if the import failed.
+    Import a dotted module path and return the module or attribute/class
+    designated by the path. Raise ImportError if the import failed.
     """
-    try:
-        module_path, class_name = dotted_path.rsplit(".", 1)
-    except ValueError as err:
-        raise ImportError("%s doesn't look like a module path" % dotted_path) from err
+    if "." not in dotted_path:
+        return cached_import(dotted_path)
+    else:
+        # Force a consistent state by eagerly importing the entire dotted path.
+        try:
+            cached_import(dotted_path)
+        except ImportError:
+            pass
 
-    try:
-        return cached_import(module_path, class_name)
-    except AttributeError as err:
-        raise ImportError(
-            'Module "%s" does not define a "%s" attribute/class'
-            % (module_path, class_name)
-        ) from err
+        module_path, class_name = dotted_path.rsplit(".", 1)
+        module = cached_import(module_path)
+
+        # Attempt getattr first, which will return any named objects
+        # in a loaded module or a previously loaded submodule.
+        try:
+            import_target = getattr(module, class_name)
+        except AttributeError:
+            try:
+                import_target = cached_import(dotted_path)
+            except ImportError as err:
+                raise ImportError(
+                    'Module "%s" does not define a "%s" attribute/class'
+                    % (module_path, class_name)
+                ) from err
+        return import_target
 
 
 def autodiscover_modules(*args, **kwargs):

--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -824,9 +824,10 @@ Functions for working with Python modules.
 
 .. function:: import_string(dotted_path)
 
-    Imports a dotted module path and returns the attribute/class designated by
-    the last name in the path. Raises ``ImportError`` if the import failed. For
-    example::
+    Imports a dotted module path and returns the module or attribute/class
+    designated by the path. When ``dotted_path`` could resolve to either a
+    class or a module, the module will be preferentially imported. Raises
+    :exc:`ImportError` if the import failed. For example::
 
         from django.utils.module_loading import import_string
 
@@ -835,6 +836,11 @@ Functions for working with Python modules.
     is equivalent to::
 
         from django.core.exceptions import ValidationError
+
+    .. versionchanged:: 6.2
+
+        Support for importing modules was added, along with deterministic
+        handling for ambiguous cases.
 
 ``django.utils.safestring``
 ===========================

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -238,6 +238,10 @@ URLs
 Utilities
 ~~~~~~~~~
 
+* :func:`.utils.module_loading.import_string` now supports modules. Previously,
+  top-level modules did not work, and submodules only worked if already
+  imported.
+
 * ...
 
 Validators
@@ -271,6 +275,10 @@ Miscellaneous
   ``datetime.time`` objects if they have zero milliseconds. For example,
   ``datetime.datetime(2000, 1, 1, 0, 0, 0, 1)`` now serializes to
   ``"2000-01-01T00:00:00"`` rather than ``"2000-01-01T00:00:00.000"``.
+
+* :func:`.utils.module_loading.import_string` now deterministically favors
+  submodules in ambiguous cases where depending on prior import state, a
+  same-named attribute of the parent module might have been returned instead.
 
 .. _deprecated-features-6.2:
 

--- a/tests/auth_tests/test_models.py
+++ b/tests/auth_tests/test_models.py
@@ -464,7 +464,7 @@ class UserWithPermTestCase(TestCase):
             )
 
     def test_invalid_backend_submodule(self):
-        with self.assertRaises(ImportError):
+        with self.assertRaises(TypeError):
             User.objects.with_perm(
                 "auth.test",
                 backend="json.tool",

--- a/tests/auth_tests/test_validators.py
+++ b/tests/auth_tests/test_validators.py
@@ -51,10 +51,19 @@ class PasswordValidationTest(SimpleTestCase):
 
         self.assertEqual(get_password_validators([]), [])
 
-    def test_get_password_validators_custom_invalid(self):
+    def test_get_password_validators_custom_nonexistent(self):
+        validator_config = [{"NAME": "does.not.exist"}]
+        msg = (
+            "The module in NAME could not be imported: does.not.exist. "
+            "Check your AUTH_PASSWORD_VALIDATORS setting."
+        )
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+            get_password_validators(validator_config)
+
+    def test_get_password_validators_custom_uncallable(self):
         validator_config = [{"NAME": "json.tool"}]
         msg = (
-            "The module in NAME could not be imported: json.tool. "
+            "The configured validator in NAME is not callable: json.tool. "
             "Check your AUTH_PASSWORD_VALIDATORS setting."
         )
         with self.assertRaisesMessage(ImproperlyConfigured, msg):

--- a/tests/utils_tests/test_module/collision/__init__.py
+++ b/tests/utils_tests/test_module/collision/__init__.py
@@ -1,0 +1,1 @@
+collider = "I'm an object"

--- a/tests/utils_tests/test_module/collision/collider.py
+++ b/tests/utils_tests/test_module/collision/collider.py
@@ -1,0 +1,1 @@
+content = "In the collider submodule"

--- a/tests/utils_tests/test_module_loading.py
+++ b/tests/utils_tests/test_module_loading.py
@@ -135,10 +135,39 @@ class ModuleImportTests(SimpleTestCase):
 
         # Test exceptions raised
         with self.assertRaises(ImportError):
-            import_string("no_dots_in_path")
+            import_string("does_not_exist")
         msg = 'Module "utils_tests" does not define a "unexistent" attribute'
         with self.assertRaisesMessage(ImportError, msg):
             import_string("utils_tests.unexistent")
+        msg = (
+            'Module "utils_tests.test_module" does not define a "unexistent" attribute'
+        )
+        with self.assertRaisesMessage(ImportError, msg):
+            import_string("utils_tests.test_module.unexistent")
+
+    def test_import_string_objects_collision_handling(self):
+        collision_dotpath = "utils_tests.test_module.collision.collider"
+        self.addCleanup(sys.modules.pop, collision_dotpath, None)
+
+        # When there is a name collision between __init__-defined variables and
+        # submodules, we get back the submodule.
+        cls = import_string(collision_dotpath)
+        mod = import_module(collision_dotpath)
+        self.assertEqual(mod, cls)
+
+    def test_import_string_unloaded_module(self):
+        module_dotpath = "utils_tests"
+        self.addCleanup(sys.modules.pop, module_dotpath, None)
+        import_string(module_dotpath)
+
+    def test_import_string_unloaded_submodule(self):
+        submodule_dotpath = "utils_tests.test_module.good_module"
+        self.addCleanup(sys.modules.pop, submodule_dotpath, None)
+        import_string(submodule_dotpath)
+
+    def test_import_string_empty(self):
+        with self.assertRaisesMessage(ValueError, "Empty module name"):
+            import_string("")
 
 
 @modify_settings(INSTALLED_APPS={"append": "utils_tests.test_module"})


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-36864

#### Branch description
Adds support for importing modules from the utils.module_loading.import_string function.

It may be worth noting that the signature for cached_import has changed to only take a module path and load it, rather than also attempting the getattr call as well since it seems that all of the caching functionality was centered around module loading. This function does not appear in the documentation, so I believe it is not public.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
