### PR TITLE
Fixed #37106 -- Clarified pylibmc workaround in unit test docs.

### DIFF
--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -39,10 +39,12 @@ that your computer doesn't have installed. You can usually figure out which
 package to install by doing a web search for the last line or so of the error
 message. Try adding your operating system to the search query if needed.
 
-If you have trouble installing the requirements, you can skip that step. See
+If you have trouble installing an optional test dependency, you can skip that
+dependency locally. For example, if installing ``pylibmc`` fails, comment out
+its line in ``requirements/py3.txt`` and continue with ``./runtests.py``.
+Tests that require ``pylibmc`` will be skipped automatically. See
 :ref:`running-unit-tests-dependencies` for details on installing the optional
-test dependencies. If you don't have an optional dependency installed, the
-tests that require it will be skipped.
+test dependencies.
 
 Running the tests requires a Django settings module that defines the databases
 to use. To help you get started, Django provides and uses a sample settings


### PR DESCRIPTION
#### Trac ticket number

[ticket-37106](https://code.djangoproject.com/ticket/37106)

#### Branch description
I made a small update to the [Unit Tests docs](https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/unit-tests/#quickstart) to clarify a workaround for a common issue installing pylibmc. I kept the fix as a specific example rather than adding OS-specific third-party install instructions to Django’s docs. 

With the line `pylibmc` commented out in `tests/requirements/py3.txt`, the requirements installed successfully and `./runtests.py` completed successfully with `OK (skipped=1512, expected failures=4)`. With pylibmc installed, `./runtests.py` completed successfully with `OK (skipped=1421, expected failures=4)`.

Tests:
- `tox -e lint-docs` passed.
- `tox -e docs` passed.

Additional context: [Forum discussion](https://forum.djangoproject.com/t/error-when-installing-requirements-for-django-tests-fatal-error-libmemcached-memcached-h-file-not-found-include-libmemcached-memcached-h/1685).

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **AI tools were used** for research and reviewing my doc fix for correctness.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests. **(N/A)**
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes. **(N/A)**