### PR TITLE
Fixed #37152 -- Raised ValueError for Bcc in EmailMessage headers.

### DIFF
--- a/django/core/mail/message.py
+++ b/django/core/mail/message.py
@@ -360,8 +360,14 @@ class EmailMessage:
             # Use cached DNS_NAME for performance
             msg["Message-ID"] = make_msgid(domain=DNS_NAME)
         for name, value in self.extra_headers.items():
+            header = name.lower()
+            if header == "bcc":
+                raise ValueError(
+                    'Bcc is not a valid email header. Use the "bcc" '
+                    "argument to specify blind carbon copy recipients."
+                )
             # Avoid headers handled above.
-            if name.lower() not in {"from", "to", "cc", "reply-to"}:
+            if header not in {"from", "to", "cc", "reply-to"}:
                 msg[name] = force_str(value, strings_only=True)
         self._idna_encode_address_header_domains(msg)
         return msg

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -470,6 +470,10 @@ Email
   ``EmailMessage``. (This behavior was never documented. The ``send()`` method
   will still *use* a ``connection`` that is set on the message before sending.)
 
+* :meth:`.EmailMessage.message` now raises a ``ValueError`` if ``Bcc`` is
+  included in the ``headers`` argument or ``extra_headers`` attribute. Use the
+  ``bcc`` argument instead.
+
 Models
 ------
 

--- a/docs/topics/email.txt
+++ b/docs/topics/email.txt
@@ -505,7 +505,7 @@ email backend API :ref:`provides an alternative
     * ``cc``: A list or tuple of recipient addresses used in the "Cc" header
       when sending the email.
 
-    * ``bcc``: A list or tuple of addresses used in the "Bcc" header when
+    * ``bcc``: A list or tuple of addresses used for blind carbon copies when
       sending the email.
 
     * ``reply_to``: A list or tuple of recipient addresses used in the

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -397,6 +397,18 @@ class EmailMessageTests(MailTestsMixin, SimpleTestCase):
         self.assertNotIn("bcc@example.com", message.as_string())
         self.assertEqual(email.recipients(), ["to@example.com", "bcc@example.com"])
 
+    def test_bcc_in_headers_raises_error(self):
+        email = EmailMessage(
+            to=["to@example.com"],
+            headers={"Bcc": "bcc@example.com"},
+        )
+        msg = (
+            'Bcc is not a valid email header. Use the "bcc" argument to '
+            "specify blind carbon copy recipients."
+        )
+        with self.assertRaisesMessage(ValueError, msg):
+            email.message()
+
     def test_reply_to(self):
         with self.subTest("Single Reply-To"):
             email = EmailMessage(


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37152

#### Branch description
Currently, a Bcc value passed via headers is serialized into the email message, exposing the addresses in the message headers. This change makes EmailMessage.message() raise ValueError when `Bcc` is included in headers and directs users to use the bcc argument instead.

A release note documents this backwards-incompatible change.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
