### PR TITLE
Fixed #36225 - Made implementation of natural_key optional on User Model Manager

### DIFF
--- a/django/contrib/auth/management/commands/createsuperuser.py
+++ b/django/contrib/auth/management/commands/createsuperuser.py
@@ -298,9 +298,13 @@ class Command(BaseCommand):
             for unique_constraint in self.UserModel._meta.total_unique_constraints
         )
 
+    @cached_property
+    def natural_key_defined(self):
+        return hasattr(self.UserModel._default_manager, "get_by_natural_key")
+
     def _validate_username(self, username, verbose_field_name, database):
         """Validate username. If invalid, return a string error message."""
-        if self.username_is_unique:
+        if self.username_is_unique and self.natural_key_defined:
             try:
                 self.UserModel._default_manager.db_manager(database).get_by_natural_key(
                     username

--- a/tests/auth_tests/models/__init__.py
+++ b/tests/auth_tests/models/__init__.py
@@ -8,6 +8,7 @@ from .custom_user import (
 from .invalid_models import CustomUserNonUniqueUsername
 from .is_active import IsActiveTestUser1
 from .minimal import MinimalUser
+from .no_natural_key import CustomUserNoNaturalKey
 from .no_password import NoPasswordUser
 from .proxy import Proxy, UserProxy
 from .uuid_pk import UUIDUser
@@ -23,6 +24,7 @@ __all__ = (
     "CustomPermissionsUser",
     "CustomUser",
     "CustomUserCompositePrimaryKey",
+    "CustomUserNoNaturalKey",
     "CustomUserNonUniqueUsername",
     "CustomUserWithFK",
     "CustomUserWithM2M",

--- a/tests/auth_tests/models/no_natural_key.py
+++ b/tests/auth_tests/models/no_natural_key.py
@@ -1,0 +1,22 @@
+from django.contrib.auth.hashers import make_password
+from django.db import models
+
+
+class CustomUserNoNaturalKeyManager(models.Manager):
+    def create_superuser(self, email, password=None, **extra_fields):
+        user = self.model(email=email, is_superuser=True, **extra_fields)
+        user.password = make_password(password)
+        user.save(using=self._db)
+        return user
+
+
+class CustomUserNoNaturalKey(models.Model):
+    email = models.EmailField(max_length=255, unique=True)
+    password = models.CharField(max_length=128)
+    is_superuser = models.BooleanField(default=False)
+    is_staff = models.BooleanField(default=False)
+
+    USERNAME_FIELD = "email"
+    REQUIRED_FIELDS = []
+
+    objects = CustomUserNoNaturalKeyManager()

--- a/tests/auth_tests/test_management.py
+++ b/tests/auth_tests/test_management.py
@@ -19,12 +19,14 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.db import migrations
+from django.db.utils import IntegrityError
 from django.test import TestCase, override_settings
 from django.test.testcases import TransactionTestCase
 from django.utils.translation import gettext_lazy as _
 
 from .models import (
     CustomUser,
+    CustomUserNoNaturalKey,
     CustomUserNonUniqueUsername,
     CustomUserWithFK,
     CustomUserWithM2M,
@@ -469,6 +471,66 @@ class CreatesuperuserManagementCommandTestCase(TestCase):
 
         users = CustomUserNonUniqueUsername.objects.filter(username="joe")
         self.assertEqual(users.count(), 2)
+
+    @override_settings(AUTH_USER_MODEL="auth_tests.CustomUserNoNaturalKey")
+    def test_swappable_user_no_natural_key_non_interactive(self):
+        new_io = StringIO()
+        call_command(
+            "createsuperuser",
+            interactive=False,
+            email="joe@somewhere.org",
+            stdout=new_io,
+        )
+        command_output = new_io.getvalue().strip()
+        self.assertEqual(command_output, "Superuser created successfully.")
+
+        user = CustomUserNoNaturalKey._default_manager.get(email="joe@somewhere.org")
+        self.assertIsNotNone(user)
+
+    @override_settings(AUTH_USER_MODEL="auth_tests.CustomUserNoNaturalKey")
+    def test_swappable_user_no_natural_key_interactive(self):
+        @mock_inputs(
+            {
+                "Email: ": "joe@somewhere.org",
+                "password": "nopasswd",
+            }
+        )
+        def createsuperuser():
+            new_io = StringIO()
+            call_command(
+                "createsuperuser",
+                interactive=True,
+                stdout=new_io,
+                stdin=MockTTY(),
+            )
+            command_output = new_io.getvalue().strip()
+            self.assertEqual(command_output, "Superuser created successfully.")
+
+        createsuperuser()
+        user = CustomUserNoNaturalKey._default_manager.get(email="joe@somewhere.org")
+        self.assertIsNotNone(user)
+
+    @override_settings(AUTH_USER_MODEL="auth_tests.CustomUserNoNaturalKey")
+    def test_swappable_user_no_natural_key_duplicate_allowed(self):
+        """Without get_by_natural_key,
+        duplicate username validation is skipped."""
+        new_io = StringIO()
+        call_command(
+            "createsuperuser",
+            interactive=False,
+            email="joe@somewhere.org",
+            stdout=new_io,
+        )
+        # Creating a second user with the same email won't be caught by
+        # _validate_username since there's no get_by_natural_key; it will
+        # fail at the database level instead due to the unique constraint.
+        with self.assertRaises(IntegrityError):
+            call_command(
+                "createsuperuser",
+                interactive=False,
+                email="joe@somewhere.org",
+                stdout=new_io,
+            )
 
     def test_skip_if_not_in_TTY(self):
         """


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-36225

#### Branch description
Fixes ticket-36225. In cases where a custom user model is defined that lacks a natural key (nullable username field given as an example), `createsuperuser` should bypass it's own uniqueness check since this is a [supported configuration](https://github.com/django/django/blob/46bd92274c57fd6f138c067562696092732cec59/docs/topics/serialization.txt#L635-L637) for the user manager.

(Uniqueness checks, should they exist, can still be enforced by the DB util; this config is part of the added tests)

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude Code (Opus 4.6) was used to prepare the **tests only**. Output has been verified and modified by me where needed.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
