### PR TITLE
Fixed #37129 -- Clarified database cache culling behavior in docs.

### DIFF
--- a/docs/topics/cache.txt
+++ b/docs/topics/cache.txt
@@ -253,8 +253,10 @@ In this example, the cache table's name is ``my_cache_table``::
     }
 
 Unlike other cache backends, the database cache does not support automatic
-culling of expired entries at the database level. Instead, expired cache
-entries are culled when an ``add()``, ``set()``, or ``touch()`` is called.
+culling of expired entries at the database level. Instead, an expired cache
+entry is deleted when evaluated by a ``get()`` request. Furthermore,
+expired cache entries are culled when ``add()``, ``set()``, or ``touch()``
+is called and the number of entries exceeds ``MAX_ENTRIES``.
 
 Since the cull operation can be expensive for a large cache, you may control
 how often this check occurs by setting ``CULL_PROBABILITY`` to a value between


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37129

#### Branch description
The database cache documentation was a bit incomplete regarding when expired entries are actually culled. The previous wording implied that a bulk culling pass happens on every ``add()``, ``set()``, or ``touch()``, which misses the ``MAX_ENTRIES`` threshold check.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [X] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [X] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [X] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [X] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
