### PR TITLE
Fixed #37145 -- Made ModelFormSet respect custom Form.add_prefix().

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -736,7 +736,9 @@ class BaseModelFormSet(BaseFormSet, AltersData):
         pk_required = i < self.initial_form_count()
         if pk_required:
             if self.is_bound:
-                pk_key = "%s-%s" % (self.add_prefix(i), self.model._meta.pk.name)
+                form_kwargs = {"prefix": self.add_prefix(i), **kwargs}
+                pk_form = self.form(**form_kwargs)
+                pk_key = pk_form.add_prefix(self.model._meta.pk.name)
                 try:
                     pk = self.data[pk_key]
                 except KeyError:

--- a/tests/forms_tests/tests/test_formsets.py
+++ b/tests/forms_tests/tests/test_formsets.py
@@ -267,6 +267,28 @@ class FormsFormsetTestCase(SimpleTestCase):
             '<li>Votes: <input type="number" name="choices-1-votes"></li>',
         )
 
+    def test_formset_with_overridden_add_prefix(self):
+        class CustomAddPrefixChoice(Choice):
+            def add_prefix(self, field_name):
+                return (
+                    "%s.%s" % (self.prefix, field_name) if self.prefix else field_name
+                )
+
+        FormSet = formset_factory(CustomAddPrefixChoice)
+        data = {
+            "form-TOTAL_FORMS": "1",
+            "form-INITIAL_FORMS": "0",
+            "form-MIN_NUM_FORMS": "0",
+            "form-MAX_NUM_FORMS": "0",
+            "form-0.choice": "Calexico",
+            "form-0.votes": "100",
+        }
+        formset = FormSet(data)
+        self.assertTrue(formset.is_valid())
+        self.assertEqual(
+            formset.forms[0].cleaned_data, {"choice": "Calexico", "votes": 100}
+        )
+
     def test_blank_form_unfilled(self):
         """A form that's displayed as blank may be submitted as blank."""
         formset = self.make_choiceformset(

--- a/tests/model_formsets/tests.py
+++ b/tests/model_formsets/tests.py
@@ -171,6 +171,32 @@ class ModelFormsetTest(TestCase):
         with self.assertRaisesMessage(ImproperlyConfigured, message):
             modelformset_factory(Author)
 
+    def test_overridden_add_prefix(self):
+        class AuthorForm(forms.ModelForm):
+            class Meta:
+                model = Author
+                fields = "__all__"
+
+            def add_prefix(self, field_name):
+                return (
+                    "%s.%s" % (self.prefix, field_name) if self.prefix else field_name
+                )
+
+        author = Author.objects.create(name="Charles Baudelaire")
+        FormSet = modelformset_factory(Author, form=AuthorForm, fields="__all__")
+        data = {
+            "form-TOTAL_FORMS": "1",
+            "form-INITIAL_FORMS": "1",
+            "form-MAX_NUM_FORMS": "0",
+            "form-0.id": str(author.pk),
+            "form-0.name": "Charles Baudelaire",
+        }
+        formset = FormSet(data, queryset=Author.objects.all())
+        self.assertTrue(formset.is_valid())
+        self.assertEqual(formset[0].instance.pk, author.pk)
+        formset.save()
+        self.assertEqual(Author.objects.count(), 1)
+
     def test_simple_save(self):
         qs = Author.objects.all()
         AuthorFormSet = modelformset_factory(Author, fields="__all__", extra=3)


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37145

#### Branch description
`BaseModelFormSet._construct_form()` built the primary-key lookup key using a hardcoded hyphen separator, bypassing forms that override `add_prefix()`. This caused bound model formsets with existing objects to fail to associate submitted primary keys when the form used a custom prefix format.

This PR updates the primary-key lookup to use the form's `add_prefix()` implementation.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
