### PR TITLE
Fixed #37134 -- Fixed OS icons for console block tabs in locally generated HTML docs.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -477,6 +477,7 @@ answer newbie questions, and generally made Django that much better:
     Jakub Wiśniowski <restless.being@gmail.com>
     james_027@yahoo.com
     James Aylett
+    James Beard <james@smallsaucepan.com>
     James Bennett <james@b-list.org>
     James Gillard <jamesgillard@live.co.uk>
     James Murty

--- a/docs/_theme/djangodocs/static/console-tabs.css
+++ b/docs/_theme/djangodocs/static/console-tabs.css
@@ -1,4 +1,4 @@
-@import url("{{ pathto('_static/fontawesome/css/fa-brands.min.css', 1) }}");
+@import url("fontawesome/css/fa-brands.min.css");
 
 .console-block {
     text-align: right;

--- a/docs/_theme/djangodocs/static/fontawesome/css/fa-brands.min.css
+++ b/docs/_theme/djangodocs/static/fontawesome/css/fa-brands.min.css
@@ -2,4 +2,5 @@
  * Font Awesome Free 5.0.4 by @fontawesome - http://fontawesome.com
  * License - http://fontawesome.com/license (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
  */
-@font-face{font-family:Font Awesome\ 5 Brands;font-style:normal;font-weight:400;src:url(../webfonts/fa-brands-400.eot);src:url(../webfonts/fa-brands-400.eot?#iefix) format("embedded-opentype"),url(../webfonts/fa-brands-400.woff2) format("woff2"),url(../webfonts/fa-brands-400.woff) format("woff"),url(../webfonts/fa-brands-400.ttf) format("truetype"),url(../webfonts/fa-brands-400.svg#fontawesome) format("svg")}.fab{font-family:Font Awesome\ 5 Brands}
+@font-face{font-family:FontAwesome;font-style:normal;font-weight:400;src:url(../webfonts/fa-brands-400.eot);src:url(../webfonts/fa-brands-400.eot?#iefix) format("embedded-opentype"),url(../webfonts/fa-brands-400.woff2) format("woff2"),url(../webfonts/fa-brands-400.woff) format("woff"),url(../webfonts/fa-brands-400.ttf) format("truetype"),url(../webfonts/fa-brands-400.svg#fontawesome) format("svg")}.fab{font-family:FontAwesome}
+


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37134

#### Branch description
When generating HTML docs locally, the default djangodocs theme had some incorrect references to the Fontawesome font used to provide the tab icons of console sections. As a result an undefined unicode symbol indicator would be shown instead:

<img width="1268" height="152" alt="Screenshot 2026-06-02 at 23 11 47" src="https://github.com/user-attachments/assets/1e0fd372-2c0a-4d05-b64d-764992691609" />

With the changes in this PR this now appears as:

<img width="1260" height="144" alt="Screenshot 2026-06-02 at 23 13 40" src="https://github.com/user-attachments/assets/07e2b6c0-1f44-4056-a495-9ae6076a4b52" />


#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
