### PR TITLE
Refs #28586 -- Doc'd writing a custom fetch mode.

### DIFF
--- a/docs/topics/db/fetch-modes.txt
+++ b/docs/topics/db/fetch-modes.txt
@@ -113,10 +113,46 @@ access of ``book.author``, like:
 
 .. code-block:: python
 
-    FieldFetchBlocked("Fetching of Primary.value blocked.")
+    FieldFetchBlocked("Fetching of Book.author blocked.")
 
 This mode can prevent unintentional queries in performance-critical
 sections of code.
+
+.. _writing-your-own-fetch-mode:
+
+Writing your own
+================
+
+You can implement your own fetch mode to perform side effects, such as emitting
+a warning. In this example the fallback strategy is ``FetchOne``, but you could
+inherit from ``FetchPeers`` instead:
+
+.. code-block::
+
+    import warnings
+    from django.db.models.fetch_modes import FetchOne
+
+
+    class LazyFetchWarning(RuntimeWarning): ...
+
+
+    class FetchWarn(FetchOne):
+        def fetch(self, fetcher, instance):
+            """Emit a warning before delegating to FetchOne."""
+            klass = instance.__class__.__qualname__
+            field_name = fetcher.field.name
+            warnings.warn(
+                f"Lazy fetch of {klass}.{field_name}",
+                LazyFetchWarning,
+            )
+            return super().fetch(fetcher, instance)
+
+.. code-block:: pycon
+
+    >>> book = Book.objects.fetch_mode(FetchWarn()).first()
+    >>> book.author
+    LazyFetchWarning: Lazy fetch of Book.author
+    <Author: ...>
 
 .. _fetch-modes-custom-manager:
 


### PR DESCRIPTION
#### Trac ticket number
ticket-28586

#### Branch description
During review of this feature we [agreed](https://github.com/django/django/pull/17554#discussion_r2345545473) we would document an example of writing a custom fetch mode. We said we might wait for 6.2, ~but I think I like shipping for the 6.1 docs, as I think the question "how do I just warn instead" will come up immediately.~ ~EDIT: never mind, we can avoid the complexity around the the `django_file_prefixes()` util moving in 6.2 if we just wait.~ RE-EDIT: we decided not to document `django_file_prefixes()`, so we can just backport this freely to 6.1 after all.

/cc @tim-mccurrach

See [DryORM fiddle](https://dryorm.xterm.info/fetch-mode-warn).

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.