### PR TITLE
Fixed #26756 -- Updated permission names when model's verbose_name changes.

### DIFF
--- a/django/contrib/auth/management/__init__.py
+++ b/django/contrib/auth/management/__init__.py
@@ -83,17 +83,17 @@ def create_permissions(
     )
 
     # Find all the Permissions that have a content_type for a model we're
-    # looking for. We don't need to check for codenames since we already have
-    # a list of the ones we're going to create.
-    all_perms = set(
-        Permission.objects.using(using)
-        .filter(
-            content_type__in=set(ctypes.values()),
-        )
-        .values_list("content_type", "codename")
-    )
+    # looking for, along with their current names, to determine which
+    # permissions need to be created and which need their name updated.
+    all_perms = {
+        (ct, codename): (pk, name)
+        for pk, name, ct, codename in Permission.objects.using(using)
+        .filter(content_type__in=set(ctypes.values()))
+        .values_list("id", "name", "content_type", "codename")
+    }
 
-    perms = []
+    perms_to_create = []
+    perms_to_update = []
     for model in models:
         ctype = ctypes[model]
         for codename, name in _get_all_permissions(model._meta):
@@ -103,12 +103,23 @@ def create_permissions(
                 permission.codename = codename
                 permission.name = name
                 permission.content_type = ctype
-                perms.append(permission)
+                perms_to_create.append(permission)
+            else:
+                if name != all_perms[(ctype.pk, codename)][1]:
+                    permission = Permission()
+                    permission._state.db = using
+                    permission.pk = all_perms[(ctype.pk, codename)][0]
+                    permission.name = name
+                    perms_to_update.append(permission)
 
-    Permission.objects.using(using).bulk_create(perms)
+    Permission.objects.using(using).bulk_create(perms_to_create)
+    if perms_to_update:
+        Permission.objects.using(using).bulk_update(perms_to_update, ["name"])
     if verbosity >= 2:
-        for perm in perms:
+        for perm in perms_to_create:
             print("Adding permission '%s'" % perm)
+        for perm in perms_to_update:
+            print("Updating permission '%s'" % perm)
 
 
 def _get_permission_metadata(apps, app_label, model_name):

--- a/tests/auth_tests/test_management.py
+++ b/tests/auth_tests/test_management.py
@@ -1532,6 +1532,45 @@ class CreatePermissionsTests(TestCase):
             ).exists()
         )
 
+    def test_verbose_name_change(self):
+        auth_tests_config = apps.get_app_config("auth_tests")
+        org_content_type = ContentType.objects.get_by_natural_key(
+            "auth_tests", "organization"
+        )
+        original_verbose_name = Organization._meta.verbose_name
+        original_verbose_name_raw = Organization._meta.verbose_name_raw
+        try:
+            Organization._meta.verbose_name = "test org"
+            Organization._meta.verbose_name_raw = "test org"
+            create_permissions(auth_tests_config, verbosity=0)
+
+            self.assertTrue(
+                Permission.objects.filter(
+                    content_type=org_content_type,
+                    name="Can add test org",
+                ).exists()
+            )
+
+            Organization._meta.verbose_name = "new test org"
+            Organization._meta.verbose_name_raw = "new test org"
+            create_permissions(auth_tests_config, verbosity=0)
+
+            self.assertTrue(
+                Permission.objects.filter(
+                    content_type=org_content_type,
+                    name="Can add new test org",
+                ).exists()
+            )
+            self.assertFalse(
+                Permission.objects.filter(
+                    content_type=org_content_type,
+                    name="Can add test org",
+                ).exists()
+            )
+        finally:
+            Organization._meta.verbose_name = original_verbose_name
+            Organization._meta.verbose_name_raw = original_verbose_name_raw
+
 
 @override_settings(
     MIGRATION_MODULES=dict(


### PR DESCRIPTION
The create_permissions() function now detects existing permissions whose names no longer match the model's verbose_name and updates them via bulk_update(), in addition to creating missing permissions.

#### Trac ticket number

ticket-26756

#### Branch description

Django's built-in permissions are named after the model's verbose_name (e.g. "Can add organization"). When a model's verbose_name is changed, running migrations has no effect on the existing permission names in the database and they silently retain their old values. Dropping and recreating the database fixes it, but that's not viable in production.
  
create_permissions() is called after every migrate run, but it only created missing permissions and never reconciled names on existing ones. This change extends it to also detect permissions whose stored name no longer matches the current verbose_name and update them in bulk.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
