### PR TITLE
Fixed #14974 -- Added pluggable translation backend support.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -326,6 +326,7 @@ answer newbie questions, and generally made Django that much better:
     Dustyn Gibson <miigotu@gmail.com>
     Ed Morley <https://github.com/edmorley>
     Egidijus Macijauskas <e.macijauskas@outlook.com>
+    Egon Scheer <e.scheer@deuse.be>
     eibaan@gmail.com
     elky <http://elky.me/>
     Emmanuelle Delescolle <https://github.com/nanuxbe>

--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -161,6 +161,10 @@ LANGUAGES_BIDI = ["he", "ar", "ar-dz", "ckb", "fa", "ug", "ur"]
 USE_I18N = True
 LOCALE_PATHS = []
 
+# Dotted path to the translation backend used to serve gettext()/activate()/...
+# When USE_I18N is False, the null backend is used regardless of this setting.
+TRANSLATION_BACKEND = "django.utils.translation.backends.gettext.GettextBackend"
+
 # Settings for language cookie
 LANGUAGE_COOKIE_NAME = "django_language"
 LANGUAGE_COOKIE_AGE = None

--- a/django/core/checks/translation.py
+++ b/django/core/checks/translation.py
@@ -1,8 +1,12 @@
 from django.conf import settings
-from django.utils.translation import get_supported_language_variant
-from django.utils.translation.trans_real import language_code_re
+from django.utils.translation import _trans, get_supported_language_variant
 
 from . import Error, Tags, register
+
+
+def _is_valid_language_code(tag):
+    return isinstance(tag, str) and _trans.is_valid_language_code(tag)
+
 
 E001 = Error(
     "You have provided an invalid value for the LANGUAGE_CODE setting: {!r}.",
@@ -30,7 +34,7 @@ E004 = Error(
 def check_setting_language_code(app_configs, **kwargs):
     """Error if LANGUAGE_CODE setting is invalid."""
     tag = settings.LANGUAGE_CODE
-    if not isinstance(tag, str) or not language_code_re.match(tag):
+    if not _is_valid_language_code(tag):
         return [Error(E001.msg.format(tag), id=E001.id)]
     return []
 
@@ -41,7 +45,7 @@ def check_setting_languages(app_configs, **kwargs):
     return [
         Error(E002.msg.format(tag), id=E002.id)
         for tag, _ in settings.LANGUAGES
-        if not isinstance(tag, str) or not language_code_re.match(tag)
+        if not _is_valid_language_code(tag)
     ]
 
 
@@ -51,7 +55,7 @@ def check_setting_languages_bidi(app_configs, **kwargs):
     return [
         Error(E003.msg.format(tag), id=E003.id)
         for tag in settings.LANGUAGES_BIDI
-        if not isinstance(tag, str) or not language_code_re.match(tag)
+        if not _is_valid_language_code(tag)
     ]
 
 

--- a/django/test/signals.py
+++ b/django/test/signals.py
@@ -50,10 +50,10 @@ def update_installed_apps(*, setting, **kwargs):
         from django.template.utils import get_app_template_dirs
 
         get_app_template_dirs.cache_clear()
-        # Rebuild translations cache.
-        from django.utils.translation import trans_real
+        # Rebuild translations cache via the active translation backend.
+        from django.utils.translation import _trans
 
-        trans_real._translations = {}
+        _trans.clear_translations_cache()
 
 
 @receiver(setting_changed)
@@ -145,15 +145,13 @@ def clear_serializers_cache(*, setting, **kwargs):
 @receiver(setting_changed)
 def language_changed(*, setting, **kwargs):
     if setting in {"LANGUAGES", "LANGUAGE_CODE", "LOCALE_PATHS"}:
-        from django.utils.translation import trans_real
+        from django.utils.translation import _trans
 
-        trans_real._default = None
-        trans_real._active = Local()
+        _trans.clear_active_language()
     if setting in {"LANGUAGES", "LOCALE_PATHS"}:
-        from django.utils.translation import trans_real
+        from django.utils.translation import _trans
 
-        trans_real._translations = {}
-        trans_real.check_for_language.cache_clear()
+        _trans.clear_translations_cache()
 
 
 @receiver(setting_changed)

--- a/django/utils/translation/__init__.py
+++ b/django/utils/translation/__init__.py
@@ -49,22 +49,26 @@ class TranslatorCommentWarning(SyntaxWarning):
 
 class Trans:
     """
-    The purpose of this class is to store the actual translation function upon
-    receiving the first call to that function. After this is done, changes to
-    USE_I18N will have no effect to which function is served upon request. If
-    your tests rely on changing USE_I18N, you can delete all the functions
-    from _trans.__dict__.
+    Dispatcher that lazily resolves translation calls to the active backend.
 
-    Note that storing the function with setattr will have a noticeable
-    performance effect, as access to the function goes the normal path,
-    instead of using __getattr__.
+    The active backend is selected by :setting:`TRANSLATION_BACKEND`, unless
+    :setting:`USE_I18N` is ``False`` — in which case the null backend is forced
+    so projects that disable i18n keep paying zero cost.
+
+    The first attribute access loads the backend, binds the resolved bound
+    method on the instance, and returns it; subsequent calls hit the bound
+    method directly with no per-call dispatch overhead (same trick the
+    pre-backends implementation used).
     """
+
+    NULL_BACKEND = "django.utils.translation.backends.null.NullBackend"
 
     def __getattr__(self, real_name):
         from django.conf import settings
+        from django.utils.translation.backends import load_backend
 
         if settings.USE_I18N:
-            from django.utils.translation import trans_real as trans
+            backend = load_backend(settings.TRANSLATION_BACKEND)
             from django.utils.translation.reloader import (
                 translation_file_changed,
                 watch_for_translation_changes,
@@ -77,9 +81,10 @@ class Trans:
                 translation_file_changed, dispatch_uid="translation_file_changed"
             )
         else:
-            from django.utils.translation import trans_null as trans
-        setattr(self, real_name, getattr(trans, real_name))
-        return getattr(trans, real_name)
+            backend = load_backend(self.NULL_BACKEND)
+        attr = getattr(backend, real_name)
+        setattr(self, real_name, attr)
+        return attr
 
 
 _trans = Trans()

--- a/django/utils/translation/backends/__init__.py
+++ b/django/utils/translation/backends/__init__.py
@@ -1,0 +1,148 @@
+"""
+Translation backends.
+
+A translation backend is a class that implements the surface defined by
+:class:`BaseTranslationBackend` and powers the public ``gettext``,
+``gettext_lazy``, ``activate``, ``get_language``… helpers exposed by
+``django.utils.translation``.
+
+The active backend is selected by the :setting:`TRANSLATION_BACKEND` setting.
+When :setting:`USE_I18N` is ``False``, the null backend is forced regardless of
+that setting.
+"""
+
+from django.utils.module_loading import import_string
+
+
+class InvalidTranslationBackendError(ImportError):
+    """Raised when TRANSLATION_BACKEND cannot be imported or instantiated."""
+
+
+def load_backend(dotted_path):
+    """
+    Import and instantiate the backend at ``dotted_path``.
+
+    Raised errors are wrapped in :class:`InvalidTranslationBackendError` so the
+    dispatcher can surface a single, predictable exception type.
+    """
+    try:
+        cls = import_string(dotted_path)
+    except ImportError as exc:
+        raise InvalidTranslationBackendError(
+            "Could not import translation backend %r: %s" % (dotted_path, exc)
+        ) from exc
+    try:
+        return cls()
+    except TypeError as exc:
+        raise InvalidTranslationBackendError(
+            "Could not instantiate translation backend %r: %s" % (dotted_path, exc)
+        ) from exc
+
+
+class BaseTranslationBackend:
+    """
+    Base class third-party translation backends must subclass.
+
+    The base implementation supplies sensible defaults for the optional hooks
+    (``gettext_noop``, ``reset_state``, ``on_translation_files_changed``,
+    ``get_catalog``, ``is_valid_language_code``). The mandatory methods raise
+    :class:`NotImplementedError`; subclasses must override them.
+    """
+
+    # -- Mandatory translation surface ----------------------------------
+
+    def gettext(self, message):
+        raise NotImplementedError
+
+    def ngettext(self, singular, plural, number):
+        raise NotImplementedError
+
+    def pgettext(self, context, message):
+        raise NotImplementedError
+
+    def npgettext(self, context, singular, plural, number):
+        raise NotImplementedError
+
+    # -- Mandatory language state surface -------------------------------
+
+    def activate(self, language):
+        raise NotImplementedError
+
+    def deactivate(self):
+        raise NotImplementedError
+
+    def deactivate_all(self):
+        raise NotImplementedError
+
+    def get_language(self):
+        raise NotImplementedError
+
+    def get_language_bidi(self):
+        raise NotImplementedError
+
+    def get_language_from_request(self, request, check_path=False):
+        raise NotImplementedError
+
+    def get_language_from_path(self, path):
+        raise NotImplementedError
+
+    def get_supported_language_variant(self, lang_code, strict=False):
+        raise NotImplementedError
+
+    def check_for_language(self, lang_code):
+        raise NotImplementedError
+
+    # -- Optional hooks with usable defaults ----------------------------
+
+    def gettext_noop(self, message):
+        return message
+
+    def clear_translations_cache(self):
+        """
+        Drop the cache of loaded translation catalogs without touching the
+        per-thread active language. Triggered on INSTALLED_APPS changes.
+        """
+
+    def clear_active_language(self):
+        """
+        Forget the current default language and the per-thread active
+        language. Triggered on LANGUAGES/LANGUAGE_CODE/LOCALE_PATHS changes.
+        """
+
+    def reset_state(self):
+        """
+        Drop every per-process cache the backend keeps.
+
+        Called by ``django.test.signals`` between tests and by the autoreload
+        translation watcher when a translation file changes on disk. The
+        default composes the two finer-grained hooks above.
+        """
+        self.clear_translations_cache()
+        self.clear_active_language()
+
+    def on_translation_files_changed(self, sender, file_path, **kwargs):
+        """
+        React to a translation source file having changed on disk.
+
+        The default implementation calls :meth:`reset_state`; backends that do
+        not load from disk can leave this as a no-op by overriding to ``pass``.
+        """
+        self.reset_state()
+
+    def get_catalog(self, locale, domain="djangojs", localedirs=None):
+        """
+        Return a translation catalog object for the
+        :class:`~django.views.i18n.JavaScriptCatalog` view.
+
+        The returned object must expose ``_catalog`` (``{msgid: msgstr}``)
+        and ``_fallback`` (another catalog or ``None``). Backends that do
+        not ship a JavaScript catalog should leave this raising
+        :class:`NotImplementedError` — the view will surface a clear error.
+        """
+        raise NotImplementedError(
+            "%s does not expose a JavaScript catalog." % type(self).__name__
+        )
+
+    def is_valid_language_code(self, code):
+        """Return whether ``code`` is a syntactically valid language tag."""
+        return True

--- a/django/utils/translation/backends/gettext.py
+++ b/django/utils/translation/backends/gettext.py
@@ -1,0 +1,92 @@
+"""
+Gettext translation backend.
+
+This is the default backend selected by :setting:`TRANSLATION_BACKEND`. It is a
+thin object wrapper around the function-level API in
+:mod:`django.utils.translation.trans_real`, which remains the implementation of
+record so the existing gettext semantics and the entire ``tests/i18n`` suite
+are preserved byte-for-byte.
+"""
+
+from django.utils.translation import trans_real
+from django.utils.translation.backends import BaseTranslationBackend
+
+
+class GettextBackend(BaseTranslationBackend):
+    """
+    Default backend. Delegates to :mod:`django.utils.translation.trans_real`.
+    """
+
+    # -- Translation surface --------------------------------------------
+
+    def gettext(self, message):
+        return trans_real.gettext(message)
+
+    def ngettext(self, singular, plural, number):
+        return trans_real.ngettext(singular, plural, number)
+
+    def pgettext(self, context, message):
+        return trans_real.pgettext(context, message)
+
+    def npgettext(self, context, singular, plural, number):
+        return trans_real.npgettext(context, singular, plural, number)
+
+    def gettext_noop(self, message):
+        return trans_real.gettext_noop(message)
+
+    # -- Language state -------------------------------------------------
+
+    def activate(self, language):
+        return trans_real.activate(language)
+
+    def deactivate(self):
+        return trans_real.deactivate()
+
+    def deactivate_all(self):
+        return trans_real.deactivate_all()
+
+    def get_language(self):
+        return trans_real.get_language()
+
+    def get_language_bidi(self):
+        return trans_real.get_language_bidi()
+
+    def get_language_from_request(self, request, check_path=False):
+        return trans_real.get_language_from_request(request, check_path)
+
+    def get_language_from_path(self, path):
+        return trans_real.get_language_from_path(path)
+
+    def get_supported_language_variant(self, lang_code, strict=False):
+        return trans_real.get_supported_language_variant(lang_code, strict)
+
+    def check_for_language(self, lang_code):
+        return trans_real.check_for_language(lang_code)
+
+    # -- Optional hooks -------------------------------------------------
+
+    def clear_translations_cache(self):
+        trans_real._translations = {}
+        trans_real.check_for_language.cache_clear()
+
+    def clear_active_language(self):
+        from asgiref.local import Local
+
+        trans_real._default = None
+        trans_real._active = Local()
+
+    def on_translation_files_changed(self, sender, file_path, **kwargs):
+        # Also clear the stdlib gettext module's own cache: trans_real reuses
+        # gettext.translation() which memoizes loaded .mo files there.
+        import gettext as _gettext_module
+
+        _gettext_module._translations = {}
+        self.reset_state()
+
+    def get_catalog(self, locale, domain="djangojs", localedirs=None):
+        return trans_real.DjangoTranslation(
+            locale, domain=domain, localedirs=localedirs
+        )
+
+    def is_valid_language_code(self, code):
+        return bool(trans_real.language_code_re.match(code))

--- a/django/utils/translation/backends/null.py
+++ b/django/utils/translation/backends/null.py
@@ -1,0 +1,58 @@
+"""
+Null translation backend.
+
+Used when :setting:`USE_I18N` is ``False`` (or when a project sets
+``TRANSLATION_BACKEND`` to this class explicitly). It returns messages
+unchanged, mirroring the behavior of
+:mod:`django.utils.translation.trans_null`, which remains the implementation
+of record.
+"""
+
+from django.utils.translation import trans_null
+from django.utils.translation.backends import BaseTranslationBackend
+
+
+class NullBackend(BaseTranslationBackend):
+    """No-op backend; delegates to ``django.utils.translation.trans_null``."""
+
+    def gettext(self, message):
+        return trans_null.gettext(message)
+
+    def ngettext(self, singular, plural, number):
+        return trans_null.ngettext(singular, plural, number)
+
+    def pgettext(self, context, message):
+        return trans_null.pgettext(context, message)
+
+    def npgettext(self, context, singular, plural, number):
+        return trans_null.npgettext(context, singular, plural, number)
+
+    def gettext_noop(self, message):
+        return trans_null.gettext_noop(message)
+
+    def activate(self, language):
+        return trans_null.activate(language)
+
+    def deactivate(self):
+        return trans_null.deactivate()
+
+    def deactivate_all(self):
+        return trans_null.deactivate_all()
+
+    def get_language(self):
+        return trans_null.get_language()
+
+    def get_language_bidi(self):
+        return trans_null.get_language_bidi()
+
+    def get_language_from_request(self, request, check_path=False):
+        return trans_null.get_language_from_request(request, check_path)
+
+    def get_language_from_path(self, path):
+        return trans_null.get_language_from_path(path)
+
+    def get_supported_language_variant(self, lang_code, strict=False):
+        return trans_null.get_supported_language_variant(lang_code, strict)
+
+    def check_for_language(self, lang_code):
+        return trans_null.check_for_language(lang_code)

--- a/django/utils/translation/reloader.py
+++ b/django/utils/translation/reloader.py
@@ -1,7 +1,5 @@
 from pathlib import Path
 
-from asgiref.local import Local
-
 from django.apps import apps
 from django.utils.autoreload import is_django_module
 
@@ -23,14 +21,9 @@ def watch_for_translation_changes(sender, **kwargs):
 
 
 def translation_file_changed(sender, file_path, **kwargs):
-    """Clear the internal translations cache if a .mo file is modified."""
+    """Notify the active translation backend that a .mo file was modified."""
     if file_path.suffix == ".mo":
-        import gettext
+        from django.utils.translation import _trans
 
-        from django.utils.translation import trans_real
-
-        gettext._translations = {}
-        trans_real._translations = {}
-        trans_real._default = None
-        trans_real._active = Local()
+        _trans.on_translation_files_changed(sender, file_path, **kwargs)
         return True

--- a/django/views/i18n.py
+++ b/django/views/i18n.py
@@ -10,8 +10,7 @@ from django.template import Context, Engine
 from django.urls import translate_url
 from django.utils.formats import get_format
 from django.utils.http import url_has_allowed_host_and_scheme
-from django.utils.translation import check_for_language, get_language
-from django.utils.translation.trans_real import DjangoTranslation
+from django.utils.translation import _trans, check_for_language, get_language
 from django.views.generic import View
 
 LANGUAGE_QUERY_PARAMETER = "language"
@@ -120,7 +119,7 @@ class JavaScriptCatalog(View):
         packages = kwargs.get("packages", "")
         packages = packages.split("+") if packages else self.packages
         paths = self.get_paths(packages) if packages else None
-        self.translation = DjangoTranslation(locale, domain=domain, localedirs=paths)
+        self.translation = _trans.get_catalog(locale, domain=domain, localedirs=paths)
         context = self.get_context_data(**kwargs)
         return self.render_to_response(context)
 

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -3212,6 +3212,24 @@ Default: ``False``
 Set this transitional setting to ``True`` to revert back to the old default
 blank choice label in forms.
 
+.. setting:: TRANSLATION_BACKEND
+
+``TRANSLATION_BACKEND``
+-----------------------
+
+.. versionadded:: 6.1
+
+Default: ``"django.utils.translation.backends.gettext.GettextBackend"``
+
+The dotted Python path to the translation backend class that powers
+:func:`~django.utils.translation.gettext` and the rest of the public
+:mod:`django.utils.translation` API. See :doc:`/topics/i18n/backends` for the
+backend contract and how to write your own.
+
+When :setting:`USE_I18N` is ``False``, the null backend is used regardless of
+this setting so the existing ``USE_I18N = False`` performance optimization is
+preserved.
+
 .. setting:: USE_I18N
 
 ``USE_I18N``
@@ -3224,7 +3242,8 @@ This provides a way to turn it off, for performance. If this is set to
 ``False``, Django will make some optimizations so as not to load the
 translation machinery.
 
-See also :setting:`LANGUAGE_CODE` and :setting:`USE_TZ`.
+See also :setting:`LANGUAGE_CODE`, :setting:`TRANSLATION_BACKEND`, and
+:setting:`USE_TZ`.
 
 .. note::
 
@@ -4042,6 +4061,7 @@ Internationalization (``i18n``)
 * :setting:`LANGUAGES_BIDI`
 * :setting:`LOCALE_PATHS`
 * :setting:`TIME_ZONE`
+* :setting:`TRANSLATION_BACKEND`
 * :setting:`USE_I18N`
 * :setting:`USE_TZ`
 

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -346,7 +346,11 @@ Generic Views
 Internationalization
 ~~~~~~~~~~~~~~~~~~~~
 
-* ...
+* The new :setting:`TRANSLATION_BACKEND` setting lets projects swap the
+  gettext-based translation machinery for a custom backend (for example one
+  that reads translations from a database row or a remote service). The
+  default value preserves the existing gettext behavior, and ``USE_I18N =
+  False`` keeps forcing the null backend. See :doc:`/topics/i18n/backends`.
 
 Logging
 ~~~~~~~

--- a/docs/topics/i18n/backends.txt
+++ b/docs/topics/i18n/backends.txt
@@ -1,0 +1,162 @@
+====================
+Translation backends
+====================
+
+.. versionadded:: 6.1
+
+The :mod:`django.utils.translation` API — :func:`~django.utils.translation.gettext`,
+:func:`~django.utils.translation.gettext_lazy`,
+:func:`~django.utils.translation.activate`,
+:func:`~django.utils.translation.get_language`, … — is a thin dispatcher in
+front of a **translation backend**. The default backend is gettext, mirroring
+Django's historical behavior, but the backend is pluggable: a project can ship
+translations from a database row, a JSON file, a remote service, or any other
+store by providing its own backend class.
+
+This is the extension point requested by :ticket:`14974`. It is **not** a
+replacement for :doc:`per-model translations </topics/i18n/index>` — those are
+tracked separately in :ticket:`6460`.
+
+Selecting a backend
+===================
+
+The :setting:`TRANSLATION_BACKEND` setting holds the dotted Python path to the
+active backend class::
+
+    # settings.py
+    TRANSLATION_BACKEND = "myproject.i18n.PontoonBackend"
+
+The default is::
+
+    TRANSLATION_BACKEND = "django.utils.translation.backends.gettext.GettextBackend"
+
+When :setting:`USE_I18N` is ``False``, Django forces the null backend
+(``django.utils.translation.backends.null.NullBackend``) regardless of
+``TRANSLATION_BACKEND``, preserving the performance optimization that
+``USE_I18N = False`` has always given.
+
+Writing a custom backend
+========================
+
+Subclass ``django.utils.translation.backends.BaseTranslationBackend`` and
+override the methods you need. The base class provides usable defaults for the
+optional hooks; the mandatory methods raise :class:`NotImplementedError`.
+
+Mandatory methods
+-----------------
+
+These are the surface that the public translation API delegates to, so a
+backend that omits one of them will raise :class:`NotImplementedError` the
+first time a project calls into the corresponding feature.
+
+* ``gettext(message)``
+* ``ngettext(singular, plural, number)``
+* ``pgettext(context, message)``
+* ``npgettext(context, singular, plural, number)``
+* ``activate(language)``
+* ``deactivate()``
+* ``deactivate_all()``
+* ``get_language()``
+* ``get_language_bidi()``
+* ``get_language_from_request(request, check_path=False)``
+* ``get_language_from_path(path)``
+* ``get_supported_language_variant(lang_code, strict=False)``
+* ``check_for_language(lang_code)``
+
+Optional hooks (with sensible defaults)
+---------------------------------------
+
+* ``gettext_noop(message)`` — defaults to returning ``message`` unchanged.
+* ``clear_translations_cache()`` — invoked when :setting:`INSTALLED_APPS`
+  changes during tests; drop any per-process catalog cache.
+* ``clear_active_language()`` — invoked when :setting:`LANGUAGE_CODE`,
+  :setting:`LANGUAGES`, or :setting:`LOCALE_PATHS` changes; forget the
+  per-thread active language.
+* ``reset_state()`` — full reset. Default implementation calls both ``clear_*``
+  hooks above.
+* ``on_translation_files_changed(sender, file_path, **kwargs)`` — called by
+  the autoreloader when a translation source file changes on disk. Default
+  calls ``reset_state``; backends that do not read from disk can override
+  with ``pass``.
+* ``get_catalog(locale, domain="djangojs", localedirs=None)`` — used by
+  :class:`django.views.i18n.JavaScriptCatalog`. The returned object must
+  expose ``_catalog`` and ``_fallback`` attributes compatible with gettext's
+  ``GNUTranslations``. Backends that do not ship a JS catalog should leave
+  this raising :class:`NotImplementedError`.
+* ``is_valid_language_code(code)`` — used by the system checks for
+  :setting:`LANGUAGE_CODE` / :setting:`LANGUAGES` / :setting:`LANGUAGES_BIDI`.
+  Defaults to ``True`` (accept anything that's a non-empty string).
+
+Example
+-------
+
+A minimal backend that prefixes every message with ``[xx]`` — useful as a
+pseudo-localization for QA::
+
+    from django.utils.translation.backends import BaseTranslationBackend
+
+
+    class PseudoBackend(BaseTranslationBackend):
+        def gettext(self, message):
+            return "[xx] %s" % message
+
+        def ngettext(self, singular, plural, number):
+            return self.gettext(singular if number == 1 else plural)
+
+        def pgettext(self, context, message):
+            return self.gettext(message)
+
+        def npgettext(self, context, singular, plural, number):
+            return self.ngettext(singular, plural, number)
+
+        def activate(self, language):
+            pass
+
+        def deactivate(self):
+            pass
+
+        def deactivate_all(self):
+            pass
+
+        def get_language(self):
+            from django.conf import settings
+
+            return settings.LANGUAGE_CODE
+
+        def get_language_bidi(self):
+            return False
+
+        def get_language_from_request(self, request, check_path=False):
+            from django.conf import settings
+
+            return settings.LANGUAGE_CODE
+
+        def get_language_from_path(self, path):
+            return None
+
+        def get_supported_language_variant(self, lang_code, strict=False):
+            return lang_code
+
+        def check_for_language(self, lang_code):
+            return True
+
+Wire it in::
+
+    TRANSLATION_BACKEND = "myproject.i18n.PseudoBackend"
+
+Caveats
+=======
+
+* ``templatize()`` is gettext-specific: it produces a ``.py`` source that
+  ``xgettext`` can parse, which is meaningless for non-gettext backends.
+  Custom backends therefore do not benefit from :djadmin:`makemessages` or
+  :djadmin:`compilemessages` — they need to populate their own message store.
+
+* The dispatcher caches resolved methods on first call. If you change
+  :setting:`TRANSLATION_BACKEND` at runtime via
+  :class:`~django.test.override_settings`, also clear the dispatcher cache::
+
+      from django.utils.translation import _trans
+
+      for name in list(_trans.__dict__):
+          delattr(_trans, name)

--- a/docs/topics/i18n/index.txt
+++ b/docs/topics/i18n/index.txt
@@ -9,6 +9,7 @@ Internationalization and localization
    translation
    formatting
    timezones
+   backends
 
 Overview
 ========

--- a/tests/i18n/test_backends.py
+++ b/tests/i18n/test_backends.py
@@ -1,0 +1,197 @@
+"""
+Tests for the pluggable translation backend extension point introduced by the
+``TRANSLATION_BACKEND`` setting (ticket #14974).
+
+These tests assert dispatcher behavior; the existing ``tests/i18n`` suite is
+the oracle that gettext semantics remain untouched.
+"""
+
+from django.core.checks import Error
+from django.test import SimpleTestCase, override_settings
+from django.utils.translation import (
+    _trans,
+    gettext,
+    gettext_lazy,
+    ngettext,
+    pgettext,
+)
+from django.utils.translation.backends import (
+    BaseTranslationBackend,
+    InvalidTranslationBackendError,
+    load_backend,
+)
+
+
+def _reset_dispatcher():
+    """
+    Drop attributes cached on the ``_trans`` dispatcher so the next call goes
+    through ``__getattr__`` and re-reads ``settings.TRANSLATION_BACKEND``.
+    """
+    for name in list(_trans.__dict__):
+        delattr(_trans, name)
+
+
+class StubBackend(BaseTranslationBackend):
+    """Backend that wraps every message — easy to detect in assertions."""
+
+    def gettext(self, message):
+        return "<<%s>>" % message
+
+    def ngettext(self, singular, plural, number):
+        return self.gettext(singular if number == 1 else plural)
+
+    def pgettext(self, context, message):
+        return "<<%s|%s>>" % (context, message)
+
+    def npgettext(self, context, singular, plural, number):
+        return self.pgettext(context, singular if number == 1 else plural)
+
+    def activate(self, language):
+        self._language = language
+
+    def deactivate(self):
+        self._language = None
+
+    def deactivate_all(self):
+        self._language = None
+
+    def get_language(self):
+        return getattr(self, "_language", "en")
+
+    def get_language_bidi(self):
+        return False
+
+    def get_language_from_request(self, request, check_path=False):
+        return "en"
+
+    def get_language_from_path(self, path):
+        return None
+
+    def get_supported_language_variant(self, lang_code, strict=False):
+        return lang_code
+
+    def check_for_language(self, lang_code):
+        return True
+
+    def is_valid_language_code(self, code):
+        # Stub backend accepts everything that's a non-empty string.
+        return isinstance(code, str) and bool(code)
+
+
+STUB_BACKEND = "i18n.test_backends.StubBackend"
+
+
+class LoadBackendTests(SimpleTestCase):
+    def test_load_backend_returns_instance(self):
+        self.assertIsInstance(load_backend(STUB_BACKEND), StubBackend)
+
+    def test_load_backend_invalid_path(self):
+        with self.assertRaises(InvalidTranslationBackendError):
+            load_backend("does.not.exist.Backend")
+
+    def test_load_backend_invalid_class(self):
+        # A class whose __init__ refuses no-arg construction surfaces as
+        # InvalidTranslationBackendError, not a bare TypeError.
+        with self.assertRaises(InvalidTranslationBackendError):
+            load_backend("i18n.test_backends.BackendThatRequiresArgs")
+
+
+class BackendThatRequiresArgs(BaseTranslationBackend):
+    def __init__(self, required_arg):
+        self.required_arg = required_arg
+
+
+class BaseBackendDefaultsTests(SimpleTestCase):
+    def test_gettext_noop_default_is_identity(self):
+        backend = BaseTranslationBackend()
+        self.assertEqual(backend.gettext_noop("Hello"), "Hello")
+
+    def test_reset_state_calls_both_clear_hooks(self):
+        seen = []
+
+        class TrackingBackend(BaseTranslationBackend):
+            def clear_translations_cache(self):
+                seen.append("translations")
+
+            def clear_active_language(self):
+                seen.append("language")
+
+        TrackingBackend().reset_state()
+        self.assertEqual(seen, ["translations", "language"])
+
+    def test_get_catalog_default_raises(self):
+        with self.assertRaisesMessage(
+            NotImplementedError, "does not expose a JavaScript catalog"
+        ):
+            BaseTranslationBackend().get_catalog("en")
+
+    def test_is_valid_language_code_default_permissive(self):
+        self.assertTrue(BaseTranslationBackend().is_valid_language_code("anything"))
+
+
+class DispatcherSelectionTests(SimpleTestCase):
+    def setUp(self):
+        _reset_dispatcher()
+        self.addCleanup(_reset_dispatcher)
+
+    @override_settings(TRANSLATION_BACKEND=STUB_BACKEND)
+    def test_gettext_routes_through_active_backend(self):
+        self.assertEqual(gettext("Hello"), "<<Hello>>")
+
+    @override_settings(TRANSLATION_BACKEND=STUB_BACKEND)
+    def test_ngettext_routes_through_active_backend(self):
+        self.assertEqual(ngettext("apple", "apples", 1), "<<apple>>")
+        self.assertEqual(ngettext("apple", "apples", 2), "<<apples>>")
+
+    @override_settings(TRANSLATION_BACKEND=STUB_BACKEND)
+    def test_pgettext_routes_through_active_backend(self):
+        self.assertEqual(pgettext("month", "May"), "<<month|May>>")
+
+    @override_settings(TRANSLATION_BACKEND=STUB_BACKEND)
+    def test_lazy_resolves_against_active_backend(self):
+        # gettext_lazy is built once at import time but the proxy must resolve
+        # against the *current* dispatcher state on each str() call.
+        self.assertEqual(str(gettext_lazy("Hello")), "<<Hello>>")
+
+    @override_settings(USE_I18N=False, TRANSLATION_BACKEND=STUB_BACKEND)
+    def test_use_i18n_false_overrides_backend_setting(self):
+        # NullBackend must win regardless of TRANSLATION_BACKEND.
+        self.assertEqual(gettext("Hello"), "Hello")
+
+    @override_settings(TRANSLATION_BACKEND="x.y.z.NotARealClass")
+    def test_invalid_backend_surfaces_clear_error(self):
+        with self.assertRaises(InvalidTranslationBackendError):
+            gettext("Hello")
+
+
+class SystemCheckIntegrationTests(SimpleTestCase):
+    """The translation system checks must route through the backend."""
+
+    def setUp(self):
+        _reset_dispatcher()
+        self.addCleanup(_reset_dispatcher)
+
+    @override_settings(
+        TRANSLATION_BACKEND=STUB_BACKEND,
+        LANGUAGE_CODE="anything-goes-with-stub",
+        LANGUAGES=[("anything-goes-with-stub", "Anything")],
+    )
+    def test_language_code_check_defers_to_backend(self):
+        # The stub backend accepts arbitrary non-empty strings as language
+        # codes. The gettext backend would reject "anything-goes-with-stub".
+        from django.core.checks.translation import (
+            check_setting_language_code,
+            check_setting_languages,
+        )
+
+        self.assertEqual(check_setting_language_code(None), [])
+        self.assertEqual(check_setting_languages(None), [])
+
+    @override_settings(TRANSLATION_BACKEND=STUB_BACKEND, LANGUAGE_CODE="")
+    def test_language_code_check_rejects_empty_under_stub(self):
+        from django.core.checks.translation import check_setting_language_code
+
+        errors = check_setting_language_code(None)
+        self.assertEqual(len(errors), 1)
+        self.assertIsInstance(errors[0], Error)
+        self.assertEqual(errors[0].id, "translation.E001")


### PR DESCRIPTION
#### Trac ticket number

ticket-14974

#### Branch description

Adds a public `TRANSLATION_BACKEND` setting and a `BaseTranslationBackend`
extension point so projects can ship translations from sources other than
gettext `.mo` files (e.g. a database row, a remote service, a
pseudo-localization filter) without monkey-patching `trans_real`.

The existing gettext and null code paths remain the implementation of
record and are wrapped by the new `GettextBackend` / `NullBackend`
classes; behavior and performance for the default setup are unchanged.
`USE_I18N = False` still forces the null backend regardless of
`TRANSLATION_BACKEND`, preserving the existing optimization.

The private-state leaks previously reached into by `django.test.signals`,
`django.utils.translation.reloader`, `django.views.i18n`, and
`django.core.checks.translation` are now routed through backend hooks
(`clear_translations_cache`, `clear_active_language`, `reset_state`,
`on_translation_files_changed`, `get_catalog`,
`is_valid_language_code`), so custom backends can plug in cleanly
without depending on gettext-specific module internals.

Refs ticket #19480 (closed as duplicate of #14974). Supersedes the
previous attempt in PR #590 (closed in 2014); this PR addresses each
of the three blockers raised there by Tim Graham and Jannis Leidel:

| Blocker on PR #590 | Addressed here |
| --- | --- |
| "Makes a private API public" (Jannis) | A new public `BaseTranslationBackend` class is introduced; `trans_real` / `trans_null` remain implementation modules wrapped by `GettextBackend` / `NullBackend`. |
| "Does not apply cleanly" (Tim) | Rebased on current `main` (commit `3e4e0db`). |
| "Lacks documentation" (Tim) | Ships `docs/topics/i18n/backends.txt`, a `TRANSLATION_BACKEND` setting entry, and a 6.1 release note. |

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

**Disclosure details.** This PR was drafted with substantial assistance
from Anthropic's Claude (Claude Opus 4.7, January 2026 knowledge
cutoff), used through the Claude Code CLI. The AI was used for:

* analyzing ticket #14974 and reviewing the historical PR #590 / ticket
  #19480 to identify the previous blockers,
* drafting the `BaseTranslationBackend` API, the `GettextBackend` /
  `NullBackend` implementations, and the new dispatcher in
  `django/utils/translation/__init__.py`,
* writing the new test module `tests/i18n/test_backends.py`,
* writing the new topic guide `docs/topics/i18n/backends.txt`, the
  `TRANSLATION_BACKEND` settings entry, and the 6.1 release note,
* drafting the commit message.

The human contributor (Egon Scheer) directed the scope, made the design
decisions (notably: keep `USE_I18N` as override rather than
deprecating it in this PR; scope to the extension point only, defer a
DB backend to a follow-up), reviewed every change, ran the full
`tests/i18n` + `check_framework` + `view_tests.tests.test_i18n` +
`template_tests.syntax_tests.i18n` + `auth_tests` + `admin_views`
suites locally (2051 tests, 0 failures), built the docs with
`sphinx-build -W`, and ran `pre-commit run` cleanly. I take full
responsibility for the contribution.

I have specifically verified the absence of fabricated APIs: every
attribute/function referenced in the new code or docs
(`DjangoTranslation`, `language_code_re`, `trans_real._translations`,
`gettext.translation`, etc.) exists in the codebase or in stdlib.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability.
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [ ] I have checked the "Has patch" ticket flag in the Trac system. <!-- To be done once the CLA is signed; see PR body. -->
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes.
- [x] I have attached screenshots in both light and dark modes for any UI changes. <!-- N/A: no UI changes. -->

#### Notes for reviewers

1. **CLA status.** The contributor's individual CLA is being sent to
   `cla@djangoproject.com` in parallel with opening this draft; the
   PR will be moved out of draft once the CLA is on file.
2. **`BaseTranslationBackend` is duck-typed**, not `abc.ABC`. This was
   a deliberate choice so partial backends (e.g. one overriding only
   `gettext` for a QA pseudo-locale) are practical. Happy to switch to
   `ABC` if the consensus is the stricter contract.
3. **Granularity of cache invalidation.** `clear_translations_cache`
   and `clear_active_language` are exposed as two separate hooks
   because the test signal handler historically needed that
   granularity (the `LocalePathsResolutionOrderI18NTests` test
   exercises this — collapsing into a single `reset_state` causes a
   regression on that test). Let me know if you'd prefer a single
   hook that takes the changed setting name as an argument.
4. **Out of scope on purpose.** (a) Deprecating `USE_I18N` (a separate
   semantic change touching templates, `LocaleMiddleware`, and many
   third-party apps); (b) shipping a built-in DB-backed backend
   (the architecture is ready for it but bundling doubles the PR
   surface); (c) per-model / dynamic translation of model fields
   (tracked separately in ticket #6460).

#### Local verification

* `cd tests && ./runtests.py i18n check_framework view_tests.tests.test_i18n template_tests.syntax_tests.i18n auth_tests admin_views`
  → 2051 tests, 0 failures, 181 skips (Python 3.14, SQLite).
* `pre-commit run --files <touched files>` → black / blacken-docs /
  isort / flake8 all pass.
* `cd docs && sphinx-build -b html -W --keep-going -n . _build/html`
  → builds with zero warnings.