### PR TITLE
Fixed #37145 -- Made ModelFormSet respect custom Form.add_prefix().

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -736,7 +736,9 @@ class BaseModelFormSet(BaseFormSet, AltersData):
         pk_required = i < self.initial_form_count()
         if pk_required:
             if self.is_bound:
-                pk_key = "%s-%s" % (self.add_prefix(i), self.model._meta.pk.name)
+                form_kwargs = {"prefix": self.add_prefix(i), **kwargs}
+                pk_form = self.form(**form_kwargs)
+                pk_key = pk_form.add_prefix(self.model._meta.pk.name)
                 try:
                     pk = self.data[pk_key]
                 except KeyError:

--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -736,7 +736,14 @@ class BaseModelFormSet(BaseFormSet, AltersData):
         pk_required = i < self.initial_form_count()
         if pk_required:
             if self.is_bound:
-                pk_key = "%s-%s" % (self.add_prefix(i), self.model._meta.pk.name)
+                # Avoid initializing the form only to compute its prefix when
+                # it uses BaseForm.add_prefix().
+                if self.form.add_prefix is BaseForm.add_prefix:
+                    pk_key = "%s-%s" % (self.add_prefix(i), self.model._meta.pk.name)
+                else:
+                    form_kwargs = {"prefix": self.add_prefix(i), **kwargs}
+                    pk_form = self.form(**form_kwargs)
+                    pk_key = pk_form.add_prefix(self.model._meta.pk.name)
                 try:
                     pk = self.data[pk_key]
                 except KeyError:

--- a/tests/model_formsets/tests.py
+++ b/tests/model_formsets/tests.py
@@ -171,6 +171,32 @@ class ModelFormsetTest(TestCase):
         with self.assertRaisesMessage(ImproperlyConfigured, message):
             modelformset_factory(Author)
 
+    def test_overridden_add_prefix(self):
+        class AuthorForm(forms.ModelForm):
+            class Meta:
+                model = Author
+                fields = "__all__"
+
+            def add_prefix(self, field_name):
+                return (
+                    "%s.%s" % (self.prefix, field_name) if self.prefix else field_name
+                )
+
+        author = Author.objects.create(name="Charles Baudelaire")
+        FormSet = modelformset_factory(Author, form=AuthorForm, fields="__all__")
+        data = {
+            "form-TOTAL_FORMS": "1",
+            "form-INITIAL_FORMS": "1",
+            "form-MAX_NUM_FORMS": "0",
+            "form-0.id": str(author.pk),
+            "form-0.name": "Charles Baudelaire",
+        }
+        formset = FormSet(data, queryset=Author.objects.all())
+        self.assertTrue(formset.is_valid())
+        self.assertEqual(formset[0].instance.pk, author.pk)
+        formset.save()
+        self.assertEqual(Author.objects.count(), 1)
+
     def test_simple_save(self):
         qs = Author.objects.all()
         AuthorFormSet = modelformset_factory(Author, fields="__all__", extra=3)

--- a/tests/model_formsets/tests.py
+++ b/tests/model_formsets/tests.py
@@ -2,6 +2,7 @@ import datetime
 import re
 from datetime import date
 from decimal import Decimal
+from unittest import mock
 
 from django import forms
 from django.core.exceptions import ImproperlyConfigured
@@ -1987,6 +1988,58 @@ class ModelFormsetTest(TestCase):
         # The name of other_author shouldn't be changed and new models aren't
         # created.
         self.assertSequenceEqual(Author.objects.all(), [author, other_author])
+
+    def test_overridden_add_prefix(self):
+        class AuthorForm(forms.ModelForm):
+            class Meta:
+                model = Author
+                fields = "__all__"
+
+            def add_prefix(self, field_name):
+                return f"{self.prefix}.{field_name}" if self.prefix else field_name
+
+        author = Author.objects.create(name="Charles Baudelaire")
+        AuthorFormSet = modelformset_factory(Author, form=AuthorForm)
+        data = {
+            "form-TOTAL_FORMS": "1",
+            "form-INITIAL_FORMS": "1",
+            "form-MAX_NUM_FORMS": "0",
+            "form-0.id": str(author.pk),
+            "form-0.name": "Charles P. Baudelaire",
+        }
+        formset = AuthorFormSet(data, queryset=Author.objects.all())
+
+        self.assertIs(formset.is_valid(), True)
+        self.assertEqual(formset.forms[0].instance, author)
+        formset.save()
+        author.refresh_from_db()
+        self.assertEqual(author.name, "Charles P. Baudelaire")
+
+    def test_form_initialized_once_with_default_add_prefix(self):
+        initialization = mock.Mock()
+
+        class AuthorForm(forms.ModelForm):
+            class Meta:
+                model = Author
+                fields = "__all__"
+
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                initialization()
+
+        author = Author.objects.create(name="Charles Baudelaire")
+        AuthorFormSet = modelformset_factory(Author, form=AuthorForm)
+        formset = AuthorFormSet(
+            {
+                "form-TOTAL_FORMS": "1",
+                "form-INITIAL_FORMS": "1",
+                "form-0-id": str(author.pk),
+            },
+            queryset=Author.objects.all(),
+        )
+
+        self.assertEqual(formset.forms[0].instance, author)
+        initialization.assert_called_once_with()
 
     def test_validation_without_id(self):
         AuthorFormSet = modelformset_factory(Author, fields="__all__")


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37145

#### Branch description
`BaseModelFormSet._construct_form()` built the primary-key lookup key using a hardcoded hyphen separator, bypassing forms that override `add_prefix()`. This caused bound model formsets with existing objects to fail to associate submitted primary keys when the form used a custom prefix format.

This PR updates the primary-key lookup to use the form's `add_prefix()` implementation.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
