### PR TITLE
Refs #28560 -- Deprecated distinct() with values() and hidden ordering columns.

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -24,11 +24,21 @@ from django.db.models.sql.constants import (
 )
 from django.db.models.sql.query import Query, get_order_dir
 from django.db.transaction import TransactionManagementError
-from django.utils.deprecation import RemovedInDjango70Warning
+from django.utils.deprecation import (
+    RemovedInDjango70Warning,
+    RemovedInDjango71Warning,
+)
 from django.utils.functional import cached_property
 from django.utils.hashable import make_hashable
 from django.utils.regex_helper import _lazy_re_compile
 from django.utils.warnings import django_file_prefixes
+
+DISTINCT_VALUES_ORDERING_DEPRECATION_MSG = (
+    "Using QuerySet.distinct() with values() or values_list() and ordering by "
+    "fields not selected in the restricted column list is deprecated. In "
+    "Django 7.1, this will raise a DatabaseError. Add the ordering fields to "
+    "values() or values_list(), or clear the ordering with order_by()."
+)
 
 
 class PositionRef(Ref):
@@ -546,6 +556,14 @@ class SQLCompiler:
                 without_ordering = self.ordering_parts.search(sql)[1]
                 if not is_ref and (without_ordering, params) not in select_sql:
                     extra_select.append((expr, (without_ordering, params), None))
+            if extra_select and self.query.has_select_fields:
+                # RemovedInDjango71Warning: When the deprecation ends, raise
+                # DatabaseError instead.
+                warnings.warn(
+                    DISTINCT_VALUES_ORDERING_DEPRECATION_MSG,
+                    category=RemovedInDjango71Warning,
+                    skip_file_prefixes=django_file_prefixes(),
+                )
         return extra_select
 
     def quote_name(self, name):

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -15,6 +15,10 @@ about each item can often be found in the release notes of two versions prior.
 See the :ref:`Django 6.2 release notes <deprecated-features-6.2>` for more
 details on these changes.
 
+* Using ``QuerySet.distinct()`` with ``values()`` or ``values_list()`` while
+  ordering by fields not included in the selected values will raise
+  ``DatabaseError``.
+
 .. _deprecation-removed-in-7.0:
 
 7.0

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -540,6 +540,14 @@ query spans multiple tables, it's possible to get duplicate results when a
     :meth:`values` together, be careful when ordering by fields not in the
     :meth:`values` call.
 
+    .. deprecated:: 6.2
+
+        Using ``distinct()`` with :meth:`values` or :meth:`values_list` while
+        ordering by fields not included in the selected values is deprecated.
+        In Django 7.1, this will raise ``DatabaseError``. Include the ordering
+        fields in :meth:`values` or :meth:`values_list`, or clear ordering with
+        ``order_by()``.
+
 On PostgreSQL only, you can pass positional arguments (``*fields``) in order to
 specify the names of fields to which the ``DISTINCT`` should apply. This
 translates to a ``SELECT DISTINCT ON`` SQL query. Here's the difference. For a

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -278,3 +278,8 @@ Miscellaneous
 
 * The ``safe`` parameter is deprecated from :class:`~django.http.JsonResponse`.
   Omitting the argument is equivalent to the prior ``safe=False`` usage.
+
+* Using ``QuerySet.distinct()`` with ``values()`` or ``values_list()`` while
+  ordering by fields not included in the selected values is deprecated. In
+  Django 7.1, this will raise ``DatabaseError``. Include the ordering fields in
+  ``values()`` or ``values_list()``, or clear ordering with ``order_by()``.

--- a/tests/extra_regress/tests.py
+++ b/tests/extra_regress/tests.py
@@ -1,7 +1,9 @@
 import datetime
 
 from django.contrib.auth.models import User
+from django.db.models.sql.compiler import DISTINCT_VALUES_ORDERING_DEPRECATION_MSG
 from django.test import TestCase
+from django.utils.deprecation import RemovedInDjango71Warning
 
 from .models import Order, RevisionableModel, TestObject
 
@@ -461,11 +463,23 @@ class ExtraRegressTests(TestCase):
             .values_list("id", flat=True)
             .distinct()
         )
-        self.assertSequenceEqual(qs.order_by("second_extra"), [t1.pk, t2.pk])
-        self.assertSequenceEqual(qs.order_by("-second_extra"), [t2.pk, t1.pk])
+        with self.assertWarnsMessage(
+            RemovedInDjango71Warning,
+            DISTINCT_VALUES_ORDERING_DEPRECATION_MSG,
+        ):
+            self.assertSequenceEqual(qs.order_by("second_extra"), [t1.pk, t2.pk])
+        with self.assertWarnsMessage(
+            RemovedInDjango71Warning,
+            DISTINCT_VALUES_ORDERING_DEPRECATION_MSG,
+        ):
+            self.assertSequenceEqual(qs.order_by("-second_extra"), [t2.pk, t1.pk])
         # Note: the extra ordering must appear in select clause, so we get two
         # non-distinct results here (this is on purpose, see #7070).
         # Extra select doesn't appear in result values.
-        self.assertSequenceEqual(
-            qs.order_by("-second_extra").values_list("first"), [("a",), ("a",)]
-        )
+        with self.assertWarnsMessage(
+            RemovedInDjango71Warning,
+            DISTINCT_VALUES_ORDERING_DEPRECATION_MSG,
+        ):
+            self.assertSequenceEqual(
+                qs.order_by("-second_extra").values_list("first"), [("a",), ("a",)]
+            )

--- a/tests/filtered_relation/tests.py
+++ b/tests/filtered_relation/tests.py
@@ -18,8 +18,10 @@ from django.db.models import (
 )
 from django.db.models.functions import Concat
 from django.db.models.lookups import Exact, IStartsWith
+from django.db.models.sql.compiler import DISTINCT_VALUES_ORDERING_DEPRECATION_MSG
 from django.test import TestCase
 from django.test.testcases import skipUnlessDBFeature
+from django.utils.deprecation import RemovedInDjango71Warning
 
 from .models import (
     Author,
@@ -533,13 +535,17 @@ class FilteredRelationTests(TestCase):
             .order_by("name", "alice_editors__name")
             .distinct()
         )
-        self.assertSequenceEqual(
-            qs,
-            [
-                {"name": self.author1.name, "alice_editors__pk": self.editor_a.pk},
-                {"name": self.author2.name, "alice_editors__pk": None},
-            ],
-        )
+        with self.assertWarnsMessage(
+            RemovedInDjango71Warning,
+            DISTINCT_VALUES_ORDERING_DEPRECATION_MSG,
+        ):
+            self.assertSequenceEqual(
+                qs,
+                [
+                    {"name": self.author1.name, "alice_editors__pk": self.editor_a.pk},
+                    {"name": self.author2.name, "alice_editors__pk": None},
+                ],
+            )
 
     def test_nested_m2m_filtered(self):
         qs = (

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -10,11 +10,12 @@ from django.db import DEFAULT_DB_ALIAS, connection
 from django.db.models import CharField, Count, Exists, F, Max, OuterRef, Q
 from django.db.models.expressions import RawSQL
 from django.db.models.functions import ExtractYear, Length, LTrim
+from django.db.models.sql.compiler import DISTINCT_VALUES_ORDERING_DEPRECATION_MSG
 from django.db.models.sql.constants import LOUTER
 from django.db.models.sql.where import AND, OR, NothingNode, WhereNode
 from django.test import SimpleTestCase, TestCase, skipUnlessDBFeature
 from django.test.utils import CaptureQueriesContext, ignore_warnings, register_lookup
-from django.utils.deprecation import RemovedInDjango70Warning
+from django.utils.deprecation import RemovedInDjango70Warning, RemovedInDjango71Warning
 
 from .models import (
     FK1,
@@ -693,9 +694,41 @@ class Queries1Tests(TestCase):
         # are multiple values in the ordering cols), as in this example. This
         # isn't a bug; it's a warning to be careful with the selection of
         # ordering columns.
+        with self.assertWarnsMessage(
+            RemovedInDjango71Warning,
+            DISTINCT_VALUES_ORDERING_DEPRECATION_MSG,
+        ):
+            self.assertSequenceEqual(
+                Note.objects.values("misc").distinct().order_by("note", "-misc"),
+                [{"misc": "foo"}, {"misc": "bar"}, {"misc": "foo"}],
+            )
+
+    def test_distinct_values_default_ordering_deprecation(self):
+        with self.assertWarnsMessage(
+            RemovedInDjango71Warning,
+            DISTINCT_VALUES_ORDERING_DEPRECATION_MSG,
+        ):
+            self.assertSequenceEqual(
+                Tag.objects.filter(parent=self.t1).values("parent").distinct(),
+                [{"parent": self.t1.pk}, {"parent": self.t1.pk}],
+            )
+
+    def test_distinct_values_list_default_ordering_deprecation(self):
+        with self.assertWarnsMessage(
+            RemovedInDjango71Warning,
+            DISTINCT_VALUES_ORDERING_DEPRECATION_MSG,
+        ):
+            self.assertSequenceEqual(
+                Tag.objects.filter(parent=self.t1)
+                .values_list("parent", flat=True)
+                .distinct(),
+                [self.t1.pk, self.t1.pk],
+            )
+
+    def test_distinct_values_cleared_ordering(self):
         self.assertSequenceEqual(
-            Note.objects.values("misc").distinct().order_by("note", "-misc"),
-            [{"misc": "foo"}, {"misc": "bar"}, {"misc": "foo"}],
+            Tag.objects.filter(parent=self.t1).order_by().values("parent").distinct(),
+            [{"parent": self.t1.pk}],
         )
 
     def test_ticket4358(self):
@@ -2482,28 +2515,37 @@ class SubqueryTests(TestCase):
             ["first", "fourth"],
         )
         # Explicit values('id').
-        self.assertSequenceEqual(
-            NamedCategory.objects.filter(
-                id__in=NamedCategory.objects.distinct()
-                .order_by("-name")
-                .values("id")[0:2],
+        with self.assertWarnsMessage(
+            RemovedInDjango71Warning,
+            DISTINCT_VALUES_ORDERING_DEPRECATION_MSG,
+        ):
+            self.assertSequenceEqual(
+                NamedCategory.objects.filter(
+                    id__in=NamedCategory.objects.distinct()
+                    .order_by("-name")
+                    .values("id")[0:2],
+                )
+                .order_by("name")
+                .values_list("name", flat=True),
+                ["second", "third"],
             )
-            .order_by("name")
-            .values_list("name", flat=True),
-            ["second", "third"],
-        )
-        # Annotated value.
-        self.assertSequenceEqual(
-            DumbCategory.objects.filter(
-                id__in=DumbCategory.objects.annotate(double_id=F("id") * 2)
+        # RemovedInDjango71Warning: When the deprecation ends, this query will
+        # need to select "id" as well.
+        with self.assertWarnsMessage(
+            RemovedInDjango71Warning,
+            DISTINCT_VALUES_ORDERING_DEPRECATION_MSG,
+        ):
+            self.assertSequenceEqual(
+                DumbCategory.objects.filter(
+                    id__in=DumbCategory.objects.annotate(double_id=F("id") * 2)
+                    .order_by("id")
+                    .distinct()
+                    .values("double_id")[0:2],
+                )
                 .order_by("id")
-                .distinct()
-                .values("double_id")[0:2],
+                .values_list("id", flat=True),
+                [2, 4],
             )
-            .order_by("id")
-            .values_list("id", flat=True),
-            [2, 4],
-        )
 
 
 class QuerySetBitwiseOperationTests(TestCase):


### PR DESCRIPTION
#### Trac ticket number

ticket-28560

#### Branch description

`distinct()` currently appends ordering expressions to the SQL `SELECT` list when needed by the database. When a queryset also uses `values()` or `values_list()` to restrict the selected columns, those hidden ordering expressions can make otherwise duplicate returned values survive `DISTINCT`.

This PR deprecates using `distinct()` with `values()` or `values_list()` when the SQL compiler must add hidden ordering columns. In Django 7.1, this will raise `DatabaseError`. The PR also updates existing regression tests that intentionally rely on the current behavior and documents the migration paths: include the ordering fields in `values()`/`values_list()`, or clear ordering with `order_by()`.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

I used Codex to help draft the patch and run local verification. I reviewed and verified the changes and test output.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes. N/A: no UI changes.

#### Tests

- `PYTHONPATH=. ./.venv314/bin/python tests/runtests.py --parallel auto`
- `PYTHONPATH=. ./.venv314/bin/python tests/runtests.py aggregation aggregation_regress annotations expressions lookup model_fields ordering queryset_pickle basic composite_pk many_to_many multiple_database queries extra_regress --parallel auto`
- `PYTHONPATH=. ./.venv314/bin/python tests/runtests.py filtered_relation --parallel auto`
- `PYTHONPATH=. ./.venv314/bin/python -m compileall -q django/db/models/sql/compiler.py tests/queries/tests.py tests/extra_regress/tests.py tests/filtered_relation/tests.py`
- `./.venv314/bin/python -m isort --check-only --diff django/db/models/sql/compiler.py tests/queries/tests.py tests/extra_regress/tests.py tests/filtered_relation/tests.py`
- `./.venv314/bin/python -m flake8 django/db/models/sql/compiler.py tests/queries/tests.py tests/extra_regress/tests.py tests/filtered_relation/tests.py`
- `git diff --check`
