### PR TITLE
Fixed #37118 -- Added variable support to the {% now %} template tag.

### DIFF
--- a/django/template/defaulttags.py
+++ b/django/template/defaulttags.py
@@ -395,13 +395,17 @@ class LoadNode(Node):
 
 
 class NowNode(Node):
-    def __init__(self, format_string, asvar=None):
-        self.format_string = format_string
+    def __init__(self, format_expr, asvar=None):
+        self.format_expr = format_expr
         self.asvar = asvar
 
     def render(self, context):
         tzinfo = timezone.get_current_timezone() if settings.USE_TZ else None
-        formatted = date(datetime.now(tz=tzinfo), self.format_string)
+        format_string = self.format_expr.resolve(context)
+        formatted = date(datetime.now(tz=tzinfo), format_string)
+
+        if not self.asvar and self.format_expr.is_var:
+            return render_value_in_context(formatted, context)
 
         if self.asvar:
             context[self.asvar] = formatted
@@ -1181,7 +1185,7 @@ def lorem(parser, token):
 @register.tag
 def now(parser, token):
     """
-    Display the date, formatted according to the given string.
+    Display the date, formatted according to the given string or variable.
 
     Use the same format as PHP's ``date()`` function; see https://php.net/date
     for all the possible values.
@@ -1189,6 +1193,10 @@ def now(parser, token):
     Sample usage::
 
         It is {% now "jS F Y H:i" %}
+
+    You can also pass a template variable as the format string:
+
+        It is {% now my_date_format %}
     """
     bits = token.split_contents()
     asvar = None
@@ -1197,8 +1205,8 @@ def now(parser, token):
         bits = bits[:-2]
     if len(bits) != 2:
         raise TemplateSyntaxError("'now' statement takes one argument")
-    format_string = bits[1][1:-1]
-    return NowNode(format_string, asvar)
+    format_expr = parser.compile_filter(bits[1])
+    return NowNode(format_expr, asvar)
 
 
 @register.tag(name="partialdef")

--- a/django/template/defaulttags.py
+++ b/django/template/defaulttags.py
@@ -404,14 +404,12 @@ class NowNode(Node):
         format_string = self.format_expr.resolve(context)
         formatted = date(datetime.now(tz=tzinfo), format_string)
 
-        if not self.asvar and self.format_expr.is_var:
-            return render_value_in_context(formatted, context)
-
         if self.asvar:
             context[self.asvar] = formatted
             return ""
-        else:
-            return formatted
+        if context.autoescape and (self.format_expr.is_var or self.format_expr.filters):
+            return conditional_escape(formatted)
+        return formatted
 
 
 class PartialDefNode(Node):

--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -974,6 +974,16 @@ This would display as "It is the 4th of September".
 
         It is {% now "SHORT_DATETIME_FORMAT" %}
 
+You can also pass a template variable as the format string:
+
+.. code-block:: html+django
+
+    It is {% now my_date_format %}
+
+.. versionchanged:: 6.2
+
+    Support for resolving template variables was added.
+
 You can also use the syntax ``{% now "Y" as current_year %}`` to store the
 output (as a string) inside a variable. This is useful if you want to use
 ``{% now %}`` inside a template tag like :ttag:`blocktranslate` for example:

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -213,7 +213,8 @@ Tasks
 Templates
 ~~~~~~~~~
 
-* ...
+* The :ttag:`now` template tag now supports passing a template variable as
+  the format-string.
 
 Tests
 ~~~~~

--- a/tests/template_tests/syntax_tests/test_now.py
+++ b/tests/template_tests/syntax_tests/test_now.py
@@ -122,3 +122,25 @@ class NowTagTests(SimpleTestCase):
                 datetime.now().year,
             ),
         )
+
+    @setup({"now_var_escape": "{% now my_format %}"})
+    def test_now_var_escape(self):
+        """
+        Test that dynamic variables are properly escaped to prevent XSS.
+        """
+        evil_format = r"\<\i\m\g \s\r\c=\x\o\n\e\r\r\o\r=\a\l\e\r\t\(1\)\>"
+        output = self.engine.render_to_string(
+            "now_var_escape", {"my_format": evil_format}
+        )
+        self.assertEqual(output, "&lt;img src=xonerror=alert(1)&gt;")
+
+    @setup({"now_filter_escape": '{% now ""|add:my_format %}'})
+    def test_now_filter_escape(self):
+        """
+        Test that formats constructed via filter chains are properly escaped.
+        """
+        evil_format = r"\<\i\m\g \s\r\c=\x\o\n\e\r\r\o\r=\a\l\e\r\t\(1\)\>"
+        output = self.engine.render_to_string(
+            "now_filter_escape", {"my_format": evil_format}
+        )
+        self.assertEqual(output, "&lt;img src=xonerror=alert(1)&gt;")

--- a/tests/template_tests/syntax_tests/test_now.py
+++ b/tests/template_tests/syntax_tests/test_now.py
@@ -96,3 +96,29 @@ class NowTagTests(SimpleTestCase):
             TemplateSyntaxError, "'now' statement takes one argument"
         ):
             self.engine.render_to_string("no_args")
+
+    @setup({"now_var": "{% now my_format %}"})
+    def test_now_variable(self):
+        output = self.engine.render_to_string("now_var", {"my_format": "j n Y"})
+        self.assertEqual(
+            output,
+            "%d %d %d"
+            % (
+                datetime.now().day,
+                datetime.now().month,
+                datetime.now().year,
+            ),
+        )
+
+    @setup({"now_var_as": "{% now my_format as N %}-{{ N }}-"})
+    def test_now_variable_as(self):
+        output = self.engine.render_to_string("now_var_as", {"my_format": "j n Y"})
+        self.assertEqual(
+            output,
+            "-%d %d %d-"
+            % (
+                datetime.now().day,
+                datetime.now().month,
+                datetime.now().year,
+            ),
+        )


### PR DESCRIPTION
#### Trac ticket number
ticket-37118

#### Branch description
This PR implements the accepted feature from [new-features#115](https://github.com/django/new-features/issues/115) to allow dynamic formatting in the `{% now %}` tag.

Previously, the `now` tag relied on a hardcoded string slice (`[1:-1]`) to strip quotes, which prevented passing context variables and caused silent, malformed output when quotes were missing. 

By migrating to `parser.compile_filter()`, the tag now natively supports resolving template variables dynamically from the context. It correctly preserves the existing behavior for hardcoded strings and handles the `as` assignment syntax properly.

**Changes:**
- Updated `def now()` to use `parser.compile_filter()`.
- Updated `NowNode.render()` to `resolve()` the format object.
- Added tests for context variable resolution and variable assignment (`as` syntax).
- Updated the tag's docstring to document variable usage.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
*(Used Gemini for codebase navigation and formatting. Code manually tested.)*

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. 
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.