### PR TITLE
Fixed CustomStorage._save() signature to accept content argument.

### DIFF
--- a/tests/file_storage/test_base.py
+++ b/tests/file_storage/test_base.py
@@ -12,7 +12,7 @@ class CustomStorage(Storage):
     def exists(self, name):
         return False
 
-    def _save(self, name):
+    def _save(self, name, content):
         return name
 
 


### PR DESCRIPTION
Storage.save() always calls self._save(name, content), but the base class contract.

  #### Trac ticket number
N/A - typo
  
  #### Branch description
 The `CustomStorage` test stub in `tests/file_storage/test_base.py` defined `_save(self, name)` without the required `content` argument. Since `Storage.save()` always calls `self._save(name, content)`, this stub violated the base class contract. Fixed the signature to match. 

  #### AI Assistance Disclosure (REQUIRED)
  - [N/A] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

  #### Checklist
  - [x] This PR follows the contribution guidelines.
  - [x] This PR **does not** disclose a security vulnerability.
  - [x] This PR targets the `main` branch.
  - [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
  - [x] I have not requested, and will not request, an automated AI review for this PR.
  - [N/A] I have checked the "Has patch" ticket flag in the Trac system.
  - [x] I have added or updated relevant tests.
  - [N/A] I have added or updated relevant docs, including release notes if applicable.
  - [N/A] I have attached screenshots in both light and dark modes for any UI changes. *(N/A — no UI changes)*