### PR TITLE
Fixed #29187 -- Fixed flaky receiver count assertion in signals tests.

### DIFF
--- a/tests/signals/tests.py
+++ b/tests/signals/tests.py
@@ -1,4 +1,5 @@
 import contextvars
+import gc
 from inspect import markcoroutinefunction
 from unittest import mock
 
@@ -14,26 +15,34 @@ from .models import Author, Book, Car, Page, Person
 
 
 class BaseSignalSetup:
+    def _signal_counts(self):
+        # Clear dead receivers before counting.
+        counts = []
+        for signal in (
+            signals.pre_save,
+            signals.post_save,
+            signals.pre_delete,
+            signals.post_delete,
+        ):
+            with signal.lock:
+                signal._clear_dead_receivers()
+            counts.append(len(signal.receivers))
+        return tuple(counts)
+
     def setUp(self):
-        # Save up the number of connected signals so that we can check at the
-        # end that all the signals we register get properly unregistered
-        # (#9989)
-        self.pre_signals = (
-            len(signals.pre_save.receivers),
-            len(signals.post_save.receivers),
-            len(signals.pre_delete.receivers),
-            len(signals.post_delete.receivers),
-        )
+        # The count comparison in tearDown() is a regression check for
+        # Signal.disconnect() failing to remove entries (#9989). Collect first
+        # so the baseline contains only reachable receivers; a receiver
+        # connected elsewhere in the suite and then garbage-collected could
+        # linger as a dead weakref, inflating the count (#29187). No collection
+        # in tearDown(): a weak receiver kept alive by a cycle should be
+        # counted, to catch a forgotten disconnect.
+        gc.collect()
+        self.pre_signals = self._signal_counts()
 
     def tearDown(self):
         # All our signals got disconnected properly.
-        post_signals = (
-            len(signals.pre_save.receivers),
-            len(signals.post_save.receivers),
-            len(signals.pre_delete.receivers),
-            len(signals.post_delete.receivers),
-        )
-        self.assertEqual(self.pre_signals, post_signals)
+        self.assertEqual(self.pre_signals, self._signal_counts())
 
 
 class SignalTests(BaseSignalSetup, TestCase):


### PR DESCRIPTION
#### Trac ticket number
ticket-29187

#### Branch description
See recent failures ([logs](https://github.com/django/django/actions/runs/27252316146/job/80479217495)).

`Signal.receivers` prunes dead weak references lazily, so a weak receiver garbage-collected elsewhere could still occupy a slot when `BaseSignalSetup.setUp()` counted receivers. The test's own connect/send/disconnect calls would then prune before `tearDown()` counted again.

To reproduce the underlying issue more consistently, you can use this test case authored by Claude (Fable 5). I think it would be overkill to commit this.
<details>
<summary>Reproduction</summary>

```py
class Ticket29187ReproTests(BaseSignalSetup, TestCase):
    """
    Temporary repro for #29187. Plant a dead weak receiver on post_delete
    before BaseSignalSetup.setUp() takes its baseline, then trigger lazy
    pruning during the test body, exactly as another test's GC'd weak
    receiver + test_delete_signals' own signal activity does in the wild.
    """

    @classmethod
    def setUpClass(cls):
        super().setUpClass()

        def doomed(**kwargs):
            pass

        signals.post_delete.connect(doomed)  # weak=True by default
        del doomed
        gc.collect()  # No-op on CPython (refcount already killed it);
                      # needed on PyPy. Weakref is now dead, but the
                      # entry stays in receivers — pruning is lazy.

    def test_corpse_is_purged_mid_test(self):
        # Mirror test_delete_signals' signal activity: connect and
        # disconnect both call _clear_dead_receivers(), sweeping the
        # corpse that setUp() may have counted.
        def handler(**kwargs):
            pass

        signals.post_delete.connect(handler, weak=False)
        try:
            pass  # the real test does model work here; irrelevant to the count
        finally:
            signals.post_delete.disconnect(handler)
```
</details>

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

I iterated with Claude (Fable 5) on the diagnosis and fix.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.