### PR TITLE
Refs #36560, CVE-2026-35193 -- Replaced substring check on Cache-control directives in UpdateCacheMiddleware.

### DIFF
--- a/django/middleware/cache.py
+++ b/django/middleware/cache.py
@@ -56,6 +56,7 @@ from django.utils.cache import (
     learn_cache_key,
     patch_response_headers,
     patch_vary_headers,
+    split_header_value,
 )
 from django.utils.deprecation import MiddlewareMixin
 from django.utils.http import parse_http_date_safe
@@ -106,8 +107,9 @@ class UpdateCacheMiddleware(MiddlewareMixin):
         # Don't cache responses when the Cache-Control header is set to
         # private, no-cache, or no-store.
         cache_control = response.get("Cache-Control", "").lower()
+        cache_control_parts = list(split_header_value(cache_control))
         if cache_control and any(
-            directive in cache_control
+            directive in cache_control_parts
             for directive in (
                 "private",
                 "no-cache",
@@ -137,7 +139,7 @@ class UpdateCacheMiddleware(MiddlewareMixin):
         # header, unless allowed by "public" per RFC 9111, Section 3.5. No
         # exceptions are made for "s-maxage" and "must-revalidate" since these
         # are not currently implemented by Django.
-        if request.headers.get("Authorization") and "public" not in cache_control:
+        if request.headers.get("Authorization") and "public" not in cache_control_parts:
             patch_vary_headers(response, ("Authorization",))
         if timeout and response.status_code == 200:
             cache_key = learn_cache_key(

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -3026,6 +3026,23 @@ class CacheMiddlewareTest(SimpleTestCase):
                 response = view(request, "2")
                 self.assertEqual(response.content, b"Hello World 2")
 
+    def test_cache_control_not_cached_superstring(self):
+        """
+        "myprivate", a hypothetical extension directive, is not confused for
+        "private".
+        """
+
+        @cache_page(3)
+        @cache_control(myprivate=True)
+        def view(request, value):
+            return HttpResponse(f"Hello World {value}")
+
+        request = self.factory.get("/view/")
+        response = view(request, "1")
+        self.assertEqual(response.content, b"Hello World 1")
+        response = view(request, "2")
+        self.assertEqual(response.content, b"Hello World 1")
+
     def test_vary_asterisk_not_cached(self):
         views_with_cache = (
             cache_page(3)(hello_world_view_patch_vary_headers_asterisk),
@@ -3063,6 +3080,16 @@ class CacheMiddlewareTest(SimpleTestCase):
         request = self.factory.get("/view/", headers={"Authorization": "token"})
         response = view_with_cache(request, "1")
         self.assertIs(has_vary_header(response, "Authorization"), False)
+
+    def test_authorization_header_exception_superstring(self):
+        """
+        "nopublic", a hypothetical extension directive, is not confused for
+        "public".
+        """
+        view_with_cache = cache_page(3)(cache_control(no_public=True)(hello_world_view))
+        request = self.factory.get("/view/", headers={"Authorization": "token"})
+        response = view_with_cache(request, "1")
+        self.assertIs(has_vary_header(response, "Authorization"), True)
 
     def test_sensitive_cookie_not_cached(self):
         """


### PR DESCRIPTION

#### Trac ticket number
ticket-36560
CVE-2026-35193

#### Branch description
Avoid false positives from hypothetical extension directives that could be superstrings of the ones we are checking.

The Security Team is not aware of any directives that might meet this condition, so we're handling in public.
#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.