### PR TITLE
Fixed #36947 -- Avoided column alteration for db_comment-only changes.

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -374,6 +374,8 @@ class BaseDatabaseFeatures:
     supports_comments = False
     # Does the backend support column comments in ADD COLUMN statements?
     supports_comments_inline = False
+    # Does the backend support standalone COMMENT ON COLUMN statements?
+    supports_alter_column_comment_standalone = False
 
     # Does the backend support stored generated columns?
     supports_stored_generated_columns = False

--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -1113,20 +1113,34 @@ class BaseDatabaseSchemaEditor:
         old_type_suffix = old_field.db_type_suffix(connection=self.connection)
         new_type_suffix = new_field.db_type_suffix(connection=self.connection)
         # Type, collation, or comment change?
-        if (
+        type_or_collation_changed = (
             old_type != new_type
             or old_type_suffix != new_type_suffix
             or old_collation != new_collation
-            or (
-                self.connection.features.supports_comments
-                and old_field.db_comment != new_field.db_comment
-            )
-        ):
-            fragment, other_actions = self._alter_column_type_sql(
-                model, old_field, new_field, new_type, old_collation, new_collation
-            )
-            actions.append(fragment)
-            post_actions.extend(other_actions)
+        )
+        comment_changed = (
+            self.connection.features.supports_comments
+            and old_field.db_comment != new_field.db_comment
+        )
+        if type_or_collation_changed or comment_changed:
+            if (
+                not type_or_collation_changed
+                and comment_changed
+                and self.connection.features.supports_alter_column_comment_standalone
+            ):
+                # Only the column comment changed; avoid an unnecessary
+                # ALTER COLUMN by emitting a standalone COMMENT ON COLUMN.
+                comment_sql, comment_params = self._alter_column_comment_sql(
+                    model, new_field, new_type, new_field.db_comment
+                )
+                if comment_sql:
+                    post_actions.append((comment_sql, comment_params))
+            else:
+                fragment, other_actions = self._alter_column_type_sql(
+                    model, old_field, new_field, new_type, old_collation, new_collation
+                )
+                actions.append(fragment)
+                post_actions.extend(other_actions)
 
         if new_field.has_db_default():
             if (

--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -31,6 +31,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_deferrable_unique_constraints = True
     truncates_names = True
     supports_comments = True
+    supports_alter_column_comment_standalone = True
     supports_tablespaces = True
     supports_sequence_reset = False
     can_introspect_materialized_views = True

--- a/django/db/backends/postgresql/features.py
+++ b/django/db/backends/postgresql/features.py
@@ -24,6 +24,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     has_select_for_no_key_update = True
     can_release_savepoints = True
     supports_comments = True
+    supports_alter_column_comment_standalone = True
     supports_tablespaces = True
     supports_transactions = True
     can_introspect_materialized_views = True

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -5083,6 +5083,51 @@ class SchemaTests(TransactionTestCase):
             [None, ""],
         )
 
+    @skipUnlessDBFeature("supports_alter_column_comment_standalone")
+    def test_alter_db_comment_only_does_not_alter_column(self):
+        old_field = Author._meta.get_field("name")
+        new_field = CharField(max_length=255, db_comment="Custom comment")
+        new_field.set_attributes_from_name("name")
+        new_field.model = Author
+        with connection.schema_editor(collect_sql=True) as editor:
+            editor.alter_field(Author, old_field, new_field, strict=True)
+
+        self.assertEqual(len(editor.collected_sql), 1)
+        sql = editor.collected_sql[0].upper()
+        self.assertIn("COMMENT ON COLUMN", sql)
+        self.assertNotIn("ALTER COLUMN", sql)
+
+    @skipUnlessDBFeature("supports_comments")
+    def test_alter_db_comment_only_unsupported_standalone_alters_column(self):
+        old_field = Author._meta.get_field("name")
+        new_field = CharField(max_length=255, db_comment="Custom comment")
+        new_field.set_attributes_from_name("name")
+        new_field.model = Author
+        with mock.patch.object(
+            connection.features,
+            "supports_alter_column_comment_standalone",
+            False,
+        ):
+            with connection.schema_editor(collect_sql=True) as editor:
+                editor.alter_field(Author, old_field, new_field, strict=True)
+
+        self.assertIn("ALTER TABLE", editor.collected_sql[0].upper())
+        sql = "\n".join(editor.collected_sql).upper()
+        self.assertIn("COMMENT", sql)
+
+    @skipUnlessDBFeature("supports_alter_column_comment_standalone")
+    def test_alter_db_comment_with_type_change_alters_column(self):
+        old_field = Author._meta.get_field("name")
+        new_field = CharField(max_length=511, db_comment="Custom comment")
+        new_field.set_attributes_from_name("name")
+        new_field.model = Author
+        with connection.schema_editor(collect_sql=True) as editor:
+            editor.alter_field(Author, old_field, new_field, strict=True)
+
+        self.assertIn("ALTER TABLE", editor.collected_sql[0].upper())
+        sql = "\n".join(editor.collected_sql).upper()
+        self.assertIn("COMMENT ON COLUMN", sql)
+
     @skipUnlessDBFeature("supports_comments", "supports_foreign_keys")
     def test_alter_db_comment_foreign_key(self):
         with connection.schema_editor() as editor:


### PR DESCRIPTION
#### Trac ticket number
ticket-36947

#### Branch description
This branch introduces support for standalone `COMMENT ON COLUMN` statements on PostgreSQL and Oracle when only a column comment changes. This avoids unnecessary `ALTER COLUMN` operations, reducing lock severity (`SHARE UPDATE EXCLUSIVE` instead of `ACCESS EXCLUSIVE`) and preventing migration failures involving `GeneratedField`s or columns backed by database views, while preserving the existing fallback behavior for other backends.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

> Used GPT-5.5 for initial test structure and code review. All code was reviewed, tested, and verified manually.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
