### PR TITLE
Fixed #34566 -- Implemented get_queryset() over get_ordering() to fix related admin unresolved keyword error.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -305,11 +305,13 @@ class BaseModelAdmin(metaclass=forms.MediaDefiningClass):
         except NotRegistered:
             return None
         else:
-            ordering = related_admin.get_ordering(request)
+            if related_admin is not None:
+                ordering = related_admin.get_ordering(request)
             if ordering is not None and ordering != ():
-                return db_field.remote_field.model._default_manager.using(db).order_by(
-                    *ordering
-                )
+                queryset = related_admin.get_queryset(request)
+                if db:
+                    queryset - queryset.using(db)
+                return queryset.order_by(*ordering)
         return None
 
     def formfield_for_foreignkey(self, db_field, request, **kwargs):

--- a/tests/admin_ordering/models.py
+++ b/tests/admin_ordering/models.py
@@ -36,3 +36,20 @@ class DynOrderingBandAdmin(admin.ModelAdmin):
             return ["rank"]
         else:
             return ["name"]
+
+
+class UserPermission(models.Model):
+    permission = models.CharField(max_length=50)
+
+
+class SystemUser(models.Model):
+    name = models.CharField(max_length=50)
+    permissions = models.ManyToManyField(
+        UserPermission,
+        help_text="Specific permissions for this user.",
+    )
+
+
+class ReportData(models.Model):
+    title = models.CharField(max_length=255)
+    owner = models.ForeignKey(SystemUser, on_delete=models.CASCADE)

--- a/tests/admin_ordering/tests.py
+++ b/tests/admin_ordering/tests.py
@@ -1,15 +1,20 @@
 from django.contrib import admin
 from django.contrib.admin.options import ModelAdmin
+from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.models import User
+from django.db import models
 from django.db.models import F
 from django.test import RequestFactory, TestCase
 
 from .models import (
     Band,
     DynOrderingBandAdmin,
+    ReportData,
     Song,
     SongInlineDefaultOrdering,
     SongInlineNewOrdering,
+    SystemUser,
+    UserPermission,
 )
 
 
@@ -206,3 +211,42 @@ class TestRelatedFieldsAdminOrdering(TestCase):
         site.register(Band, StaticOrderingBandAdmin)
 
         self.check_ordering_of_field_choices([self.b2])
+
+
+class TestCustomAdminOrdering(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        # Create permissions
+        perm1 = UserPermission.objects.create(permission="Permission 1")
+        perm2 = UserPermission.objects.create(permission="Permission 2")
+        perm3 = UserPermission.objects.create(permission="Permission 3")
+
+        # Create users with permissions
+        cls.user1 = SystemUser.objects.create(name="User 1")
+        cls.user2 = SystemUser.objects.create(name="User 2")
+
+        cls.user1.permissions.add(perm1, perm2)
+        cls.user2.permissions.add(perm1, perm2, perm3)
+
+        # Register Admin classes
+        class UserLocalAdmin(UserAdmin):
+            list_display = ("username", "email", "custom_perm_count")
+            ordering = ["-permissions__count"]
+
+            def get_queryset(self, request):
+                qs = super().get_queryset(request)
+                return qs.annotate(permissions__count=models.Count("permissions"))
+
+        class ReportAdmin(admin.ModelAdmin):
+            filter_fields = ["title'"]
+
+        admin.site.register(SystemUser, UserLocalAdmin)
+        admin.site.register(ReportData, ReportAdmin)
+
+    def test_system_user_ordering(self):
+        # Test for no 'count' keyword error & correct SystemUser Admin ordering
+        fk_field = admin.site._registry[ReportData].formfield_for_foreignkey(
+            ReportData.owner.field, request=None
+        )
+        expected_order = [self.user2, self.user1]  # Ordering by permissions
+        self.assertEqual(list(fk_field.queryset), expected_order)


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-34566

#### Branch description
Implemented get_queryset() within the get_field_queryset() function to fix related admin ordering not returning related admin querysets and returning an unresolved keyword error.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
