### PR TITLE
Fixed #33752 -- Display exception groups on the technical 500 debug page on Python 3.11+.

### DIFF
--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -341,6 +341,20 @@ class ExceptionReporter:
             path=self.request.get_full_path(),
         )
 
+    def _get_exception_group_data(self, exc):
+        is_group = isinstance(exc, BaseExceptionGroup)
+        data = {
+            "type": exc.__class__.__name__,
+            "message": exc,
+            "is_group": is_group,
+        }
+        if is_group:
+            data["children"] = [
+                self._get_exception_group_data(child) for child in exc.exceptions
+            ]
+            data["count"] = len(exc.exceptions)
+        return data
+
     def get_traceback_data(self):
         """Return a dictionary containing traceback information."""
         if self.exc_type and issubclass(self.exc_type, TemplateDoesNotExist):
@@ -417,6 +431,8 @@ class ExceptionReporter:
             c["exception_value"] = getattr(
                 self.exc_value, "raw_error_message", self.exc_value
             )
+            if isinstance(self.exc_value, BaseExceptionGroup):
+                c["exception_group"] = self._get_exception_group_data(self.exc_value)
             if exc_notes := getattr(self.exc_value, "__notes__", None):
                 c["exception_notes"] = "\n" + "\n".join(exc_notes)
         if frames:

--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -353,10 +353,11 @@ class ExceptionReporter:
             ]
         return data
 
-    def _get_exception_group_as_text(self, exc):
-        formatted = traceback.TracebackException.from_exception(self.exc_value)
-        exception_only_text = "".join(formatted.format_exception_only(show_group=True))
-        return exception_only_text
+    def _get_exception_group_text(self, node, indent=0):
+        text = "%s%s: %s" % ("   " * indent, node["type"], node["message"])
+        for child in node.get("children", ()):
+            text += "\n" + self._get_exception_group_text(child, indent + 1)
+        return text
 
     def get_traceback_data(self):
         """Return a dictionary containing traceback information."""

--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -3,6 +3,7 @@ import inspect
 import itertools
 import re
 import sys
+import traceback
 import types
 import warnings
 from pathlib import Path
@@ -342,18 +343,20 @@ class ExceptionReporter:
         )
 
     def _get_exception_group_data(self, exc):
-        is_group = isinstance(exc, BaseExceptionGroup)
         data = {
             "type": exc.__class__.__name__,
             "message": exc,
-            "is_group": is_group,
         }
-        if is_group:
+        if isinstance(exc, BaseExceptionGroup):
             data["children"] = [
                 self._get_exception_group_data(child) for child in exc.exceptions
             ]
-            data["count"] = len(exc.exceptions)
         return data
+
+    def _get_exception_group_as_text(self, exc):
+        formatted = traceback.TracebackException.from_exception(self.exc_value)
+        exception_only_text = "".join(formatted.format_exception_only(show_group=True))
+        return exception_only_text
 
     def get_traceback_data(self):
         """Return a dictionary containing traceback information."""
@@ -433,6 +436,9 @@ class ExceptionReporter:
             )
             if isinstance(self.exc_value, BaseExceptionGroup):
                 c["exception_group"] = self._get_exception_group_data(self.exc_value)
+                c["exception_group_text"] = self._get_exception_group_as_text(
+                    self.exc_value
+                )
             if exc_notes := getattr(self.exc_value, "__notes__", None):
                 c["exception_notes"] = "\n" + "\n".join(exc_notes)
         if frames:

--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -3,7 +3,6 @@ import inspect
 import itertools
 import re
 import sys
-import traceback
 import types
 import warnings
 from pathlib import Path
@@ -436,9 +435,10 @@ class ExceptionReporter:
                 self.exc_value, "raw_error_message", self.exc_value
             )
             if isinstance(self.exc_value, BaseExceptionGroup):
-                c["exception_group"] = self._get_exception_group_data(self.exc_value)
-                c["exception_group_text"] = self._get_exception_group_as_text(
-                    self.exc_value
+                exc_group_data = self._get_exception_group_data(self.exc_value)
+                c["exception_group"] = exc_group_data
+                c["exception_group_text"] = self._get_exception_group_text(
+                    exc_group_data
                 )
             if exc_notes := getattr(self.exc_value, "__notes__", None):
                 c["exception_notes"] = "\n" + "\n".join(exc_notes)

--- a/django/views/templates/technical_500.html
+++ b/django/views/templates/technical_500.html
@@ -58,6 +58,13 @@
     #traceback { background: light-dark(#eee, #121212); }
     #requestinfo { background: light-dark(#f6f6f6, #1e1e1e); padding-left:120px; }
     #summary table { border:none; background:transparent; }
+    #exception_group li { list-style: none; }
+    #exception_group ul ul li { padding-left: 40px; }
+    #exception_group ul li { position: relative; line-height: 1.25em;}
+    #exception_group ul li::before { position: absolute; left: 30px; top: 0px; border-left: 1.5px dashed; border-bottom: 1.5px dashed; content: ""; width: 9px; height: 0.5em; }
+    #exception_group ul li::after { position: absolute; left: 30px; bottom: 0px; border-left: 1.5px dashed; content: ""; width: 6px; height: 100%; }
+    #exception_group ul li:last-child::after { display: none }
+    #exception_group > ul > li::before { display: none }
     #requestinfo h2, #requestinfo h3 { position:relative; margin-left:-100px; }
     #requestinfo h3 { margin-bottom:-1em; }
     .error { background: light-dark(#ffc, #3d3d00); }
@@ -132,7 +139,10 @@
 {% if exception_type and exception_value %}
     <tr>
       <th scope="row">Exception Value:</th>
-      <td><pre>{{ exception_value|force_escape }}</pre></td>
+{% partialdef exception %}<li><pre>{{ exception.type }}: {{ exception.message }}</pre></li>{% endpartialdef %}
+{% partialdef exception_group %}<li><pre>{{ exception.type }}: {{ exception.message }}</pre><ul>{% for child in exception.children %}{% with exception=child %}{% partial exception_router %}{% endwith %}{% endfor %}</ul></li>{% endpartialdef %}
+{% partialdef exception_router %}{% if exception.is_group %}{% partial exception_group %}{% else %}{% partial exception %}{% endif %}{% endpartialdef %}
+      <td id=exception_group>{% if exception_group %}<ul>{% with exception=exception_group %}{% partial exception_router %}{% endwith %}</ul>{% else%}<pre>{{ exception_value|force_escape }}</pre>{% endif %}</td>
     </tr>
 {% endif %}
 {% if lastframe %}

--- a/django/views/templates/technical_500.html
+++ b/django/views/templates/technical_500.html
@@ -349,7 +349,7 @@ During handling of the above exception ({{ frame.exc_cause|force_escape }}), ano
 Exception Type: {{ exception_type }}{% if request %} at {{ request.path_info }}{% endif %}
 Exception Value: {{ exception_value|force_escape }}{% if exception_notes %}{{ exception_notes }}{% endif %}
 {% if exception_group_text %}Exception Group Tree:
-{{ exception_group_text }}{% endif %}
+{{ exception_group_text|force_escape }}{% endif %}
 
 </textarea>
   <br><br>

--- a/django/views/templates/technical_500.html
+++ b/django/views/templates/technical_500.html
@@ -115,6 +115,7 @@
   <h1>{% if exception_type %}{{ exception_type }}{% else %}Report{% endif %}
       {% if request %} at {{ request.path_info }}{% endif %}</h1>
   <pre class="exception_value">{% if exception_value %}{{ exception_value|force_escape }}{% if exception_notes %}{{ exception_notes }}{% endif %}{% else %}No exception message supplied{% endif %}</pre>
+  {% partialdef exception_tree %}<li><pre>{{ exception.type }}: {{ exception.message|force_escape }}</pre>{% if exception.children %}<ul>{% for exception in exception.children %}{% partial exception_tree %}{% endfor %}</ul>{% endif %}</li>{% endpartialdef %}
   <table class="meta">
 {% if request %}
     <tr>
@@ -139,10 +140,7 @@
 {% if exception_type and exception_value %}
     <tr>
       <th scope="row">Exception Value:</th>
-{% partialdef exception %}<li><pre>{{ exception.type }}: {{ exception.message }}</pre></li>{% endpartialdef %}
-{% partialdef exception_group %}<li><pre>{{ exception.type }}: {{ exception.message }}</pre><ul>{% for child in exception.children %}{% with exception=child %}{% partial exception_router %}{% endwith %}{% endfor %}</ul></li>{% endpartialdef %}
-{% partialdef exception_router %}{% if exception.is_group %}{% partial exception_group %}{% else %}{% partial exception %}{% endif %}{% endpartialdef %}
-      <td id=exception_group>{% if exception_group %}<ul>{% with exception=exception_group %}{% partial exception_router %}{% endwith %}</ul>{% else%}<pre>{{ exception_value|force_escape }}</pre>{% endif %}</td>
+      <td id="exception_group">{% if exception_group %}<ul>{% with exception=exception_group %}{% partial exception_tree %}{% endwith %}</ul>{% else %}<pre>{{ exception_value|force_escape }}</pre>{% endif %}</td>
     </tr>
 {% endif %}
 {% if lastframe %}
@@ -350,6 +348,9 @@ During handling of the above exception ({{ frame.exc_cause|force_escape }}), ano
 
 Exception Type: {{ exception_type }}{% if request %} at {{ request.path_info }}{% endif %}
 Exception Value: {{ exception_value|force_escape }}{% if exception_notes %}{{ exception_notes }}{% endif %}
+{% if exception_group_text %}Exception Group Tree:
+{{ exception_group_text }}{% endif %}
+
 </textarea>
   <br><br>
   <input type="submit" value="Share this traceback on a public website">

--- a/django/views/templates/technical_500.txt
+++ b/django/views/templates/technical_500.txt
@@ -35,6 +35,9 @@ Traceback (most recent call last):
 {% endfor %}
 {% if exception_type %}Exception Type: {{ exception_type }}{% if request %} at {{ request.path_info }}{% endif %}
 {% if exception_value %}Exception Value: {{ exception_value }}{% endif %}{% if exception_notes %}{{ exception_notes }}{% endif %}{% endif %}{% endif %}
+{% if exception_group_text %}Exception Group Tree:
+{{ exception_group_text }}
+{% endif %}
 {% if raising_view_name %}Raised during: {{ raising_view_name }}{% endif %}
 {% if request %}Request information:
 {% if user_str %}USER: {{ user_str }}{% endif %}

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -140,7 +140,9 @@ Email
 Error Reporting
 ~~~~~~~~~~~~~~~
 
-* ...
+* The HTML and plain text technical 500 debug pages now 
+  display the nested exceptions in :exc:`BaseExceptionGroup`
+  instances.
 
 File Storage
 ~~~~~~~~~~~~

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -140,7 +140,7 @@ Email
 Error Reporting
 ~~~~~~~~~~~~~~~
 
-* The HTML and plain text technical 500 debug pages now 
+* The HTML and plain text technical 500 debug pages now
   display the nested exceptions in :exc:`BaseExceptionGroup`
   instances.
 

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -767,6 +767,66 @@ class ExceptionReporterTests(SimpleTestCase):
             text,
         )
 
+    def test_exception_group(self):
+        request = self.rf.get("/test_view")
+        try:
+            raise ExceptionGroup(
+                "Oops group",
+                [RuntimeError("Oops 1"), ValueError("Oops 2"), ValueError("Oops 3")],
+            )
+        except Exception:
+            exc_type, exc_value, tb = sys.exc_info()
+        reporter = ExceptionReporter(request, exc_type, exc_value, tb)
+        html = reporter.get_traceback_html()
+        self.assertInHTML("<h1>ExceptionGroup at /test_view</h1>", html)
+        self.assertIn(
+            '<pre class="exception_value">Oops group (3 sub-exceptions)</pre>', html
+        )
+        self.assertIn('<th scope="row">Exception Type:</th>', html)
+        self.assertIn('<th scope="row">Exception Value:</th>', html)
+        self.assertIn("<pre>RuntimeError: Oops 1</pre>", html)
+        self.assertIn("<pre>ValueError: Oops 2</pre>", html)
+        self.assertIn("<pre>ValueError: Oops 3</pre>", html)
+
+    def test_nested_exception_group(self):
+        request = self.rf.get("/test_view")
+        try:
+            raise ExceptionGroup(
+                "Outer Oops group",
+                [
+                    RuntimeError("Outer Oops"),
+                    ExceptionGroup(
+                        "Inner Oops group",
+                        [
+                            ValueError("Inner Oops 1"),
+                            ValueError("Inner Oops 2"),
+                            ValueError("Inner Oops 3"),
+                        ],
+                    ),
+                ],
+            )
+        except Exception:
+            exc_type, exc_value, tb = sys.exc_info()
+        reporter = ExceptionReporter(request, exc_type, exc_value, tb)
+        html = reporter.get_traceback_html()
+        self.assertInHTML("<h1>ExceptionGroup at /test_view</h1>", html)
+        self.assertIn(
+            '<pre class="exception_value">Outer Oops group (2 sub-exceptions)</pre>',
+            html,
+        )
+        self.assertIn('<th scope="row">Exception Type:</th>', html)
+        self.assertIn('<th scope="row">Exception Value:</th>', html)
+        self.assertIn(
+            "<pre>ExceptionGroup: Outer Oops group (2 sub-exceptions)</pre>", html
+        )
+        self.assertIn("<pre>RuntimeError: Outer Oops</pre>", html)
+        self.assertIn(
+            "<pre>ExceptionGroup: Inner Oops group (3 sub-exceptions)</pre>", html
+        )
+        self.assertIn("<pre>ValueError: Inner Oops 1</pre>", html)
+        self.assertIn("<pre>ValueError: Inner Oops 2</pre>", html)
+        self.assertIn("<pre>ValueError: Inner Oops 3</pre>", html)
+
     def test_mid_stack_exception_without_traceback(self):
         try:
             try:

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -787,6 +787,7 @@ class ExceptionReporterTests(SimpleTestCase):
         self.assertIn("<pre>RuntimeError: Oops 1</pre>", html)
         self.assertIn("<pre>ValueError: Oops 2</pre>", html)
         self.assertIn("<pre>ValueError: Oops 3</pre>", html)
+        self.assertIn("Exception Group Tree:", html)
 
     def test_nested_exception_group(self):
         request = self.rf.get("/test_view")
@@ -826,6 +827,33 @@ class ExceptionReporterTests(SimpleTestCase):
         self.assertIn("<pre>ValueError: Inner Oops 1</pre>", html)
         self.assertIn("<pre>ValueError: Inner Oops 2</pre>", html)
         self.assertIn("<pre>ValueError: Inner Oops 3</pre>", html)
+        self.assertIn("Exception Group Tree:", html)
+
+    def test_exception_group_text(self):
+        request = self.rf.get("/test_view")
+        try:
+            raise ExceptionGroup(
+                "Outer Oops group",
+                [
+                    RuntimeError("Outer Oops"),
+                    ExceptionGroup(
+                        "Inner Oops group",
+                        [
+                            ValueError("Inner Oops 1"),
+                            ValueError("Inner Oops 2"),
+                            ValueError("Inner Oops 3"),
+                        ],
+                    ),
+                ],
+            )
+        except Exception:
+            exc_type, exc_value, tb = sys.exc_info()
+        reporter = ExceptionReporter(request, exc_type, exc_value, tb)
+        text = reporter.get_traceback_text()
+        self.assertIn("Exception Group Tree:", text)
+        self.assertIn("ExceptionGroup: Outer Oops group (2 sub-exceptions)", text)
+        self.assertIn("RuntimeError: Outer Oops", text)
+        self.assertIn("ValueError: Inner Oops 1", text)
 
     def test_mid_stack_exception_without_traceback(self):
         try:


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-33752

#### Branch description
Add support for displaying ExceptionGroup child exceptions on Django’s technical 500 debug page, including nested groups.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [X] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [X] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [X] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [X] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [X] I have attached screenshots in both light and dark modes for any UI changes.

<img width="1327" height="946" alt="Snímek obrazovky 2026-06-10 153005" src="https://github.com/user-attachments/assets/c3f8dfd7-a896-4424-b2b6-d920b0cfb7eb" /> 
