### PR TITLE
Fixed #37146 -- Improved new-user experience of README's Trac Link.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -683,6 +683,7 @@ answer newbie questions, and generally made Django that much better:
     Marc Seguí Coll <metarizard@gmail.com>
     Marc Tamlyn <marc.tamlyn@gmail.com>
     Marc-Aurèle Brothier <ma.brothier@gmail.com>
+    Margaret Fero <maggiefero@gmail.com>
     Marian Andre <django@andre.sk>
     Marijke Luttekes <mail@marijkeluttekes.dev>
     Marijn Vriens <marijn@metronomo.cl>

--- a/README.rst
+++ b/README.rst
@@ -24,8 +24,10 @@ here's how we recommend you read the docs:
 * See ``docs/README`` for instructions on building an HTML version of the docs.
 
 Docs are updated rigorously. If you find any problems in the docs, or think
-they should be clarified in any way, please take 30 seconds to fill out a
-ticket here: https://code.djangoproject.com/newticket
+they should be clarified in any way, please take 30 seconds to
+`fill out a ticket <https://code.djangoproject.com/newticket>`_. You can log in
+with your GitHub account, or with a DjangoProject account if you have one. Once
+you log in, a New Ticket button is available next to View Tickets.
 
 To get more help:
 


### PR DESCRIPTION
#### Trac ticket number

ticket-37146

#### Branch description

The link to Trac in the README went to a page that showed "Error: Forbidden" with several warning banners if you weren't logged in, as newcomers consistently wouldn't be. After this change, the link goes to the homepage and is contextualized with how to log in and where the button will be. While the link is now less specific, new users who had to create an account were already not being taken to the new ticket destination without an extra click after login.

#### AI Assistance Disclosure (REQUIRED)

- [X] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [X] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [X] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [X] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [ N/A ] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
- [ N/A ] I have attached screenshots in both light and dark modes for any UI changes.