### PR TITLE
Refs #16281 -- Fixed isolation of admin_views.ViewOnSiteTests.

### DIFF
--- a/tests/admin_views/test_multidb.py
+++ b/tests/admin_views/test_multidb.py
@@ -3,6 +3,7 @@ from unittest import mock
 from django.contrib import admin
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
+from django.contrib.sites.models import Site
 from django.http import HttpResponse
 from django.test import TestCase, override_settings
 from django.urls import path, reverse
@@ -192,6 +193,11 @@ class ViewOnSiteRouter:
 @override_settings(ROOT_URLCONF=__name__, DATABASE_ROUTERS=[ViewOnSiteRouter()])
 class ViewOnSiteTests(TestCase):
     databases = {"default", "other"}
+
+    def tearDown(self):
+        # Reads via ViewOnSiteRouter may prime the global SITE_CACHE using the
+        # "other" db, which is problematic for other tests that do not use it.
+        Site.objects.clear_cache()
 
     def test_contenttype_in_separate_db(self):
         ContentType.objects.using("other").all().delete()

--- a/tests/sites_tests/tests.py
+++ b/tests/sites_tests/tests.py
@@ -270,8 +270,9 @@ class CreateDefaultSiteTests(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        # Delete the site created as part of the default migration process.
-        Site.objects.all().delete()
+        # Delete the sites created in post_migrate signals on test db creation.
+        for using in cls.databases:
+            Site.objects.all().using(using).delete()
 
     def setUp(self):
         self.app_config = apps.get_app_config("sites")


### PR DESCRIPTION
#### Trac ticket number
ticket-16281
ticket-23929

#### Branch description
See occasional [failures](https://github.com/django/django/actions/runs/27135282367/job/80086098996) like:

```py
======================================================================
ERROR: setUpClass (flatpages_tests.test_sitemaps.FlatpagesSitemapTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\hostedtoolcache\windows\Python\3.14.5\x64\Lib\unittest\suite.py", line 166, in _handleClassSetUp
    setUpClass()
    ^^^
  File "D:\a\django\django\tests\flatpages_tests\test_sitemaps.py", line 16, in setUpClass
    super().setUpClass()
    ^^^^^^^^^^^^^^^
  File "D:\a\django\django\django\test\testcases.py", line 1442, in setUpClass
    cls.setUpTestData()
    ^^^^^^^^^^^
  File "D:\a\django\django\tests\flatpages_tests\test_sitemaps.py", line 25, in setUpTestData
    current_site.flatpage_set.create(url="/foo/", title="foo")
...
django.test.testcases.DatabaseOperationForbidden: Database queries to 'other' are not allowed in this test. Add 'other' to flatpages_tests.test_sitemaps.FlatpagesSitemapTests.databases to ensure proper test isolation and silence this failure.
```

Traced to a pollution of the global `SITE_CACHE` in `ViewOnSiteTests`.

While debugging, I also noticed that we had test methods in `CreateDefaultSiteTests` not exercising their intended functionality because of incomplete test preparation (`Site` objects created from `post_migrate` signals only being deleted on the default db). Fixed in a separate commit.
#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.