### PR TITLE
Fixed #37118 -- Added variable support to the {% now %} template tag

### DIFF
--- a/django/template/defaulttags.py
+++ b/django/template/defaulttags.py
@@ -395,13 +395,15 @@ class LoadNode(Node):
 
 
 class NowNode(Node):
-    def __init__(self, format_string, asvar=None):
-        self.format_string = format_string
+    def __init__(self, format_obj, asvar=None):
+        self.format_obj = format_obj
         self.asvar = asvar
 
     def render(self, context):
         tzinfo = timezone.get_current_timezone() if settings.USE_TZ else None
-        formatted = date(datetime.now(tz=tzinfo), self.format_string)
+        format_string = self.format_obj.resolve(context)
+
+        formatted = date(datetime.now(tz=tzinfo), format_string)
 
         if self.asvar:
             context[self.asvar] = formatted
@@ -1181,7 +1183,7 @@ def lorem(parser, token):
 @register.tag
 def now(parser, token):
     """
-    Display the date, formatted according to the given string.
+    Display the date, formatted according to the given string or variable.
 
     Use the same format as PHP's ``date()`` function; see https://php.net/date
     for all the possible values.
@@ -1189,6 +1191,10 @@ def now(parser, token):
     Sample usage::
 
         It is {% now "jS F Y H:i" %}
+
+    You can also pass a template variable as the format string:
+
+        It is {% now my_date_format %}
     """
     bits = token.split_contents()
     asvar = None
@@ -1197,8 +1203,8 @@ def now(parser, token):
         bits = bits[:-2]
     if len(bits) != 2:
         raise TemplateSyntaxError("'now' statement takes one argument")
-    format_string = bits[1][1:-1]
-    return NowNode(format_string, asvar)
+    format_obj = parser.compile_filter(bits[1])
+    return NowNode(format_obj, asvar)
 
 
 @register.tag(name="partialdef")

--- a/tests/template_tests/syntax_tests/test_now.py
+++ b/tests/template_tests/syntax_tests/test_now.py
@@ -96,3 +96,29 @@ class NowTagTests(SimpleTestCase):
             TemplateSyntaxError, "'now' statement takes one argument"
         ):
             self.engine.render_to_string("no_args")
+
+    @setup({"now_var": "{% now my_format %}"})
+    def test_now_variable(self):
+        output = self.engine.render_to_string("now_var", {"my_format": "j n Y"})
+        self.assertEqual(
+            output,
+            "%d %d %d"
+            % (
+                datetime.now().day,
+                datetime.now().month,
+                datetime.now().year,
+            ),
+        )
+
+    @setup({"now_var_as": "{% now my_format as N %}-{{ N }}-"})
+    def test_now_variable_as(self):
+        output = self.engine.render_to_string("now_var_as", {"my_format": "j n Y"})
+        self.assertEqual(
+            output,
+            "-%d %d %d-"
+            % (
+                datetime.now().day,
+                datetime.now().month,
+                datetime.now().year,
+            ),
+        )


### PR DESCRIPTION
#### Trac ticket number
ticket-37118

#### Branch description
This PR implements the accepted feature from [new-features#115](https://github.com/django/new-features/issues/115) to allow dynamic formatting in the `{% now %}` tag.

Previously, the `now` tag relied on a hardcoded string slice (`[1:-1]`) to strip quotes, which prevented passing context variables and caused silent, malformed output when quotes were missing. 

By migrating to `parser.compile_filter()`, the tag now natively supports resolving template variables dynamically from the context. It correctly preserves the existing behavior for hardcoded strings and handles the `as` assignment syntax properly.

**Changes:**
- Updated `def now()` to use `parser.compile_filter()`.
- Updated `NowNode.render()` to `resolve()` the format object.
- Added tests for context variable resolution and variable assignment (`as` syntax).
- Updated the tag's docstring to document variable usage.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
*(Used Gemini for codebase navigation and formatting. Code manually tested.)*

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [ ] This PR targets the `main` branch. - [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. - [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.