### PR TITLE
Fix model_to_dict to return empty dict when fields=[]

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -83,7 +83,7 @@ def model_to_dict(instance, fields=None, exclude=None):
     for f in chain(opts.concrete_fields, opts.private_fields, opts.many_to_many):
         if not getattr(f, 'editable', False):
             continue
-        if fields and f.name not in fields:
+        if fields is not None and f.name not in fields:
             continue
         if exclude and f.name in exclude:
             continue

--- a/tests/model_forms/test_model_to_dict_empty_fields.py
+++ b/tests/model_forms/test_model_to_dict_empty_fields.py
@@ -1,0 +1,36 @@
+"""
+Test for model_to_dict with empty fields list.
+"""
+from django.test import SimpleTestCase
+from django.db import models
+from django.forms.models import model_to_dict
+
+
+class TestModel(models.Model):
+    name = models.CharField(max_length=100)
+    value = models.IntegerField(default=0)
+    
+    class Meta:
+        app_label = 'test_app'
+
+
+class ModelToDictTests(SimpleTestCase):
+    def test_model_to_dict_empty_fields_list(self):
+        """model_to_dict with empty fields list should return empty dict."""
+        instance = TestModel(name='test', value=42)
+        result = model_to_dict(instance, fields=[])
+        self.assertEqual(result, {})
+    
+    def test_model_to_dict_no_fields_param(self):
+        """model_to_dict without fields param should return all fields."""
+        instance = TestModel(name='test', value=42)
+        result = model_to_dict(instance)
+        self.assertIn('name', result)
+        self.assertIn('value', result)
+    
+    def test_model_to_dict_specific_fields(self):
+        """model_to_dict with specific fields should return only those fields."""
+        instance = TestModel(name='test', value=42)
+        result = model_to_dict(instance, fields=['name'])
+        self.assertIn('name', result)
+        self.assertNotIn('value', result)


### PR DESCRIPTION
When fields is an empty list, model_to_dict should return an empty dict since no fields were requested. The previous implementation used `if fields and f.name not in fields:` which evaluates to False when fields is an empty list, causing all fields to be returned.

The fix changes the condition to `if fields is not None and f.name not in fields:` to properly handle the empty list case.

Refs: https://github.com/django/django/pull/11150