### PR TITLE
Fixed #37140 -- Documented NULL handling of exclude() with __in subqueries.

### DIFF
--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -265,6 +265,9 @@ Note the second example is more restrictive.
 If you need to execute more complex queries (for example, queries with ``OR``
 statements), you can use :class:`Q objects <django.db.models.Q>` (``*args``).
 
+For the behavior of ``exclude(field__in=...)`` when the right-hand side is
+a queryset whose column can be ``NULL``, see the :lookup:`in` field lookup.
+
 ``annotate()``
 ~~~~~~~~~~~~~~
 
@@ -3361,6 +3364,27 @@ extract two field values, where only one is expected::
     # Bad code! Will raise a TypeError.
     inner_qs = Blog.objects.filter(name__contains="Ch").values("name", "id")
     entries = Entry.objects.filter(blog__name__in=inner_qs)
+
+.. warning::
+
+    When the right-hand side of ``__in`` is a
+    :class:`~django.db.models.Subquery` or a ``values()`` /
+    ``values_list()`` queryset whose returned column is nullable,
+    ``exclude(field__in=...)`` compiles to SQL ``NOT IN (subquery)``. If
+    the subquery returns a ``NULL`` value, the whole condition evaluates
+    to UNKNOWN under SQL's three-valued logic and the queryset returns
+    no rows.
+
+    Use :class:`~django.db.models.Exists` with
+    :class:`~django.db.models.OuterRef` instead. It compiles to
+    ``NOT EXISTS`` and handles ``NULL`` correctly::
+
+        Entry.objects.exclude(
+            Exists(Blog.objects.filter(name__contains="Cheddar", pk=OuterRef("blog")))
+        )
+
+    See :ticket:`20024` for the related case of literal ``None`` values
+    in ``__in`` lists.
 
 .. _nested-queries-performance:
 


### PR DESCRIPTION
#### Trac ticket number

ticket-37140

#### Branch description

Adds a `.. warning::` block to the `in` field lookup reference in
`docs/ref/models/querysets.txt` describing the behavior of
`exclude(field__in=subquery)` when the subquery's returned column can be
`NULL`. Under SQL's three-valued logic, `NOT IN (subquery)` evaluates to
UNKNOWN as soon as the subquery returns a `NULL`, and the queryset returns
no rows. The warning points readers to `Exists` with `OuterRef` as the
NULL-safe replacement and cross-references #20024 (the literal-list case,
fixed in cec10f99).

Also adds a one-line cross-reference under the `exclude()` method
documentation pointing to the new warning.

Motivation: this behavior was identified by Anssi Kääriäinen and Simon
Riggs on django-developers in 2013 [1], but the ORM-side fix never landed.
The literal-list flavor was fixed in #20024. The subquery flavor remains,
and the docs do not currently warn about it. We hit it in production on a
real queryset and traced it to the documented `NOT IN` / `NULL` semantics.

Documentation-only change; no behavior change.

[1] https://groups.google.com/g/django-developers/c/OG1unUV-MOU

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude (Sonnet 4.6) was used to draft the warning text following Django's
existing admonition voice, to surface the relevant Trac history (#20024
and the 2013 django-developers thread), and to draft this PR description.
All wording was reviewed and verified before submission.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [x] (n/a) I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] (n/a) I have attached screenshots in both light and dark modes for any UI changes.
