### PR TITLE
Fixed #20562 -- Documented database connections with multiprocessing.

### DIFF
--- a/docs/howto/custom-management-commands.txt
+++ b/docs/howto/custom-management-commands.txt
@@ -91,6 +91,22 @@ to ``False`` for each one. If the user referenced any nonexistent polls, a
 the :doc:`tutorial</intro/tutorial02>` and was added to
 ``polls.models.Question`` for this example.
 
+Database connections and multiprocessing
+========================================
+
+If a custom management command uses :mod:`multiprocessing`, avoid sharing
+database connections created in the parent process with child processes. Close
+all database connections before starting worker processes so each child process
+opens its own connection on first database access::
+
+    from django.db import connections
+
+    connections.close_all()
+
+This is especially important when using the ``fork`` start method and the
+management command has already performed ORM queries before starting child
+processes.
+
 .. _custom-commands-options:
 
 Accepting optional arguments


### PR DESCRIPTION
#### Trac ticket number

ticket-20562

#### Branch description

Added a short note to the custom management commands how-to about closing Django database connections before starting multiprocessing workers. This follows the ticket discussion and the prior review suggestion to place the guidance in the management commands documentation rather than the general ORM query documentation.

#### AI Assistance Disclosure (REQUIRED)

- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

AI assistance used: OpenAI Codex helped analyze the ticket, prior PR feedback, and draft this documentation change. I reviewed the final diff against Django's documented API and contribution guidelines.

#### Validation

- `git diff --check`
- `cd docs && make html SPHINXBUILD=../.venv/bin/sphinx-build`
- `cd docs && PATH="$PWD/../.venv/bin:$PATH" make check SPHINXBUILD=../.venv/bin/sphinx-build`

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [ ] I have checked the "Has patch" ticket flag in the Trac system. I don't have an authenticated Trac session available in this runtime, so this remains pending.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] No runtime tests are needed for this documentation-only change.
- [x] Screenshots are not applicable; there are no UI changes.
