### PR TITLE
Fixed #36972 -- Added "(input hidden)" information for clarification in password prompts.

### DIFF
--- a/django/contrib/auth/management/commands/changepassword.py
+++ b/django/contrib/auth/management/commands/changepassword.py
@@ -14,7 +14,7 @@ class Command(BaseCommand):
     requires_migrations_checks = True
     requires_system_checks = []
 
-    def _get_pass(self, prompt="Password: "):
+    def _get_pass(self, prompt="Password (input hidden): "):
         p = getpass.getpass(prompt=prompt)
         if not p:
             raise CommandError("aborted")
@@ -57,7 +57,7 @@ class Command(BaseCommand):
         password_validated = False
         while (p1 != p2 or not password_validated) and count < MAX_TRIES:
             p1 = self._get_pass()
-            p2 = self._get_pass("Password (again): ")
+            p2 = self._get_pass("Password (again, input hidden): ")
             if p1 != p2:
                 self.stdout.write("Passwords do not match. Please try again.")
                 count += 1

--- a/django/contrib/auth/management/commands/createsuperuser.py
+++ b/django/contrib/auth/management/commands/createsuperuser.py
@@ -171,8 +171,8 @@ class Command(BaseCommand):
 
                 # Prompt for a password if the model has one.
                 while PASSWORD_FIELD in user_data and user_data[PASSWORD_FIELD] is None:
-                    password = getpass.getpass()
-                    password2 = getpass.getpass("Password (again): ")
+                    password = getpass.getpass("Password (input hidden): ")
+                    password2 = getpass.getpass("Password (again, input hidden): ")
                     if password != password2:
                         self.stderr.write("Error: Your passwords didn't match.")
                         # Don't validate passwords that don't match.

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -50,6 +50,10 @@ Minor features
 * The default iteration count for the PBKDF2 password hasher is increased from
   1,500,000 to 1,800,000.
 
+* The :djadmin:`createsuperuser` and :djadmin:`changepassword` management
+  commands now display ``(input hidden)`` in their password prompts to clarify
+  that no characters are echoed while typing.
+
 :mod:`django.contrib.contenttypes`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/auth_tests/test_management.py
+++ b/tests/auth_tests/test_management.py
@@ -191,6 +191,17 @@ class ChangepasswordManagementCommandTestCase(TestCase):
         with self.assertRaisesMessage(CommandError, "aborted"):
             call_command("changepassword", username="joe", stdout=self.stdout)
 
+    @mock.patch.object(getpass, "getpass", return_value="password")
+    def test_password_prompt_text(self, mock_get_pass):
+        call_command("changepassword", username="joe", stdout=self.stdout)
+        self.assertEqual(
+            mock_get_pass.call_args_list,
+            [
+                mock.call(prompt="Password (input hidden): "),
+                mock.call(prompt="Password (again, input hidden): "),
+            ],
+        )
+
     @mock.patch.object(changepassword.Command, "_get_pass", return_value="new_password")
     def test_system_username(self, mock_get_pass):
         """The system username is used if --username isn't provided."""
@@ -397,6 +408,24 @@ class CreatesuperuserManagementCommandTestCase(TestCase):
         u = User._default_manager.get(username="joe+admin@somewhere.org")
         self.assertEqual(u.email, "joe@somewhere.org")
         self.assertFalse(u.has_usable_password())
+
+    @mock.patch.object(getpass, "getpass", return_value="password")
+    def test_password_prompt_text(self, mock_getpass):
+        call_command(
+            "createsuperuser",
+            interactive=True,
+            username="prompttestuser",
+            email="prompt@example.com",
+            stdout=StringIO(),
+            stdin=MockTTY(),
+        )
+        self.assertEqual(
+            mock_getpass.call_args_list,
+            [
+                mock.call("Password (input hidden): "),
+                mock.call("Password (again, input hidden): "),
+            ],
+        )
 
     @override_settings(AUTH_USER_MODEL="auth_tests.CustomUser")
     def test_swappable_user(self):


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-36972

#### Branch description
The **createsuperuser** and **changepassword** management commands previously showed bare **Password:** prompts with no indication that input is hidden. New users would assume the terminal had frozen since nothing appears while typing.

  This adds **(input hidden)** to the prompt text in both commands:

  **Password (input hidden):**
  **Password (again, input hidden):**

  No behaviour changes only the prompt strings are updated.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
