### PR TITLE
Fixed #24213 -- Implemented RFC 2231 §4.1 parameter continuation in p…

### DIFF
--- a/django/utils/http.py
+++ b/django/utils/http.py
@@ -34,6 +34,7 @@ __Y2 = r"(?P<year>[0-9]{2})"
 __T = r"(?P<hour>[0-9]{2}):(?P<min>[0-9]{2}):(?P<sec>[0-9]{2})"
 RFC1123_DATE = _lazy_re_compile(r"^\w{3}, %s %s %s %s GMT$" % (__D, __M, __Y, __T))
 RFC850_DATE = _lazy_re_compile(r"^\w{6,9}, %s-%s-%s %s GMT$" % (__D, __M, __Y2, __T))
+_RFC2231_CONTINUATION_RE = _lazy_re_compile(r"\*(\d{1,4})$", re.ASCII)
 ASCTIME_DATE = _lazy_re_compile(r"^\w{3} %s %s %s %s$" % (__M, __D2, __T, __Y))
 
 RFC3986_GENDELIMS = ":/?#[]@"
@@ -349,13 +350,14 @@ def parse_header_parameters(line, max_length=MAX_HEADER_LENGTH):
     parts = _parseparam(";" + line)
     key = parts.__next__().lower()
     pdict = {}
+    continuations = {}  # RFC 2231 §4.1: {base: {seg_num: (starred, value)}}
     for p in parts:
         i = p.find("=")
         if i >= 0:
             has_encoding = False
             name = p[:i].strip().lower()
-            if name.endswith("*"):
-                # Embedded lang/encoding, like "filename*=UTF-8''file.ext".
+            starred = name.endswith("*")
+            if starred:
                 # https://tools.ietf.org/html/rfc2231#section-4
                 name = name[:-1]
                 if p.count("'") == 2:
@@ -364,6 +366,14 @@ def parse_header_parameters(line, max_length=MAX_HEADER_LENGTH):
             if len(value) >= 2 and value[0] == value[-1] == '"':
                 value = value[1:-1]
                 value = value.replace("\\\\", "\\").replace('\\"', '"')
+            # RFC 2231 §4.1: continuation params end with *N after stripping.
+            if m := _RFC2231_CONTINUATION_RE.search(name):
+                if base := name[: m.start()]:
+                    continuations.setdefault(base, {})[int(m.group(1))] = (
+                        starred,
+                        value,
+                    )
+                    continue
             if has_encoding:
                 encoding, lang, value = value.split("'")
                 try:
@@ -372,6 +382,25 @@ def parse_header_parameters(line, max_length=MAX_HEADER_LENGTH):
                     msg = f"Invalid encoding {encoding!r} for RFC 2231 param."
                     raise ValueError(msg)
             pdict[name] = value
+    for base, segments in continuations.items():
+        charset = None
+        combined = []
+        for seg_num in sorted(segments):
+            is_starred, value = segments[seg_num]
+            if is_starred:
+                if seg_num == 0 and value.count("'") >= 2:
+                    charset, _, value = value.split("'", 2)
+                    charset = charset or None
+                if charset:
+                    try:
+                        value = unquote(value, encoding=charset)
+                    except (LookupError, UnicodeDecodeError):
+                        msg = f"Invalid encoding {charset!r} for RFC 2231 param."
+                        raise ValueError(msg)
+            combined.append(value)
+        pdict[base] = "".join(
+            combined
+        )  # continuation overrides any direct param with same name
     return key, pdict
 
 

--- a/django/utils/http.py
+++ b/django/utils/http.py
@@ -1,4 +1,5 @@
 import base64
+import logging
 import re
 import unicodedata
 from binascii import Error as BinasciiError
@@ -10,6 +11,8 @@ from urllib.parse import urlsplit
 
 from django.utils.datastructures import MultiValueDict
 from django.utils.regex_helper import _lazy_re_compile
+
+logger = logging.getLogger("django.request")
 
 # Based on RFC 9110 Appendix A.
 ETAG_MATCH = _lazy_re_compile(
@@ -351,28 +354,35 @@ def parse_header_parameters(line, max_length=MAX_HEADER_LENGTH):
     key = parts.__next__().lower()
     pdict = {}
     continuations = {}  # RFC 2231 §4.1: {base: {seg_num: (starred, value)}}
-    for p in parts:
-        i = p.find("=")
-        if i >= 0:
+    malformed_continuations = set()  # bases with invalid segment numbers
+    for param in parts:
+        eq_idx = param.find("=")
+        if eq_idx >= 0:
             has_encoding = False
-            name = p[:i].strip().lower()
+            name = param[:eq_idx].strip().lower()
             starred = name.endswith("*")
             if starred:
                 # https://tools.ietf.org/html/rfc2231#section-4
                 name = name[:-1]
-                if p.count("'") == 2:
+                if param.count("'") == 2:
                     has_encoding = True
-            value = p[i + 1 :].strip()
+            value = param[eq_idx + 1 :].strip()
             if len(value) >= 2 and value[0] == value[-1] == '"':
                 value = value[1:-1]
                 value = value.replace("\\\\", "\\").replace('\\"', '"')
-            # RFC 2231 §4.1: continuation params end with *N after stripping.
-            if m := _RFC2231_CONTINUATION_RE.search(name):
-                if base := name[: m.start()]:
-                    continuations.setdefault(base, {})[int(m.group(1))] = (
-                        starred,
-                        value,
-                    )
+            # RFC 2231 §4.1: only continuation params still contain * after
+            # the trailing * is stripped; skip the regex for everything else.
+            if "*" in name and (match := _RFC2231_CONTINUATION_RE.search(name)):
+                if base := name[: match.start()]:
+                    seg_str = match.group(1)
+                    if len(seg_str) > 1 and seg_str[0] == "0":
+                        # Leading zeros (e.g. *01) are invalid per RFC 2231.
+                        malformed_continuations.add(base)
+                    else:
+                        continuations.setdefault(base, {})[int(seg_str)] = (
+                            starred,
+                            value,
+                        )
                     continue
             if has_encoding:
                 encoding, lang, value = value.split("'")
@@ -383,24 +393,51 @@ def parse_header_parameters(line, max_length=MAX_HEADER_LENGTH):
                     raise ValueError(msg)
             pdict[name] = value
     for base, segments in continuations.items():
+        sorted_segs = sorted(segments)
+        # Skip invalid groups: leading-zero segment, missing seg 0, or gaps.
+        if base in malformed_continuations or sorted_segs != list(
+            range(len(sorted_segs))
+        ):
+            logger.debug("Skipping malformed RFC 2231 continuation for %r.", base)
+            continue
         charset = None
-        combined = []
-        for seg_num in sorted(segments):
+        # Collect (is_encoded, raw_value); join encoded parts before decoding.
+        parts = []
+        for seg_num in sorted_segs:
             is_starred, value = segments[seg_num]
-            if is_starred:
-                if seg_num == 0 and value.count("'") >= 2:
-                    charset, _, value = value.split("'", 2)
-                    charset = charset or None
-                if charset:
-                    try:
-                        value = unquote(value, encoding=charset)
-                    except (LookupError, UnicodeDecodeError):
-                        msg = f"Invalid encoding {charset!r} for RFC 2231 param."
-                        raise ValueError(msg)
-            combined.append(value)
-        pdict[base] = "".join(
-            combined
-        )  # continuation overrides any direct param with same name
+            if not is_starred:
+                parts.append((False, value))
+                continue
+            if seg_num == 0 and value.count("'") >= 2:
+                charset, _, value = value.split("'", 2)
+                charset = charset or None
+            parts.append((True, value))
+        if not charset:
+            pdict[base] = "".join(val for _, val in parts)
+            continue
+        # Join encoded parts before decoding; multi-byte sequences may
+        # span segments.
+        result = []
+        encoded_buf = []
+        for is_encoded, value in parts:
+            if is_encoded:
+                encoded_buf.append(value)
+                continue
+            if encoded_buf:
+                try:
+                    result.append(unquote("".join(encoded_buf), encoding=charset))
+                except (LookupError, UnicodeDecodeError):
+                    raise ValueError(
+                        f"Invalid encoding {charset!r} for RFC 2231 param."
+                    )
+                encoded_buf = []
+            result.append(value)
+        if encoded_buf:
+            try:
+                result.append(unquote("".join(encoded_buf), encoding=charset))
+            except (LookupError, UnicodeDecodeError):
+                raise ValueError(f"Invalid encoding {charset!r} for RFC 2231 param.")
+        pdict[base] = "".join(result)
     return key, pdict
 
 

--- a/tests/utils_tests/test_http.py
+++ b/tests/utils_tests/test_http.py
@@ -562,6 +562,28 @@ class ParseHeaderParameterTests(unittest.TestCase):
                     parsed[1]["title" if "title" in raw_line else "filename"], expected
                 )
 
+    def test_rfc2231_malformed_continuation_preserves_direct_param(self):
+        """Invalid continuation groups leave the direct param intact."""
+        tests = [
+            # No segment 0.
+            "attachment; filename=safe; filename*1=evil",
+            # Gap between segments.
+            "attachment; filename=safe; filename*0=bad; filename*2=evil",
+            # Leading zero in segment number.
+            "attachment; filename=safe; filename*0=bad; filename*01=evil",
+        ]
+        for raw_line in tests:
+            with self.subTest(raw_line=raw_line):
+                _, params = parse_header_parameters(raw_line)
+                self.assertEqual(params["filename"], "safe")
+
+    def test_rfc2231_continuation_splits_utf8_sequence(self):
+        """Multi-byte UTF-8 sequences split across continuation segments
+        decode correctly."""
+        raw_line = "attachment; filename*0*=UTF-8''%E2%82; filename*1*=%AC"
+        _, params = parse_header_parameters(raw_line)
+        self.assertEqual(params["filename"], "\u20ac")  # €
+
     def test_rfc2231_continuation_mixed_with_regular_params(self):
         """Continuation params coexist with regular params."""
         raw_line = "attachment; filename*0*=UTF-8''foo; filename*1=.txt; size=123"

--- a/tests/utils_tests/test_http.py
+++ b/tests/utils_tests/test_http.py
@@ -521,6 +521,65 @@ class ParseHeaderParameterTests(unittest.TestCase):
             parsed = parse_header_parameters(raw_line)
             self.assertEqual(parsed[1]["title"], expected_title)
 
+    def test_rfc2231_continuation(self):
+        """RFC 2231 §4.1 parameter continuation (#24213)."""
+        tests = [
+            (
+                "Content-Type: application/x-stuff;"
+                " title*0*=us-ascii'en'This%20is%20even%20more%20;"
+                " title*1*=%2A%2A%2Afun%2A%2A%2A%20;"
+                ' title*2="isn\'t it!"',
+                "This is even more ***fun*** isn't it!",
+            ),
+            # Quoted segment values.
+            (
+                "Content-Type: application/x-stuff;"
+                " title*0*=\"us-ascii'en'This%20is%20even%20more%20\";"
+                ' title*1*="%2A%2A%2Afun%2A%2A%2A%20";'
+                ' title*2="isn\'t it!"',
+                "This is even more ***fun*** isn't it!",
+            ),
+            # Unencoded segments.
+            (
+                "Content-Type: application/x-stuff; title*0=Hello; title*1=World",
+                "HelloWorld",
+            ),
+            # Single segment.
+            (
+                "Content-Type: application/x-stuff; filename*0*=UTF-8''test.txt",
+                "test.txt",
+            ),
+            # Out-of-order segments.
+            (
+                "Content-Type: application/x-stuff; title*1=World; title*0=Hello",
+                "HelloWorld",
+            ),
+        ]
+        for raw_line, expected in tests:
+            with self.subTest(raw_line=raw_line):
+                parsed = parse_header_parameters(raw_line)
+                self.assertEqual(
+                    parsed[1]["title" if "title" in raw_line else "filename"], expected
+                )
+
+    def test_rfc2231_continuation_mixed_with_regular_params(self):
+        """Continuation params coexist with regular params."""
+        raw_line = "attachment; filename*0*=UTF-8''foo; filename*1=.txt; size=123"
+        _, params = parse_header_parameters(raw_line)
+        self.assertEqual(params["filename"], "foo.txt")
+        self.assertEqual(params["size"], "123")
+
+    def test_rfc2231_continuation_invalid_encoding(self):
+        """Invalid encoding in a continuation segment raises ValueError."""
+        test_data = [
+            "attachment; filename*0*=BOGUS''%E2%80%A6; filename*1=.txt",
+            "attachment; filename*0*=INVALID''%E2%80%A6; filename*1=.txt",
+        ]
+        msg = "Invalid encoding"
+        for header in test_data:
+            with self.subTest(raw_line=header), self.assertRaisesRegex(ValueError, msg):
+                parse_header_parameters(header)
+
     def test_rfc2231_invalid_encoding(self):
         test_data = [
             # Invalid encoding name with percent-encoded value


### PR DESCRIPTION
#### Trac ticket number

ticket-24213

#### Branch description

Implements RFC 2231 §4.1 parameter continuation in `parse_header_parameters()`.

RFC 2231 §4 (single encoded parameter) has been supported since ticket-24209 was fixed in 2015.
§4.1 — splitting a long parameter value across multiple numbered segments — was noted as
missing in the same PR and has been open since:

```
Content-Type: application/x-stuff;
    title*0*=us-ascii'en'This%20is%20even%20more%20;
    title*1*=%2A%2A%2Afun%2A%2A%2A%20;
    title*2="isn't it!"
```

**Background**

#35440 (merged Mar 2025, PR #18424) attempted to close this gap by replacing the custom
`_parseparam` loop with `email.message.Message.get_params()`, which handles §4.1 natively
via `decode_params`. It was reverted in ticket-36520 (Sep 2025) due to a **5x performance
regression** on the common no-params path (`text/plain`), caused by the overhead of
instantiating `Message` and calling `get_params()` on every request.

**This approach**

Instead of delegating to stdlib, §4.1 is implemented as a lightweight second pass on top
of the existing `_parseparam` loop, adding negligible overhead to the common paths:

1. A `starred` flag replaces the implicit `name.endswith("*")` check (no behaviour change).
2. After stripping the trailing `*`, continuation params are the *only* names that still
   contain `*` (e.g. `title*0` from `title*0*=...`). A module-level `_RFC2231_CONTINUATION_RE`
   (`_lazy_re_compile(r"\*(\d{1,4})$", re.ASCII)`) detects them. The pattern has no
   backtracking risk — no greedy wildcard, `re.ASCII` restricts `\d` to `[0-9]` only, and
   `{1,4}` caps segments at 9999, making the subsequent `int()` call unconditionally safe.
   Benchmarking confirmed this is identical in performance to an equivalent `rfind` +
   `isdigit` approach; the regex is kept for readability and because it matches Werkzeug's
   implementation of the same feature.
3. Continuation segments are collected in a `continuations` dict during the loop. The
   combination step (charset extraction, percent-decoding, concatenation) only runs if
   that dict is non-empty, which is false for the vast majority of requests.

**Review fixes**

- **Multi-byte sequences split across segments** (`filename*0*=UTF-8''%E2%82; filename*1*=%AC`):
  the original code decoded each segment independently, corrupting UTF-8 byte sequences
  spanning a segment boundary. Fixed by accumulating raw percent-encoded strings from
  consecutive starred segments and calling `unquote()` once on the joined result.

- **Malformed continuation groups**: three classes of invalid groups are now detected and
  skipped, preserving any direct parameter value with the same name:
  - Missing segment 0 (e.g. `filename*1=evil` with no `filename*0`)
  - Gaps in the sequence (e.g. `filename*0=a; filename*2=b`)
  - Leading zeros in segment numbers (e.g. `filename*01=evil`, invalid per RFC 2231)

  A `logger.debug` message via `django.request` is emitted when a group is skipped.

**Benchmark** (Python 3.12, 100 000 iterations, same headers as ticket-36520)

|                            | #36520 baseline | main     | this PR   | Δ vs main |
|----------------------------|-----------------|----------|-----------|-----------|
| `text/plain`               | 0.329 μs        | 0.142 μs | 0.147 μs  | +4%       |
| `charset+boundary`         | 1.441 μs        | 2.669 μs | 2.640 μs  | -1%       |
| `rfc2231 §4`               | 1.997 μs        | 6.995 μs | 7.214 μs  | +3%       |
| `rfc2231 §4.1 (new)`       | n/a             | 6.139 μs ¹ | 12.860 μs | +110% ² |
| `split utf-8 (fix)`        | n/a             | n/a      | 8.846 μs  | new       |
| `malformed (no seg 0)`     | n/a             | n/a      | 5.667 μs  | new       |
| `malformed (gap)`          | n/a             | n/a      | 8.090 μs  | new       |
| `malformed (leading zero)` | n/a             | n/a      | 7.693 μs  | new       |

¹ Before silently ignored continuation segments (wrong result).  
² Expected — this is the cost of actually doing the work correctly.

The `text/plain` fast path is essentially unchanged. Non-continuation paths
(`charset+boundary`, `rfc2231 §4`) stay at main-level performance thanks to a
`"*" in name` guard that skips the regex for params that cannot be continuations.

For reference, the `requests` library parser benchmarks 2–6x faster than Django's
`_parseparam`-based implementation, but achieves this by skipping quoted-string safety
(`filename="strange;name"` breaks it), RFC 2231 encoding, and all edge-case handling —
it is not a viable drop-in (confirmed by Jake Howard in ticket-36520 comment:17).

#### Notes for mergers

- No release note added; `parse_header_parameters()` is undocumented/internal.
- The Trac ticket flag "Has patch" has been set.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude Sonnet 4.6 was used for research, implementation guidance, and benchmark scripting during development. All output was reviewed and verified before being applied.

#### Checklist

- [x] This PR follows the contribution guidelines.
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/dev/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/committing-code/)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
