### PR TITLE
Fixed #36104 -- Returned NotImplemented in Media.__add__ for non-Media RHS.

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -262,6 +262,8 @@ class Media:
             return list(dict.fromkeys(chain.from_iterable(filter(None, lists))))
 
     def __add__(self, other):
+        if not isinstance(other, Media):
+            return NotImplemented
         combined = Media()
         combined._css_lists = self._css_lists[:]
         combined._js_lists = self._js_lists[:]

--- a/tests/forms_tests/tests/test_media.py
+++ b/tests/forms_tests/tests/test_media.py
@@ -859,6 +859,13 @@ class FormsMediaTestCase(SimpleTestCase):
         self.assertEqual(merged._css_lists, [{"screen": ["a.css"]}])
         self.assertEqual(merged._js_lists, [["a"]])
 
+    def test_add_invalid_type(self):
+        class InvalidType:
+            pass
+
+        with self.assertRaises(TypeError):
+            Media() + InvalidType()
+
     def test_render_js_with_attrs(self):
         media = Media(js=[Script("/path/to/js", integrity="sha256-abc")])
         self.assertHTMLEqual(


### PR DESCRIPTION
#### Trac ticket number
ticket-36104

#### Branch description
Return the idiomatic sentinel for `__add__`, leading to readable `TypeError` messages for incompatible arguments to `Media.__add__()` instead of making it look like duck-typing protocol is supported here (it isn't).

/cc @matthiask

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.