### PR TITLE
Refs #25342 -- implemented 3D point comparison.

### DIFF
--- a/django/contrib/gis/geos/geometry.py
+++ b/django/contrib/gis/geos/geometry.py
@@ -153,11 +153,22 @@ class GEOSGeometryBase(GEOSBase):
                 other = GEOSGeometry.from_ewkt(other)
             except (ValueError, GEOSException):
                 return False
-        return (
-            isinstance(other, GEOSGeometry)
-            and self.srid == other.srid
-            and self.equals_exact(other)
-        )
+
+        if not isinstance(other, GEOSGeometry):
+            return False
+        if not self.srid == other.srid:
+            return False
+
+        try:
+            # If both the geometries have Z values,
+            # then use equals_identical, since equals_exact ignores the Z
+            return (
+                self.equals_identical(other)
+                if self.hasz and other.hasz
+                else self.equals_exact(other)
+            )
+        except GEOSException:
+            return self.equals_exact(other)
 
     def __hash__(self):
         return hash((self.srid, self.wkt))

--- a/tests/gis_tests/geos_tests/test_geos.py
+++ b/tests/gis_tests/geos_tests/test_geos.py
@@ -721,6 +721,17 @@ class GEOSTest(SimpleTestCase, TestDataMixin):
         self.assertGreater(p4, p3)
         self.assertLess(p3, p4)
 
+    def test_point_comparison(self):
+        p1 = Point(0, 0, 0)
+        p2 = Point(0, 0, 1)
+        self.assertNotEqual(p1, p2)
+
+        # Fallback to 2d comparison if both the points don't have Z values
+        p3 = Point(0, 0)
+
+        self.assertEqual(p1, p3)
+        self.assertEqual(p2, p3)
+
     def test_multipolygons(self):
         "Testing MultiPolygon objects."
         fromstr("POINT (0 0)")


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-25342

#### Branch description
Implemented equality check for 3D points using `equals_identical()`, fallback to regular comparison in case both the geometries don't have a Z.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
