### PR TITLE
Fixed #10227 - Adding OneToOneField.related_default

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -563,6 +563,7 @@ answer newbie questions, and generally made Django that much better:
     Jonny Park <jonnythebard9@gmail.com>
     Jordan Bae <qoentlr37@gmail.com>
     Jordan Dimov <s3x3y1@gmail.com>
+    Jordan Hyatt <jordan.t.hyatt@gmail.com>
     Jordi J. Tablada <jordi.joan@gmail.com>
     Jorge Bastida <me@jorgebastida.com>
     Jorge Gajon <gajon@gajon.org>

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1354,13 +1354,24 @@ class OneToOneField(ForeignKey):
     one_to_many = False
     one_to_one = True
 
+    class RelatedDefaultRaiseException:
+        pass
+
     related_accessor_class = ReverseOneToOneDescriptor
     forward_related_accessor_class = ForwardOneToOneDescriptor
     rel_class = OneToOneRel
 
     description = _("One-to-one relationship")
 
-    def __init__(self, to, on_delete, to_field=None, **kwargs):
+    def __init__(
+        self,
+        to,
+        on_delete,
+        to_field=None,
+        related_default=RelatedDefaultRaiseException,
+        **kwargs,
+    ):
+        self.related_default = related_default
         kwargs["unique"] = True
         super().__init__(to, on_delete, to_field=to_field, **kwargs)
 

--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -539,10 +539,18 @@ class ReverseOneToOneDescriptor:
             self.related.set_cached_value(instance, rel_obj)
 
         if rel_obj is None:
-            raise self.RelatedObjectDoesNotExist(
-                "%s has no %s."
-                % (instance.__class__.__name__, self.related.accessor_name)
-            )
+            if (
+                self.related.field.related_default
+                == self.related.field.RelatedDefaultRaiseException
+            ):
+                raise self.RelatedObjectDoesNotExist(
+                    "%s has no %s."
+                    % (instance.__class__.__name__, self.related.accessor_name)
+                )
+            elif callable(self.related.field.related_default):
+                return self.related.field.related_default.__call__()
+            else:
+                return self.related.field.related_default
         else:
             return rel_obj
 

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -2346,7 +2346,7 @@ supervisor designated by ``MySpecialUser``::
 .. _onetoone-arguments:
 
 Additionally, ``OneToOneField`` accepts all of the extra arguments
-accepted by :class:`ForeignKey`, plus one extra argument:
+accepted by :class:`ForeignKey`, plus two extra arguments:
 
 .. attribute:: OneToOneField.parent_link
 
@@ -2355,6 +2355,17 @@ accepted by :class:`ForeignKey`, plus one extra argument:
     link back to the parent class, rather than the extra
     ``OneToOneField`` which would normally be implicitly created by
     subclassing.
+
+.. attribute:: OneToOneField.related_default
+
+    Determines the behavior of a reverse lookup in the event that the
+    related instance does not exist.
+
+    Defaults to ``RelatedDefaultRaiseException``
+    which will raise a RelatedObjectDoesNotExist exception.
+    If a value is provided, such as ``None``, that value will be returned.
+    The value can also be a callable in which case the result of
+    that callable will be returned.
 
 See :doc:`One-to-one relationships </topics/db/examples/one_to_one>` for usage
 examples of ``OneToOneField``.

--- a/tests/one_to_one/models.py
+++ b/tests/one_to_one/models.py
@@ -31,6 +31,16 @@ class Bar(models.Model):
     serves_cocktails = models.BooleanField(default=True)
 
 
+class TikiBar(models.Model):
+    place = models.OneToOneField(Place, models.CASCADE, related_default=None)
+
+
+class SandBar(models.Model):
+    place = models.OneToOneField(
+        Place, models.CASCADE, related_default=lambda: "DEFAULT_VALUE"
+    )
+
+
 class UndergroundBar(models.Model):
     place = models.OneToOneField(Place, models.SET_NULL, null=True)
     serves_cocktails = models.BooleanField(default=True)

--- a/tests/one_to_one/tests.py
+++ b/tests/one_to_one/tests.py
@@ -14,8 +14,10 @@ from .models import (
     Pointer,
     RelatedModel,
     Restaurant,
+    SandBar,
     School,
     Target,
+    TikiBar,
     ToFieldPointer,
     UndergroundBar,
     Waiter,
@@ -695,3 +697,17 @@ class OneToOneTests(TestCase):
             p1.restaurant._state.fetch_mode,
             FETCH_PEERS,
         )
+
+    def test_related_default_value(self):
+        # confirm self.p1.tikibar gives the default of None
+        self.assertIsNone(self.p1.tikibar)
+        # confirm normal behavior when tikibar exists
+        tiki = TikiBar.objects.create(place=self.p1)
+        self.assertEqual(self.p1.tikibar, tiki)
+
+    def test_related_default_callable(self):
+        # confirm self.p1.tikibar gives the callable default of DEFAULT_VALUE
+        self.assertEqual(self.p1.sandbar, "DEFAULT_VALUE")
+        # confirm normal behavior when sandbar exists
+        sandy = SandBar.objects.create(place=self.p1)
+        self.assertEqual(self.p1.sandbar, sandy)


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-10227

#### Branch description
Support a related_default on OneToOne fields

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [X] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [X] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [X] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [X] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
