### PR TITLE
Fixed #33185 -- Fixed sqlmigrate crash for RenameModel with a self-referential foreign key.

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -153,6 +153,9 @@ class BaseDatabaseSchemaEditor:
         self.collect_sql = collect_sql
         if self.collect_sql:
             self.collected_sql = []
+            # Tables renamed while collecting SQL don't exist under their new
+            # name in the database, so introspection must target the old name.
+            self.collected_table_renames = {}
         self.atomic_migration = self.connection.features.can_rollback_ddl and atomic
 
     # State-managing methods
@@ -697,6 +700,14 @@ class BaseDatabaseSchemaEditor:
                 "new_table": self.quote_name(new_db_table),
             }
         )
+        if self.collect_sql:
+            # The rename isn't executed, so later introspection of the new
+            # table name must be redirected to the still-existing old one,
+            # following any earlier rename of the same table in this batch.
+            existing_table = self.collected_table_renames.pop(
+                old_db_table, old_db_table
+            )
+            self.collected_table_renames[new_db_table] = existing_table
         # Rename all references to the old table name.
         for sql in self.deferred_sql:
             if isinstance(sql, Statement):
@@ -2019,9 +2030,12 @@ class BaseDatabaseSchemaEditor:
                 )
                 for name in column_names
             ]
+        table_name = model._meta.db_table
+        if self.collect_sql:
+            table_name = self.collected_table_renames.get(table_name, table_name)
         with self.connection.cursor() as cursor:
             constraints = self.connection.introspection.get_constraints(
-                cursor, model._meta.db_table
+                cursor, table_name
             )
         result = []
         for name, infodict in constraints.items():

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -938,6 +938,44 @@ class OperationTests(OperationTestBase):
                 "test_rmwsrf_rider", ["friend_id"], ("test_rmwsrf_horserider", "id")
             )
 
+    def test_rename_model_with_self_referential_fk_collect_sql(self):
+        """
+        Collecting SQL (e.g. sqlmigrate) for a RenameModel operation on a model
+        with a self-referential foreign key doesn't introspect the renamed
+        table, which doesn't exist yet (#33185).
+        """
+        project_state = self.set_up_test_model("test_rmwsrfcs", related_model=True)
+        operation = migrations.RenameModel("Rider", "HorseRider")
+        new_state = project_state.clone()
+        operation.state_forwards("test_rmwsrfcs", new_state)
+        # Forwards: only the old table exists, so the renamed table can't be
+        # introspected. The rename is collected and the self-referential FK is
+        # handled (rather than silently skipped) using the constraint
+        # introspected from the still-existing old table.
+        with connection.schema_editor(collect_sql=True) as editor:
+            operation.database_forwards(
+                "test_rmwsrfcs", editor, project_state, new_state
+            )
+            collected_sql = "\n".join(editor.collected_sql)
+        self.assertIn(
+            connection.ops.quote_name("test_rmwsrfcs_horserider"), collected_sql
+        )
+        self.assertIn(connection.ops.quote_name("friend_id"), collected_sql)
+        # Backwards: apply the rename for real so the renamed table exists,
+        # then collect the reverse SQL. The same redirection must happen, this
+        # time back to the "horserider" table.
+        with connection.schema_editor() as editor:
+            operation.database_forwards(
+                "test_rmwsrfcs", editor, project_state, new_state
+            )
+        with connection.schema_editor(collect_sql=True) as editor:
+            operation.database_backwards(
+                "test_rmwsrfcs", editor, new_state, project_state
+            )
+            collected_sql = "\n".join(editor.collected_sql)
+        self.assertIn(connection.ops.quote_name("test_rmwsrfcs_rider"), collected_sql)
+        self.assertIn(connection.ops.quote_name("friend_id"), collected_sql)
+
     def test_rename_model_with_superclass_fk(self):
         """
         Tests the RenameModel operation on a model which has a superclass that


### PR DESCRIPTION
#### Trac ticket number

ticket-33185

#### Branch description

`sqlmigrate` crashes when previewing a `RenameModel` for a model with a self-referential foreign key.

The problem:

- `sqlmigrate` runs the schema editor with `collect_sql=True`, so the table rename is collected but never executed.
- To drop and recreate the self-referential FK, the schema editor introspects the table for the existing constraint name.
- It introspects the *new* table name, which doesn't exist yet.
- MySQL raises `ProgrammingError (1146, "Table doesn't exist")`. PostgreSQL silently finds nothing and emits incorrect SQL.

The fix:

- `BaseDatabaseSchemaEditor` records table renames while collecting SQL (`collected_table_renames`, set in `alter_db_table()`).
- `_constraint_names()` redirects introspection back to the still-existing old table name.
- Introspection now runs against the real schema and returns exact, backend-correct names — no Python-side name reconstruction.
- Scoped to `collect_sql` mode, so normal `migrate` behavior is unchanged.

A regression test covers the `collect_sql` path; it fails before this change and passes after (verified on PostgreSQL, where the missing constraint is observable).

Builds on the earlier closed attempts #20523, #20671, and #20693. Unlike #20693, it avoids reconstructing constraint names (whose real names carry a suffix after `_fk`) and reuses real introspection against the pre-rename table.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

I used Claude Code to help draft the initial patch and run local verification. I reviewed and verified the changes and the test output myself.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable. <!-- Backportable bugfix; the release note belongs in the point-release notes and can be added on backport. -->
- [x] I have attached screenshots in both light and dark modes for any UI changes. N/A: no UI changes.
