### PR TITLE
Fixed #37108 -- Made DjangoJSONEncoder consistently omit .000 microseconds

### DIFF
--- a/django/core/serializers/json.py
+++ b/django/core/serializers/json.py
@@ -90,9 +90,10 @@ class DjangoJSONEncoder(json.JSONEncoder):
     def default(self, o):
         # See "Date Time String Format" in the ECMA-262 specification.
         if isinstance(o, datetime.datetime):
-            r = o.isoformat()
-            if o.microsecond:
-                r = r[:23] + r[26:]
+            r = o.isoformat(
+                sep="T",
+                timespec="milliseconds" if o.microsecond // 1000 else "seconds",
+            )
             if r.endswith("+00:00"):
                 r = r.removesuffix("+00:00") + "Z"
             return r
@@ -101,9 +102,9 @@ class DjangoJSONEncoder(json.JSONEncoder):
         elif isinstance(o, datetime.time):
             if is_aware(o):
                 raise ValueError("JSON can't represent timezone-aware times.")
-            r = o.isoformat()
-            if o.microsecond:
-                r = r[:12]
+            r = o.isoformat(
+                timespec="milliseconds" if o.microsecond // 1000 else "seconds"
+            )
             return r
         elif isinstance(o, datetime.timedelta):
             return duration_iso_string(o)

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -256,6 +256,12 @@ Miscellaneous
   pollution vulnerability in the ``Array`` prototype was fixed in
   `ES5 <https://262.ecma-international.org/5.1/#sec-11.1.4>`_.
 
+* :class:`~django.core.serializers.json.DjangoJSONEncoder` now omits the
+  millisecond component of serialized ``datetime.datetime`` and
+  ``datetime.time`` objects if they have zero milliseconds. For example,
+  ``datetime.datetime(2000, 1, 1, 0, 0, 0, 1)`` now serializes to
+  ``"2000-01-01T00:00:00"`` rather than ``"2000-01-01T00:00:00.000"``.
+
 .. _deprecated-features-6.2:
 
 Features deprecated in 6.2

--- a/tests/serializers/test_json.py
+++ b/tests/serializers/test_json.py
@@ -329,3 +329,28 @@ class DjangoJSONEncoderTests(SimpleTestCase):
             json.dumps({"duration": duration}, cls=DjangoJSONEncoder),
             '{"duration": "P0DT00H00M00S"}',
         )
+
+    def test_datetime_and_time_microseconds(self):
+        tests = [
+            (datetime.datetime(2000, 1, 1, 0, 0, 0, 0), '"2000-01-01T00:00:00"'),
+            (datetime.datetime(2000, 1, 1, 0, 0, 0, 1), '"2000-01-01T00:00:00"'),
+            (
+                datetime.datetime(2000, 1, 1, 0, 0, 0, 1000),
+                '"2000-01-01T00:00:00.001"',
+            ),
+            (
+                datetime.datetime(2000, 1, 1, 0, 0, 0, 1001),
+                '"2000-01-01T00:00:00.001"',
+            ),
+            (
+                datetime.datetime(2000, 1, 1, 0, 0, 0, 123000),
+                '"2000-01-01T00:00:00.123"',
+            ),
+            (datetime.time(0, 0, 0, 0), '"00:00:00"'),
+            (datetime.time(0, 0, 0, 1), '"00:00:00"'),
+            (datetime.time(0, 0, 0, 1000), '"00:00:00.001"'),
+            (datetime.time(0, 0, 0, 123000), '"00:00:00.123"'),
+        ]
+        for value, expected in tests:
+            with self.subTest(value=value):
+                self.assertEqual(json.dumps(value, cls=DjangoJSONEncoder), expected)


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37108

#### Branch description
Updated `DjangoJSONEncoder` to consistently omit the `.000` fractional second suffix for `datetime.datetime` and `datetime.time` objects when the microsecond value evaluates to false. 

This was achieved by utilizing `timespec="milliseconds"` and stripping the resulting `.000` string, ensuring consistent JSON output regardless of how the datetime/time object was initialized.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I used an AI coding assistant to help me write the boundary regression tests and debug the CI linter failures. I have fully reviewed, tested, and verified all of the code.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
