### PR TITLE
Removed unnecessary direct dev dependency on puppeteer.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.15",
-    "puppeteer": "^25.0.4",
     "grunt": "^1.6.2",
     "grunt-cli": "^1.5.0",
     "grunt-contrib-qunit": "^10.2.0",


### PR DESCRIPTION
#### Trac ticket number
N/a

#### Branch description
`npm ls` gave:
├─┬ grunt-contrib-qunit@10.2.0
│ └── puppeteer@24.43.1
└── puppeteer@25.1.0

Checked the PR [discussion](https://github.com/django/django/pull/15551#discussion_r877625888), and this was added in an attempt to pin the version of puppeteer, but this would have been done with adding an `overrides` entry, not by adding a direct dependency.

Bug in d407340e7f8463ee885aaa37789d8aef657b73f5.

EDIT: removed reference to hypothesis about relation to failing JS tests job, seems to be still happening.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

I did futz around with Claude a bit, but I found the `npm ls puppeteer` discrepancy myself.