### PR TITLE
[5.2.x] Added executor_class attribute to migrate command for customization.

### DIFF
--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -587,8 +587,9 @@ class BaseCommand:
         """
         from django.db.migrations.executor import MigrationExecutor
 
+        executor_class = getattr(self, "executor_class", MigrationExecutor)
         try:
-            executor = MigrationExecutor(connections[DEFAULT_DB_ALIAS])
+            executor = executor_class(connections[DEFAULT_DB_ALIAS])
         except ImproperlyConfigured:
             # No databases are configured (or the dummy one)
             return

--- a/django/core/management/commands/migrate.py
+++ b/django/core/management/commands/migrate.py
@@ -16,6 +16,7 @@ from django.utils.text import Truncator
 
 class Command(BaseCommand):
     autodetector = MigrationAutodetector
+    executor_class = MigrationExecutor
     help = (
         "Updates database schema. Manages both apps with migrations and those without."
     )
@@ -111,7 +112,7 @@ class Command(BaseCommand):
         # Hook for backends needing any database preparation
         connection.prepare_database()
         # Work out which apps have migrations and which do not
-        executor = MigrationExecutor(connection, self.migration_progress_callback)
+        executor = self.executor_class(connection, self.migration_progress_callback)
 
         # Raise an error if any migrations are applied before their dependencies.
         executor.loader.check_consistent_history(connection)

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -34,6 +34,7 @@ from django.core.management.commands.loaddata import Command as LoaddataCommand
 from django.core.management.commands.runserver import Command as RunserverCommand
 from django.core.management.commands.testserver import Command as TestserverCommand
 from django.db import ConnectionHandler, connection
+from django.db.migrations.executor import MigrationExecutor
 from django.db.migrations.recorder import MigrationRecorder
 from django.test import LiveServerTestCase, SimpleTestCase, TestCase, override_settings
 from django.test.utils import captured_stderr, captured_stdout
@@ -1811,6 +1812,22 @@ class ManageRunserverMigrationWarning(TestCase):
             "app_waiting_migration.",
             output,
         )
+
+    @override_settings(INSTALLED_APPS=["admin_scripts.app_waiting_migration"])
+    def test_check_migrations_custom_executor(self):
+        executor_calls = []
+
+        class CustomExecutor(MigrationExecutor):
+            def __init__(self, *args, **kwargs):
+                executor_calls.append((args, kwargs))
+                super().__init__(*args, **kwargs)
+
+        self.runserver_command.executor_class = CustomExecutor
+        try:
+            self.runserver_command.check_migrations()
+        finally:
+            del self.runserver_command.executor_class
+        self.assertGreater(len(executor_calls), 0)
 
 
 class ManageRunserverEmptyAllowedHosts(AdminScriptTestCase):

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -28,6 +28,7 @@ from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.backends.utils import truncate_name
 from django.db.migrations.autodetector import MigrationAutodetector
 from django.db.migrations.exceptions import InconsistentMigrationHistory
+from django.db.migrations.executor import MigrationExecutor
 from django.db.migrations.recorder import MigrationRecorder
 from django.test import TestCase, override_settings, skipUnlessDBFeature
 from django.test.utils import captured_stdout, extend_sys_path, isolate_apps
@@ -3436,3 +3437,22 @@ class CustomMigrationCommandTests(MigrationTestBase):
             )
         finally:
             call_command(command, "migrated_app", "zero", verbosity=0)
+
+    @override_settings(INSTALLED_APPS=["migrations.migrations_test_apps.migrated_app"])
+    def test_migrate_custom_executor(self):
+        executor_calls = []
+
+        class CustomExecutor(MigrationExecutor):
+            def __init__(self, *args, **kwargs):
+                executor_calls.append((args, kwargs))
+                super().__init__(*args, **kwargs)
+
+        class CustomMigrateCommand(MigrateCommand):
+            executor_class = CustomExecutor
+
+        command = CustomMigrateCommand(stdout=io.StringIO())
+        try:
+            call_command(command, verbosity=0)
+        finally:
+            call_command(command, "migrated_app", "zero", verbosity=0)
+        self.assertGreater(len(executor_calls), 0)


### PR DESCRIPTION
Introduced executor_class = MigrationExecutor as a class-level attribute on the migrate management command, alongside the existing autodetector attribute. The handle() method now uses self.executor_class() instead of instantiating MigrationExecutor directly.

BaseCommand.check_migrations() was also updated to resolve the executor via getattr(self, 'executor_class', MigrationExecutor), so custom commands overriding executor_class get consistent behavior during the pre-execution migration check.

This follows the existing composition pattern established by autodetector = MigrationAutodetector on both migrate and makemigrations commands.

Note: This patch was drafted with AI assistance (Claude) and has been manually reviewed for correctness, test coverage, and alignment with Django contributing guidelines.