### PR TITLE
Fixed #35818 -- Used last suffix only when generating alternative fil…

### DIFF
--- a/django/core/files/storage/base.py
+++ b/django/core/files/storage/base.py
@@ -84,7 +84,7 @@ class Storage:
                 "Detected path traversal attempt in '%s'" % dir_name
             )
         validate_file_name(file_name)
-        file_ext = "".join(pathlib.PurePath(file_name).suffixes)
+        file_ext = pathlib.PurePath(file_name).suffix
         file_root = file_name.removesuffix(file_ext)
         # If the filename is not available, generate an alternative
         # filename until one is available.

--- a/tests/file_storage/tests.py
+++ b/tests/file_storage/tests.py
@@ -708,6 +708,18 @@ class OverwritingStorageTests(FileStorageTests):
         ):
             self.storage.save(name, file, max_length=5)
 
+    def test_file_name_truncation_with_dots_in_name(self):
+        # Saving a file whose name contains multiple dots should not raise
+        # SuspiciousFileOperation when a max_length forces truncation. The
+        # dots that are part of the stem (not a file extension) should not
+        # prevent truncation. Regression test for #35818.
+        name = "this.is.a.very." + "o" * 50 + ".txt"
+        file = ContentFile(b"content")
+        max_length = 30
+        stored_name = self.storage.save(name, file, max_length=max_length)
+        self.addCleanup(self.storage.delete, stored_name)
+        self.assertLessEqual(len(stored_name), max_length)
+
 
 class DiscardingFalseContentStorage(FileSystemStorage):
     def _save(self, name, content):
@@ -830,12 +842,21 @@ class FileFieldStorageTests(TestCase):
 
     def test_duplicate_filename(self):
         # Multiple files with the same name get _(7 random chars) appended to
-        # them.
+        # them. Only the last extension is preserved; dots in the stem are part
+        # of the file root and remain when an alternative name is generated.
         tests = [
-            ("multiple_files", "txt"),
-            ("multiple_files_many_extensions", "tar.gz"),
+            (
+                "multiple_files",
+                "txt",
+                f"tests/multiple_files_{FILE_SUFFIX_REGEX}.txt",
+            ),
+            (
+                "multiple_files_many_extensions",
+                "tar.gz",
+                f"tests/multiple_files_many_extensions.tar_{FILE_SUFFIX_REGEX}.gz",
+            ),
         ]
-        for filename, extension in tests:
+        for filename, extension, expected_pattern in tests:
             with self.subTest(filename=filename):
                 objs = [Storage() for i in range(2)]
                 for o in objs:
@@ -843,9 +864,7 @@ class FileFieldStorageTests(TestCase):
                 try:
                     names = [o.normal.name for o in objs]
                     self.assertEqual(names[0], f"tests/{filename}.{extension}")
-                    self.assertRegex(
-                        names[1], f"tests/{filename}_{FILE_SUFFIX_REGEX}.{extension}"
-                    )
+                    self.assertRegex(names[1], expected_pattern)
                 finally:
                     for o in objs:
                         o.delete()


### PR DESCRIPTION
…enames.

#### Trac ticket number
ticket-35818

#### Branch description
Fixes a SuspiciousFileOperation raised when saving a file whose name contains multiple dots and whose length exceeds the FileField's max_length. The bug was introduced in Django 5.1 when extension detection was changed to use all suffixes (e.g. .is.a.very.long.txt for this.is.a.very.long.txt), leaving almost nothing in file_root for truncation to work with. This fix uses only the last suffix (e.g. .txt) as the extension when generating alternative filenames, keeping intermediate dots as part of the stem.

#### AI Assistance Disclosure (REQUIRED)
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
