### PR TITLE
Fixed #37122 -- Updated JSONField has_changed method to check for dis…

### DIFF
--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -1390,6 +1390,8 @@ class JSONField(CharField):
         return json.dumps(value, ensure_ascii=False, cls=self.encoder)
 
     def has_changed(self, initial, data):
+        if self.disabled:
+            return False
         if super().has_changed(initial, data):
             return True
         # For purposes of seeing whether something has changed, True isn't the

--- a/tests/forms_tests/field_tests/test_jsonfield.py
+++ b/tests/forms_tests/field_tests/test_jsonfield.py
@@ -80,6 +80,10 @@ class JSONFieldTest(SimpleTestCase):
         self.assertIs(field.has_changed({"a": True}, '{"a": 1}'), True)
         self.assertIs(field.has_changed({"a": 1, "b": 2}, '{"b": 2, "a": 1}'), False)
 
+    def test_disabled_has_changed(self):
+        field = JSONField(disabled=True)
+        self.assertIs(field.has_changed({"a": 1}, '{"a": 2}'), False)
+
     def test_custom_encoder_decoder(self):
         class CustomDecoder(json.JSONDecoder):
             def __init__(self, object_hook=None, *args, **kwargs):


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37122

#### Branch description
The problem is that a disabled JSONField still reports changes via has_changed because there was no additional check for disabled.
The fix is to add a check for when disabled is set to false

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
Used Codex to create a tests, reviewed the generated work and verified the output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
