### PR TITLE
Refs #32577 -- Added DEFAULT_PK_FIELD for implicit primary keys.

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -450,6 +450,9 @@ DEFAULT_INDEX_TABLESPACE = ""
 # Default primary key field type.
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
+# Optional default primary key field type.
+DEFAULT_PK_FIELD = None
+
 # Default X-Frame-Options header value
 X_FRAME_OPTIONS = "DENY"
 

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -10,6 +10,7 @@ from django.db import connections
 from django.db.models import (
     AutoField,
     CompositePrimaryKey,
+    Field,
     Manager,
     OrderWrt,
     UniqueConstraint,
@@ -259,19 +260,28 @@ class Options:
         return new_objs
 
     def _get_default_pk_class(self):
-        pk_class_path = getattr(
-            self.app_config,
-            "default_auto_field",
-            settings.DEFAULT_AUTO_FIELD,
-        )
-        if self.app_config and self.app_config._is_default_auto_field_overridden:
-            app_config_class = type(self.app_config)
-            source = (
-                f"{app_config_class.__module__}."
-                f"{app_config_class.__qualname__}.default_auto_field"
-            )
+        if settings.DEFAULT_PK_FIELD is not None:
+            pk_class_path = settings.DEFAULT_PK_FIELD
+            source = "DEFAULT_PK_FIELD"
+            pk_class_required_base = Field
+            pk_class_required_base_name = "Field"
         else:
-            source = "DEFAULT_AUTO_FIELD"
+            pk_class_path = getattr(
+                self.app_config,
+                "default_auto_field",
+                settings.DEFAULT_AUTO_FIELD,
+            )
+            if self.app_config and self.app_config._is_default_auto_field_overridden:
+                app_config_class = type(self.app_config)
+                source = (
+                    f"{app_config_class.__module__}."
+                    f"{app_config_class.__qualname__}.default_auto_field"
+                )
+            else:
+                source = "DEFAULT_AUTO_FIELD"
+            pk_class_required_base = AutoField
+            pk_class_required_base_name = "AutoField"
+
         if not pk_class_path:
             raise ImproperlyConfigured(f"{source} must not be empty.")
         try:
@@ -282,10 +292,10 @@ class Options:
                 f"not be imported."
             )
             raise ImproperlyConfigured(msg) from e
-        if not issubclass(pk_class, AutoField):
+        if not issubclass(pk_class, pk_class_required_base):
             raise ValueError(
                 f"Primary key '{pk_class_path}' referred by {source} must "
-                f"subclass AutoField."
+                f"subclass {pk_class_required_base_name}."
             )
         return pk_class
 

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -1351,6 +1351,43 @@ any format valid in the chosen email sending protocol.
 This doesn't affect error messages sent to :setting:`ADMINS` and
 :setting:`MANAGERS`. See :setting:`SERVER_EMAIL` for that.
 
+
+.. setting:: DEFAULT_PK_FIELD
+
+``DEFAULT_PK_FIELD``
+--------------------
+
+.. versionadded:: 6.2
+
+Default: ``None``
+
+The default primary key field type to use for models that don't define a
+primary key field explicitly.
+
+When set to ``None``, Django uses :setting:`DEFAULT_AUTO_FIELD`.
+
+Unlike :setting:`DEFAULT_AUTO_FIELD`, this setting may refer to any
+:class:`~django.db.models.Field` subclass. The field is created with
+``primary_key=True`` and ``auto_created=True``.
+
+For example, to use UUID primary keys by default::
+
+    import uuid
+
+    from django.db import models
+
+
+    class UUIDPrimaryKeyField(models.UUIDField):
+        def __init__(self, *args, **kwargs):
+            kwargs.setdefault("default", uuid.uuid4)
+            kwargs.setdefault("editable", False)
+            super().__init__(*args, **kwargs)
+
+
+Then configure::
+
+    DEFAULT_PK_FIELD = "app.fields.UUIDPrimaryKeyField"
+
 .. setting:: DEFAULT_INDEX_TABLESPACE
 
 ``DEFAULT_INDEX_TABLESPACE``

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -183,6 +183,11 @@ Migrations
 Models
 ~~~~~~
 
+* The new :setting:`DEFAULT_PK_FIELD` setting allows projects to configure the
+  default primary key field type for models that don't define a primary key
+  explicitly, without requiring the field to subclass
+  :class:`~django.db.models.AutoField`.
+
 * ...
 
 Requests and Responses

--- a/tests/model_options/test_default_pk.py
+++ b/tests/model_options/test_default_pk.py
@@ -1,3 +1,5 @@
+import uuid
+
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.test import SimpleTestCase, override_settings
@@ -6,6 +8,13 @@ from django.test.utils import isolate_apps
 
 class MyBigAutoField(models.BigAutoField):
     pass
+
+
+class UUIDPrimaryKeyField(models.UUIDField):
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("default", uuid.uuid4)
+        kwargs.setdefault("editable", False)
+        super().__init__(*args, **kwargs)
 
 
 @isolate_apps("model_options")
@@ -26,6 +35,40 @@ class TestDefaultPK(SimpleTestCase):
             "imported."
         )
         with self.assertRaisesMessage(ImproperlyConfigured, msg):
+
+            class Model(models.Model):
+                pass
+
+    @override_settings(DEFAULT_PK_FIELD="django.db.models.NonexistentField")
+    def test_default_pk_field_setting_nonexistent(self):
+        msg = (
+            "DEFAULT_PK_FIELD refers to the module "
+            "'django.db.models.NonexistentField' that could not be imported."
+        )
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+
+            class Model(models.Model):
+                pass
+
+    @override_settings(
+        DEFAULT_PK_FIELD="model_options.test_default_pk.UUIDPrimaryKeyField"
+    )
+    def test_default_pk_field_can_use_uuid_field(self):
+        class Model(models.Model):
+            pass
+
+        self.assertIsInstance(Model._meta.pk, UUIDPrimaryKeyField)
+        self.assertEqual(Model._meta.pk.name, "id")
+        self.assertTrue(Model._meta.pk.primary_key)
+        self.assertFalse(Model._meta.pk.editable)
+
+    @override_settings(DEFAULT_PK_FIELD="django.db.models.Model")
+    def test_default_pk_field_setting_non_field(self):
+        msg = (
+            "Primary key 'django.db.models.Model' referred by "
+            "DEFAULT_PK_FIELD must subclass Field."
+        )
+        with self.assertRaisesMessage(ValueError, msg):
 
             class Model(models.Model):
                 pass


### PR DESCRIPTION
#### Trac ticket number

ticket-32577

#### Branch description

This PR adds `DEFAULT_PK_FIELD` as an optional setting for configuring the default primary key field used by models that don't define a primary key explicitly.

When `DEFAULT_PK_FIELD` is `None`, Django keeps the existing `DEFAULT_AUTO_FIELD` behavior. When `DEFAULT_PK_FIELD` is set, Django imports the configured field class and requires it to subclass `Field` rather than `AutoField`.

This provides a generic path for non-`AutoField` implicit primary keys, including UUID-based primary keys, without changing the existing `DEFAULT_AUTO_FIELD` behavior.

Tests run locally:

```bash
python runtests.py model_options.test_default_pk
python runtests.py model_options
python runtests.py apps
```

#### AI Assistance Disclosure (REQUIRED)

* [ ] **No AI tools were used** in preparing this PR.
* [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

I used ChatGPT to help analyze the ticket discussion, plan the patch, and review the tests and documentation. I reviewed the changes and ran the tests locally before submission.

#### Checklist

* [x] This PR follows the [[contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/)](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
* [x] This PR **does not** disclose a security vulnerability (see [[vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)](https://docs.djangoproject.com/en/stable/internals/security/)).
* [x] This PR targets the `main` branch.
* [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
* [x] I have not requested, and will not request, an automated AI review for this PR.
* [ ] I have checked the "Has patch" ticket flag in the Trac system.
* [x] I have added or updated relevant tests.
* [x] I have added or updated relevant docs, including release notes if applicable.
* [x] Not applicable: this PR does not include UI changes.