### PR TITLE
Refs new-features#170 -- Prototyped console EmailBackend friendly mode.

### DIFF
--- a/django/conf/project_template/project_name/settings.py-tpl
+++ b/django/conf/project_template/project_name/settings.py-tpl
@@ -123,5 +123,8 @@ STATIC_URL = 'static/'
 MAILERS = {
     'default': {
         'BACKEND': 'django.core.mail.backends.console.EmailBackend',
+        'OPTIONS': {
+            'raw': False,
+        },
     },
 }

--- a/django/core/mail/backends/console.py
+++ b/django/core/mail/backends/console.py
@@ -4,27 +4,101 @@ Email backend that writes messages to console instead of sending them.
 
 import sys
 import threading
+import warnings
 
 from django.core.mail.backends.base import BaseEmailBackend
+from django.utils.deprecation import RemovedInDjango71Warning
 
 
 class EmailBackend(BaseEmailBackend):
-    def __init__(self, fail_silently=False, **kwargs):
+    def __init__(
+        self,
+        fail_silently=False,
+        *,
+        raw=None,
+        max_text_length=1024,
+        **kwargs,
+    ):
         self.stream = kwargs.pop("stream", sys.stdout)
         self._lock = threading.RLock()
         super().__init__(**kwargs)
         self.fail_silently = fail_silently
 
+        # RemovedInDjango71Warning.
+        # (Also change the parameter default to `raw=False`.)
+        if raw is None:
+            warnings.warn(
+                RemovedInDjango71Warning(
+                    "The console EmailBackend will default to raw=False in Django 7.1. "
+                    "Add 'raw': True in MAILERS OPTIONS to preserve the old behavior."
+                ),
+            )
+            raw = True
+        self.raw = raw
+        self.max_text_length = max_text_length
+
     def write_message(self, message):
+        msg_data = self.serialize(message)
+        self.stream.write("%s\n" % msg_data)
+        self.stream.write("-" * 79)
+        self.stream.write("\n")
+
+    def serialize(self, message):
+        if self.raw:
+            return self.serialize_raw(message)
+        return self.serialize_friendly(message)
+
+    def serialize_raw(self, message):
         msg = message.message()
         msg_data = msg.as_bytes()
         charset = (
             msg.get_charset().get_output_charset() if msg.get_charset() else "utf-8"
         )
-        msg_data = msg_data.decode(charset)
-        self.stream.write("%s\n" % msg_data)
-        self.stream.write("-" * 79)
-        self.stream.write("\n")
+        return msg_data.decode(charset)
+
+    def serialize_friendly(self, message):
+        msg = message.message()
+        formatted = "".join(self._serialize_part_friendly(msg))
+        if message.bcc:
+            # Use invalid header name "(Bcc):" to avoid accidents.
+            bcc = ", ".join(str(address) for address in message.bcc)
+            formatted = f"(Bcc): {bcc}\n{formatted}"
+        return formatted
+
+    def _serialize_part_friendly(self, part, level=0):
+        # Headers.
+        if part.is_multipart() and not part.get_boundary():
+            part.set_boundary(f"=====multipart-boundary-{level}=====")
+        for field, value in part.items():
+            yield f"{field}: {value}\n"
+        yield "\n"
+
+        # Body.
+        if part.is_multipart():
+            boundary = part.get_boundary()
+            for subpart in part.iter_parts():
+                yield f"--{boundary}\n"
+                yield from self._serialize_part_friendly(subpart, level + 1)
+            yield f"--{boundary}--\n"
+        else:
+            content = part.get_content()
+            if content:
+                length = len(content)
+                if isinstance(content, str):
+                    if (
+                        self.max_text_length is not None
+                        and length > self.max_text_length
+                    ):
+                        truncated = length - self.max_text_length
+                        yield content[: self.max_text_length]
+                        yield f"\n[... {truncated:_} more characters]\n"
+                    else:
+                        yield content
+                        if not content.endswith("\n"):
+                            yield "\n"
+                else:
+                    content_type = part.get_content_type()
+                    yield f"[Binary {content_type}: {length:_} bytes]\n"
 
     def send_messages(self, email_messages):
         """Write all messages to the stream in a thread-safe way."""

--- a/django/core/mail/backends/filebased.py
+++ b/django/core/mail/backends/filebased.py
@@ -10,7 +10,7 @@ from django.core.mail.backends.console import EmailBackend as ConsoleEmailBacken
 
 
 class EmailBackend(ConsoleEmailBackend):
-    def __init__(self, fail_silently=False, file_path=None, **kwargs):
+    def __init__(self, fail_silently=False, file_path=None, raw=True, **kwargs):
         self._fname = None
         # Since we're using the console-based backend as a base, force the
         # stream to be None, so we don't default to stdout.


### PR DESCRIPTION
#### Trac ticket number

https://github.com/django/new-features/issues/170

#### Branch description
Implemented a "friendly" output option for the console EmailBackend. When enabled, the backend shows email message content (headers and text bodies) in their original Unicode forms, rather than encoded for 7-bit SMTP transmission. In addition, binary payloads are elided as (e.g.,) `[Binary image/gif: 2_048 bytes]`, and multipart boundaries are human- readable, deterministic strings.

```python
# settings.py

MAILERS = {
    "default": {
        "BACKEND": "django.core.mail.backends.console.EmailBackend",
        "OPTIONS": {
            "friendly": True,  # <-- add this to enable
        },
    },
}
```

The friendly formatting is (generally) not valid under any relevant RFC but is much more readable as console output. (Examples in later comments.) Notably, the *Content-Transfer-Encoding* headers in the friendly version indicate the CTE that will be used in the raw send, but the content shown for those parts is deliberately *not* encoded.

This is a proof of concept implementation to facilitate new-feature discussion. There are no tests or documentation yet.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
  * PyCharm AI Assistant "next edit suggestions": general editing
  * Gemini 3 Flash: investigating "friendly formatting" approaches

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [x] (n/a) I have attached screenshots in both light and dark modes for any UI changes.
