### PR TITLE
Fixed typo in Configuring email docs.

### DIFF
--- a/docs/topics/email.txt
+++ b/docs/topics/email.txt
@@ -72,8 +72,8 @@ is printed to the console as a development aid (for projects created with
 :djadmin:`startproject`) or results in a ``MailerDoesNotExist`` error (when the
 :setting:`MAILERS` setting isn't defined).
 
-Define edit the :setting:`MAILERS` setting to tell Django how to send email.
-For example, to send through an SMTP server running on the local machine::
+Use the :setting:`MAILERS` setting to tell Django how to send email. For
+example, to send through an SMTP server running on the local machine::
 
     MAILERS = {
         "default": {


### PR DESCRIPTION
#### Trac ticket number
N/A - typo in docs

#### Branch description

This originally said "Define **or** edit the `MAILERS` setting…," but looks like the "or" got dropped during some other editing.

I changed it to "<ins>Use</ins> the `MAILERS` setting…," which (imho) reads better anyway.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] (n/a) I have checked the "Has patch" ticket flag in the Trac system.
- [x] (n/a) I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] (n/a) I have attached screenshots in both light and dark modes for any UI changes.
