### PR TITLE
Fixed #37132 -- Replaced Python 2-style super() call.

### DIFF
--- a/django/core/mail/message.py
+++ b/django/core/mail/message.py
@@ -217,7 +217,7 @@ class SafeMIMEText(MIMEMixin, MIMEText):
             # Quoted-Printable encoding has the side effect of shortening long
             # lines, if any (#22561).
             charset = utf8_charset_qp if has_long_lines else utf8_charset
-        MIMEText.set_payload(self, payload, charset=charset)
+        super().set_payload(payload, charset=charset)
 
 
 # RemovedInDjango70Warning.

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -2765,8 +2765,10 @@ class DeprecatedInternalsTests(SimpleTestCase):
         # (Using surrogateescape for non-utf8 is covered in test_encoding().)
         from django.core.mail import SafeMIMEText
 
-        def simplified_set_payload(instance, payload, charset):
-            instance._payload = payload
+        captured = []
+
+        def simplified_set_payload(payload, charset):
+            captured.append(payload)
 
         mock_set_payload.side_effect = simplified_set_payload
 
@@ -2775,6 +2777,7 @@ class DeprecatedInternalsTests(SimpleTestCase):
         ).encode("iso-8859-1")
         body = text.decode("ascii", errors="surrogateescape")
         message = SafeMIMEText(body, "plain", "ascii")
+        message._payload = captured[0]
         mock_set_payload.assert_called_once()
         self.assertEqual(message.get_payload(decode=True), text)
 


### PR DESCRIPTION
MIMEText.set_payload(self, payload, charset=charset) passed self
  explicitly as an unbound call. Use super().set_payload() instead,
  ambiguity when the method is mocked with autospec.

  #### Trac ticket number
  ticket-37132
  
  #### Branch description
  `SafeMIMEText.set_payload()` used a Python 2-style unbound method call,
  passing `self` explicitly to `MIMEText.set_payload()`. This breaks when
  the method is tested with `autospec`, since `self` ends up passed twice.
  Replaced with `super().set_payload()`, the correct Python 3 idiom.

  #### AI Assistance Disclosure (REQUIRED)
  - [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
  Claude (claude.ai) was used to assist with this contribution. 

  #### Checklist
  - [x] This PR follows the contribution guidelines.
  - [x] This PR **does not** disclose a security vulnerability.
  - [x] This PR targets the `main` branch.
  - [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
  - [x] I have not requested, and will not request, an automated AI review for this PR.
  - [x] I have checked the "Has patch" ticket flag in the Trac system.
  - [x] I have added or updated relevant tests.
  - [x] I have added or updated relevant docs, including release notes if applicable.
  - [ ] I have attached screenshots in both light and dark modes for any UI changes. *(N/A — no UI changes)*

