### PR TITLE
Added complete pattern lookup tests on non-string fields.

### DIFF
--- a/django/db/backends/postgresql/features.py
+++ b/django/db/backends/postgresql/features.py
@@ -124,7 +124,22 @@ class DatabaseFeatures(BaseDatabaseFeatures):
 
     @cached_property
     def django_test_expected_failures(self):
-        expected_failures = set()
+        expected_failures = {
+            # Pattern lookups can't handle expressions. e.g. function
+            # replace(smallint, unknown, unknown) does not exist
+            # LINE 1: ...on"."gt"::text) LIKE '%' ||
+            # UPPER(REPLACE(REPLACE(REPLACE(("...
+            "lookup.tests.TextLookupsNonStringTests.test_contains_f_expression",
+            "lookup.tests.TextLookupsNonStringTests.test_endswith_f_expression",
+            "lookup.tests.TextLookupsNonStringTests.test_icontains_f_expression",
+            "lookup.tests.TextLookupsNonStringTests.test_iendswith_f_expression",
+            "lookup.tests.TextLookupsNonStringTests.test_iendswith_f_expression",
+            "lookup.tests.TextLookupsNonStringTests.test_iexact_f_expression",
+            "lookup.tests.TextLookupsNonStringTests.test_iregex_f_expression",
+            "lookup.tests.TextLookupsNonStringTests.test_istartswith_f_expression",
+            "lookup.tests.TextLookupsNonStringTests.test_regex_f_expression",
+            "lookup.tests.TextLookupsNonStringTests.test_startswith_f_expression",
+        }
         if self.uses_server_side_binding:
             expected_failures.update(
                 {

--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -52,6 +52,8 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         # The django_format_dtdelta() function doesn't properly handle mixed
         # Date/DateTime fields and timedeltas.
         "expressions.tests.FTimeDeltaTests.test_mixed_comparisons1",
+        # This backend's regex lookup can't handle column references.
+        "lookup.tests.TextLookupsNonStringTests.test_regex_f_expression",
     }
     insert_test_table_with_defaults = 'INSERT INTO {} ("null") VALUES (1)'
     supports_default_keyword_in_insert = False

--- a/tests/lookup/tests.py
+++ b/tests/lookup/tests.py
@@ -1418,13 +1418,6 @@ class LookupTests(TestCase):
         bio_column = connection.ops.quote_name(Author._meta.get_field("bio").column)
         self.assertIn(f"{bio_column} IS NULL", ctx.captured_queries[0]["sql"])
 
-    def test_regex_non_string(self):
-        """
-        A regex lookup does not fail on non-string fields
-        """
-        s = Season.objects.create(year=2013, gt=444)
-        self.assertQuerySetEqual(Season.objects.filter(gt__regex=r"^444$"), [s])
-
     def test_regex_non_ascii(self):
         """
         A regex lookup does not trip on non-ASCII characters.
@@ -1795,6 +1788,108 @@ class LookupTests(TestCase):
             self.assertIs(Author.objects.filter(GreaterThan(2, 1)).exists(), True)
         # Direct values on RHS are not wrapped.
         self.assertIn("2 > 1", ctx.captured_queries[0]["sql"])
+
+
+class TextLookupsNonStringTests(TestCase):
+    """Regex and pattern lookups work on non-string fields."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.s1 = Season.objects.create(year=2013, gt=2013)
+        cls.s2 = Season.objects.create(year=2014, gt=2)
+        cls.s3 = Season.objects.create(year=2015, gt=13)
+        cls.s4 = Season.objects.create(year=2016, gt=1)
+        cls.s5 = Season.objects.create(year=2017, gt=12017)
+        cls.s6 = Season.objects.create(year=2018, gt=2017)
+        cls.s7 = Season.objects.create(year=2019, gt=2020)
+        cls.s8 = Season.objects.create(year=2020, gt=2021)
+        cls.s9 = Season.objects.create(year=20210, gt=20211)
+
+    def test_regex(self):
+        self.assertCountEqual(Season.objects.filter(gt__regex=r"^444$"), [])
+
+    def test_regex_f_expression(self):
+        self.assertCountEqual(
+            Season.objects.filter(gt__regex=F("year")), [self.s1, self.s5]
+        )
+
+    def test_iregex(self):
+        self.assertCountEqual(Season.objects.filter(gt__iregex=r"^444$"), [])
+
+    def test_iregex_f_expression(self):
+        self.assertCountEqual(
+            Season.objects.filter(gt__iregex=F("year")), [self.s1, self.s5]
+        )
+
+    def test_startswith(self):
+        self.assertCountEqual(
+            Season.objects.filter(gt__startswith="2"),
+            [self.s1, self.s2, self.s6, self.s7, self.s8, self.s9],
+        )
+
+    def test_startswith_f_expression(self):
+        self.assertCountEqual(
+            Season.objects.filter(gt__startswith=F("year")), [self.s1]
+        )
+
+    def test_istartswith(self):
+        self.assertCountEqual(
+            Season.objects.filter(gt__istartswith="2"),
+            [self.s1, self.s2, self.s6, self.s7, self.s8, self.s9],
+        )
+
+    def test_istartswith_f_expression(self):
+        self.assertCountEqual(
+            Season.objects.filter(gt__istartswith=F("year")), [self.s1]
+        )
+
+    def test_endswith(self):
+        self.assertCountEqual(
+            Season.objects.filter(gt__endswith="13"), [self.s1, self.s3]
+        )
+
+    def test_endswith_f_expression(self):
+        self.assertCountEqual(
+            Season.objects.filter(gt__endswith=F("year")), [self.s1, self.s5]
+        )
+
+    def test_iendswith(self):
+        self.assertCountEqual(
+            Season.objects.filter(gt__iendswith="13"), [self.s1, self.s3]
+        )
+
+    def test_iendswith_f_expression(self):
+        self.assertCountEqual(
+            Season.objects.filter(gt__iendswith=F("year")), [self.s1, self.s5]
+        )
+
+    def test_contains(self):
+        self.assertCountEqual(
+            Season.objects.filter(gt__contains="1"),
+            [self.s1, self.s3, self.s4, self.s5, self.s6, self.s8, self.s9],
+        )
+
+    def test_contains_f_expression(self):
+        self.assertCountEqual(
+            Season.objects.filter(gt__contains=F("year")), [self.s1, self.s5]
+        )
+
+    def test_icontains(self):
+        self.assertCountEqual(
+            Season.objects.filter(gt__icontains="1"),
+            [self.s1, self.s3, self.s4, self.s5, self.s6, self.s8, self.s9],
+        )
+
+    def test_icontains_f_expression(self):
+        self.assertCountEqual(
+            Season.objects.filter(gt__icontains=F("year")), [self.s1, self.s5]
+        )
+
+    def test_iexact(self):
+        self.assertCountEqual(Season.objects.filter(gt__iexact="2013"), [self.s1])
+
+    def test_iexact_f_expression(self):
+        self.assertCountEqual(Season.objects.filter(gt__iexact=F("year")), [self.s1])
 
 
 class LookupQueryingTests(TestCase):


### PR DESCRIPTION
These tests cover all code added in https://github.com/mongodb/django-mongodb-backend/pull/567.

I considered using `subTest()` but it's not conducive to marking only some cases as expected failure. Also, if there is a failure, subsequent assertions fail with "current transaction is aborted, commands ignored until end of transaction block".

AI disclosure: I used Claude to assist with test creation and refactoring from subTest to separate test methods.