### PR TITLE
Fixed #37109 -- Consolidated SIGINT handling logic into the base database client.

### DIFF
--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -435,6 +435,11 @@ class BaseCommand:
             else:
                 self.stderr.write("%s: %s" % (e.__class__.__name__, e))
             sys.exit(e.returncode)
+        except KeyboardInterrupt:
+            if options.traceback:
+                raise
+            self.stderr.write("\nOperation cancelled.")
+            sys.exit(1)
         finally:
             try:
                 connections.close_all()

--- a/django/db/backends/base/client.py
+++ b/django/db/backends/base/client.py
@@ -1,4 +1,5 @@
 import os
+import signal
 import subprocess
 
 
@@ -28,4 +29,19 @@ class BaseDatabaseClient:
             self.connection.settings_dict, parameters
         )
         env = {**os.environ, **env} if env else None
-        subprocess.run(args, env=env, check=True)
+        sigint_handler = None
+        if hasattr(signal, "SIGINT"):
+            try:
+                sigint_handler = signal.getsignal(signal.SIGINT)
+            except ValueError:
+                pass
+        try:
+            if sigint_handler is not None:
+                signal.signal(signal.SIGINT, signal.SIG_IGN)
+            subprocess.run(args, env=env, check=True)
+        finally:
+            if sigint_handler is not None:
+                try:
+                    signal.signal(signal.SIGINT, sigint_handler)
+                except ValueError:
+                    pass

--- a/django/db/backends/base/client.py
+++ b/django/db/backends/base/client.py
@@ -31,17 +31,14 @@ class BaseDatabaseClient:
         env = {**os.environ, **env} if env else None
         sigint_handler = None
         if hasattr(signal, "SIGINT"):
-            try:
-                sigint_handler = signal.getsignal(signal.SIGINT)
-            except ValueError:
-                pass
+            sigint_handler = signal.getsignal(signal.SIGINT)
         try:
             if sigint_handler is not None:
-                signal.signal(signal.SIGINT, signal.SIG_IGN)
+                try:
+                    signal.signal(signal.SIGINT, signal.SIG_IGN)
+                except ValueError:
+                    sigint_handler = None
             subprocess.run(args, env=env, check=True)
         finally:
             if sigint_handler is not None:
-                try:
-                    signal.signal(signal.SIGINT, sigint_handler)
-                except ValueError:
-                    pass
+                signal.signal(signal.SIGINT, sigint_handler)

--- a/django/db/backends/mysql/client.py
+++ b/django/db/backends/mysql/client.py
@@ -1,5 +1,3 @@
-import signal
-
 from django.db.backends.base.client import BaseDatabaseClient
 
 
@@ -60,13 +58,3 @@ class DatabaseClient(BaseDatabaseClient):
             args += [database]
         args.extend(parameters)
         return args, env
-
-    def runshell(self, parameters):
-        sigint_handler = signal.getsignal(signal.SIGINT)
-        try:
-            # Allow SIGINT to pass to mysql to abort queries.
-            signal.signal(signal.SIGINT, signal.SIG_IGN)
-            super().runshell(parameters)
-        finally:
-            # Restore the original SIGINT handler.
-            signal.signal(signal.SIGINT, sigint_handler)

--- a/django/db/backends/postgresql/client.py
+++ b/django/db/backends/postgresql/client.py
@@ -1,5 +1,3 @@
-import signal
-
 from django.db.backends.base.client import BaseDatabaseClient
 
 
@@ -52,13 +50,3 @@ class DatabaseClient(BaseDatabaseClient):
         if passfile:
             env["PGPASSFILE"] = str(passfile)
         return args, (env or None)
-
-    def runshell(self, parameters):
-        sigint_handler = signal.getsignal(signal.SIGINT)
-        try:
-            # Allow SIGINT to pass to psql to abort queries.
-            signal.signal(signal.SIGINT, signal.SIG_IGN)
-            super().runshell(parameters)
-        finally:
-            # Restore the original SIGINT handler.
-            signal.signal(signal.SIGINT, sigint_handler)

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -290,6 +290,14 @@ Management Commands
 * The :djadmin:`sendtestemail` command now supports a :option:`--using
   <sendtestemail --using>` option to specify the :setting:`MAILERS` alias.
 
+* Management commands now handle ``KeyboardInterrupt`` (e.g. pressing
+  :kbd:`Ctrl-C`) gracefully by exiting with status code 1 instead of showing a
+  Python traceback, unless the :option:`--traceback` option is used.
+
+* The :djadmin:`dbshell` command now forwards :kbd:`Ctrl-C` (SIGINT) to the
+  underlying database client on all backends, preventing the parent
+  ``manage.py`` process from crashing and leaving orphaned shell processes.
+
 Models
 ~~~~~~
 

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -2258,6 +2258,31 @@ class CommandTypes(AdminScriptTestCase):
         with self.assertRaises(CommandError):
             command.run_from_argv(["", "", "--traceback"])
 
+    def test_run_from_argv_keyboard_interrupt(self):
+        """
+        Test run_from_argv handles KeyboardInterrupt cleanly by printing an
+        error message and exiting with 1.
+        """
+        err = StringIO()
+        command = BaseCommand(stderr=err)
+
+        def raise_keyboard_interrupt(*args, **kwargs):
+            raise KeyboardInterrupt()
+
+        command.execute = raise_keyboard_interrupt
+
+        # If --traceback is not present, should print "Operation cancelled."
+        # and exit with SystemExit(1)
+        err.truncate(0)
+        with self.assertRaises(SystemExit) as cm:
+            command.run_from_argv(["", ""])
+        self.assertEqual(cm.exception.code, 1)
+        self.assertIn("Operation cancelled.", err.getvalue())
+
+        # If --traceback is present, should propagate KeyboardInterrupt
+        with self.assertRaises(KeyboardInterrupt):
+            command.run_from_argv(["", "", "--traceback"])
+
     def test_run_from_argv_non_ascii_error(self):
         """
         Non-ASCII message of CommandError does not raise any

--- a/tests/dbshell/tests.py
+++ b/tests/dbshell/tests.py
@@ -15,3 +15,25 @@ class DbshellCommandTestCase(SimpleTestCase):
         with self.assertRaisesMessage(CommandError, msg):
             with mock.patch("subprocess.run", side_effect=FileNotFoundError):
                 call_command("dbshell")
+
+    @mock.patch("django.db.backends.base.client.subprocess.run")
+    def test_sigint_ignored_during_runshell(self, mock_run):
+        import signal
+
+        from django.db.backends.base.client import BaseDatabaseClient
+
+        original_handler = signal.getsignal(signal.SIGINT)
+
+        def mock_run_side_effect(*args, **kwargs):
+            self.assertEqual(signal.getsignal(signal.SIGINT), signal.SIG_IGN)
+
+        mock_run.side_effect = mock_run_side_effect
+
+        client = BaseDatabaseClient(connection)
+        # Mock settings_to_cmd_args_env to return dummy args
+        with mock.patch.object(
+            client, "settings_to_cmd_args_env", return_value=(["mock_db_client"], None)
+        ):
+            client.runshell([])
+
+        self.assertEqual(signal.getsignal(signal.SIGINT), original_handler)

--- a/tests/dbshell/tests.py
+++ b/tests/dbshell/tests.py
@@ -37,3 +37,25 @@ class DbshellCommandTestCase(SimpleTestCase):
             client.runshell([])
 
         self.assertEqual(signal.getsignal(signal.SIGINT), original_handler)
+
+    @mock.patch("django.db.backends.base.client.subprocess.run")
+    def test_sigint_ignored_during_runshell_non_main_thread(self, mock_run):
+        import threading
+
+        from django.db.backends.base.client import BaseDatabaseClient
+
+        client = BaseDatabaseClient(connection)
+
+        def call_runshell():
+            with mock.patch.object(
+                client,
+                "settings_to_cmd_args_env",
+                return_value=(["mock_db_client"], None),
+            ):
+                client.runshell([])
+
+        thread = threading.Thread(target=call_runshell)
+        thread.start()
+        thread.join()
+
+        mock_run.assert_called_once()


### PR DESCRIPTION
#### Trac ticket number
ticket-37109

#### Branch description
When pressing Ctrl+C inside `manage.py dbshell` (specifically on backends like
SQLite or Oracle), Python's parent process receives a SIGINT signal and raises
a `KeyboardInterrupt`. This prematurely crashes the blocking `subprocess.run()`
call inside the database client, bringing down `manage.py` with a traceback and
leaving the database shell process (e.g. `sqlite3`) running as an orphaned
process in the background.

The `mysql` and `postgresql` database clients previously solved this by
overriding `runshell` to ignore `SIGINT` (`signal.SIG_IGN`) during execution,
letting the child database shell handle it directly. However, this fix was never
applied to the base class, leaving SQLite, Oracle, and any custom backends
unprotected.

Additionally, as noted in the comment by Sarah Boyce ([ticket #36016](https://code.djangoproject.com/ticket/37109#comment:1)),
pressing Ctrl+C during any management command produces a noisy Python traceback
in the terminal, which is confusing and unhelpful to users.

This PR addresses both issues:

**1. Consolidated SIGINT handling in `BaseDatabaseClient.runshell`**
- Moved the SIGINT-ignoring logic from the MySQL and PostgreSQL client overrides
  into the base class `BaseDatabaseClient.runshell`, so it applies uniformly to
  all backends (including SQLite and Oracle).
- Uses `hasattr(signal, "SIGINT")` and `try/except ValueError` for portability
  when called from non-main threads.
- Removed the now-redundant `runshell` overrides and unused `signal` imports
  from `django/db/backends/mysql/client.py` and
  `django/db/backends/postgresql/client.py`.

**2. Graceful `KeyboardInterrupt` handling in `BaseCommand.run_from_argv`**
- Added an `except KeyboardInterrupt` block in `BaseCommand.run_from_argv` so
  that pressing Ctrl+C during any management command prints a clean
  `"Operation cancelled."` message and exits with code `1`, instead of
  dumping a full Python traceback.
- Respects the `--traceback` flag: if set, the `KeyboardInterrupt` is
  re-raised as expected for debugging.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

AI Disclosure: This PR was prepared with assistance from Google DeepMind's
Gemini and Anthropic's Claude models via the Antigravity coding assistant. The
AI assisted in analyzing the issue, drafting the signal handling logic, and
drafting the unit tests. All code changes and tests have been manually reviewed,
executed, and verified against the local Django test suite
(`tests/runtests.py dbshell` and `tests/runtests.py admin_scripts`) by the
author.

#### Checklist
- [x] This PR follows the contribution guidelines.
- [x] This PR does not disclose a security vulnerability.
- [x] This PR targets the main branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
