### PR TITLE
Fixed #37150 -- Made djangodocs Sphinx extension work with any html builder.

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -58,7 +58,7 @@ clean:
 	-rm -rf $(BUILDDIR)/*
 
 html:
-	$(SPHINXBUILD) -b djangohtml $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/docs/_ext/djangodocs.py
+++ b/docs/_ext/djangodocs.py
@@ -2,8 +2,6 @@
 Sphinx plugins for Django documentation.
 """
 
-import json
-import os
 import re
 
 from docutils import nodes
@@ -11,12 +9,10 @@ from docutils.parsers.rst import Directive
 from docutils.statemachine import ViewList
 from sphinx import addnodes
 from sphinx import version_info as sphinx_version
-from sphinx.builders.html import StandaloneHTMLBuilder
 from sphinx.directives.code import CodeBlock
 from sphinx.domains.std import Cmdoption
 from sphinx.errors import ExtensionError
 from sphinx.util import logging
-from sphinx.util.console import bold
 from sphinx.writers.html import HTMLTranslator
 
 logger = logging.getLogger(__name__)
@@ -55,9 +51,7 @@ def setup(app):
     app.add_config_value("django_next_version", "0.0", True)
     app.add_directive("versionadded", VersionDirective)
     app.add_directive("versionchanged", VersionDirective)
-    app.add_builder(DjangoStandaloneHTMLBuilder)
-    app.set_translator("djangohtml", DjangoHTMLTranslator)
-    app.set_translator("json", DjangoHTMLTranslator)
+    app.connect("builder-inited", set_django_html_translator)
     app.add_node(
         ConsoleNode,
         html=(visit_console_html, None),
@@ -70,6 +64,11 @@ def setup(app):
     app.connect("html-page-context", html_page_context_hook)
     app.add_role("default-role-error", default_role_error)
     return {"parallel_read_safe": True}
+
+
+def set_django_html_translator(app):
+    if app.builder.format == "html":
+        app.set_translator(app.builder.name, DjangoHTMLTranslator, override=True)
 
 
 class VersionDirective(Directive):
@@ -189,36 +188,6 @@ def parse_django_admin_node(env, sig, signode):
     return command
 
 
-class DjangoStandaloneHTMLBuilder(StandaloneHTMLBuilder):
-    """
-    Subclass to add some extra things we need.
-    """
-
-    name = "djangohtml"
-
-    def finish(self):
-        super().finish()
-        logger.info(bold("writing templatebuiltins.js..."))
-        xrefs = self.env.domaindata["std"]["objects"]
-        templatebuiltins = {
-            "ttags": [
-                n
-                for ((t, n), (k, a)) in xrefs.items()
-                if t == "templatetag" and k == "ref/templates/builtins"
-            ],
-            "tfilters": [
-                n
-                for ((t, n), (k, a)) in xrefs.items()
-                if t == "templatefilter" and k == "ref/templates/builtins"
-            ],
-        }
-        outfilename = os.path.join(self.outdir, "templatebuiltins.js")
-        with open(outfilename, "w") as fp:
-            fp.write("var django_template_builtins = ")
-            json.dump(templatebuiltins, fp)
-            fp.write(";\n")
-
-
 class ConsoleNode(nodes.literal_block):
     """
     Custom node to override the visit/depart event handlers at registration
@@ -248,7 +217,7 @@ def depart_console_dummy(self, node):
 
 def visit_console_html(self, node):
     """Generate HTML for the console directive."""
-    if self.builder.name in ("djangohtml", "json") and node["win_console_text"]:
+    if self.builder.format == "html" and node["win_console_text"]:
         # Put a mark on the document object signaling the fact the directive
         # has been used on it.
         self.document._console_directive_used_flag = True
@@ -363,9 +332,9 @@ class ConsoleDirective(CodeBlock):
         self.arguments = ["console"]
         lit_blk_obj = super().run()[0]
 
-        # Only do work when the djangohtml HTML Sphinx builder is being used,
+        # Only do work when an HTML-format Sphinx builder is being used,
         # invoke the default behavior for the rest.
-        if env.app.builder.name not in ("djangohtml", "json"):
+        if env.app.builder.format != "html":
             return [lit_blk_obj]
 
         lit_blk_obj["uid"] = str(env.new_serialno("console"))
@@ -385,9 +354,8 @@ class ConsoleDirective(CodeBlock):
 
 def html_page_context_hook(app, pagename, templatename, context, doctree):
     # Put a bool on the context used to render the template. It's used to
-    # control inclusion of console-tabs.css and activation of the JavaScript.
-    # This way it's include only from HTML files rendered from reST files where
-    # the ConsoleDirective is used.
+    # control inclusion of console-tabs.css. This way it's included only from
+    # HTML files rendered from reST files where the ConsoleDirective is used.
     context["include_console_assets"] = getattr(
         doctree, "_console_directive_used_flag", False
     )

--- a/docs/_ext/djangodocs.py
+++ b/docs/_ext/djangodocs.py
@@ -11,7 +11,6 @@ from sphinx import addnodes
 from sphinx import version_info as sphinx_version
 from sphinx.directives.code import CodeBlock
 from sphinx.domains.std import Cmdoption
-from sphinx.errors import ExtensionError
 from sphinx.util import logging
 from sphinx.writers.html import HTMLTranslator
 
@@ -98,11 +97,7 @@ class VersionDirective(Directive):
         node["type"] = self.name
         if self.content:
             self.state.nested_parse(self.content, self.content_offset, node)
-        try:
-            env.get_domain("changeset").note_changeset(node)
-        except ExtensionError:
-            # Sphinx < 1.8: Domain 'changeset' is not registered
-            env.note_versionchange(node["type"], node["version"], node, self.lineno)
+        env.get_domain("changeset").note_changeset(node)
         return ret
 
 

--- a/docs/_theme/djangodocs/layout.html
+++ b/docs/_theme/djangodocs/layout.html
@@ -17,60 +17,6 @@
 {%- endmacro %}
 
 {% block extrahead %}
-{# When building htmlhelp (CHM format) disable jQuery inclusion, #}
-{# as it causes problems in compiled CHM files.                  #}
-{% if builder != "htmlhelp" %}
-{{ super() }}
-<script src="{{ pathto('templatebuiltins.js', 1) }}"></script>
-<script>
-(function($) {
-    if (!django_template_builtins) {
-       // templatebuiltins.js missing, do nothing.
-       return;
-    }
-    $(document).ready(function() {
-        // Hyperlink Django template tags and filters
-        var base = "{{ pathto('ref/templates/builtins') }}";
-        if (base == "#") {
-            // Special case for builtins.html itself
-            base = "";
-        }
-        // Tags are keywords, class '.k'
-        $("div.highlight\\-html\\+django span.k").each(function(i, elem) {
-             var tagname = $(elem).text();
-             if ($.inArray(tagname, django_template_builtins.ttags) != -1) {
-                 var fragment = tagname.replace(/_/, '-');
-                 $(elem).html("<a href='" + base + "#" + fragment + "'>" + tagname + "</a>");
-             }
-        });
-        // Filters are functions, class '.nf'
-        $("div.highlight\\-html\\+django span.nf").each(function(i, elem) {
-             var filtername = $(elem).text();
-             if ($.inArray(filtername, django_template_builtins.tfilters) != -1) {
-                 var fragment = filtername.replace(/_/, '-');
-                 $(elem).html("<a href='" + base + "#" + fragment + "'>" + filtername + "</a>");
-             }
-        });
-    });
-})(jQuery);
-{%- if include_console_assets -%}
-(function($) {
-    $(document).ready(function() {
-        $(".c-tab-unix").on("click", function() {
-            $("section.c-content-unix").show();
-            $("section.c-content-win").hide();
-            $(".c-tab-unix").prop("checked", true);
-        });
-        $(".c-tab-win").on("click", function() {
-            $("section.c-content-win").show();
-            $("section.c-content-unix").hide();
-            $(".c-tab-win").prop("checked", true);
-        });
-    });
-})(jQuery);
-{%- endif -%}
-</script>
-{% endif %}
 {%- if include_console_assets -%}
 <link rel="stylesheet" href="{{ pathto('_static/console-tabs.css', 1) }}">
 {%- endif -%}


### PR DESCRIPTION
#### Trac ticket number

ticket-37150

#### Branch description
Changed djangodocs extension to register DjangoHTMLTranslator for any html format builder (in the builder-inited hook), rather than a limited list of builders at startup. That fixes missing content in dirhtml and standard html builds (including ReadTheDocs PR previews).

Removed other dead or unnecessary code in djangodocs extension and djangodocs theme template.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
   * PyCharm AI Assistant "next edit suggestions": general editing
   * Claude 4.8 Opus: Sphinx extension assistance

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] (n/a—djangodocs extension is not tested) I have added or updated relevant tests.
- [x] (n/a) I have added or updated relevant docs, including release notes if applicable.
- [x] (n/a) I have attached screenshots in both light and dark modes for any UI changes.
