### PR TITLE
Refs #36439 -- Added missing thread_sensitive=False to dummy password hasher path.

### DIFF
--- a/django/contrib/auth/__init__.py
+++ b/django/contrib/auth/__init__.py
@@ -402,6 +402,7 @@ def check_password_with_timing_attack_mitigation(user, password):
 async def acheck_password_with_timing_attack_mitigation(user, password):
     """See check_user_with_timing_attack_mitigation."""
     if user is None:
-        await sync_to_async(get_user_model()().set_password)(password)
+        set_password = get_user_model()().set_password
+        await sync_to_async(set_password, thread_sensitive=False)(password)
     else:
         return await user.acheck_password(password)


### PR DESCRIPTION
#### Trac ticket number
ticket-36439

#### Branch description
The existing user path also uses `thread_sensitive=False` in `acheck_password()`:

https://github.com/django/django/blob/ea9742c6d02edf64fc0969f21506f2048c976051/django/contrib/auth/hashers.py#L89-L94

Follow-up to 7f66c3b41f0fb0fb938d7b96e20a28dccdaa2ecd.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
