### PR TITLE
Fixed #37141 -- Added --using option to sendtestemail command.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -788,6 +788,7 @@ answer newbie questions, and generally made Django that much better:
     Mushtaq Ali <mushtaak@gmail.com>
     Mykola Zamkovoi <nickzam@gmail.com>
     Nadège Michel <michel.nadege@gmail.com>
+    Naga Kartheek Reddy Kona <konanagakartheek@gmail.com>
     Nagy Károly <charlie@rendszergazda.com>
     Nasimul Haque <nasim.haque@gmail.com>
     Nasir Hussain <nasirhjafri@gmail.com>

--- a/django/core/management/commands/sendtestemail.py
+++ b/django/core/management/commands/sendtestemail.py
@@ -28,8 +28,16 @@ class Command(BaseCommand):
             action="store_true",
             help="Send a test email to the addresses specified in settings.ADMINS.",
         )
+        parser.add_argument(
+            "--using",
+            default=None,
+            help=(
+                "Specify the MAILERS alias to use for sending the test email. "
+                "Defaults to 'default'."
+            ),
+        )
 
-    def handle(self, *args, **kwargs):
+    def handle(self, *args, using=None, **kwargs):
         subject = "Test email from %s on %s" % (socket.gethostname(), timezone.now())
 
         send_mail(
@@ -37,10 +45,13 @@ class Command(BaseCommand):
             message="If you're reading this, it was successful.",
             from_email=None,
             recipient_list=kwargs["email"],
+            using=using,
         )
 
         if kwargs["managers"]:
-            mail_managers(subject, "This email was sent to the site managers.")
+            mail_managers(
+                subject, "This email was sent to the site managers.", using=using
+            )
 
         if kwargs["admins"]:
-            mail_admins(subject, "This email was sent to the site admins.")
+            mail_admins(subject, "This email was sent to the site admins.", using=using)

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1069,8 +1069,15 @@ recipient(s) specified. For example:
 
     django-admin sendtestemail foo@example.com bar@example.com
 
-There are a couple of options, and you may use any combination of them
-together:
+The following options may be used in any combination with each other and with
+recipient email arguments.
+
+.. django-admin-option:: --using ALIAS
+
+.. versionadded:: 6.1
+
+Specifies the :setting:`MAILERS` alias to use for sending the test email to
+the recipients given as arguments. Defaults to the ``"default"`` mailer.
 
 .. django-admin-option:: --managers
 

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -274,6 +274,9 @@ Management Commands
   :data:`~django.db.models.signals.m2m_changed` signals with ``raw=True`` when
   loading fixtures.
 
+* The :djadmin:`sendtestemail` command now supports a :option:`--using
+  <sendtestemail --using>` option to specify the :setting:`MAILERS` alias.
+
 Models
 ~~~~~~
 

--- a/tests/mail/test_sendtestemail.py
+++ b/tests/mail/test_sendtestemail.py
@@ -1,4 +1,5 @@
 from django.core import mail
+from django.core.mail import MailerDoesNotExist
 from django.core.management import CommandError, call_command
 from django.test import SimpleTestCase, override_settings
 
@@ -6,7 +7,10 @@ from django.test import SimpleTestCase, override_settings
 @override_settings(
     ADMINS=["admin@example.com", "admin_and_manager@example.com"],
     MANAGERS=["manager@example.com", "admin_and_manager@example.com"],
-    MAILERS={"default": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"}},
+    MAILERS={
+        "default": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"},
+        "notifications": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"},
+    },
 )
 class SendTestEmailManagementCommand(SimpleTestCase):
     """
@@ -108,3 +112,32 @@ class SendTestEmailManagementCommand(SimpleTestCase):
                 "admin_and_manager@example.com",
             ],
         )
+
+    def test_using_option(self):
+        recipient = "joe@example.com"
+        call_command("sendtestemail", "--using", "notifications", recipient)
+        self.assertEqual(len(mail.outbox), 1)
+        mail_message = mail.outbox[0]
+        self.assertEqual(mail_message.sent_using, "notifications")
+
+    def test_using_default(self):
+        recipient = "joe@example.com"
+        call_command("sendtestemail", recipient)
+        self.assertEqual(len(mail.outbox), 1)
+        mail_message = mail.outbox[0]
+        self.assertEqual(mail_message.sent_using, "default")
+
+    def test_using_option_with_managers(self):
+        call_command("sendtestemail", "--using", "notifications", "--managers")
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].sent_using, "notifications")
+
+    def test_using_option_with_admins(self):
+        call_command("sendtestemail", "--using", "notifications", "--admins")
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].sent_using, "notifications")
+
+    def test_using_nonexistent_mailer(self):
+        msg = "The mailer 'nonexistent' is not configured."
+        with self.assertRaisesMessage(MailerDoesNotExist, msg):
+            call_command("sendtestemail", "--using", "nonexistent", "joe@example.com")


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37141

#### Branch description
Fixed #37141 -- Added --using option to sendtestemail management command.

  The sendtestemail command previously had no way to test non-default mailer configuration. This change adds an optional      --using ALIAS argument that specifies which **setting->MAILERS** alias to use when sending to the recipients which are given as arguments.

  ./manage.py sendtestemail --using notifications to@example.com
  ./manage.py sendtestemail --using notifications --managers --admins

  If --using is omitted, the command continues to use the default mailer. The option applies only to direct recipient emails,         --managers and --admins continue to use their own default mailer path via mail_managers() and mail_admins().

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
