### PR TITLE
Fixed #37164 -- Supported subclasses’ _get_lines() in jsonl Deserializer.

### DIFF
--- a/django/core/serializers/jsonl.py
+++ b/django/core/serializers/jsonl.py
@@ -47,7 +47,7 @@ class Deserializer(PythonDeserializer):
             stream_or_string = stream_or_string.decode()
         if isinstance(stream_or_string, str):
             stream_or_string = stream_or_string.splitlines()
-        super().__init__(Deserializer._get_lines(stream_or_string), **options)
+        super().__init__(self._get_lines(stream_or_string), **options)
 
     def _handle_object(self, obj):
         try:

--- a/tests/serializers/test_jsonl.py
+++ b/tests/serializers/test_jsonl.py
@@ -4,6 +4,7 @@ import re
 
 from django.core import serializers
 from django.core.serializers.base import DeserializationError
+from django.core.serializers.jsonl import Deserializer as JsonlDeserializer
 from django.db import models
 from django.test import TestCase, TransactionTestCase
 from django.test.utils import isolate_apps
@@ -269,3 +270,22 @@ class JsonSerializerTransactionTestCase(
         }""",
     ]
     fwd_ref_str = "\n".join([s.replace("\n", "") for s in fwd_ref_str])
+
+
+class JsonlDeserializerTests(TestCase):
+    def test_subclass_can_override_get_lines(self):
+        collected = []
+
+        class CustomDeserializer(JsonlDeserializer):
+            @staticmethod
+            def _get_lines(stream):
+                for obj in JsonlDeserializer._get_lines(stream):
+                    collected.append(obj)
+                    yield obj
+
+        data = (
+            '{"pk": 1, "model": "serializers.author", "fields": {"name": "Jane"}}\n'
+            '{"pk": 2, "model": "serializers.author", "fields": {"name": "Joe"}}\n'
+        )
+        list(CustomDeserializer(data))
+        self.assertEqual(len(collected), 2)


### PR DESCRIPTION
#### Trac ticket number

ticket-37164

#### Branch description

The jsonl `Deserializer` class calls `Deserializer._get_lines()` directly, rather than via `self`, preventing subclasses from overriding this methods (for example, to use an alternative JSON library). This has been the case since ee5147cfd7de2add74a285537a8968ec074e70cd. Let's change it to use `self`.

I did a quick check for other occurrences of calling a class' staticmethods' directly and didn't find any.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

I used Claude to find this issue, and to run the "quick check" for other versions of the pattern.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
