### PR TITLE
Refs #36532 -- Optimized CSP decorator async checking.

### DIFF
--- a/django/views/decorators/csp.py
+++ b/django/views/decorators/csp.py
@@ -9,11 +9,15 @@ def _make_csp_decorator(config_attr_name, config_attr_value):
         raise TypeError("CSP config should be a mapping.")
 
     def decorator(view_func):
-        @wraps(view_func)
-        async def _wrapped_async_view(request, *args, **kwargs):
-            response = await view_func(request, *args, **kwargs)
-            setattr(response, config_attr_name, config_attr_value)
-            return response
+        if iscoroutinefunction(view_func):
+
+            @wraps(view_func)
+            async def _wrapped_async_view(request, *args, **kwargs):
+                response = await view_func(request, *args, **kwargs)
+                setattr(response, config_attr_name, config_attr_value)
+                return response
+
+            return _wrapped_async_view
 
         @wraps(view_func)
         def _wrapped_sync_view(request, *args, **kwargs):
@@ -21,8 +25,6 @@ def _make_csp_decorator(config_attr_name, config_attr_value):
             setattr(response, config_attr_name, config_attr_value)
             return response
 
-        if iscoroutinefunction(view_func):
-            return _wrapped_async_view
         return _wrapped_sync_view
 
     return decorator


### PR DESCRIPTION
#### Trac ticket number

ticket-36532

#### Branch description

The previous approach created both sync and async wrappers, before checking which one was needed. Checking first shaves about 1 microsecond off each decorator application.

IPython, before:

```
Python 3.14.5 (main, Jun  2 2026, 22:28:56) [Clang 22.1.3 ]
...

In [1]: from django.views.decorators.csp import csp_override

In [2]: %%timeit
   ...: @csp_override({})
   ...: def foo(): pass
   ...:
   ...:
2.51 μs ± 9.86 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [3]: %%timeit
   ...: @csp_override({})
   ...: async def foo(): pass
2.36 μs ± 10.2 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

After:

```
In [1]: from django.views.decorators.csp import csp_override

In [2]: %%timeit
   ...: @csp_override({})
   ...: def foo(): pass
   ...:
   ...:
1.66 μs ± 9.07 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [3]: %%timeit
   ...: @csp_override({})
   ...: async def foo(): pass
1.49 μs ± 5.56 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```

#### AI Assistance Disclosure (REQUIRED)

- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
