### PR TITLE
Fixed #37161 -- Added system check for default MAILERS configuration.

### DIFF
--- a/django/core/checks/__init__.py
+++ b/django/core/checks/__init__.py
@@ -18,6 +18,7 @@ import django.core.checks.async_checks  # NOQA isort:skip
 import django.core.checks.caches  # NOQA isort:skip
 import django.core.checks.commands  # NOQA isort:skip
 import django.core.checks.compatibility.django_4_0  # NOQA isort:skip
+import django.core.checks.compatibility.django_7_0  # NOQA isort:skip
 import django.core.checks.database  # NOQA isort:skip
 import django.core.checks.files  # NOQA isort:skip
 import django.core.checks.model_checks  # NOQA isort:skip

--- a/django/core/checks/compatibility/django_7_0.py
+++ b/django/core/checks/compatibility/django_7_0.py
@@ -1,0 +1,25 @@
+from django.conf import settings
+from django.core.checks import Tags, Warning, register
+from django.core.mail.handler import DEFAULT_MAILER_ALIAS
+
+
+@register(Tags.compatibility)
+def check_mailers_default_alias(app_configs, **kwargs):
+    if not hasattr(settings, "MAILERS"):
+        return []
+
+    if DEFAULT_MAILER_ALIAS in settings.MAILERS:
+        return []
+
+    if settings.MAILERS:
+        hint = "Sending email without specifying 'using' will cause an error."
+    else:
+        hint = "Sending email will cause an error."
+
+    return [
+        Warning(
+            "There is no 'default' configuration in your MAILERS setting.",
+            hint=hint,
+            id="7_0.W001",
+        )
+    ]

--- a/tests/check_framework/test_7_0_compatibility.py
+++ b/tests/check_framework/test_7_0_compatibility.py
@@ -1,0 +1,47 @@
+from django.core.checks import Warning
+from django.core.checks.compatibility.django_7_0 import check_mailers_default_alias
+from django.test import SimpleTestCase, override_settings
+
+
+class MailersDefaultAliasCheckTests(SimpleTestCase):
+    @override_settings(
+        MAILERS={
+            "default": {
+                "BACKEND": "django.core.mail.backends.smtp.EmailBackend",
+            }
+        }
+    )
+    def test_mailers_default_alias_configured(self):
+        self.assertEqual(check_mailers_default_alias(None), [])
+
+    @override_settings(MAILERS={})
+    def test_mailers_empty(self):
+        self.assertEqual(
+            check_mailers_default_alias(None),
+            [
+                Warning(
+                    "There is no 'default' configuration in your MAILERS setting.",
+                    hint="Sending email will cause an error.",
+                    id="7_0.W001",
+                )
+            ],
+        )
+
+    @override_settings(
+        MAILERS={
+            "secondary": {
+                "BACKEND": "django.core.mail.backends.smtp.EmailBackend",
+            }
+        }
+    )
+    def test_mailers_without_default_alias(self):
+        self.assertEqual(
+            check_mailers_default_alias(None),
+            [
+                Warning(
+                    "There is no 'default' configuration in your MAILERS setting.",
+                    hint="Sending email without specifying 'using' will cause an error.",
+                    id="7_0.W001",
+                )
+            ],
+        )


### PR DESCRIPTION
#### Trac ticket number

ticket-37161

#### Branch description

Added a compatibility system check for the `MAILERS` setting.

The check warns when `settings.MAILERS` is configured but does not contain the `default` alias. It uses different hints depending on whether `MAILERS` is empty or contains only non-default aliases.

#### AI Assistance Disclosure (REQUIRED)

* [ ] **No AI tools were used** in preparing this PR.
* [x] **AI tools were used**; I have disclosed which ones, and fully reviewed and verified their output.

AI tools used: ChatGPT.

I used ChatGPT to help understand the ticket scope and review the proposed implementation. I wrote, tested, and verified the final patch locally.

#### Checklist

* [x] This PR follows the [[contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/)](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
* [x] This PR **does not** disclose a security vulnerability.
* [x] This PR targets the `main` branch.
* [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
* [x] I have not requested, and will not request, an automated AI review for this PR.
* [ ] I have checked the "Has patch" ticket flag in the Trac system.
* [x] I have added or updated relevant tests.
* [ ] I have added or updated relevant docs, including release notes if applicable.
* [ ] I have attached screenshots in both light and dark modes for any UI changes.

Tests:

* `python tests/runtests.py check_framework.test_7_0_compatibility`
* `python tests/runtests.py check_framework`