### PR TITLE
Fixed #37133: Fixed always False check.

### DIFF
--- a/django/utils/translation/trans_real.py
+++ b/django/utils/translation/trans_real.py
@@ -105,7 +105,7 @@ class TranslationCatalog:
     def update(self, trans):
         # Merge if plural function is the same as the top catalog, else
         # prepend.
-        if trans.plural.__code__ == self._plurals[0]:
+        if trans.plural.__code__ == self._plurals[0].__code__:
             self._catalogs[0].update(trans._catalog)
         else:
             self._catalogs.insert(0, trans._catalog.copy())

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -177,7 +177,7 @@ class TranslationTests(SimpleTestCase):
         self.assertEqual(len(french._catalog._catalogs), 6)
         # Translations from this last one are supposed to win.
         self.assertEqual(french.gettext("I win"), "Je gagne")
-        # Merge a third translation file with the same plural forms as the second one.
+        # Merge a third translation file with the same plural forms.
         catalog3 = _create_translation_from_string(
             'msgid ""\n'
             'msgstr ""\n'

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -152,6 +152,7 @@ class TranslationTests(SimpleTestCase):
                 )
 
         french = trans_real.catalog()
+        self.assertEqual(len(french._catalog._catalogs), 4)
         # Merge a new translation file with different plural forms.
         catalog1 = _create_translation_from_string(
             'msgid ""\n'
@@ -162,6 +163,7 @@ class TranslationTests(SimpleTestCase):
             'msgstr "Je perds"\n'
         )
         french.merge(catalog1)
+        self.assertEqual(len(french._catalog._catalogs), 5)
         # Merge a second translation file with plural forms from django.conf.
         catalog2 = _create_translation_from_string(
             'msgid ""\n'
@@ -172,8 +174,20 @@ class TranslationTests(SimpleTestCase):
             'msgstr "Je gagne"\n'
         )
         french.merge(catalog2)
+        self.assertEqual(len(french._catalog._catalogs), 6)
         # Translations from this last one are supposed to win.
         self.assertEqual(french.gettext("I win"), "Je gagne")
+        # Merge a third translation file with the same plural forms as the second one.
+        catalog3 = _create_translation_from_string(
+            'msgid ""\n'
+            'msgstr ""\n'
+            '"Content-Type: text/plain; charset=UTF-8\\n"\n'
+            '"Plural-Forms: Plural-Forms: nplurals=2; plural=(n > 1);\\n"\n'
+            'msgid "I win"\n'
+            'msgstr "Je gagne"\n'
+        )
+        french.merge(catalog3)
+        self.assertEqual(len(french._catalog._catalogs), 6)
 
     def test_override(self):
         activate("de")


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37133

#### Branch description
The comparison of the top catalog to the merge one always resulted to False, as the `__code__` was compared to the function itself. The fix uses `__code__` on both sides. This was introduced in a previous commit, as the version before it had the same format of comparing the `.__code__`s.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [X] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [X] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [X] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [X] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
- [X] I have attached screenshots in both light and dark modes for any UI changes.
