### PR TITLE
Fixed #37151 -- Allowed squashing through AddIndex, AddConstraint, AlterConstraint.

### DIFF
--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -882,6 +882,17 @@ class IndexOperation(Operation):
     def model_name_lower(self):
         return self.model_name.lower()
 
+    def references_model(self, name, app_label):
+        return name.lower() == self.model_name_lower
+
+    def reduce(self, operation, app_label):
+        return super().reduce(operation, app_label) or self.can_reduce_through(
+            operation, app_label
+        )
+
+    def can_reduce_through(self, operation, app_label):
+        return not operation.references_model(self.model_name, app_label)
+
 
 class AddIndex(IndexOperation):
     """Add an index on a model."""
@@ -937,6 +948,21 @@ class AddIndex(IndexOperation):
     @property
     def migration_name_fragment(self):
         return "%s_%s" % (self.model_name_lower, self.index.name.lower())
+
+    def references_field(self, model_name, name, app_label):
+        return self.index.expressions or name in {f.lower() for f in self.index.fields}
+
+    def can_reduce_through(self, operation, app_label):
+        if not super().can_reduce_through(operation, app_label):
+            return False
+        if self.index.expressions:
+            return False
+        if isinstance(operation, FieldOperation):
+            if self.references_field(
+                self.model_name_lower, operation.name_lower, app_label
+            ):
+                return False
+        return True
 
     def reduce(self, operation, app_label):
         if isinstance(operation, RemoveIndex) and self.index.name == operation.name:
@@ -1181,6 +1207,21 @@ class AddConstraint(IndexOperation):
     def migration_name_fragment(self):
         return "%s_%s" % (self.model_name_lower, self.constraint.name.lower())
 
+    def references_field(self, model_name, name, app_label):
+        return self.constraint.expressions or name in {f.lower() for f in self.constraint.fields}
+
+    def can_reduce_through(self, operation, app_label):
+        if not super().can_reduce_through(operation, app_label):
+            return False
+        if self.constraint.expressions:
+            return False
+        if isinstance(operation, FieldOperation):
+            if self.references_field(
+                self.model_name_lower, operation.name_lower, app_label
+            ):
+                return False
+        return True
+
     def reduce(self, operation, app_label):
         if (
             isinstance(operation, RemoveConstraint)
@@ -1277,6 +1318,21 @@ class AlterConstraint(IndexOperation):
     @property
     def migration_name_fragment(self):
         return "alter_%s_%s" % (self.model_name_lower, self.constraint.name.lower())
+
+    def references_field(self, model_name, name, app_label):
+        return self.constraint.expressions or name in {f.lower() for f in self.constraint.fields}
+
+    def can_reduce_through(self, operation, app_label):
+        if not super().can_reduce_through(operation, app_label):
+            return False
+        if self.constraint.expressions:
+            return False
+        if isinstance(operation, FieldOperation):
+            if self.references_field(
+                self.model_name_lower, operation.name_lower, app_label
+            ):
+                return False
+        return True
 
     def reduce(self, operation, app_label):
         if (

--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -1208,19 +1208,25 @@ class AddConstraint(IndexOperation):
         return "%s_%s" % (self.model_name_lower, self.constraint.name.lower())
 
     def references_field(self, model_name, name, app_label):
-        return self.constraint.expressions or name in {f.lower() for f in self.constraint.fields}
+        return isinstance(self.constraint, models.UniqueConstraint) and (
+            self.constraint.expressions
+            or name in {f.lower() for f in self.constraint.fields}
+        )
 
     def can_reduce_through(self, operation, app_label):
         if not super().can_reduce_through(operation, app_label):
             return False
-        if self.constraint.expressions:
-            return False
-        if isinstance(operation, FieldOperation):
-            if self.references_field(
-                self.model_name_lower, operation.name_lower, app_label
-            ):
+        if isinstance(self.constraint, models.UniqueConstraint):
+            if self.constraint.expressions:
                 return False
-        return True
+            if isinstance(operation, FieldOperation):
+                if self.references_field(
+                    self.model_name_lower, operation.name_lower, app_label
+                ):
+                    return False
+            return True
+        else:
+            return False
 
     def reduce(self, operation, app_label):
         if (
@@ -1320,19 +1326,24 @@ class AlterConstraint(IndexOperation):
         return "alter_%s_%s" % (self.model_name_lower, self.constraint.name.lower())
 
     def references_field(self, model_name, name, app_label):
-        return self.constraint.expressions or name in {f.lower() for f in self.constraint.fields}
+        return isinstance(self.constraint, models.UniqueConstraint) and (
+            self.constraint.expressions
+            or name in {f.lower() for f in self.constraint.fields}
+        )
 
     def can_reduce_through(self, operation, app_label):
         if not super().can_reduce_through(operation, app_label):
             return False
-        if self.constraint.expressions:
-            return False
-        if isinstance(operation, FieldOperation):
-            if self.references_field(
-                self.model_name_lower, operation.name_lower, app_label
-            ):
+        if isinstance(self.constraint, models.UniqueConstraint):
+            if self.constraint.expressions:
                 return False
-        return True
+            if isinstance(operation, FieldOperation):
+                if self.references_field(
+                    self.model_name_lower, operation.name_lower, app_label
+                ):
+                    return False
+            return True
+        return False
 
     def reduce(self, operation, app_label):
         if (

--- a/tests/migrations/test_optimizer.py
+++ b/tests/migrations/test_optimizer.py
@@ -1520,3 +1520,109 @@ class OptimizerTests(OptimizerTestBase):
                 ),
             ],
         )
+
+    def test_optimize_through_add_index(self):
+        self.assertOptimizesTo(
+            [
+                migrations.CreateModel("A", fields=[("id", models.BigAutoField())]),
+                migrations.AddIndex("b", models.Index(fields=["id"], name="b_idx")),
+                migrations.AddField("a", "name", models.IntegerField()),
+            ],
+            [
+                migrations.AddIndex("b", models.Index(fields=["id"], name="b_idx")),
+                migrations.CreateModel("A", fields=[("id", models.BigAutoField()), ("name", models.IntegerField())]),
+            ],
+        )
+
+    def test_not_optimize_through_add_index_same_field(self):
+        self.assertDoesNotOptimize(
+            [
+                migrations.AddField("a", "name", models.IntegerField()),
+                migrations.AddIndex("a", models.Index(fields=["name"], name="a_idx")),
+                migrations.RenameField("a", "name", "new_name"),
+            ],
+        )
+
+    def test_not_optimize_through_add_index_expressions(self):
+        self.assertDoesNotOptimize(
+            [
+                migrations.AddField("a", "name", models.IntegerField()),
+                migrations.AddIndex("a", models.Index(models.F("id"), name="a_idx")),
+                migrations.RenameField("a", "name", "new_name"),
+            ],
+        )
+
+    def test_optimize_through_add_contraint(self):
+        self.assertOptimizesTo(
+            [
+                migrations.CreateModel("A", fields=[("id", models.BigAutoField())]),
+                migrations.AddConstraint("b", models.UniqueConstraint(fields=["id"], name="b_uniq")),
+                migrations.AddField("a", "name", models.IntegerField()),
+            ],
+            [
+                migrations.AddConstraint("b", models.UniqueConstraint(fields=["id"], name="b_uniq")),
+                migrations.CreateModel(
+                    "A",
+                    fields=[
+                        ("id", models.BigAutoField()),
+                        ("name", models.IntegerField()),
+                    ],
+                ),
+            ],
+        )
+
+    def test_not_optimize_through_add_contraint_same_field(self):
+        self.assertDoesNotOptimize(
+            [
+                migrations.AddField("a", "name", models.IntegerField()),
+                migrations.AddConstraint("a", models.UniqueConstraint(fields=["name"], name="a_uniq")),
+                migrations.RenameField("a", "name", "new_name"),
+            ],
+        )
+
+    def test_not_optimize_through_add_contraint_expressions(self):
+        self.assertDoesNotOptimize(
+            [
+                migrations.AddField("a", "name", models.IntegerField()),
+                migrations.AddConstraint("a", models.UniqueConstraint(models.F("id"), name="a_uniq")),
+                migrations.RenameField("a", "name", "new_name"),
+            ],
+        )
+
+
+    def test_optimize_through_alter_contraint(self):
+        self.assertOptimizesTo(
+            [
+                migrations.CreateModel("A", fields=[("id", models.BigAutoField())]),
+                migrations.AlterConstraint("b", "b_uniq", models.UniqueConstraint(fields=["id"], name="b_uniq")),
+                migrations.AddField("a", "name", models.IntegerField()),
+            ],
+            [
+                migrations.AlterConstraint("b", "b_uniq", models.UniqueConstraint(fields=["id"], name="b_uniq")),
+                migrations.CreateModel(
+                    "A",
+                    fields=[
+                        ("id", models.BigAutoField()),
+                        ("name", models.IntegerField()),
+                    ],
+                ),
+            ],
+        )
+
+    def test_not_optimize_through_alter_contraint_same_field(self):
+        self.assertDoesNotOptimize(
+            [
+                migrations.AddField("a", "name", models.IntegerField()),
+                migrations.AlterConstraint("a", "a_uniq", models.UniqueConstraint(fields=["name"], name="a_uniq")),
+                migrations.RenameField("a", "name", "new_name"),
+            ],
+        )
+
+    def test_not_optimize_through_alter_contraint_expressions(self):
+        self.assertDoesNotOptimize(
+            [
+                migrations.AddField("a", "name", models.IntegerField()),
+                migrations.AlterConstraint("a", "a_uniq", models.UniqueConstraint(models.F("id"), name="a_uniq")),
+                migrations.RenameField("a", "name", "new_name"),
+            ],
+        )


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37151

#### Branch description
Previously, AddIndex, AddConstraint, AlterConstraint prevented squashing migration operations through them. Regardless, if the AddIndex, etc. operations referred to the same model or field or not.

This commit adjusts the behavior to allow squashing through these operations if eitehr the model name is different or, when using index/constraint.fields, the respective field isn't listed. When an index or constraint uses expressions, squashing through them is forbidden.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
