### PR TITLE
Updated links to severity levels in release notes.

### DIFF
--- a/docs/releases/2.2.26.txt
+++ b/docs/releases/2.2.26.txt
@@ -19,7 +19,7 @@ In order to mitigate this issue, relatively long values are now ignored by
 ``UserAttributeSimilarityValidator``.
 
 This issue has severity "medium" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.
 
 CVE-2021-45116: Potential information disclosure in ``dictsort`` template filter
 ================================================================================
@@ -35,7 +35,7 @@ dictionaries.
 As a reminder, all untrusted user input should be validated before use.
 
 This issue has severity "low" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.
 
 CVE-2021-45452: Potential directory-traversal via ``Storage.save()``
 ====================================================================
@@ -44,4 +44,4 @@ CVE-2021-45452: Potential directory-traversal via ``Storage.save()``
 crafted file names.
 
 This issue has severity "low" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.

--- a/docs/releases/3.2.11.txt
+++ b/docs/releases/3.2.11.txt
@@ -19,7 +19,7 @@ In order to mitigate this issue, relatively long values are now ignored by
 ``UserAttributeSimilarityValidator``.
 
 This issue has severity "medium" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.
 
 CVE-2021-45116: Potential information disclosure in ``dictsort`` template filter
 ================================================================================
@@ -35,7 +35,7 @@ dictionaries.
 As a reminder, all untrusted user input should be validated before use.
 
 This issue has severity "low" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.
 
 CVE-2021-45452: Potential directory-traversal via ``Storage.save()``
 ====================================================================
@@ -44,4 +44,4 @@ CVE-2021-45452: Potential directory-traversal via ``Storage.save()``
 crafted file names.
 
 This issue has severity "low" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.

--- a/docs/releases/4.0.1.txt
+++ b/docs/releases/4.0.1.txt
@@ -19,7 +19,7 @@ In order to mitigate this issue, relatively long values are now ignored by
 ``UserAttributeSimilarityValidator``.
 
 This issue has severity "medium" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.
 
 CVE-2021-45116: Potential information disclosure in ``dictsort`` template filter
 ================================================================================
@@ -35,7 +35,7 @@ dictionaries.
 As a reminder, all untrusted user input should be validated before use.
 
 This issue has severity "low" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.
 
 CVE-2021-45452: Potential directory-traversal via ``Storage.save()``
 ====================================================================
@@ -44,7 +44,7 @@ CVE-2021-45452: Potential directory-traversal via ``Storage.save()``
 crafted file names.
 
 This issue has severity "low" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.
 
 Bugfixes
 ========

--- a/docs/releases/4.2.28.txt
+++ b/docs/releases/4.2.28.txt
@@ -16,7 +16,7 @@ The ``django.contrib.auth.handlers.modwsgi.check_password()`` function for
 allowed remote attackers to enumerate users via a timing attack.
 
 This issue has severity "low" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.
 
 CVE-2025-14550: Potential denial-of-service vulnerability via repeated headers when using ASGI
 ==============================================================================================
@@ -28,7 +28,7 @@ repeated string concatenation while combining repeated headers, which
 produced super-linear computation resulting in service degradation or outage.
 
 This issue has severity "moderate" according to the :ref:`Django security
-policy <security-disclosure>`.
+policy <severity-levels>`.
 
 CVE-2026-1207: Potential SQL injection via raster lookups on PostGIS
 ====================================================================
@@ -40,7 +40,7 @@ index.
 As a reminder, all untrusted user input should be validated before use.
 
 This issue has severity "high" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.
 
 CVE-2026-1285: Potential denial-of-service vulnerability in ``django.utils.text.Truncator`` HTML methods
 ========================================================================================================
@@ -52,7 +52,7 @@ denial-of-service attack via certain inputs with a large number of unmatched
 HTML end tags, which could cause quadratic time complexity during HTML parsing.
 
 This issue has severity "moderate" according to the :ref:`Django security
-policy <security-disclosure>`.
+policy <severity-levels>`.
 
 CVE-2026-1287: Potential SQL injection in column aliases via control characters
 ===============================================================================
@@ -65,7 +65,7 @@ expansion, as the ``**kwargs`` passed to :meth:`.QuerySet.annotate`,
 :meth:`~.QuerySet.alias`.
 
 This issue has severity "high" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.
 
 CVE-2026-1312: Potential SQL injection via ``QuerySet.order_by`` and ``FilteredRelation``
 =========================================================================================
@@ -75,4 +75,4 @@ containing periods when the same alias was, using a suitably crafted
 dictionary, with dictionary expansion, used in :class:`.FilteredRelation`.
 
 This issue has severity "high" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.

--- a/docs/releases/4.2.29.txt
+++ b/docs/releases/4.2.29.txt
@@ -27,7 +27,7 @@ validation, but if you rely on custom validators, ensure they do not depend on
 the previous behavior of ``URLField.to_python()``.
 
 This issue has severity "moderate" according to the :ref:`Django security
-policy <security-disclosure>`.
+policy <severity-levels>`.
 
 CVE-2026-25674: Potential incorrect permissions on newly created file system objects
 ====================================================================================
@@ -42,4 +42,4 @@ Django now applies the requested permissions via :func:`~os.chmod` after
 :func:`~os.mkdir`, removing the dependency on the process-wide umask.
 
 This issue has severity "low" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.

--- a/docs/releases/4.2.30.txt
+++ b/docs/releases/4.2.30.txt
@@ -25,7 +25,7 @@ Headers containing underscores are now ignored by ``ASGIRequest``, matching the
 behavior of :pypi:`Daphne <daphne>`, the reference server for ASGI.
 
 This issue has severity "low" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.
 
 CVE-2026-4277: Privilege abuse in ``GenericInlineModelAdmin``
 =============================================================
@@ -35,7 +35,7 @@ forged ``POST`` data in
 :class:`~django.contrib.contenttypes.admin.GenericInlineModelAdmin`.
 
 This issue has severity "low" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.
 
 CVE-2026-4292: Privilege abuse in ``ModelAdmin.list_editable``
 ==============================================================
@@ -45,7 +45,7 @@ Admin changelist forms using
 instances to be created via forged ``POST`` data.
 
 This issue has severity "low" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.
 
 CVE-2026-33033: Potential denial-of-service vulnerability in ``MultiPartParser`` via base64-encoded file upload
 ===============================================================================================================
@@ -55,7 +55,7 @@ with ``Content-Transfer-Encoding: base64`` that include excessive whitespace
 may trigger repeated memory copying, potentially degrading performance.
 
 This issue has severity "moderate" according to the :ref:`Django security
-policy <security-disclosure>`.
+policy <severity-levels>`.
 
 CVE-2026-33034: Potential denial-of-service vulnerability in ASGI requests via memory upload limit bypass
 =========================================================================================================
@@ -66,4 +66,4 @@ bypass the :setting:`DATA_UPLOAD_MAX_MEMORY_SIZE` limit when reading
 memory and causing service degradation.
 
 This issue has severity "low" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.

--- a/docs/releases/5.2.11.txt
+++ b/docs/releases/5.2.11.txt
@@ -16,7 +16,7 @@ The ``django.contrib.auth.handlers.modwsgi.check_password()`` function for
 allowed remote attackers to enumerate users via a timing attack.
 
 This issue has severity "low" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.
 
 CVE-2025-14550: Potential denial-of-service vulnerability via repeated headers when using ASGI
 ==============================================================================================
@@ -28,7 +28,7 @@ repeated string concatenation while combining repeated headers, which
 produced super-linear computation resulting in service degradation or outage.
 
 This issue has severity "moderate" according to the :ref:`Django security
-policy <security-disclosure>`.
+policy <severity-levels>`.
 
 CVE-2026-1207: Potential SQL injection via raster lookups on PostGIS
 ====================================================================
@@ -40,7 +40,7 @@ index.
 As a reminder, all untrusted user input should be validated before use.
 
 This issue has severity "high" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.
 
 CVE-2026-1285: Potential denial-of-service vulnerability in ``django.utils.text.Truncator`` HTML methods
 ========================================================================================================
@@ -52,7 +52,7 @@ denial-of-service attack via certain inputs with a large number of unmatched
 HTML end tags, which could cause quadratic time complexity during HTML parsing.
 
 This issue has severity "moderate" according to the :ref:`Django security
-policy <security-disclosure>`.
+policy <severity-levels>`.
 
 CVE-2026-1287: Potential SQL injection in column aliases via control characters
 ===============================================================================
@@ -65,7 +65,7 @@ expansion, as the ``**kwargs`` passed to :meth:`.QuerySet.annotate`,
 :meth:`~.QuerySet.alias`.
 
 This issue has severity "high" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.
 
 CVE-2026-1312: Potential SQL injection via ``QuerySet.order_by`` and ``FilteredRelation``
 =========================================================================================
@@ -75,4 +75,4 @@ containing periods when the same alias was, using a suitably crafted
 dictionary, with dictionary expansion, used in :class:`.FilteredRelation`.
 
 This issue has severity "high" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.

--- a/docs/releases/5.2.12.txt
+++ b/docs/releases/5.2.12.txt
@@ -28,7 +28,7 @@ validation, but if you rely on custom validators, ensure they do not depend on
 the previous behavior of ``URLField.to_python()``.
 
 This issue has severity "moderate" according to the :ref:`Django security
-policy <security-disclosure>`.
+policy <severity-levels>`.
 
 CVE-2026-25674: Potential incorrect permissions on newly created file system objects
 ====================================================================================
@@ -43,7 +43,7 @@ Django now applies the requested permissions via :func:`~os.chmod` after
 :func:`~os.mkdir`, removing the dependency on the process-wide umask.
 
 This issue has severity "low" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.
 
 Bugfixes
 ========

--- a/docs/releases/5.2.13.txt
+++ b/docs/releases/5.2.13.txt
@@ -25,7 +25,7 @@ Headers containing underscores are now ignored by ``ASGIRequest``, matching the
 behavior of :pypi:`Daphne <daphne>`, the reference server for ASGI.
 
 This issue has severity "low" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.
 
 CVE-2026-4277: Privilege abuse in ``GenericInlineModelAdmin``
 =============================================================
@@ -35,7 +35,7 @@ forged ``POST`` data in
 :class:`~django.contrib.contenttypes.admin.GenericInlineModelAdmin`.
 
 This issue has severity "low" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.
 
 CVE-2026-4292: Privilege abuse in ``ModelAdmin.list_editable``
 ==============================================================
@@ -45,7 +45,7 @@ Admin changelist forms using
 instances to be created via forged ``POST`` data.
 
 This issue has severity "low" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.
 
 CVE-2026-33033: Potential denial-of-service vulnerability in ``MultiPartParser`` via base64-encoded file upload
 ===============================================================================================================
@@ -55,7 +55,7 @@ with ``Content-Transfer-Encoding: base64`` that include excessive whitespace
 may trigger repeated memory copying, potentially degrading performance.
 
 This issue has severity "moderate" according to the :ref:`Django security
-policy <security-disclosure>`.
+policy <severity-levels>`.
 
 CVE-2026-33034: Potential denial-of-service vulnerability in ASGI requests via memory upload limit bypass
 =========================================================================================================
@@ -66,4 +66,4 @@ bypass the :setting:`DATA_UPLOAD_MAX_MEMORY_SIZE` limit when reading
 memory and causing service degradation.
 
 This issue has severity "low" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.

--- a/docs/releases/5.2.14.txt
+++ b/docs/releases/5.2.14.txt
@@ -18,7 +18,7 @@ As a reminder, Django :ref:`expects a limit to be configured
 relying on :setting:`FILE_UPLOAD_MAX_MEMORY_SIZE`.
 
 This issue has severity "low" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.
 
 CVE-2026-35192: Session fixation via public cached pages and ``SESSION_SAVE_EVERY_REQUEST``
 ===========================================================================================
@@ -29,7 +29,7 @@ session was not modified, but :setting:`SESSION_SAVE_EVERY_REQUEST` was
 a cached public page.
 
 This issue has severity "low" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.
 
 CVE-2026-6907: Potential exposure of private data due to incorrect handling of ``Vary: *`` in ``UpdateCacheMiddleware``
 =======================================================================================================================
@@ -39,4 +39,4 @@ erroneously cache requests where the ``Vary`` header contained an asterisk
 (``'*'``). This could lead to private data being stored and served.
 
 This issue has severity "low" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.

--- a/docs/releases/6.0.2.txt
+++ b/docs/releases/6.0.2.txt
@@ -16,7 +16,7 @@ The ``django.contrib.auth.handlers.modwsgi.check_password()`` function for
 allowed remote attackers to enumerate users via a timing attack.
 
 This issue has severity "low" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.
 
 CVE-2025-14550: Potential denial-of-service vulnerability via repeated headers when using ASGI
 ==============================================================================================
@@ -28,7 +28,7 @@ repeated string concatenation while combining repeated headers, which
 produced super-linear computation resulting in service degradation or outage.
 
 This issue has severity "moderate" according to the :ref:`Django security
-policy <security-disclosure>`.
+policy <severity-levels>`.
 
 CVE-2026-1207: Potential SQL injection via raster lookups on PostGIS
 ====================================================================
@@ -40,7 +40,7 @@ index.
 As a reminder, all untrusted user input should be validated before use.
 
 This issue has severity "high" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.
 
 CVE-2026-1285: Potential denial-of-service vulnerability in ``django.utils.text.Truncator`` HTML methods
 ========================================================================================================
@@ -52,7 +52,7 @@ denial-of-service attack via certain inputs with a large number of unmatched
 HTML end tags, which could cause quadratic time complexity during HTML parsing.
 
 This issue has severity "moderate" according to the :ref:`Django security
-policy <security-disclosure>`.
+policy <severity-levels>`.
 
 CVE-2026-1287: Potential SQL injection in column aliases via control characters
 ===============================================================================
@@ -65,7 +65,7 @@ expansion, as the ``**kwargs`` passed to :meth:`.QuerySet.annotate`,
 :meth:`~.QuerySet.alias`.
 
 This issue has severity "high" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.
 
 CVE-2026-1312: Potential SQL injection via ``QuerySet.order_by`` and ``FilteredRelation``
 =========================================================================================
@@ -75,7 +75,7 @@ containing periods when the same alias was, using a suitably crafted
 dictionary, with dictionary expansion, used in :class:`.FilteredRelation`.
 
 This issue has severity "high" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.
 
 Bugfixes
 ========

--- a/docs/releases/6.0.3.txt
+++ b/docs/releases/6.0.3.txt
@@ -27,7 +27,7 @@ validation, but if you rely on custom validators, ensure they do not depend on
 the previous behavior of ``URLField.to_python()``.
 
 This issue has severity "moderate" according to the :ref:`Django security
-policy <security-disclosure>`.
+policy <severity-levels>`.
 
 CVE-2026-25674: Potential incorrect permissions on newly created file system objects
 ====================================================================================
@@ -42,7 +42,7 @@ Django now applies the requested permissions via :func:`~os.chmod` after
 :func:`~os.mkdir`, removing the dependency on the process-wide umask.
 
 This issue has severity "low" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.
 
 Bugfixes
 ========

--- a/docs/releases/6.0.4.txt
+++ b/docs/releases/6.0.4.txt
@@ -25,7 +25,7 @@ Headers containing underscores are now ignored by ``ASGIRequest``, matching the
 behavior of :pypi:`Daphne <daphne>`, the reference server for ASGI.
 
 This issue has severity "low" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.
 
 CVE-2026-4277: Privilege abuse in ``GenericInlineModelAdmin``
 =============================================================
@@ -35,7 +35,7 @@ forged ``POST`` data in
 :class:`~django.contrib.contenttypes.admin.GenericInlineModelAdmin`.
 
 This issue has severity "low" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.
 
 CVE-2026-4292: Privilege abuse in ``ModelAdmin.list_editable``
 ==============================================================
@@ -45,7 +45,7 @@ Admin changelist forms using
 instances to be created via forged ``POST`` data.
 
 This issue has severity "low" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.
 
 CVE-2026-33033: Potential denial-of-service vulnerability in ``MultiPartParser`` via base64-encoded file upload
 ===============================================================================================================
@@ -55,7 +55,7 @@ with ``Content-Transfer-Encoding: base64`` that include excessive whitespace
 may trigger repeated memory copying, potentially degrading performance.
 
 This issue has severity "moderate" according to the :ref:`Django security
-policy <security-disclosure>`.
+policy <severity-levels>`.
 
 CVE-2026-33034: Potential denial-of-service vulnerability in ASGI requests via memory upload limit bypass
 =========================================================================================================
@@ -66,7 +66,7 @@ bypass the :setting:`DATA_UPLOAD_MAX_MEMORY_SIZE` limit when reading
 memory and causing service degradation.
 
 This issue has severity "low" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.
 
 Bugfixes
 ========

--- a/docs/releases/6.0.5.txt
+++ b/docs/releases/6.0.5.txt
@@ -19,7 +19,7 @@ As a reminder, Django :ref:`expects a limit to be configured
 relying on :setting:`FILE_UPLOAD_MAX_MEMORY_SIZE`.
 
 This issue has severity "low" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.
 
 CVE-2026-35192: Session fixation via public cached pages and ``SESSION_SAVE_EVERY_REQUEST``
 ===========================================================================================
@@ -30,7 +30,7 @@ session was not modified, but :setting:`SESSION_SAVE_EVERY_REQUEST` was
 a cached public page.
 
 This issue has severity "low" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.
 
 CVE-2026-6907: Potential exposure of private data due to incorrect handling of ``Vary: *`` in ``UpdateCacheMiddleware``
 =======================================================================================================================
@@ -40,7 +40,7 @@ erroneously cache requests where the ``Vary`` header contained an asterisk
 (``'*'``). This could lead to private data being stored and served.
 
 This issue has severity "low" according to the :ref:`Django security policy
-<security-disclosure>`.
+<severity-levels>`.
 
 Bugfixes
 ========


### PR DESCRIPTION
This boilerplate sentence in security release notes mentions severity levels, so we could link to severity levels instead of the disclosure process. (Alternatively, we could link to the top of the doc, since the link is on "security policy".)