### PR TITLE
Fixed #37140 -- Documented NULL handling for __in subquery lookups.

### DIFF
--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -265,6 +265,13 @@ Note the second example is more restrictive.
 If you need to execute more complex queries (for example, queries with ``OR``
 statements), you can use :class:`Q objects <django.db.models.Q>` (``*args``).
 
+.. note::
+
+    Using :meth:`exclude` with an ``__in`` lookup whose subquery can contain
+    ``NULL`` values may *silently* return no results due to SQL's three-valued
+    logic. See the :lookup:`in` lookup for details and a recommended
+    workaround.
+
 ``annotate()``
 ~~~~~~~~~~~~~~
 
@@ -3361,6 +3368,34 @@ extract two field values, where only one is expected::
     # Bad code! Will raise a TypeError.
     inner_qs = Blog.objects.filter(name__contains="Ch").values("name", "id")
     entries = Entry.objects.filter(blog__name__in=inner_qs)
+
+.. warning::
+
+    If the ``QuerySet`` used as the subquery can return ``NULL`` values, take
+    extra care when using it with :meth:`exclude`. Unlike a literal list, where
+    Django removes ``None`` automatically, the values produced by a subquery
+    are used as-is, so a ``NULL`` can reach the generated SQL. Because of the
+    way SQL handles ``NULL`` in three-valued logic, a ``NULL`` in the list of
+    values makes the ``NOT IN`` condition evaluate to unknown (instead of true)
+    for any row that doesn't match a non-``NULL`` value, so no rows qualify and
+    the query may *silently* return no results.
+
+    For example, since an ``Entry`` may have no authors, the ``authors`` values
+    can contain ``NULL``, and this query to find authors who aren't credited on
+    any entry unexpectedly returns nothing::
+
+        credited = Entry.objects.values("authors")
+        Author.objects.exclude(pk__in=credited)
+
+    To avoid this, exclude ``NULL`` values inside the subquery so that the
+    generated list of values never contains ``NULL``::
+
+        credited = Entry.objects.filter(authors__isnull=False).values("authors")
+        Author.objects.exclude(pk__in=credited)
+
+    A :meth:`filter` using ``__in`` is not affected in the same way (it still
+    returns the matching rows), but excluding ``NULL`` values from the subquery
+    is recommended.
 
 .. _nested-queries-performance:
 


### PR DESCRIPTION
#### Trac ticket number

ticket-37140

#### Branch description

Documents a `NULL`-handling pitfall for `__in` lookups that use a subquery.

When the subquery can produce `NULL` values, `exclude(field__in=subquery)`
silently returns no results because of SQL's three-valued logic (`NOT IN`
against a `NULL` evaluates to *unknown* rather than *true*). Unlike an
in-memory list, where Django strips `None` automatically, the values produced
by a subquery are used as-is, so the `NULL` reaches the generated SQL.

Following Simon Charette's guidance on the ticket, this documents the issue
under the `in` lookup and recommends excluding `NULL` inside the subquery
(`filter(field__isnull=False)`) as the workaround, covering both `filter()`
and `exclude()`. A cross-reference is added from `exclude()`. The
`~Exists(OuterRef(...))` approach from the earlier patch is intentionally not
recommended.

#### AI Assistance Disclosure (REQUIRED)

- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

This contribution was prepared with assistance from Claude Code (Anthropic
Claude Opus 4.8). The AI tool was used to analyze the Trac ticket and the
maintainer's guidance, draft the documentation wording, and **empirically
verify** the documented behavior against a local editable `Django 6.2.dev`
checkout. The verification confirmed that `Entry.objects.values("authors")`
yields `NULL` (via a `LEFT OUTER JOIN`) for entries without authors, that
`Author.objects.exclude(pk__in=...)` then silently returns no rows, and that
adding `filter(authors__isnull=False)` to the subquery restores the expected
result. The output was reviewed and verified before submission, and the docs
build cleanly (`sphinx-build`, `sphinx-lint`, and `blacken-docs` all pass with
no warnings).

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability.
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [ ] I have checked the "Has patch" ticket flag in the Trac system. <!-- Will be set by the ticket owner on Trac. -->
- [x] N/A — documentation-only change; no code behavior changed, so no tests were added.
- [x] I have added or updated relevant docs. No release note: this clarifies existing behavior rather than changing it.
- [x] N/A — no UI changes, so no screenshots.
