### PR TITLE
Fixed #37168 -- Made admin display database defaults as empty values.

### DIFF
--- a/django/contrib/admin/utils.py
+++ b/django/contrib/admin/utils.py
@@ -435,6 +435,7 @@ def help_text_for_field(name, model):
 
 def display_for_field(value, field, empty_value_display, avoid_link=False):
     from django.contrib.admin.templatetags.admin_list import _boolean_icon
+    from django.db.models.expressions import DatabaseDefault
 
     if field.name == "password" and field.model == get_user_model():
         return render_password_as_hash(value)
@@ -450,8 +451,10 @@ def display_for_field(value, field, empty_value_display, avoid_link=False):
     # BooleanField needs special-case null-handling, so it comes before the
     # general null test.
     elif isinstance(field, models.BooleanField):
+        if isinstance(value, DatabaseDefault):
+            return _boolean_icon(None)
         return _boolean_icon(value)
-    elif value in field.empty_values:
+    elif value in field.empty_values or isinstance(value, DatabaseDefault):
         return empty_value_display
     elif isinstance(field, models.DateTimeField):
         return formats.localize(timezone.template_localtime(value))
@@ -476,12 +479,15 @@ def display_for_field(value, field, empty_value_display, avoid_link=False):
 
 def display_for_value(value, empty_value_display, boolean=False):
     from django.contrib.admin.templatetags.admin_list import _boolean_icon
+    from django.db.models.expressions import DatabaseDefault
 
     if boolean:
+        if value in EMPTY_VALUES or isinstance(value, DatabaseDefault):
+            return _boolean_icon(None)
         return _boolean_icon(value)
     if isinstance(value, str) and not isinstance(value, SafeString):
         value = value.strip()
-    if value in EMPTY_VALUES:
+    if value in EMPTY_VALUES or isinstance(value, DatabaseDefault):
         return empty_value_display
     elif isinstance(value, bool):
         return str(value)

--- a/tests/admin_utils/tests.py
+++ b/tests/admin_utils/tests.py
@@ -21,6 +21,7 @@ from django.contrib.auth.models import User
 from django.contrib.auth.templatetags.auth import render_password_as_hash
 from django.core.validators import EMPTY_VALUES
 from django.db import DEFAULT_DB_ALIAS, models
+from django.db.models.expressions import DatabaseDefault
 from django.test import SimpleTestCase, TestCase, override_settings, skipUnlessDBFeature
 from django.test.utils import isolate_apps
 from django.utils.formats import localize
@@ -194,6 +195,12 @@ class UtilsTests(SimpleTestCase):
                     )
                     self.assertEqual(display_value, self.empty_value)
 
+    def test_empty_value_database_default_display_for_field(self):
+        display_value = display_for_field(
+            DatabaseDefault(models.Value(1)), models.IntegerField(), self.empty_value
+        )
+        self.assertEqual(display_value, self.empty_value)
+
     def test_empty_value_display_choices(self):
         model_field = models.CharField(choices=((None, "test_none"),))
         display_value = display_for_field(None, model_field, self.empty_value)
@@ -201,11 +208,13 @@ class UtilsTests(SimpleTestCase):
 
     def test_empty_value_display_booleanfield(self):
         model_field = models.BooleanField(null=True)
-        display_value = display_for_field(None, model_field, self.empty_value)
         expected = (
             f'<img src="{settings.STATIC_URL}admin/img/icon-unknown.svg" alt="None" />'
         )
-        self.assertHTMLEqual(display_value, expected)
+        for value in [None, DatabaseDefault(models.Value(True))]:
+            with self.subTest(empty_value=value):
+                display_value = display_for_field(value, model_field, self.empty_value)
+                self.assertHTMLEqual(display_value, expected)
 
     def test_json_display_for_field(self):
         tests = [
@@ -307,11 +316,25 @@ class UtilsTests(SimpleTestCase):
         self.assertEqual(display_for_value(True, ""), "True")
         self.assertEqual(display_for_value(False, ""), "False")
 
+    def test_list_display_for_value_boolean_database_default(self):
+        # DatabaseDefault expression is interpreted as unknown.
+        self.assertEqual(
+            display_for_value(DatabaseDefault(models.Value(True)), "", boolean=True),
+            '<img src="/static/admin/img/icon-unknown.svg" alt="None">',
+        )
+        self.assertEqual(display_for_value(DatabaseDefault(models.Value(True)), ""), "")
+
     def test_list_display_for_value_empty(self):
         for value in EMPTY_VALUES:
             with self.subTest(empty_value=value):
                 display_value = display_for_value(value, self.empty_value)
                 self.assertEqual(display_value, self.empty_value)
+
+    def test_list_display_for_database_default(self):
+        display_value = display_for_value(
+            DatabaseDefault(models.Value("1")), self.empty_value
+        )
+        self.assertEqual(display_value, self.empty_value)
 
     def test_list_display_for_value_consecutive_whitespace(self):
         cases = [


### PR DESCRIPTION
#### Trac ticket number

ticket-37168

#### Branch description

See ticket-37168. Alternatively, we can update only admin hooks:
```diff
diff --git a/django/contrib/admin/utils.py b/django/contrib/admin/utils.py
index ed6c41f52e..5f5bf34b7f 100644
--- a/django/contrib/admin/utils.py
+++ b/django/contrib/admin/utils.py
@@ -435,6 +435,7 @@ def help_text_for_field(name, model):
 
 def display_for_field(value, field, empty_value_display, avoid_link=False):
     from django.contrib.admin.templatetags.admin_list import _boolean_icon
+    from django.db.models.expressions import DatabaseDefault
 
     if field.name == "password" and field.model == get_user_model():
         return render_password_as_hash(value)
@@ -451,7 +452,7 @@ def display_for_field(value, field, empty_value_display, avoid_link=False):
     # general null test.
     elif isinstance(field, models.BooleanField):
         return _boolean_icon(value)
-    elif value in field.empty_values:
+    elif value in field.empty_values or isinstance(value, DatabaseDefault):
         return empty_value_display
     elif isinstance(field, models.DateTimeField):
         return formats.localize(timezone.template_localtime(value))
@@ -476,12 +477,13 @@ def display_for_field(value, field, empty_value_display, avoid_link=False):
 
 def display_for_value(value, empty_value_display, boolean=False):
     from django.contrib.admin.templatetags.admin_list import _boolean_icon
+    from django.db.models.expressions import DatabaseDefault
 
     if boolean:
         return _boolean_icon(value)
     if isinstance(value, str) and not isinstance(value, SafeString):
         value = value.strip()
-    if value in EMPTY_VALUES:
+    if value in EMPTY_VALUES or isinstance(value, DatabaseDefault):
         return empty_value_display
     elif isinstance(value, bool):
         return str(value)
```

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.