### PR TITLE
fix: Replace print() with logger in django

### DIFF
--- a/tests/admin_scripts/management/commands/label_command.py
+++ b/tests/admin_scripts/management/commands/label_command.py
@@ -1,3 +1,5 @@
+import logging
+logger = logging.getLogger(__name__)
 from django.core.management.base import LabelCommand
 
 
@@ -6,7 +8,7 @@ class Command(LabelCommand):
     requires_system_checks = []
 
     def handle_label(self, label, **options):
-        print(
+        logger.info(
             "EXECUTE:LabelCommand label=%s, options=%s"
             % (label, sorted(options.items()))
         )

--- a/tests/test_runner/runner.py
+++ b/tests/test_runner/runner.py
@@ -1,3 +1,5 @@
+import logging
+logger = logging.getLogger(__name__)
 from django.test.runner import DiscoverRunner
 
 
@@ -26,4 +28,4 @@ class CustomOptionsTestRunner(DiscoverRunner):
         parser.add_argument("--option_c", "-c", default="3")
 
     def run_tests(self, test_labels, **kwargs):
-        print("%s:%s:%s" % (self.option_a, self.option_b, self.option_c))
+        logger.info("%s:%s:%s" % (self.option_a, self.option_b, self.option_c))


### PR DESCRIPTION
## Summary
Replaces print() with logger for better logging.

## Verification
- GPG signed commit