### PR TITLE
Improve paginator error messages for out-of-range pages

### DIFF
--- a/django/core/paginator.py
+++ b/django/core/paginator.py
@@ -35,6 +35,7 @@ class BasePaginator:
         "invalid_page": _("That page number is not an integer"),
         "min_page": _("That page number is less than 1"),
         "no_results": _("That page contains no results"),
+        "max_page": _("That page number is too high"),
     }
 
     def __init__(
@@ -140,7 +141,10 @@ class BasePaginator:
         if number < 1:
             raise EmptyPage(self.error_messages["min_page"])
         if number > num_pages:
-            raise EmptyPage(self.error_messages["no_results"])
+            if num_pages == 0:
+                raise EmptyPage(self.error_messages["no_results"])
+            else:
+                raise EmptyPage(self.error_messages["max_page"])
         return number
 
 


### PR DESCRIPTION
Improve paginator error messages for out-of-range pages

Add a new 'max_page' error message for when users request a page number that exceeds the total number of pages, separate from the 'no_results' message used when there are no results at all.

Before:
- Both 'page 999 of 10' and 'page 1 of 0' showed: That page contains no results

After:
- 'page 999 of 10' shows: That page number is too high
- 'page 1 of 0' shows: That page contains no results

This provides clearer feedback to users about why their request failed.