### PR TITLE
Fixed #37102 -- Used **kwargs instead of *kwargs in CountsDict.init().

### DIFF
--- a/django/utils/html.py
+++ b/django/utils/html.py
@@ -278,7 +278,7 @@ def smart_urlquote(url):
 
 class CountsDict(dict):
     def __init__(self, *args, word, **kwargs):
-        super().__init__(*args, *kwargs)
+        super().__init__(*args, **kwargs)
         self.word = word
 
     def __missing__(self, key):


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37102

#### Branch description
This PR fixes a bug in `CountsDict.__init__()` in `django/utils/html.py` where `*kwargs` (positional unpacking) was used instead of `**kwargs` (keyword unpacking) in the call to `super().__init__()`. The fix changes `*kwargs` to `**kwargs` so that keyword arguments are correctly forwarded to `dict.__init__()` instead of being unpacked as positional arguments.
A regression test has been added to `tests/utils_tests/test_html.py` that passes keyword arguments to `CountsDict` to verify they are correctly forwarded.


#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
