### PR TITLE
Fixed #37161 -- Added system check for default MAILERS configuration.

### DIFF
--- a/django/core/checks/__init__.py
+++ b/django/core/checks/__init__.py
@@ -20,6 +20,7 @@ import django.core.checks.commands  # NOQA isort:skip
 import django.core.checks.compatibility.django_4_0  # NOQA isort:skip
 import django.core.checks.database  # NOQA isort:skip
 import django.core.checks.files  # NOQA isort:skip
+import django.core.checks.mail  # NOQA isort:skip
 import django.core.checks.model_checks  # NOQA isort:skip
 import django.core.checks.security.base  # NOQA isort:skip
 import django.core.checks.security.csrf  # NOQA isort:skip

--- a/django/core/checks/mail.py
+++ b/django/core/checks/mail.py
@@ -1,0 +1,25 @@
+from django.conf import settings
+from django.core.checks import Tags, Warning, register
+from django.core.mail.handler import DEFAULT_MAILER_ALIAS
+
+
+@register(Tags.mail)
+def check_mailers_default_alias(app_configs, **kwargs):
+    if not settings.is_overridden("MAILERS"):
+        return []
+
+    if DEFAULT_MAILER_ALIAS in settings.MAILERS:
+        return []
+
+    if settings.MAILERS:
+        hint = "Sending email without specifying 'using' will cause an error."
+    else:
+        hint = "Sending email will cause an error."
+
+    return [
+        Warning(
+            "There is no 'default' configuration in your MAILERS setting.",
+            hint=hint,
+            id="mail.W001",
+        )
+    ]

--- a/django/core/checks/registry.py
+++ b/django/core/checks/registry.py
@@ -17,6 +17,7 @@ class Tags:
     compatibility = "compatibility"
     database = "database"
     files = "files"
+    mail = "mail"
     models = "models"
     security = "security"
     signals = "signals"

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -159,6 +159,12 @@ The following checks verify your setup for :doc:`/topics/files`:
 * **files.E001**: The :setting:`FILE_UPLOAD_TEMP_DIR` setting refers to the
   nonexistent directory ``<path>``.
 
+Mail
+----
+
+* **mail.W001**: There is no ``default`` configuration in your ``MAILERS``
+  setting.
+
 Model fields
 ------------
 

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -237,6 +237,12 @@ CSP
   :func:`~django.template.context_processors.csp` context processor is
   configured. See :ref:`csp-nonce-config` for setup instructions.
 
+Email
+~~~~~
+
+* A new ``mail.W001`` system check warns when :setting:`MAILERS` is
+  defined without a ``"default"`` configuration.
+
 Forms
 ~~~~~
 

--- a/tests/check_framework/test_mail.py
+++ b/tests/check_framework/test_mail.py
@@ -1,0 +1,53 @@
+from django.core.checks import Warning
+from django.core.checks.mail import check_mailers_default_alias
+from django.test import SimpleTestCase, override_settings
+
+
+class MailersDefaultAliasCheckTests(SimpleTestCase):
+
+    def test_mailers_not_defined(self):
+        self.assertEqual(check_mailers_default_alias(None), [])
+
+    @override_settings(
+        MAILERS={
+            "default": {
+                "BACKEND": "django.core.mail.backends.smtp.EmailBackend",
+            }
+        }
+    )
+    def test_mailers_default_alias_configured(self):
+        self.assertEqual(check_mailers_default_alias(None), [])
+
+    @override_settings(MAILERS={})
+    def test_mailers_empty(self):
+        self.assertEqual(
+            check_mailers_default_alias(None),
+            [
+                Warning(
+                    "There is no 'default' configuration in your MAILERS setting.",
+                    hint="Sending email will cause an error.",
+                    id="mail.W001",
+                )
+            ],
+        )
+
+    @override_settings(
+        MAILERS={
+            "secondary": {
+                "BACKEND": "django.core.mail.backends.smtp.EmailBackend",
+            }
+        }
+    )
+    def test_mailers_without_default_alias(self):
+        self.assertEqual(
+            check_mailers_default_alias(None),
+            [
+                Warning(
+                    "There is no 'default' configuration in your MAILERS setting.",
+                    hint=(
+                        "Sending email without specifying 'using' will cause an error."
+                    ),
+                    id="mail.W001",
+                )
+            ],
+        )


### PR DESCRIPTION
#### Trac ticket number

ticket-37161

#### Branch description

Added a compatibility system check for the `MAILERS` setting.

The check warns when `settings.MAILERS` is configured but does not contain the `default` alias. It returns a different hint depending on whether `MAILERS` is empty or contains only non-default aliases.

Tests run locally:

```
python tests/runtests.py check_framework.test_7_0_compatibility
python tests/runtests.py check_framework
```

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

I used ChatGPT to help understand the ticket discussion, plan the patch, and review the tests. I reviewed the changes and ran the tests locally before submission.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.