### PR TITLE
Fixed #37109 -- Consolidated SIGINT handling logic into the base database client

### DIFF
--- a/django/db/backends/base/client.py
+++ b/django/db/backends/base/client.py
@@ -1,4 +1,5 @@
 import os
+import signal
 import subprocess
 
 
@@ -28,4 +29,19 @@ class BaseDatabaseClient:
             self.connection.settings_dict, parameters
         )
         env = {**os.environ, **env} if env else None
-        subprocess.run(args, env=env, check=True)
+        sigint_handler = None
+        if hasattr(signal, "SIGINT"):
+            try:
+                sigint_handler = signal.getsignal(signal.SIGINT)
+            except ValueError:
+                pass
+        try:
+            if sigint_handler is not None:
+                signal.signal(signal.SIGINT, signal.SIG_IGN)
+            subprocess.run(args, env=env, check=True)
+        finally:
+            if sigint_handler is not None:
+                try:
+                    signal.signal(signal.SIGINT, sigint_handler)
+                except ValueError:
+                    pass

--- a/django/db/backends/mysql/client.py
+++ b/django/db/backends/mysql/client.py
@@ -1,5 +1,3 @@
-import signal
-
 from django.db.backends.base.client import BaseDatabaseClient
 
 
@@ -60,13 +58,3 @@ class DatabaseClient(BaseDatabaseClient):
             args += [database]
         args.extend(parameters)
         return args, env
-
-    def runshell(self, parameters):
-        sigint_handler = signal.getsignal(signal.SIGINT)
-        try:
-            # Allow SIGINT to pass to mysql to abort queries.
-            signal.signal(signal.SIGINT, signal.SIG_IGN)
-            super().runshell(parameters)
-        finally:
-            # Restore the original SIGINT handler.
-            signal.signal(signal.SIGINT, sigint_handler)

--- a/django/db/backends/postgresql/client.py
+++ b/django/db/backends/postgresql/client.py
@@ -1,5 +1,3 @@
-import signal
-
 from django.db.backends.base.client import BaseDatabaseClient
 
 
@@ -52,13 +50,3 @@ class DatabaseClient(BaseDatabaseClient):
         if passfile:
             env["PGPASSFILE"] = str(passfile)
         return args, (env or None)
-
-    def runshell(self, parameters):
-        sigint_handler = signal.getsignal(signal.SIGINT)
-        try:
-            # Allow SIGINT to pass to psql to abort queries.
-            signal.signal(signal.SIGINT, signal.SIG_IGN)
-            super().runshell(parameters)
-        finally:
-            # Restore the original SIGINT handler.
-            signal.signal(signal.SIGINT, sigint_handler)

--- a/tests/dbshell/tests.py
+++ b/tests/dbshell/tests.py
@@ -15,3 +15,25 @@ class DbshellCommandTestCase(SimpleTestCase):
         with self.assertRaisesMessage(CommandError, msg):
             with mock.patch("subprocess.run", side_effect=FileNotFoundError):
                 call_command("dbshell")
+
+    @mock.patch("django.db.backends.base.client.subprocess.run")
+    def test_sigint_ignored_during_runshell(self, mock_run):
+        import signal
+
+        from django.db.backends.base.client import BaseDatabaseClient
+
+        original_handler = signal.getsignal(signal.SIGINT)
+
+        def mock_run_side_effect(*args, **kwargs):
+            self.assertEqual(signal.getsignal(signal.SIGINT), signal.SIG_IGN)
+
+        mock_run.side_effect = mock_run_side_effect
+
+        client = BaseDatabaseClient(connection)
+        # Mock settings_to_cmd_args_env to return dummy args
+        with mock.patch.object(
+            client, "settings_to_cmd_args_env", return_value=(["mock_db_client"], None)
+        ):
+            client.runshell([])
+
+        self.assertEqual(signal.getsignal(signal.SIGINT), original_handler)


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37109

#### Branch description
When pressing `Ctrl+C` inside `manage.py dbshell` (specifically on backends like SQLite or Oracle), Python's parent process receives a `SIGINT` signal and raises a `KeyboardInterrupt`. This prematurely crashes the blocking `subprocess.run()` call inside the database client, bringing down `manage.py` with a traceback and leaving the database shell process (e.g. `sqlite3`) running as an orphaned process in the background.

The `mysql` and `postgresql` database clients previously solved this by overriding `runshell` to ignore `SIGINT` (`signal.SIG_IGN`) during execution, letting the child database shell handle it directly.

This PR refactors the signal-ignoring logic to the common base class (`BaseDatabaseClient.runshell`) so that it applies uniformly to all database backends (including SQLite and Oracle) and cleans up the code by removing redundant overrides:
* **Consolidated Logic:** Updated `BaseDatabaseClient.runshell` to temporarily ignore `SIGINT` while running the subprocess and restore the original handler afterwards. We also check `hasattr(signal, "SIGINT")` and wrap the operations in `try/except ValueError` blocks to remain safe and portable if called in non-main threads.
* **Removed Redundant Overrides:** Removed the duplicate `runshell` methods and unused `signal` imports in `django/db/backends/mysql/client.py` and `django/db/backends/postgresql/client.py`.
* **Regression Tests:** Added `test_sigint_ignored_during_runshell` in `tests/dbshell/tests.py` referencing Ticket #37109 to verify that `SIGINT` is ignored in the parent thread during `subprocess.run` and restored to its original handler afterwards.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

***AI Disclosure:** This PR was prepared with assistance from Google DeepMind's Gemini models (`Gemini 3 Flash` and `Gemini 3.1 Pro`) via the Antigravity coding assistant. The AI assisted in analyzing the traceback, drafting the robust signal handling blocks in `BaseDatabaseClient`, cleaning up the redundant backend code, and drafting the unit test case under `tests/dbshell/tests.py`. All code changes and tests have been manually reviewed, executed, and verified against the local Django unit test suite (`tests/runtests.py dbshell`) by the author.*

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes. 
