### PR TITLE
Removed hardcoded Site pks.

### DIFF
--- a/tests/contenttypes_tests/test_views.py
+++ b/tests/contenttypes_tests/test_views.py
@@ -1,6 +1,7 @@
 import datetime
 from unittest import mock
 
+from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes.views import shortcut
 from django.contrib.sites.models import Site
@@ -26,9 +27,10 @@ from .models import (  # isort:skip
 class ContentTypesViewsTests(TestCase):
     @classmethod
     def setUpTestData(cls):
-        # Don't use the manager to ensure the site exists with pk=1, regardless
-        # of whether or not it already exists.
-        cls.site1 = Site(pk=1, domain="testserver", name="testserver")
+        # Update the default site to use the testserver domain to avoid
+        # assertRedirects() failure: "The test client is unable to fetch
+        # remote URLs (got http://example.com/authors/1/)."
+        cls.site1 = Site(pk=settings.SITE_ID, domain="testserver", name="testserver")
         cls.site1.save()
         cls.author1 = Author.objects.create(name="Boris")
         cls.article1 = Article.objects.create(
@@ -182,7 +184,7 @@ class ContentTypesViewsSiteRelTests(TestCase):
         # domains in the MockSite model.
         MockSite.objects.bulk_create(
             [
-                MockSite(pk=1, domain="example.com"),
+                MockSite(pk=settings.SITE_ID, domain="example.com"),
                 MockSite(pk=self.site_2.pk, domain=self.site_2.domain),
                 MockSite(pk=self.site_3.pk, domain=self.site_3.domain),
             ]

--- a/tests/flatpages_tests/test_csrf.py
+++ b/tests/flatpages_tests/test_csrf.py
@@ -20,15 +20,11 @@ from .settings import FLATPAGES_TEMPLATES
     ROOT_URLCONF="flatpages_tests.urls",
     CSRF_FAILURE_VIEW="django.views.csrf.csrf_failure",
     TEMPLATES=FLATPAGES_TEMPLATES,
-    SITE_ID=1,
 )
 class FlatpageCSRFTests(TestCase):
     @classmethod
     def setUpTestData(cls):
-        # don't use the manager because we want to ensure the site exists
-        # with pk=1, regardless of whether or not it already exists.
-        cls.site1 = Site(pk=1, domain="example.com", name="example.com")
-        cls.site1.save()
+        cls.site1 = Site.objects.get()
         cls.fp1 = FlatPage.objects.create(
             url="/flatpage/",
             title="A Flatpage",

--- a/tests/flatpages_tests/test_forms.py
+++ b/tests/flatpages_tests/test_forms.py
@@ -7,15 +7,7 @@ from django.utils import translation
 
 
 @modify_settings(INSTALLED_APPS={"append": ["django.contrib.flatpages"]})
-@override_settings(SITE_ID=1)
 class FlatpageAdminFormTests(TestCase):
-    @classmethod
-    def setUpTestData(cls):
-        # don't use the manager because we want to ensure the site exists
-        # with pk=1, regardless of whether or not it already exists.
-        cls.site1 = Site(pk=1, domain="example.com", name="example.com")
-        cls.site1.save()
-
     def setUp(self):
         # Site fields cache needs to be cleared after flatpages is added to
         # INSTALLED_APPS

--- a/tests/flatpages_tests/test_middleware.py
+++ b/tests/flatpages_tests/test_middleware.py
@@ -10,10 +10,7 @@ from .settings import FLATPAGES_TEMPLATES
 class TestDataMixin:
     @classmethod
     def setUpTestData(cls):
-        # don't use the manager because we want to ensure the site exists
-        # with pk=1, regardless of whether or not it already exists.
-        cls.site1 = Site(pk=1, domain="example.com", name="example.com")
-        cls.site1.save()
+        cls.site1 = Site.objects.get()
         cls.fp1 = FlatPage.objects.create(
             url="/flatpage/",
             title="A Flatpage",
@@ -65,7 +62,6 @@ class TestDataMixin:
     ],
     ROOT_URLCONF="flatpages_tests.urls",
     TEMPLATES=FLATPAGES_TEMPLATES,
-    SITE_ID=1,
 )
 class FlatpageMiddlewareTests(TestDataMixin, TestCase):
     def test_view_flatpage(self):
@@ -147,7 +143,6 @@ class FlatpageMiddlewareTests(TestDataMixin, TestCase):
     ],
     ROOT_URLCONF="flatpages_tests.urls",
     TEMPLATES=FLATPAGES_TEMPLATES,
-    SITE_ID=1,
 )
 class FlatpageMiddlewareAppendSlashTests(TestDataMixin, TestCase):
     def test_redirect_view_flatpage(self):

--- a/tests/flatpages_tests/test_sitemaps.py
+++ b/tests/flatpages_tests/test_sitemaps.py
@@ -4,10 +4,7 @@ from django.test import TestCase
 from django.test.utils import modify_settings, override_settings
 
 
-@override_settings(
-    ROOT_URLCONF="flatpages_tests.urls",
-    SITE_ID=1,
-)
+@override_settings(ROOT_URLCONF="flatpages_tests.urls")
 @modify_settings(
     INSTALLED_APPS={
         "append": ["django.contrib.sitemaps", "django.contrib.flatpages"],

--- a/tests/flatpages_tests/test_templatetags.py
+++ b/tests/flatpages_tests/test_templatetags.py
@@ -8,10 +8,7 @@ from django.test import TestCase
 class FlatpageTemplateTagTests(TestCase):
     @classmethod
     def setUpTestData(cls):
-        # don't use the manager because we want to ensure the site exists
-        # with pk=1, regardless of whether or not it already exists.
-        cls.site1 = Site(pk=1, domain="example.com", name="example.com")
-        cls.site1.save()
+        cls.site1 = Site.objects.get()
         cls.fp1 = FlatPage.objects.create(
             url="/flatpage/",
             title="A Flatpage",

--- a/tests/flatpages_tests/test_views.py
+++ b/tests/flatpages_tests/test_views.py
@@ -10,10 +10,7 @@ from .settings import FLATPAGES_TEMPLATES
 class TestDataMixin:
     @classmethod
     def setUpTestData(cls):
-        # don't use the manager because we want to ensure the site exists
-        # with pk=1, regardless of whether or not it already exists.
-        cls.site1 = Site(pk=1, domain="example.com", name="example.com")
-        cls.site1.save()
+        cls.site1 = Site.objects.get()
         cls.fp1 = FlatPage.objects.create(
             url="/flatpage/",
             title="A Flatpage",
@@ -65,7 +62,6 @@ class TestDataMixin:
     ],
     ROOT_URLCONF="flatpages_tests.urls",
     TEMPLATES=FLATPAGES_TEMPLATES,
-    SITE_ID=1,
 )
 class FlatpageViewTests(TestDataMixin, TestCase):
     def test_view_flatpage(self):
@@ -129,7 +125,6 @@ class FlatpageViewTests(TestDataMixin, TestCase):
     ],
     ROOT_URLCONF="flatpages_tests.urls",
     TEMPLATES=FLATPAGES_TEMPLATES,
-    SITE_ID=1,
 )
 class FlatpageViewAppendSlashTests(TestDataMixin, TestCase):
     def test_redirect_view_flatpage(self):

--- a/tests/redirects_tests/tests.py
+++ b/tests/redirects_tests/tests.py
@@ -12,7 +12,7 @@ from django.test import TestCase, modify_settings, override_settings
         "append": "django.contrib.redirects.middleware.RedirectFallbackMiddleware"
     }
 )
-@override_settings(APPEND_SLASH=False, ROOT_URLCONF="redirects_tests.urls", SITE_ID=1)
+@override_settings(APPEND_SLASH=False, ROOT_URLCONF="redirects_tests.urls")
 class RedirectTests(TestCase):
     @classmethod
     def setUpTestData(cls):
@@ -95,7 +95,6 @@ class OverriddenRedirectFallbackMiddleware(RedirectFallbackMiddleware):
 @modify_settings(
     MIDDLEWARE={"append": "redirects_tests.tests.OverriddenRedirectFallbackMiddleware"}
 )
-@override_settings(SITE_ID=1)
 class OverriddenRedirectMiddlewareTests(TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/tests/view_tests/tests/test_defaults.py
+++ b/tests/view_tests/tests/test_defaults.py
@@ -1,6 +1,5 @@
 import datetime
 
-from django.contrib.sites.models import Site
 from django.http import Http404
 from django.template import TemplateDoesNotExist
 from django.test import RequestFactory, TestCase
@@ -52,7 +51,6 @@ class DefaultsTests(TestCase):
             author=author,
             date_created=datetime.datetime(2001, 1, 1, 21, 22, 23),
         )
-        Site(id=1, domain="testserver", name="testserver").save()
 
     def test_page_not_found(self):
         "A 404 status is returned by the page_not_found view"


### PR DESCRIPTION
[`runtests.py` sets `SITE_ID=1`](https://github.com/django/django/blob/a53e02af6d7a07d0367b534f7107a0e2a37e3d34/tests/runtests.py#L226). For MongoDB, this is changed to `settings.SITE_ID = ObjectId("000000000000000000000001")`. 