### PR TITLE
Refs #36905 -- Moved JSONResponse safe param discussion to versionchanged box.

### DIFF
--- a/django/http/response.py
+++ b/django/http/response.py
@@ -747,9 +747,7 @@ class JsonResponse(HttpResponse):
     """
     An HTTP response class that consumes data to be serialized to JSON.
 
-    :param data: Data to be dumped into json. By default only ``dict`` objects
-      are allowed to be passed due to a security flaw before ECMAScript 5. See
-      the ``safe`` parameter for more information.
+    :param data: Data to be dumped into json.
     :param encoder: Should be a json encoder class. Defaults to
       ``django.core.serializers.json.DjangoJSONEncoder``.
     :param safe: Controls if only ``dict`` objects may be serialized. Defaults

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -1267,32 +1267,21 @@ Typical usage could look like:
 Serializing non-dictionary objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In order to serialize objects other than ``dict`` you must set the ``safe``
-parameter to ``False``:
+Objects other than ``dict`` can be serialized:
 
 .. code-block:: pycon
 
-    >>> response = JsonResponse([1, 2, 3], safe=False)
-
-Without passing ``safe=False``, a :exc:`TypeError` will be raised.
+    >>> response = JsonResponse([1, 2, 3])
 
 Note that an API based on ``dict`` objects is more extensible, flexible, and
 makes it easier to maintain forwards compatibility. Therefore, you should avoid
-using non-dict objects in JSON-encoded response.
-
-.. warning::
-
-    Before the `5th edition of ECMAScript
-    <https://262.ecma-international.org/5.1/#sec-11.1.4>`_ it was possible to
-    poison the JavaScript ``Array`` constructor. For this reason, Django does
-    not allow passing non-dict objects to the
-    :class:`~django.http.JsonResponse` constructor by default. However, most
-    modern browsers implement ECMAScript 5 which removes this attack vector.
-    Therefore it is possible to disable this security precaution.
+using non-dict objects in JSON-encoded responses.
 
 .. versionchanged:: 6.2
 
-    In earlier versions, the ``safe`` parameter defaulted to ``True``.
+    In earlier versions, it was necessary to pass ``safe=False`` to serialize
+    other objects besides dictionaries, as the (now deprecated) ``safe``
+    parameter defaulted to ``True``, raising :exc:`TypeError`.
 
 .. deprecated:: 6.2
 


### PR DESCRIPTION
#### Trac ticket number
ticket-36905

#### Branch description
Edit this section to anticipate the future by removing all discussion of the deprecated `safe` parameter to the versionchanged boxes, which will disappear in Django 7.1.

See https://github.com/django/django/pull/21319#discussion_r3327127537.

Follow-up to 6e15ac8066312328de279e3e072667416c205bfc.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.