### PR TITLE
Fixed #37130 -- Skipped DB cache deletion when culling offset is zero.

### DIFF
--- a/django/core/cache/backends/db.py
+++ b/django/core/cache/backends/db.py
@@ -278,8 +278,8 @@ class DatabaseCache(BaseDatabaseCache):
             )
             deleted_count = cursor.rowcount
             remaining_num = num - deleted_count
-            if remaining_num > self._max_entries:
-                cull_num = remaining_num // self._cull_frequency
+            cull_num = remaining_num // self._cull_frequency
+            if cull_num > 0 and remaining_num > self._max_entries:
                 cursor.execute(
                     connection.ops.cache_key_culling_sql() % table, [cull_num]
                 )

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -1361,6 +1361,24 @@ class DBCacheTests(BaseCacheTests, TransactionTestCase):
                 )
                 self.assertEqual(num_count_queries, 0)
 
+    def test_delete_query_skipped_on_high_cull_frequency(self):
+        cull_delete_cache = caches["cull"]
+        old_cull_freq = cull_delete_cache._cull_frequency
+
+        # CULL_FREQUENCY > MAX_ENTRIES forces
+        # (remaining_num // CULL_FREQUENCY) to evaluate to zero (cull_num)
+        cull_delete_cache._cull_frequency = cull_delete_cache._max_entries * 2
+        self.addCleanup(setattr, cull_delete_cache, "_cull_frequency", old_cull_freq)
+
+        self._perform_cull_test("cull", 50, 49)
+
+        with CaptureQueriesContext(connection) as captured_queries:
+            cull_delete_cache.set("force_cull", "value")
+
+        # Only the expiration DELETE query runs; culling is skipped.
+        num_delete_queries = sum("DELETE" in query["sql"] for query in captured_queries)
+        self.assertEqual(num_delete_queries, 1)
+
     def test_delete_cursor_rowcount(self):
         """
         The rowcount attribute should not be checked on a closed cursor.


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37130

#### Branch description 
Added a condition to bypass the deletion query when the calculated culling offset evaluates to zero.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
