### PR TITLE
Refs #36825 -- Fixed regression CSP selenium tests.

### DIFF
--- a/tests/middleware/test_csp.py
+++ b/tests/middleware/test_csp.py
@@ -177,13 +177,6 @@ class CSPMiddlewareWithDecoratedViewsTest(SimpleTestCase):
 
 @override_settings(
     ROOT_URLCONF="middleware.urls",
-    SECURE_CSP_REPORT_ONLY={
-        "default-src": [CSP.NONE],
-        "img-src": [CSP.SELF],
-        "script-src": [CSP.SELF],
-        "style-src": [CSP.SELF],
-        "report-uri": "/csp-report/",
-    },
 )
 @modify_settings(
     MIDDLEWARE={"append": "django.middleware.csp.ContentSecurityPolicyMiddleware"}

--- a/tests/middleware/urls.py
+++ b/tests/middleware/urls.py
@@ -1,5 +1,4 @@
 from django.urls import path, re_path
-from django.views.debug import default_urlconf
 
 from . import views
 
@@ -13,7 +12,7 @@ urlpatterns = [
     path("sensitive_fbv/", views.sensitive_fbv),
     path("sensitive_cbv/", views.SensitiveCBV.as_view()),
     # Used in CSP tests.
-    path("csp-failure/", default_urlconf),
+    path("csp-failure/", views.csp_failure),
     path("csp-report/", views.csp_report_view),
     path("csp-base/", views.empty_view),
     path("csp-nonce/", views.csp_nonce),

--- a/tests/middleware/views.py
+++ b/tests/middleware/views.py
@@ -5,7 +5,7 @@ from django.http import HttpResponse
 from django.middleware.csp import get_nonce
 from django.utils.csp import CSP
 from django.utils.decorators import method_decorator
-from django.views.debug import technical_500_response
+from django.views.debug import default_urlconf, technical_500_response
 from django.views.decorators.common import no_append_slash
 from django.views.decorators.csp import csp_override, csp_report_only_override
 from django.views.decorators.csrf import csrf_exempt
@@ -51,6 +51,19 @@ csp_policy_override = {
     "default-src": [CSP.SELF],
     "img-src": [CSP.SELF, "data:"],
 }
+
+
+@csp_override(
+    {
+        "default-src": [CSP.NONE],
+        "img-src": [CSP.SELF],
+        "script-src": [CSP.SELF],
+        "style-src": [CSP.SELF],
+        "report-uri": "/csp-report/",
+    }
+)
+def csp_failure(request):
+    return default_urlconf(request)
 
 
 @csp_override(csp_policy_override)


### PR DESCRIPTION
The CSP report test relied on the debug view having a CSP error, which has been fixed in 3e4e0db. This commit added a custom view to reintroduce the same error to verify the reporting behavior.

Ref 3e4e0db66961a48a080ff3ff91f6c0d954261366
