### PR TITLE
Fixed #37163 -- Optimized @user_passes_test async checking.

### DIFF
--- a/django/contrib/auth/decorators.py
+++ b/django/contrib/auth/decorators.py
@@ -36,25 +36,27 @@ def user_passes_test(
             return redirect_to_login(path, resolved_login_url, redirect_field_name)
 
         if iscoroutinefunction(view_func):
+            if iscoroutinefunction(test_func):
+                _async_test_func = test_func
+            else:
+                _async_test_func = sync_to_async(test_func)
 
             async def _view_wrapper(request, *args, **kwargs):
                 auser = await request.auser()
-                if iscoroutinefunction(test_func):
-                    test_pass = await test_func(auser)
-                else:
-                    test_pass = await sync_to_async(test_func)(auser)
+                test_pass = await _async_test_func(auser)
 
                 if test_pass:
                     return await view_func(request, *args, **kwargs)
                 return _redirect_to_login(request)
 
         else:
+            if iscoroutinefunction(test_func):
+                _sync_test_func = async_to_sync(test_func)
+            else:
+                _sync_test_func = test_func
 
             def _view_wrapper(request, *args, **kwargs):
-                if iscoroutinefunction(test_func):
-                    test_pass = async_to_sync(test_func)(request.user)
-                else:
-                    test_pass = test_func(request.user)
+                test_pass = _sync_test_func(request.user)
 
                 if test_pass:
                     return view_func(request, *args, **kwargs)


### PR DESCRIPTION
#### Trac ticket number

ticket-37163

#### Branch description

ticket-35030 added async support to this decorator, but put the async test and wrapping for test_func at call time. This work can instead be done once at decoration time, saving ~500 ns per request.

I benchmarked the simple sync/sync case in IPython.


Before:

```ipython
In [1]: from types import SimpleNamespace

In [2]: from django.contrib.auth.decorators import user_passes_test

In [3]: @user_passes_test(lambda *a: True)
   ...: def foo(request): pass

In [4]: %timeit foo(SimpleNamespace(user=None))
749 ns ± 2.08 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```

After:

```ipython
In [4]: %timeit foo(SimpleNamespace(user=None))
262 ns ± 0.488 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

I used Claude to find this potential optimization, from promting it to find more instances of the pattern I optimized in PR #21459.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
