### PR TITLE
Fixed #37133: Fixed always-False check.

### DIFF
--- a/django/utils/translation/trans_real.py
+++ b/django/utils/translation/trans_real.py
@@ -105,7 +105,7 @@ class TranslationCatalog:
     def update(self, trans):
         # Merge if plural function is the same as the top catalog, else
         # prepend.
-        if trans.plural.__code__ == self._plurals[0]:
+        if trans.plural.__code__ == self._plurals[0].__code__:
             self._catalogs[0].update(trans._catalog)
         else:
             self._catalogs.insert(0, trans._catalog.copy())


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37133

#### Branch description
The left-hand side of the comparison was always a code object, and the right-hand side a function. This PR changes the right-hand side to the code object as well.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [X] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [X] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [X] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [X] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
