### PR TITLE
Fixed #36905 -- Deprecated the safe parameter in JsonResponse.

### DIFF
--- a/django/http/response.py
+++ b/django/http/response.py
@@ -20,6 +20,10 @@ from django.core.serializers.json import DjangoJSONEncoder
 from django.http.cookie import SimpleCookie
 from django.utils import timezone
 from django.utils.datastructures import CaseInsensitiveMapping
+from django.utils.deprecation import (
+    RemovedInDjango71Warning,
+    django_file_prefixes,
+)
 from django.utils.encoding import iri_to_uri
 from django.utils.functional import cached_property
 from django.utils.http import (
@@ -755,10 +759,21 @@ class JsonResponse(HttpResponse):
         self,
         data,
         encoder=DjangoJSONEncoder,
-        safe=True,
+        # RemovedInDjango71Warning: Remove the safe parameter.
+        safe=None,
         json_dumps_params=None,
         **kwargs,
     ):
+        # RemovedInDjango71Warning.
+        if safe is None:
+            safe = False
+        else:
+            warnings.warn(
+                "The safe parameter is deprecated.",
+                category=RemovedInDjango71Warning,
+                skip_file_prefixes=django_file_prefixes(),
+            )
+        # RemovedInDjango71Warning.
         if safe and not isinstance(data, dict):
             raise TypeError(
                 "In order to allow non-dict objects to be serialized set the "

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -1281,6 +1281,14 @@ using non-dict objects in JSON-encoded response.
     modern browsers implement ECMAScript 5 which removes this attack vector.
     Therefore it is possible to disable this security precaution.
 
+.. versionchanged:: 6.2
+
+    In earlier versions, the ``safe`` parameter defaulted to ``True``.
+
+.. deprecated:: 6.2
+
+    The ``safe`` parameter is deprecated.
+
 Changing the default JSON encoder
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -251,7 +251,10 @@ backends.
 Miscellaneous
 -------------
 
-* ...
+* To facilitate the deprecation of the ``safe`` parameter of
+  :class:`~django.http.JsonResponse`, it now defaults to ``False``, because the
+  pollution vulnerability in the ``Array`` prototype was fixed in
+  `ES5 <https://262.ecma-international.org/5.1/#sec-11.1.4>`_.
 
 .. _deprecated-features-6.2:
 
@@ -261,4 +264,5 @@ Features deprecated in 6.2
 Miscellaneous
 -------------
 
-* ...
+* The ``safe`` parameter is deprecated from :class:`~django.http.JsonResponse`.
+  Omitting the argument is equivalent to the prior ``safe=False`` usage.

--- a/tests/httpwrappers/tests.py
+++ b/tests/httpwrappers/tests.py
@@ -24,6 +24,7 @@ from django.http import (
     parse_cookie,
 )
 from django.test import SimpleTestCase
+from django.utils.deprecation import RemovedInDjango71Warning
 from django.utils.encoding import iri_to_uri
 from django.utils.functional import lazystr
 from django.utils.http import MAX_URL_REDIRECT_LENGTH
@@ -703,25 +704,31 @@ class JsonResponseTests(SimpleTestCase):
         response = JsonResponse(data)
         self.assertEqual(json.loads(response.text), data)
 
-    def test_json_response_raises_type_error_with_default_setting(self):
-        with self.assertRaisesMessage(
-            TypeError,
-            "In order to allow non-dict objects to be serialized set the "
-            "safe parameter to False",
+    # RemovedInDjango71Warning: When the deprecation ends, remove this test.
+    def test_json_response_raises_type_error_with_safe_arg(self):
+        with (
+            self.assertRaisesMessage(
+                TypeError,
+                "In order to allow non-dict objects to be serialized set the "
+                "safe parameter to False",
+            ),
+            self.assertWarnsMessage(
+                RemovedInDjango71Warning, "The safe parameter is deprecated."
+            ),
         ):
-            JsonResponse([1, 2, 3])
+            JsonResponse([1, 2, 3], safe=True)
 
     def test_json_response_text(self):
-        response = JsonResponse("foobar", safe=False)
+        response = JsonResponse("foobar")
         self.assertEqual(json.loads(response.text), "foobar")
 
     def test_json_response_list(self):
-        response = JsonResponse(["foo", "bar"], safe=False)
+        response = JsonResponse(["foo", "bar"])
         self.assertEqual(json.loads(response.text), ["foo", "bar"])
 
     def test_json_response_uuid(self):
         u = uuid.uuid4()
-        response = JsonResponse(u, safe=False)
+        response = JsonResponse(u)
         self.assertEqual(json.loads(response.text), str(u))
 
     def test_json_response_custom_encoder(self):


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-36905

#### Branch description
Deprecated the safe parameter from JsonResponse. 

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
