### PR TITLE
Fixed #35596 - Docs update related to deprecated warnings

### DIFF
--- a/docs/topics/db/optimization.txt
+++ b/docs/topics/db/optimization.txt
@@ -189,12 +189,10 @@ Doing the following is potentially quite slow:
 First of all, ``headline`` is not indexed, which will make the underlying
 database fetch slower.
 
-Second, the lookup doesn't guarantee that only one object will be returned.
-If the query matches more than one object, it will retrieve and transfer all of
-them from the database. This penalty could be substantial if hundreds or
-thousands of records are returned. The penalty will be compounded if the
-database lives on a separate server, where network overhead and latency also
-play a factor.
+Second, the lookup may return multiple results. Even though Django applies a
+limit of 21 objects when using :meth:`~django.db.models.query.QuerySet.get`,
+the database may still need to scan everything to evaluate a non-unique
+condition. Narrowing your query up-front is more efficient.
 
 Retrieve related objects efficiently
 ====================================


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-35596

#### Branch description
Updating the docs to no longer incorrectly assert that "get()" queries may return huge numbers of results (which was the case before a fix that set a limit of 21). The docs now state what the result limit is and what is recommended while removing deprecated warnings.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [X] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [X] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [X] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [X] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
- [X] I have attached screenshots in both light and dark modes for any UI changes.