### PR TITLE
Fixed #37175 -- Added DatabaseOperations.get_hardcoded_pk() and get_nonexistent_pk().

### DIFF
--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -914,3 +914,13 @@ class BaseDatabaseOperations:
         an integer pk can be converted to bson.ObjectId().
         """
         return value
+
+    def get_nonexistent_pk(self, value):
+        """
+        Given the last created pk or a large integer value unlikely to exist,
+        return a nonexistent primary key value for use in tests.
+
+        Example use case: MongoDB uses DEFAULT_AUTO_FIELD=ObjectIdAutoField and
+        can use ObjectId() to generate a nonexistent ID.
+        """
+        return value + 1

--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -903,3 +903,14 @@ class BaseDatabaseOperations:
                     )
                 path.append(self.format_json_path_numeric_index(num))
         return "".join(path)
+
+    def get_hardcoded_pk(self, value):
+        """
+        Given an integer suggestion (which works for built-in backends because
+        they don't override DEFAULT_AUTO_FIELD), return a hardcoded primary key
+        value for use in tests.
+
+        Example use case: MongoDB uses DEFAULT_AUTO_FIELD=ObjectIdAutoField and
+        an integer pk can be converted to bson.ObjectId().
+        """
+        return value

--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -908,3 +908,14 @@ class BaseDatabaseOperations:
                     )
                 path.append(self.format_json_path_numeric_index(num))
         return "".join(path)
+
+    def get_hardcoded_pk(self, value):
+        """
+        Given an integer suggestion (which works for built-in backends because
+        they don't override DEFAULT_AUTO_FIELD), return a hardcoded primary key
+        value for use in tests.
+
+        Example use case: MongoDB uses DEFAULT_AUTO_FIELD=ObjectIdAutoField and
+        an integer pk can be converted to bson.ObjectId().
+        """
+        return value

--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -919,3 +919,13 @@ class BaseDatabaseOperations:
         an integer pk can be converted to bson.ObjectId().
         """
         return value
+
+    def get_nonexistent_pk(self, value):
+        """
+        Given the last created pk or a large integer value unlikely to exist,
+        return a nonexistent primary key value for use in tests.
+
+        Example use case: MongoDB uses DEFAULT_AUTO_FIELD=ObjectIdAutoField and
+        can use ObjectId() to generate a nonexistent ID.
+        """
+        return value + 1

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -778,7 +778,8 @@ class ChangeListTests(TestCase):
         cl = m.get_changelist_instance(request)
         self.assertEqual(cl.queryset.count(), 1)
 
-        request = self.factory.get("/concert/", data={SEARCH_VAR: band.pk + 5})
+        nonexistent_pk = connection.ops.get_nonexistent_pk(band.pk)
+        request = self.factory.get("/concert/", data={SEARCH_VAR: nonexistent_pk})
         request.user = self.superuser
         cl = m.get_changelist_instance(request)
         self.assertEqual(cl.queryset.count(), 0)

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -996,7 +996,8 @@ class ChangeListTests(TestCase):
             self.assertIs(cl.queryset.query.distinct, False)
 
         # A ManyToManyField in params does have distinct applied.
-        request = self.factory.get("/band/", {"genres": "0"})
+        pk_value = str(connection.ops.get_hardcoded_pk(0))
+        request = self.factory.get("/band/", {"genres": pk_value})
         request.user = self.superuser
         cl = m.get_changelist_instance(request)
         self.assertIs(cl.queryset.query.distinct, True)
@@ -1473,9 +1474,10 @@ class ChangeListTests(TestCase):
         default ordering defined (#17198).
         """
         superuser = self._create_superuser("superuser")
+        pk = connection.ops.get_hardcoded_pk
 
         for counter in range(1, 51):
-            UnorderedObject.objects.create(id=counter, bool=True)
+            UnorderedObject.objects.create(id=pk(counter), bool=True)
 
         class UnorderedObjectAdmin(admin.ModelAdmin):
             list_per_page = 10
@@ -1491,7 +1493,7 @@ class ChangeListTests(TestCase):
                 response = model_admin.changelist_view(request)
                 for result in response.context_data["cl"].result_list:
                     counter += 1 if ascending else -1
-                    self.assertEqual(result.id, counter)
+                    self.assertEqual(result.id, pk(counter))
             custom_site.unregister(UnorderedObject)
 
         # When no order is defined at all, everything is ordered by '-pk'.
@@ -1534,9 +1536,10 @@ class ChangeListTests(TestCase):
         defines a default ordering (#17198).
         """
         superuser = self._create_superuser("superuser")
+        pk = connection.ops.get_hardcoded_pk
 
         for counter in range(1, 51):
-            OrderedObject.objects.create(id=counter, bool=True, number=counter)
+            OrderedObject.objects.create(id=pk(counter), bool=True, number=counter)
 
         class OrderedObjectAdmin(admin.ModelAdmin):
             list_per_page = 10
@@ -1552,7 +1555,7 @@ class ChangeListTests(TestCase):
                 response = model_admin.changelist_view(request)
                 for result in response.context_data["cl"].result_list:
                     counter += 1 if ascending else -1
-                    self.assertEqual(result.id, counter)
+                    self.assertEqual(result.id, pk(counter))
             custom_site.unregister(OrderedObject)
 
         # When no order is defined at all, use the model's default ordering

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -793,7 +793,8 @@ class ChangeListTests(TestCase):
         cl = m.get_changelist_instance(request)
         self.assertEqual(cl.queryset.count(), 1)
 
-        request = self.factory.get("/concert/", data={SEARCH_VAR: band.pk + 5})
+        nonexistent_pk = connection.ops.get_nonexistent_pk(band.pk)
+        request = self.factory.get("/concert/", data={SEARCH_VAR: nonexistent_pk})
         request.user = self.superuser
         cl = m.get_changelist_instance(request)
         self.assertEqual(cl.queryset.count(), 0)

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -1011,7 +1011,8 @@ class ChangeListTests(TestCase):
             self.assertIs(cl.queryset.query.distinct, False)
 
         # A ManyToManyField in params does have distinct applied.
-        request = self.factory.get("/band/", {"genres": "0"})
+        pk_value = str(connection.ops.get_hardcoded_pk(0))
+        request = self.factory.get("/band/", {"genres": pk_value})
         request.user = self.superuser
         cl = m.get_changelist_instance(request)
         self.assertIs(cl.queryset.query.distinct, True)
@@ -1488,9 +1489,10 @@ class ChangeListTests(TestCase):
         default ordering defined (#17198).
         """
         superuser = self._create_superuser("superuser")
+        pk = connection.ops.get_hardcoded_pk
 
         for counter in range(1, 51):
-            UnorderedObject.objects.create(id=counter, bool=True)
+            UnorderedObject.objects.create(id=pk(counter), bool=True)
 
         class UnorderedObjectAdmin(admin.ModelAdmin):
             list_per_page = 10
@@ -1506,7 +1508,7 @@ class ChangeListTests(TestCase):
                 response = model_admin.changelist_view(request)
                 for result in response.context_data["cl"].result_list:
                     counter += 1 if ascending else -1
-                    self.assertEqual(result.id, counter)
+                    self.assertEqual(result.id, pk(counter))
             custom_site.unregister(UnorderedObject)
 
         # When no order is defined at all, everything is ordered by '-pk'.
@@ -1549,9 +1551,10 @@ class ChangeListTests(TestCase):
         defines a default ordering (#17198).
         """
         superuser = self._create_superuser("superuser")
+        pk = connection.ops.get_hardcoded_pk
 
         for counter in range(1, 51):
-            OrderedObject.objects.create(id=counter, bool=True, number=counter)
+            OrderedObject.objects.create(id=pk(counter), bool=True, number=counter)
 
         class OrderedObjectAdmin(admin.ModelAdmin):
             list_per_page = 10
@@ -1567,7 +1570,7 @@ class ChangeListTests(TestCase):
                 response = model_admin.changelist_view(request)
                 for result in response.context_data["cl"].result_list:
                     counter += 1 if ascending else -1
-                    self.assertEqual(result.id, counter)
+                    self.assertEqual(result.id, pk(counter))
             custom_site.unregister(OrderedObject)
 
         # When no order is defined at all, use the model's default ordering

--- a/tests/admin_inlines/tests.py
+++ b/tests/admin_inlines/tests.py
@@ -3,6 +3,7 @@ from django.contrib.admin.helpers import InlineAdminForm
 from django.contrib.admin.tests import AdminSeleniumTestCase
 from django.contrib.auth.models import Permission, User
 from django.contrib.contenttypes.models import ContentType
+from django.db import connection
 from django.test import RequestFactory, TestCase, override_settings
 from django.test.selenium import screenshot_cases
 from django.urls import reverse
@@ -525,8 +526,11 @@ class TestInline(TestDataMixin, TestCase):
         The "View on Site" link is correct for locales that use thousand
         separators.
         """
-        holder = Holder.objects.create(pk=123456789, dummy=42)
-        inner = Inner.objects.create(pk=987654321, holder=holder, dummy=42, readonly="")
+        pk = connection.ops.get_hardcoded_pk
+        holder = Holder.objects.create(pk=pk(123456789), dummy=42)
+        inner = Inner.objects.create(
+            pk=pk(987654321), holder=holder, dummy=42, readonly=""
+        )
         response = self.client.get(
             reverse("admin:admin_inlines_holder_change", args=(holder.id,))
         )

--- a/tests/admin_inlines/tests.py
+++ b/tests/admin_inlines/tests.py
@@ -6,6 +6,7 @@ from django.contrib.admin import ModelAdmin, TabularInline
 from django.contrib.admin.helpers import InlineAdminForm
 from django.contrib.auth.models import Permission, User
 from django.contrib.contenttypes.models import ContentType
+from django.db import connection
 from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
 from django.utils.translation import gettext
@@ -527,8 +528,11 @@ class TestInline(TestDataMixin, TestCase):
         The "View on Site" link is correct for locales that use thousand
         separators.
         """
-        holder = Holder.objects.create(pk=123456789, dummy=42)
-        inner = Inner.objects.create(pk=987654321, holder=holder, dummy=42, readonly="")
+        pk = connection.ops.get_hardcoded_pk
+        holder = Holder.objects.create(pk=pk(123456789), dummy=42)
+        inner = Inner.objects.create(
+            pk=pk(987654321), holder=holder, dummy=42, readonly=""
+        )
         response = self.client.get(
             reverse("admin:admin_inlines_holder_change", args=(holder.id,))
         )

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -12,7 +12,7 @@ from django.contrib.auth.admin import GroupAdmin, UserAdmin
 from django.contrib.auth.models import Group, User
 from django.core.exceptions import ValidationError
 from django.core.mail import EmailMessage
-from django.db import models
+from django.db import connection, models
 from django.forms.models import BaseModelFormSet
 from django.http import HttpResponse, JsonResponse, StreamingHttpResponse
 from django.urls import path
@@ -722,7 +722,8 @@ class FieldOverridePostAdmin(PostAdmin):
 
 class CustomChangeList(ChangeList):
     def get_queryset(self, request):
-        return self.root_queryset.order_by("pk").filter(pk=9999)  # Doesn't exist
+        nonexistent_pk = connection.ops.get_nonexistent_pk(9999)
+        return self.root_queryset.order_by("pk").filter(pk=nonexistent_pk)
 
 
 class GadgetAdmin(admin.ModelAdmin):

--- a/tests/admin_views/test_actions.py
+++ b/tests/admin_views/test_actions.py
@@ -123,7 +123,7 @@ class AdminActionsTest(TestCase):
         If USE_THOUSAND_SEPARATOR is set, the ids for the objects selected for
         deletion are rendered without separators.
         """
-        s = ExternalSubscriber.objects.create(id=9999)
+        s = ExternalSubscriber.objects.create(id=connection.ops.get_hardcoded_pk(9999))
         action_data = {
             ACTION_CHECKBOX_NAME: [s.pk, self.s2.pk],
             "action": "delete_selected",
@@ -133,7 +133,7 @@ class AdminActionsTest(TestCase):
             reverse("admin:admin_views_subscriber_changelist"), action_data
         )
         self.assertTemplateUsed(response, "admin/delete_selected_confirmation.html")
-        self.assertContains(response, 'value="9999"')  # Instead of 9,999
+        self.assertContains(response, f'value="{s.pk}"')  # Instead of 9,999
         self.assertContains(response, 'value="%s"' % self.s2.pk)
 
     def test_model_admin_default_delete_action_protected(self):

--- a/tests/admin_views/test_actions.py
+++ b/tests/admin_views/test_actions.py
@@ -103,9 +103,10 @@ class AdminActionsTest(TestCase):
         self.assertEqual(Subscriber.objects.count(), 0)
 
     def test_default_delete_action_nonexistent_pk(self):
-        self.assertFalse(Subscriber.objects.filter(id=9998).exists())
+        nonexistent_pk = connection.ops.get_nonexistent_pk(9998)
+        self.assertFalse(Subscriber.objects.filter(id=nonexistent_pk).exists())
         action_data = {
-            ACTION_CHECKBOX_NAME: ["9998"],
+            ACTION_CHECKBOX_NAME: [str(nonexistent_pk)],
             "action": "delete_selected",
             "index": 0,
         }

--- a/tests/admin_views/test_actions.py
+++ b/tests/admin_views/test_actions.py
@@ -124,7 +124,7 @@ class AdminActionsTest(TestCase):
         If USE_THOUSAND_SEPARATOR is set, the ids for the objects selected for
         deletion are rendered without separators.
         """
-        s = ExternalSubscriber.objects.create(id=9999)
+        s = ExternalSubscriber.objects.create(id=connection.ops.get_hardcoded_pk(9999))
         action_data = {
             ACTION_CHECKBOX_NAME: [s.pk, self.s2.pk],
             "action": "delete_selected",
@@ -134,7 +134,7 @@ class AdminActionsTest(TestCase):
             reverse("admin:admin_views_subscriber_changelist"), action_data
         )
         self.assertTemplateUsed(response, "admin/delete_selected_confirmation.html")
-        self.assertContains(response, 'value="9999"')  # Instead of 9,999
+        self.assertContains(response, f'value="{s.pk}"')  # Instead of 9,999
         self.assertContains(response, 'value="%s"' % self.s2.pk)
 
     def test_model_admin_default_delete_action_protected(self):

--- a/tests/admin_views/test_actions.py
+++ b/tests/admin_views/test_actions.py
@@ -104,9 +104,10 @@ class AdminActionsTest(TestCase):
         self.assertEqual(Subscriber.objects.count(), 0)
 
     def test_default_delete_action_nonexistent_pk(self):
-        self.assertFalse(Subscriber.objects.filter(id=9998).exists())
+        nonexistent_pk = connection.ops.get_nonexistent_pk(9998)
+        self.assertFalse(Subscriber.objects.filter(id=nonexistent_pk).exists())
         action_data = {
-            ACTION_CHECKBOX_NAME: ["9998"],
+            ACTION_CHECKBOX_NAME: [str(nonexistent_pk)],
             "action": "delete_selected",
             "index": 0,
         }

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -26,6 +26,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core import mail
 from django.core.checks import Error
 from django.core.files import temp as tempfile
+from django.db import connection
 from django.db.models.utils import get_blank_choice_label
 from django.forms.utils import ErrorList
 from django.template.response import TemplateResponse
@@ -3985,8 +3986,9 @@ class AdminViewDeletedObjectsTest(TestCase):
         cls.ssh1 = SuperSecretHideout.objects.create(
             location="super floating castle!", supervillain=cls.sv1
         )
-        cls.cy1 = CyclicOne.objects.create(pk=1, name="I am recursive", two_id=1)
-        cls.cy2 = CyclicTwo.objects.create(pk=1, name="I am recursive too", one_id=1)
+        pk = connection.ops.get_hardcoded_pk(1)
+        cls.cy1 = CyclicOne.objects.create(pk=pk, name="I am recursive", two_id=pk)
+        cls.cy2 = CyclicTwo.objects.create(pk=pk, name="I am recursive too", one_id=pk)
 
     def setUp(self):
         self.client.force_login(self.superuser)
@@ -8832,7 +8834,7 @@ class AdminUserMessageTest(TestCase):
         message with the level has appeared in the response.
         """
         action_data = {
-            ACTION_CHECKBOX_NAME: [1],
+            ACTION_CHECKBOX_NAME: [connection.ops.get_hardcoded_pk(1)],
             "action": "message_%s" % level,
             "index": 0,
         }
@@ -8864,7 +8866,7 @@ class AdminUserMessageTest(TestCase):
 
     def test_message_extra_tags(self):
         action_data = {
-            ACTION_CHECKBOX_NAME: [1],
+            ACTION_CHECKBOX_NAME: [connection.ops.get_hardcoded_pk(1)],
             "action": "message_extra_tags",
             "index": 0,
         }

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -26,6 +26,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core import mail
 from django.core.checks import Error
 from django.core.files import temp as tempfile
+from django.db import connection
 from django.db.models.utils import get_blank_choice_label
 from django.forms.utils import ErrorList
 from django.template.response import TemplateResponse
@@ -4109,8 +4110,9 @@ class AdminViewDeletedObjectsTest(TestCase):
         cls.ssh1 = SuperSecretHideout.objects.create(
             location="super floating castle!", supervillain=cls.sv1
         )
-        cls.cy1 = CyclicOne.objects.create(pk=1, name="I am recursive", two_id=1)
-        cls.cy2 = CyclicTwo.objects.create(pk=1, name="I am recursive too", one_id=1)
+        pk = connection.ops.get_hardcoded_pk(1)
+        cls.cy1 = CyclicOne.objects.create(pk=pk, name="I am recursive", two_id=pk)
+        cls.cy2 = CyclicTwo.objects.create(pk=pk, name="I am recursive too", one_id=pk)
 
     def setUp(self):
         self.client.force_login(self.superuser)
@@ -8746,7 +8748,7 @@ class AdminUserMessageTest(TestCase):
         message with the level has appeared in the response.
         """
         action_data = {
-            ACTION_CHECKBOX_NAME: [1],
+            ACTION_CHECKBOX_NAME: [connection.ops.get_hardcoded_pk(1)],
             "action": "message_%s" % level,
             "index": 0,
         }
@@ -8778,7 +8780,7 @@ class AdminUserMessageTest(TestCase):
 
     def test_message_extra_tags(self):
         action_data = {
-            ACTION_CHECKBOX_NAME: [1],
+            ACTION_CHECKBOX_NAME: [connection.ops.get_hardcoded_pk(1)],
             "action": "message_extra_tags",
             "index": 0,
         }

--- a/tests/admin_widgets/models.py
+++ b/tests/admin_widgets/models.py
@@ -3,7 +3,7 @@ import uuid
 
 from django.contrib.auth.models import User
 from django.core.files.storage import FileSystemStorage
-from django.db import models
+from django.db import connection, models
 
 try:
     from PIL import Image
@@ -104,11 +104,15 @@ class Inventory(models.Model):
         return self.name
 
 
+def get_event_choices():
+    return models.Q(pk__gt=connection.ops.get_hardcoded_pk(0))
+
+
 class Event(models.Model):
     main_band = models.ForeignKey(
         Band,
         models.CASCADE,
-        limit_choices_to=models.Q(pk__gt=0),
+        limit_choices_to=get_event_choices,
         related_name="events_main_band_at",
     )
     supporting_bands = models.ManyToManyField(

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -2862,9 +2862,10 @@ class AggregateAnnotationPruningTests(TestCase):
         self.assertEqual(aggregates, {"count": 1})
 
     def test_aggregate_reference_lookup_rhs_iter(self):
+        zero = connection.ops.get_hardcoded_pk(0)
         aggregates = Author.objects.annotate(
             max_book_author=Max("book__authors"),
-        ).aggregate(count=Count("id", filter=Q(id__in=[F("max_book_author"), 0])))
+        ).aggregate(count=Count("id", filter=Q(id__in=[F("max_book_author"), zero])))
         self.assertEqual(aggregates, {"count": 1})
 
     @skipUnlessDBFeature("supports_select_union")

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -2889,9 +2889,10 @@ class AggregateAnnotationPruningTests(TestCase):
         self.assertEqual(aggregates, {"count": 1})
 
     def test_aggregate_reference_lookup_rhs_iter(self):
+        zero = connection.ops.get_hardcoded_pk(0)
         aggregates = Author.objects.annotate(
             max_book_author=Max("book__authors"),
-        ).aggregate(count=Count("id", filter=Q(id__in=[F("max_book_author"), 0])))
+        ).aggregate(count=Count("id", filter=Q(id__in=[F("max_book_author"), zero])))
         self.assertEqual(aggregates, {"count": 1})
 
     @skipUnlessDBFeature("supports_select_union")

--- a/tests/aggregation_regress/tests.py
+++ b/tests/aggregation_regress/tests.py
@@ -1475,7 +1475,8 @@ class AggregationTests(TestCase):
         qs = Book.objects.annotate(n=Count("pk"))
         self.assertIs(qs.query.alias_map["aggregation_regress_book"].join_type, None)
         # The query executes without problems.
-        self.assertEqual(len(qs.exclude(publisher=-1)), 6)
+        id_ = connection.ops.get_nonexistent_pk(-1)
+        self.assertEqual(len(qs.exclude(publisher=id_)), 6)
 
     @skipUnlessDBFeature("allows_group_by_selected_pks")
     def test_aggregate_duplicate_columns(self):

--- a/tests/async/test_async_queryset.py
+++ b/tests/async/test_async_queryset.py
@@ -230,7 +230,7 @@ class AsyncQuerySetTest(TestCase):
         self.assertIs(check, True)
         # Unsaved instances are not allowed, so use an ID known not to exist.
         check = await SimpleModel.objects.acontains(
-            SimpleModel(id=self.s3.id + 1, field=4)
+            SimpleModel(id=connection.ops.get_nonexistent_pk(self.s3.id), field=4)
         )
         self.assertIs(check, False)
 

--- a/tests/auth_tests/test_management.py
+++ b/tests/auth_tests/test_management.py
@@ -18,7 +18,7 @@ from django.contrib.auth.models import Group, Permission, User
 from django.contrib.contenttypes.models import ContentType
 from django.core.management import call_command
 from django.core.management.base import CommandError
-from django.db import migrations
+from django.db import connection, migrations
 from django.db.utils import IntegrityError
 from django.test import TestCase, override_settings
 from django.test.testcases import TransactionTestCase
@@ -673,7 +673,7 @@ class CreatesuperuserManagementCommandTestCase(TestCase):
     def test_validate_fk(self):
         email = Email.objects.create(email="mymail@gmail.com")
         Group.objects.all().delete()
-        nonexistent_group_id = 1
+        nonexistent_group_id = connection.ops.get_hardcoded_pk(1)
         msg = f"group instance with id {nonexistent_group_id!r} is not a valid choice."
 
         with self.assertRaisesMessage(CommandError, msg):
@@ -690,7 +690,7 @@ class CreatesuperuserManagementCommandTestCase(TestCase):
     def test_validate_fk_environment_variable(self):
         email = Email.objects.create(email="mymail@gmail.com")
         Group.objects.all().delete()
-        nonexistent_group_id = 1
+        nonexistent_group_id = connection.ops.get_hardcoded_pk(1)
         msg = f"group instance with id {nonexistent_group_id!r} is not a valid choice."
 
         with mock.patch.dict(
@@ -710,7 +710,7 @@ class CreatesuperuserManagementCommandTestCase(TestCase):
     def test_validate_fk_via_option_interactive(self):
         email = Email.objects.create(email="mymail@gmail.com")
         Group.objects.all().delete()
-        nonexistent_group_id = 1
+        nonexistent_group_id = connection.ops.get_hardcoded_pk(1)
         msg = f"group instance with id {nonexistent_group_id!r} is not a valid choice."
 
         @mock_inputs(

--- a/tests/auth_tests/test_views.py
+++ b/tests/auth_tests/test_views.py
@@ -1780,7 +1780,8 @@ class UUIDUserTests(TestCase):
             )
         self.assertRedirects(response, user_change_url)
         row = LogEntry.objects.latest("id")
-        self.assertEqual(row.user_id, 1)  # hardcoded in CustomUserAdmin.log_change()
+        # hardcoded in CustomUserAdmin.log_change()
+        self.assertEqual(row.user_id, connection.ops.get_hardcoded_pk(1))
         self.assertEqual(row.object_id, str(u.pk))
         self.assertEqual(row.get_change_message(), "Changed password.")
 

--- a/tests/auth_tests/urls_custom_user_admin.py
+++ b/tests/auth_tests/urls_custom_user_admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.contrib.auth.admin import UserAdmin
+from django.db import connection
 from django.urls import path
 
 site = admin.AdminSite(name="custom_user_admin")
@@ -11,7 +12,7 @@ class CustomUserAdmin(UserAdmin):
         # LogEntry.user column doesn't get altered to expect a UUID, so set an
         # integer manually to avoid causing an error.
         original_pk = request.user.pk
-        request.user.pk = 1
+        request.user.pk = connection.ops.get_hardcoded_pk(1)
         super().log_change(request, obj, message)
         request.user.pk = original_pk
 

--- a/tests/backends/tests.py
+++ b/tests/backends/tests.py
@@ -630,6 +630,7 @@ class FkConstraintsTests(TransactionTestCase):
     def setUp(self):
         # Create a Reporter.
         self.r = Reporter.objects.create(first_name="John", last_name="Smith")
+        self.invalid_reporter_id = connection.ops.get_hardcoded_pk(30)
 
     def test_integrity_checks_on_creation(self):
         """
@@ -639,7 +640,7 @@ class FkConstraintsTests(TransactionTestCase):
         a1 = Article(
             headline="This is a test",
             pub_date=datetime.datetime(2005, 7, 27),
-            reporter_id=30,
+            reporter_id=self.invalid_reporter_id,
         )
         try:
             a1.save()
@@ -653,7 +654,7 @@ class FkConstraintsTests(TransactionTestCase):
             headline="This is another test",
             reporter=self.r,
             pub_date=datetime.datetime(2012, 8, 3),
-            reporter_proxy_id=30,
+            reporter_proxy_id=self.invalid_reporter_id,
         )
         with self.assertRaises(IntegrityError):
             a2.save()
@@ -671,7 +672,7 @@ class FkConstraintsTests(TransactionTestCase):
         )
         # Retrieve it from the DB
         a1 = Article.objects.get(headline="Test article")
-        a1.reporter_id = 30
+        a1.reporter_id = self.invalid_reporter_id
         try:
             a1.save()
         except IntegrityError:
@@ -690,7 +691,7 @@ class FkConstraintsTests(TransactionTestCase):
         )
         # Retrieve the second article from the DB
         a2 = Article.objects.get(headline="Another article")
-        a2.reporter_proxy_id = 30
+        a2.reporter_proxy_id = self.invalid_reporter_id
         with self.assertRaises(IntegrityError):
             a2.save()
 
@@ -708,7 +709,7 @@ class FkConstraintsTests(TransactionTestCase):
             )
             # Retrieve it from the DB
             a = Article.objects.get(headline="Test article")
-            a.reporter_id = 30
+            a.reporter_id = self.invalid_reporter_id
             try:
                 connection.disable_constraint_checking()
                 a.save()
@@ -731,7 +732,7 @@ class FkConstraintsTests(TransactionTestCase):
             )
             # Retrieve it from the DB
             a = Article.objects.get(headline="Test article")
-            a.reporter_id = 30
+            a.reporter_id = self.invalid_reporter_id
             try:
                 with connection.constraint_checks_disabled():
                     a.save()
@@ -753,7 +754,7 @@ class FkConstraintsTests(TransactionTestCase):
             )
             # Retrieve it from the DB
             a = Article.objects.get(headline="Test article")
-            a.reporter_id = 30
+            a.reporter_id = self.invalid_reporter_id
             with connection.constraint_checks_disabled():
                 a.save()
                 try:
@@ -768,7 +769,7 @@ class FkConstraintsTests(TransactionTestCase):
         with transaction.atomic():
             obj = SQLKeywordsModel.objects.create(reporter=self.r)
             obj.refresh_from_db()
-            obj.reporter_id = 30
+            obj.reporter_id = self.invalid_reporter_id
             with connection.constraint_checks_disabled():
                 obj.save()
                 try:

--- a/tests/backends/tests.py
+++ b/tests/backends/tests.py
@@ -998,15 +998,17 @@ class DBConstraintTestCase(TestCase):
         self.assertEqual(ref.obj, obj)
 
     def test_can_reference_non_existent(self):
-        self.assertFalse(Object.objects.filter(id=12345).exists())
-        ref = ObjectReference.objects.create(obj_id=12345)
-        ref_new = ObjectReference.objects.get(obj_id=12345)
+        nonexistent_id = connection.ops.get_nonexistent_pk(12345)
+        self.assertFalse(Object.objects.filter(id=nonexistent_id).exists())
+        ref = ObjectReference.objects.create(obj_id=nonexistent_id)
+        ref_new = ObjectReference.objects.get(obj_id=nonexistent_id)
         self.assertEqual(ref, ref_new)
 
         with self.assertRaises(Object.DoesNotExist):
             ref.obj
 
     def test_many_to_many(self):
+        nonexistent_id = connection.ops.get_nonexistent_pk(12345)
         obj = Object.objects.create()
         obj.related_objects.create()
         self.assertEqual(Object.objects.count(), 2)
@@ -1015,6 +1017,8 @@ class DBConstraintTestCase(TestCase):
         intermediary_model = Object._meta.get_field(
             "related_objects"
         ).remote_field.through
-        intermediary_model.objects.create(from_object_id=obj.id, to_object_id=12345)
+        intermediary_model.objects.create(
+            from_object_id=obj.id, to_object_id=nonexistent_id
+        )
         self.assertEqual(obj.related_objects.count(), 1)
         self.assertEqual(intermediary_model.objects.count(), 2)

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -671,7 +671,7 @@ class ModelLookupTest(TestCase):
             ObjectDoesNotExist, "Article matching query does not exist."
         ):
             Article.objects.get(
-                id__exact=2000,
+                id__exact=connection.ops.get_nonexistent_pk(2000),
             )
         # To avoid dict-ordering related errors check only one lookup
         # in single assert.

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -220,8 +220,9 @@ class ModelInstanceCreationTests(TestCase):
         An auto field must be refreshed by Model.save() even when a value is
         set because the database may return a value of a different type.
         """
-        a = Article.objects.create(pk="123456", pub_date=datetime(2025, 9, 16))
-        self.assertEqual(a.pk, 123456)
+        pk = connection.ops.get_hardcoded_pk(123456)
+        a = Article.objects.create(pk=str(pk), pub_date=datetime(2025, 9, 16))
+        self.assertEqual(a.pk, pk)
 
 
 class ModelTest(TestCase):
@@ -273,13 +274,14 @@ class ModelTest(TestCase):
 
     def test_manually_specify_primary_key(self):
         # You can manually specify the primary key when creating a new object.
+        pk = connection.ops.get_hardcoded_pk(101)
         a101 = Article(
-            id=101,
+            id=pk,
             headline="Article 101",
             pub_date=datetime(2005, 7, 31, 12, 30, 45),
         )
         a101.save()
-        a101 = Article.objects.get(pk=101)
+        a101 = Article.objects.get(pk=pk)
         self.assertEqual(a101.headline, "Article 101")
 
     def test_create_method(self):

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -224,8 +224,9 @@ class ModelInstanceCreationTests(TestCase):
         An auto field must be refreshed by Model.save() even when a value is
         set because the database may return a value of a different type.
         """
-        a = Article.objects.create(pk="123456", pub_date=datetime(2025, 9, 16))
-        self.assertEqual(a.pk, 123456)
+        pk = connection.ops.get_hardcoded_pk(123456)
+        a = Article.objects.create(pk=str(pk), pub_date=datetime(2025, 9, 16))
+        self.assertEqual(a.pk, pk)
 
 
 class ModelTest(TestCase):
@@ -277,13 +278,14 @@ class ModelTest(TestCase):
 
     def test_manually_specify_primary_key(self):
         # You can manually specify the primary key when creating a new object.
+        pk = connection.ops.get_hardcoded_pk(101)
         a101 = Article(
-            id=101,
+            id=pk,
             headline="Article 101",
             pub_date=datetime(2005, 7, 31, 12, 30, 45),
         )
         a101.save()
-        a101 = Article.objects.get(pk=101)
+        a101 = Article.objects.get(pk=pk)
         self.assertEqual(a101.headline, "Article 101")
 
     def test_create_method(self):

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -675,7 +675,7 @@ class ModelLookupTest(TestCase):
             ObjectDoesNotExist, "Article matching query does not exist."
         ):
             Article.objects.get(
-                id__exact=2000,
+                id__exact=connection.ops.get_nonexistent_pk(2000),
             )
         # To avoid dict-ordering related errors check only one lookup
         # in single assert.

--- a/tests/bulk_create/tests.py
+++ b/tests/bulk_create/tests.py
@@ -228,16 +228,17 @@ class BulkCreateTests(TestCase):
         Test inserting a large batch with objects having primary key set
         mixed together with objects without PK set.
         """
+        pk = connection.ops.get_hardcoded_pk
         TwoFields.objects.bulk_create(
             [
-                TwoFields(id=i if i % 2 == 0 else None, f1=i, f2=i + 1)
+                TwoFields(id=pk(i) if i % 2 == 0 else None, f1=i, f2=i + 1)
                 for i in range(100000, 101000)
             ]
         )
         self.assertEqual(TwoFields.objects.count(), 1000)
         # We can't assume much about the ID's created, except that the above
         # created IDs must exist.
-        id_range = range(100000, 101000, 2)
+        id_range = [pk(i) for i in range(100000, 101000, 2)]
         self.assertEqual(TwoFields.objects.filter(id__in=id_range).count(), 500)
         self.assertEqual(TwoFields.objects.exclude(id__in=id_range).count(), 500)
 
@@ -247,10 +248,11 @@ class BulkCreateTests(TestCase):
         Test inserting a large batch with objects having primary key set
         mixed together with objects without PK set.
         """
+        pk = connection.ops.get_hardcoded_pk
         with CaptureQueriesContext(connection) as ctx:
             TwoFields.objects.bulk_create(
                 [
-                    TwoFields(id=i if i % 2 == 0 else None, f1=i, f2=i + 1)
+                    TwoFields(id=pk(i) if i % 2 == 0 else None, f1=i, f2=i + 1)
                     for i in range(100000, 101000)
                 ]
             )

--- a/tests/db_functions/comparison/test_coalesce.py
+++ b/tests/db_functions/comparison/test_coalesce.py
@@ -1,3 +1,4 @@
+from django.db import connection
 from django.db.models import Subquery, TextField
 from django.db.models.functions import Coalesce, Lower
 from django.test import TestCase
@@ -65,11 +66,15 @@ class CoalesceTests(TestCase):
     def test_empty_queryset(self):
         Author.objects.create(name="John Smith")
         queryset = Author.objects.values("id")
+        zero = connection.ops.get_hardcoded_pk(0)
         tests = [
             (queryset.none(), "QuerySet.none()"),
-            (queryset.filter(id=0), "QuerySet.filter(id=0)"),
+            (queryset.filter(id=zero), f"QuerySet.filter(id={zero})"),
             (Subquery(queryset.none()), "Subquery(QuerySet.none())"),
-            (Subquery(queryset.filter(id=0)), "Subquery(Queryset.filter(id=0)"),
+            (
+                Subquery(queryset.filter(id=zero)),
+                f"Subquery(Queryset.filter(id={zero})",
+            ),
         ]
         for empty_query, description in tests:
             with self.subTest(description), self.assertNumQueries(1):

--- a/tests/delete_regress/models.py
+++ b/tests/delete_regress/models.py
@@ -1,6 +1,6 @@
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.contrib.contenttypes.models import ContentType
-from django.db import models
+from django.db import connection, models
 
 
 class Award(models.Model):
@@ -87,11 +87,18 @@ class Location(models.Model):
     version = models.ForeignKey(Version, models.SET_NULL, blank=True, null=True)
 
 
+pk = connection.ops.get_hardcoded_pk
+
+
 class Item(models.Model):
     version = models.ForeignKey(Version, models.CASCADE)
     location = models.ForeignKey(Location, models.SET_NULL, blank=True, null=True)
     location_value = models.ForeignKey(
-        Location, models.SET(42), default=1, db_constraint=False, related_name="+"
+        Location,
+        models.SET(pk(42)),
+        default=pk(1),
+        db_constraint=False,
+        related_name="+",
     )
 
 

--- a/tests/expressions_case/tests.py
+++ b/tests/expressions_case/tests.py
@@ -465,8 +465,9 @@ class CaseExpressionTests(TestCase):
         self.assertIs(qs.get(integer=1).test, True)
 
     def test_case_reuse(self):
+        pk = connection.ops.get_hardcoded_pk
         SOME_CASE = Case(
-            When(pk=0, then=Value("0")),
+            When(pk=pk(0), then=Value("0")),
             default=Value("1"),
         )
         self.assertQuerySetEqual(
@@ -1357,10 +1358,11 @@ class CaseExpressionTests(TestCase):
         #    would remove o from the results. So, in effect we are testing that
         #    we are promoting the fk_rel join to a left outer join here.
         # 2. The default value of 3 is generated for the case expression.
+        pk = connection.ops.get_hardcoded_pk
         self.assertQuerySetEqual(
             CaseTestModel.objects.filter(pk=o.pk).annotate(
                 foo=Case(
-                    When(fk_rel__pk=1, then=2),
+                    When(fk_rel__pk=pk(1), then=2),
                     default=3,
                 ),
             ),
@@ -1387,14 +1389,15 @@ class CaseExpressionTests(TestCase):
         #    would remove o from the results. So, in effect we are testing that
         #    we are promoting the fk_rel join to a left outer join here.
         # 2. The default value of 3 is generated for the case expression.
+        pk = connection.ops.get_hardcoded_pk
         self.assertQuerySetEqual(
             CaseTestModel.objects.filter(pk=o.pk).annotate(
                 foo=Case(
-                    When(fk_rel__pk=1, then=2),
+                    When(fk_rel__pk=pk(1), then=2),
                     default=3,
                 ),
                 bar=Case(
-                    When(fk_rel__pk=1, then=4),
+                    When(fk_rel__pk=pk(1), then=4),
                     default=5,
                 ),
             ),

--- a/tests/filtered_relation/tests.py
+++ b/tests/filtered_relation/tests.py
@@ -107,9 +107,10 @@ class FilteredRelationTests(TestCase):
         )
 
     def test_select_related_with_empty_relation(self):
+        nonexistent_pk = connection.ops.get_nonexistent_pk(-1)
         qs = (
             Author.objects.annotate(
-                book_join=FilteredRelation("book", condition=Q(pk=-1)),
+                book_join=FilteredRelation("book", condition=Q(pk=nonexistent_pk)),
             )
             .select_related("book_join")
             .order_by("pk")

--- a/tests/force_insert_update/tests.py
+++ b/tests/force_insert_update/tests.py
@@ -1,5 +1,5 @@
 from django.core.exceptions import ObjectNotUpdated
-from django.db import DatabaseError, IntegrityError, models, transaction
+from django.db import DatabaseError, IntegrityError, connection, models, transaction
 from django.test import TestCase
 
 from .models import (
@@ -109,8 +109,9 @@ class ForceInsertInheritanceTests(TestCase):
             Counter().save(force_insert=(SubCounter,))
 
     def test_force_insert_false(self):
+        pk = connection.ops.get_hardcoded_pk
         with self.assertNumQueries(3):
-            obj = SubCounter.objects.create(pk=1, value=0)
+            obj = SubCounter.objects.create(pk=pk(1), value=0)
         with self.assertNumQueries(2):
             SubCounter(pk=obj.pk, value=1).save()
         obj.refresh_from_db()
@@ -130,25 +131,27 @@ class ForceInsertInheritanceTests(TestCase):
             SubCounter.objects.create(pk=parent.pk, value=2)
 
     def test_force_insert_parent(self):
+        pk = connection.ops.get_hardcoded_pk
         with self.assertNumQueries(3):
-            SubCounter(pk=1, value=1).save(force_insert=True)
+            SubCounter(pk=pk(1), value=1).save(force_insert=True)
         # Force insert a new parent and don't UPDATE first.
         with self.assertNumQueries(2):
-            SubCounter(pk=2, value=1).save(force_insert=(Counter,))
+            SubCounter(pk=pk(2), value=1).save(force_insert=(Counter,))
         with self.assertNumQueries(2):
-            SubCounter(pk=3, value=1).save(force_insert=(models.Model,))
+            SubCounter(pk=pk(3), value=1).save(force_insert=(models.Model,))
 
     def test_force_insert_with_grandparent(self):
+        pk = connection.ops.get_hardcoded_pk
         with self.assertNumQueries(4):
-            SubSubCounter(pk=1, value=1).save(force_insert=True)
+            SubSubCounter(pk=pk(1), value=1).save(force_insert=True)
         # Force insert parents on all levels and don't UPDATE first.
         with self.assertNumQueries(3):
-            SubSubCounter(pk=2, value=1).save(force_insert=(models.Model,))
+            SubSubCounter(pk=pk(2), value=1).save(force_insert=(models.Model,))
         with self.assertNumQueries(3):
-            SubSubCounter(pk=3, value=1).save(force_insert=(Counter,))
+            SubSubCounter(pk=pk(3), value=1).save(force_insert=(Counter,))
         # Force insert only the last parent.
         with self.assertNumQueries(4):
-            SubSubCounter(pk=4, value=1).save(force_insert=(SubCounter,))
+            SubSubCounter(pk=pk(4), value=1).save(force_insert=(SubCounter,))
 
     def test_force_insert_with_existing_grandparent(self):
         # Force insert only the last child.
@@ -165,25 +168,26 @@ class ForceInsertInheritanceTests(TestCase):
             SubSubCounter(pk=grandparent.pk, value=1).save(force_insert=(Counter,))
 
     def test_force_insert_diamond_mti(self):
+        pk = connection.ops.get_hardcoded_pk
         # Force insert all parents.
         with self.assertNumQueries(4):
-            DiamondSubSubCounter(pk=1, value=1).save(
+            DiamondSubSubCounter(pk=pk(1), value=1).save(
                 force_insert=(Counter, SubCounter, OtherSubCounter)
             )
         with self.assertNumQueries(4):
-            DiamondSubSubCounter(pk=2, value=1).save(force_insert=(models.Model,))
+            DiamondSubSubCounter(pk=pk(2), value=1).save(force_insert=(models.Model,))
         # Force insert parents, and don't force insert a common grandparent.
         with self.assertNumQueries(5):
-            DiamondSubSubCounter(pk=3, value=1).save(
+            DiamondSubSubCounter(pk=pk(3), value=1).save(
                 force_insert=(SubCounter, OtherSubCounter)
             )
-        grandparent = Counter.objects.create(pk=4, value=1)
+        grandparent = Counter.objects.create(pk=pk(4), value=1)
         with self.assertNumQueries(4):
             DiamondSubSubCounter(pk=grandparent.pk, value=1).save(
                 force_insert=(SubCounter, OtherSubCounter),
             )
         # Force insert all parents, grandparent conflicts.
-        grandparent = Counter.objects.create(pk=5, value=1)
+        grandparent = Counter.objects.create(pk=pk(5), value=1)
         with self.assertRaises(IntegrityError), transaction.atomic():
             DiamondSubSubCounter(pk=grandparent.pk, value=1).save(
                 force_insert=(models.Model,)

--- a/tests/forms_tests/models.py
+++ b/tests/forms_tests/models.py
@@ -3,7 +3,7 @@ import itertools
 import tempfile
 
 from django.core.files.storage import FileSystemStorage
-from django.db import models
+from django.db import connection, models
 
 callable_default_counter = itertools.count()
 
@@ -80,11 +80,11 @@ def choice_default_list():
 
 
 def int_default():
-    return 1
+    return connection.ops.get_hardcoded_pk(1)
 
 
 def int_list_default():
-    return [1]
+    return [connection.ops.get_hardcoded_pk(1)]
 
 
 class ChoiceFieldModel(models.Model):

--- a/tests/forms_tests/tests/test_error_messages.py
+++ b/tests/forms_tests/tests/test_error_messages.py
@@ -1,5 +1,6 @@
 from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.db import connection
 from django.forms import (
     BooleanField,
     CharField,
@@ -310,9 +311,10 @@ class FormsErrorMessagesTestCase(SimpleTestCase, AssertFormErrorsMixin):
 class ModelChoiceFieldErrorMessagesTestCase(TestCase, AssertFormErrorsMixin):
     def test_modelchoicefield(self):
         # Create choices for the model choice field tests below.
-        ChoiceModel.objects.create(pk=1, name="a")
-        ChoiceModel.objects.create(pk=2, name="b")
-        ChoiceModel.objects.create(pk=3, name="c")
+        ChoiceModel.objects.create(name="a")
+        ChoiceModel.objects.create(name="b")
+        choice3 = ChoiceModel.objects.create(name="c")
+        nonexistent_pk = connection.ops.get_nonexistent_pk(choice3.pk)
 
         # ModelChoiceField
         e = {
@@ -321,7 +323,7 @@ class ModelChoiceFieldErrorMessagesTestCase(TestCase, AssertFormErrorsMixin):
         }
         f = ModelChoiceField(queryset=ChoiceModel.objects.all(), error_messages=e)
         self.assertFormErrors(["REQUIRED"], f.clean, "")
-        self.assertFormErrors(["INVALID CHOICE"], f.clean, "4")
+        self.assertFormErrors(["INVALID CHOICE"], f.clean, str(nonexistent_pk))
 
         # ModelMultipleChoiceField
         e = {
@@ -333,8 +335,12 @@ class ModelChoiceFieldErrorMessagesTestCase(TestCase, AssertFormErrorsMixin):
             queryset=ChoiceModel.objects.all(), error_messages=e
         )
         self.assertFormErrors(["REQUIRED"], f.clean, "")
-        self.assertFormErrors(["NOT A LIST OF VALUES"], f.clean, "3")
-        self.assertFormErrors(["4 IS INVALID CHOICE"], f.clean, ["4"])
+        self.assertFormErrors(["NOT A LIST OF VALUES"], f.clean, str(choice3.pk))
+        self.assertFormErrors(
+            [f"{nonexistent_pk} IS INVALID CHOICE"],
+            f.clean,
+            [str(nonexistent_pk)],
+        )
 
     def test_modelchoicefield_value_placeholder(self):
         f = ModelChoiceField(

--- a/tests/forms_tests/tests/tests.py
+++ b/tests/forms_tests/tests/tests.py
@@ -1,7 +1,7 @@
 import datetime
 
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.db import models
+from django.db import connection, models
 from django.forms import CharField, FileField, Form, ModelForm
 from django.forms.models import ModelFormMetaclass
 from django.test import SimpleTestCase, TestCase, skipUnlessDBFeature
@@ -101,9 +101,10 @@ class ModelFormCallableModelDefault(TestCase):
         The initial value for a callable default returning a queryset is the
         pk.
         """
-        obj1 = ChoiceOptionModel.objects.create(id=1, name="default")
-        obj2 = ChoiceOptionModel.objects.create(id=2, name="option 2")
-        obj3 = ChoiceOptionModel.objects.create(id=3, name="option 3")
+        pk = connection.ops.get_hardcoded_pk
+        obj1 = ChoiceOptionModel.objects.create(id=pk(1), name="default")
+        obj2 = ChoiceOptionModel.objects.create(id=pk(2), name="option 2")
+        obj3 = ChoiceOptionModel.objects.create(id=pk(3), name="option 3")
         self.assertHTMLEqual(
             ChoiceFieldForm().as_p(),
             f"""

--- a/tests/generic_relations_regress/tests.py
+++ b/tests/generic_relations_regress/tests.py
@@ -1,4 +1,5 @@
 from django.contrib.contenttypes.models import ContentType
+from django.db import connection
 from django.db.models import ProtectedError, Q, Sum
 from django.forms.models import modelform_factory
 from django.test import TestCase, skipIfDBFeature
@@ -271,9 +272,10 @@ class GenericRelationTests(TestCase):
     def test_filter_targets_related_pk(self):
         # Use hardcoded PKs to ensure different PKs for "link" and "hs2"
         # objects.
-        HasLinkThing.objects.create(pk=1)
-        hs2 = HasLinkThing.objects.create(pk=2)
-        link = Link.objects.create(content_object=hs2, pk=1)
+        pk = connection.ops.get_hardcoded_pk
+        HasLinkThing.objects.create(pk=pk(1))
+        hs2 = HasLinkThing.objects.create(pk=pk(2))
+        link = Link.objects.create(content_object=hs2, pk=pk(1))
         self.assertNotEqual(link.object_id, link.pk)
         self.assertSequenceEqual(HasLinkThing.objects.filter(links=link.pk), [hs2])
 

--- a/tests/generic_views/test_dates.py
+++ b/tests/generic_views/test_dates.py
@@ -885,8 +885,9 @@ class DateDetailViewTests(TestDataMixin, TestCase):
         self.assertEqual(res.context["book"], self.book2)
         self.assertTemplateUsed(res, "generic_views/book_detail.html")
 
+        nonexistent_pk = connection.ops.get_nonexistent_pk(9999998)
         res = self.client.get(
-            "/dates/books/get_object_custom_queryset/2008/oct/01/9999999/"
+            f"/dates/books/get_object_custom_queryset/2008/oct/01/{nonexistent_pk}/"
         )
         self.assertEqual(res.status_code, 404)
 

--- a/tests/generic_views/test_dates.py
+++ b/tests/generic_views/test_dates.py
@@ -2,6 +2,7 @@ import datetime
 from unittest import mock
 
 from django.core.exceptions import ImproperlyConfigured
+from django.db import connection
 from django.test import TestCase, override_settings, skipUnlessDBFeature
 from django.test.utils import requires_tz_support
 
@@ -890,8 +891,11 @@ class DateDetailViewTests(TestDataMixin, TestCase):
         self.assertEqual(res.status_code, 404)
 
     def test_get_object_custom_queryset_numqueries(self):
+        id_ = connection.ops.get_hardcoded_pk(2)
         with self.assertNumQueries(1):
-            self.client.get("/dates/books/get_object_custom_queryset/2006/may/01/2/")
+            self.client.get(
+                f"/dates/books/get_object_custom_queryset/2006/may/01/{id_}/"
+            )
 
     def test_datetime_date_detail(self):
         bs = BookSigning.objects.create(event_date=datetime.datetime(2008, 4, 2, 12, 0))

--- a/tests/generic_views/test_detail.py
+++ b/tests/generic_views/test_detail.py
@@ -1,6 +1,7 @@
 import datetime
 
 from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist
+from django.db import connection
 from django.test import TestCase, override_settings
 from django.test.client import RequestFactory
 from django.views.generic.base import View
@@ -51,12 +52,14 @@ class DetailViewTest(TestCase):
         self.assertTemplateUsed(res, "generic_views/author_detail.html")
 
     def test_detail_missing_object(self):
-        res = self.client.get("/detail/author/500/")
+        id_ = connection.ops.get_nonexistent_pk(500)
+        res = self.client.get(f"/detail/author/{id_}/")
         self.assertEqual(res.status_code, 404)
 
     def test_detail_object_does_not_exist(self):
+        id_ = connection.ops.get_nonexistent_pk(500)
         with self.assertRaises(ObjectDoesNotExist):
-            self.client.get("/detail/doesnotexist/1/")
+            self.client.get(f"/detail/doesnotexist/{id_}/")
 
     def test_detail_by_custom_pk(self):
         res = self.client.get("/detail/author/bycustompk/%s/" % self.author1.pk)

--- a/tests/generic_views/test_edit.py
+++ b/tests/generic_views/test_edit.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.core.exceptions import ImproperlyConfigured
+from django.db import connection
 from django.test import SimpleTestCase, TestCase, override_settings
 from django.test.client import RequestFactory
 from django.urls import reverse
@@ -239,7 +240,7 @@ class UpdateViewTests(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.author = Author.objects.create(
-            pk=1,  # Required for OneAuthorUpdate.
+            pk=connection.ops.get_hardcoded_pk(1),  # Required for OneAuthorUpdate.
             name="Randall Munroe",
             slug="randall-munroe",
         )

--- a/tests/generic_views/views.py
+++ b/tests/generic_views/views.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.decorators import login_required
 from django.core.paginator import Paginator
+from django.db import connection
 from django.urls import reverse, reverse_lazy
 from django.utils.decorators import method_decorator
 from django.views import generic
@@ -169,7 +170,7 @@ class OneAuthorUpdate(generic.UpdateView):
     fields = "__all__"
 
     def get_object(self):
-        return Author.objects.get(pk=1)
+        return Author.objects.get(pk=connection.ops.get_hardcoded_pk(1))
 
 
 class SpecializedAuthorUpdate(generic.UpdateView):

--- a/tests/get_or_create/tests.py
+++ b/tests/get_or_create/tests.py
@@ -80,12 +80,13 @@ class GetOrCreateTests(TestCase):
         """
         Using the pk property of a model is allowed.
         """
-        Thing.objects.get_or_create(pk=1)
+        Thing.objects.get_or_create(pk=connection.ops.get_hardcoded_pk(1))
 
     def test_get_or_create_with_model_property_defaults(self):
         """Using a property with a setter implemented is allowed."""
         t, _ = Thing.objects.get_or_create(
-            defaults={"capitalized_name_property": "annie"}, pk=1
+            defaults={"capitalized_name_property": "annie"},
+            pk=connection.ops.get_hardcoded_pk(1),
         )
         self.assertEqual(t.name, "Annie")
 
@@ -259,8 +260,9 @@ class GetOrCreateTransactionTests(TransactionTestCase):
         databases that delay integrity checks until the end of transactions,
         otherwise the exception is never raised.
         """
+        pk = connection.ops.get_hardcoded_pk
         try:
-            Profile.objects.get_or_create(person=Person(id=1))
+            Profile.objects.get_or_create(person=Person(id=pk(1)))
         except IntegrityError:
             pass
         else:
@@ -360,12 +362,13 @@ class UpdateOrCreateTests(TestCase):
         """
         Using the pk property of a model is allowed.
         """
-        Thing.objects.update_or_create(pk=1)
+        Thing.objects.update_or_create(pk=connection.ops.get_hardcoded_pk(1))
 
     def test_update_or_create_with_model_property_defaults(self):
         """Using a property with a setter implemented is allowed."""
         t, _ = Thing.objects.update_or_create(
-            defaults={"capitalized_name_property": "annie"}, pk=1
+            defaults={"capitalized_name_property": "annie"},
+            pk=connection.ops.get_hardcoded_pk(1),
         )
         self.assertEqual(t.name, "Annie")
 

--- a/tests/gis_tests/relatedapp/tests.py
+++ b/tests/gis_tests/relatedapp/tests.py
@@ -234,9 +234,10 @@ class RelatedGeoModelTest(TestCase):
         city_ids = (1, 2, 3, 4, 5)
         loc_ids = (1, 2, 3, 5, 4)
         ids_qs = City.objects.order_by("id").values("id", "location__id")
+        pk = connection.ops.get_hardcoded_pk
         for val_dict, c_id, l_id in zip(ids_qs, city_ids, loc_ids):
-            self.assertEqual(val_dict["id"], c_id)
-            self.assertEqual(val_dict["location__id"], l_id)
+            self.assertEqual(val_dict["id"], pk(c_id))
+            self.assertEqual(val_dict["location__id"], pk(l_id))
 
     @skipUnlessGISLookup("within")
     def test10_combine(self):
@@ -283,7 +284,7 @@ class RelatedGeoModelTest(TestCase):
     def test13c_count(self):
         "Testing `Count` aggregate with `.values()`. See #15305."
         qs = (
-            Location.objects.filter(id=5)
+            Location.objects.filter(id=connection.ops.get_hardcoded_pk(5))
             .annotate(num_cities=Count("city"))
             .values("id", "point", "num_cities")
         )

--- a/tests/indexes/tests.py
+++ b/tests/indexes/tests.py
@@ -418,7 +418,7 @@ class PartialIndexTests(TransactionTestCase):
             index = Index(
                 name="recent_article_idx",
                 fields=["id"],
-                condition=Q(pk__gt=1),
+                condition=Q(pk__gt=connection.ops.get_hardcoded_pk(1)),
             )
             self.assertIn(
                 "WHERE %s" % editor.quote_name("id"),

--- a/tests/inline_formsets/tests.py
+++ b/tests/inline_formsets/tests.py
@@ -1,3 +1,4 @@
+from django.db import connection
 from django.forms.models import ModelForm, inlineformset_factory
 from django.test import TestCase, skipUnlessDBFeature
 
@@ -174,7 +175,7 @@ class InlineFormsetFactoryTest(TestCase):
     @skipUnlessDBFeature("allows_auto_pk_0")
     def test_zero_primary_key(self):
         # Regression test for #21472
-        poet = Poet.objects.create(id=0, name="test")
+        poet = Poet.objects.create(id=connection.ops.get_hardcoded_pk(0), name="test")
         poet.poem_set.create(name="test poem")
         PoemFormSet = inlineformset_factory(Poet, Poem, fields="__all__", extra=0)
         formset = PoemFormSet(None, instance=poet)

--- a/tests/inline_formsets/tests.py
+++ b/tests/inline_formsets/tests.py
@@ -1,3 +1,4 @@
+from django.db import connection
 from django.forms.models import ModelForm, inlineformset_factory
 from django.test import TestCase, skipUnlessDBFeature
 
@@ -176,7 +177,7 @@ class InlineFormsetFactoryTest(TestCase):
     @skipUnlessDBFeature("allows_auto_pk_0")
     def test_zero_primary_key(self):
         # Regression test for #21472
-        poet = Poet.objects.create(id=0, name="test")
+        poet = Poet.objects.create(id=connection.ops.get_hardcoded_pk(0), name="test")
         poet.poem_set.create(name="test poem")
         PoemFormSet = inlineformset_factory(Poet, Poem, fields="__all__", extra=0)
         formset = PoemFormSet(None, instance=poet)

--- a/tests/lookup/tests.py
+++ b/tests/lookup/tests.py
@@ -199,7 +199,9 @@ class LookupTests(TestCase):
             Article.objects.in_bulk(frozenset([self.a3.id])), {self.a3.id: self.a3}
         )
         self.assertEqual(Article.objects.in_bulk((self.a3.id,)), {self.a3.id: self.a3})
-        self.assertEqual(Article.objects.in_bulk([1000]), {})
+        self.assertEqual(
+            Article.objects.in_bulk([connection.ops.get_nonexistent_pk(1000)]), {}
+        )
         self.assertEqual(Article.objects.in_bulk([]), {})
         self.assertEqual(
             Article.objects.in_bulk(iter([self.a1.id])), {self.a1.id: self.a1}

--- a/tests/model_fields/models.py
+++ b/tests/model_fields/models.py
@@ -36,7 +36,7 @@ class Foo(models.Model):
 
 
 def get_foo():
-    return Foo.objects.get(id=1).pk
+    return Foo.objects.get(id=connection.ops.get_hardcoded_pk(1)).pk
 
 
 class Bar(models.Model):

--- a/tests/model_fields/models.py
+++ b/tests/model_fields/models.py
@@ -43,7 +43,7 @@ class DecimalWithoutPrecision(models.Model):
 
 
 def get_foo():
-    return Foo.objects.get(id=1).pk
+    return Foo.objects.get(id=connection.ops.get_hardcoded_pk(1)).pk
 
 
 class Bar(models.Model):

--- a/tests/model_fields/test_foreignkey.py
+++ b/tests/model_fields/test_foreignkey.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 from django.apps import apps
 from django.core import checks
 from django.core.exceptions import FieldError
-from django.db import models
+from django.db import connection, models
 from django.test import TestCase, skipIfDBFeature
 from django.test.utils import isolate_apps
 
@@ -13,7 +13,8 @@ from .models import Bar, FkToChar, Foo, PrimaryKeyCharModel
 class ForeignKeyTests(TestCase):
     def test_callable_default(self):
         """A lazy callable may be used for ForeignKey.default."""
-        a = Foo.objects.create(id=1, a="abc", d=Decimal("12.34"))
+        pk = connection.ops.get_hardcoded_pk
+        a = Foo.objects.create(id=pk(1), a="abc", d=Decimal("12.34"))
         b = Bar.objects.create(b="bcd")
         self.assertEqual(b.a, a)
 

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -2173,19 +2173,17 @@ class ModelMultipleChoiceFieldTests(TestCase):
 
         # Add a Category object *after* the ModelMultipleChoiceField has
         # already been instantiated. This proves clean() checks the database
-        # during clean() rather than caching it at time of instantiation. Note,
-        # we are using an id of 1006 here since tests that run before this may
-        # create categories with primary keys up to 6. Use a number that will
-        # not conflict.
-        c6 = Category.objects.create(id=1006, name="Sixth", url="6th")
-        self.assertCountEqual(f.clean([c6.id]), [c6])
+        # during clean() rather than caching it at time of instantiation.
+        pk = connection.ops.get_nonexistent_pk(self.c3.pk)
+        c4 = Category.objects.create(id=pk, name="Fourth", url="4th")
+        self.assertCountEqual(f.clean([c4.id]), [c4])
 
         # Delete a Category object *after* the ModelMultipleChoiceField has
         # already been instantiated. This proves clean() checks the database
         # during clean() rather than caching it at time of instantiation.
-        Category.objects.get(url="6th").delete()
+        Category.objects.get(url="4th").delete()
         with self.assertRaises(ValidationError):
-            f.clean([c6.id])
+            f.clean([c4.id])
 
     def test_model_multiple_choice_required_false(self):
         f = forms.ModelMultipleChoiceField(Category.objects.all(), required=False)

--- a/tests/model_formsets/tests.py
+++ b/tests/model_formsets/tests.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 
 from django import forms
 from django.core.exceptions import ImproperlyConfigured
-from django.db import models
+from django.db import connection, models
 from django.forms.formsets import formset_factory
 from django.forms.models import (
     BaseModelFormSet,
@@ -136,6 +136,7 @@ class DeletionTests(TestCase):
         PoemFormSet = inlineformset_factory(
             Poet, Poem, fields="__all__", can_delete=True
         )
+        nonexistent_pk = connection.ops.get_nonexistent_pk(poem.pk)
 
         # Simulate deletion of an object that doesn't exist in the database
         data = {
@@ -143,13 +144,13 @@ class DeletionTests(TestCase):
             "form-INITIAL_FORMS": "2",
             "form-0-id": str(poem.pk),
             "form-0-name": "foo",
-            "form-1-id": str(poem.pk + 1),  # doesn't exist
+            "form-1-id": str(nonexistent_pk),
             "form-1-name": "bar",
             "form-1-DELETE": "on",
         }
         formset = PoemFormSet(data, instance=poet, prefix="form")
 
-        # The formset is valid even though poem.pk + 1 doesn't exist,
+        # The formset is valid even though the id in form 1 doesn't exist,
         # because it's marked for deletion anyway
         self.assertTrue(formset.is_valid())
 
@@ -158,7 +159,7 @@ class DeletionTests(TestCase):
         # Make sure the save went through correctly
         self.assertEqual(Poem.objects.get(pk=poem.pk).name, "foo")
         self.assertEqual(poet.poem_set.count(), 1)
-        self.assertFalse(Poem.objects.filter(pk=poem.pk + 1).exists())
+        self.assertFalse(Poem.objects.filter(pk=nonexistent_pk).exists())
 
 
 class ModelFormsetTest(TestCase):

--- a/tests/model_formsets_regress/tests.py
+++ b/tests/model_formsets_regress/tests.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.db import connection
 from django.forms.formsets import DELETION_FIELD_NAME, BaseFormSet
 from django.forms.models import (
     BaseModelFormSet,
@@ -201,15 +202,16 @@ class InlineFormsetTests(TestCase):
         """
         FormSet = inlineformset_factory(UserProfile, ProfileNetwork, exclude=[])
 
-        user = User.objects.create(username="guido", serial=1337, pk=1)
-        self.assertEqual(user.pk, 1)
-        profile = UserProfile.objects.create(user=user, about="about", pk=2)
-        self.assertEqual(profile.pk, 2)
+        user = User.objects.create(username="guido", serial=1337)
+        profile = UserProfile.objects.create(
+            user=user, about="about", pk=connection.ops.get_nonexistent_pk(user.pk)
+        )
+        self.assertNotEqual(user.pk, profile.pk)
         ProfileNetwork.objects.create(profile=profile, network=10, identifier=10)
         formset = FormSet(instance=profile)
 
         # Testing the inline model's relation
-        self.assertEqual(formset[0].instance.profile_id, 1)
+        self.assertEqual(formset[0].instance.profile_id, user.pk)
 
     def test_formset_with_none_instance(self):
         "A formset with instance=None can be created. Regression for #11872"

--- a/tests/model_inheritance/tests.py
+++ b/tests/model_inheritance/tests.py
@@ -451,7 +451,7 @@ class ModelInheritanceDataTests(TestCase):
 
     def test_inherited_not_updated_exception(self):
         # NotUpdated is also inherited.
-        obj = Restaurant(id=999)
+        obj = Restaurant(id=connection.ops.get_nonexistent_pk(999))
         with self.assertRaises(Place.NotUpdated):
             obj.save(update_fields={"name"})
 

--- a/tests/model_inheritance_regress/tests.py
+++ b/tests/model_inheritance_regress/tests.py
@@ -7,6 +7,7 @@ from operator import attrgetter
 from unittest import expectedFailure
 
 from django import forms
+from django.db import connection
 from django.db.models import FETCH_PEERS
 from django.test import TestCase
 from django.test.utils import ignore_warnings
@@ -439,11 +440,16 @@ class ModelInheritanceTest(TestCase):
 
     def test_inherited_nullable_exclude(self):
         obj = SelfRefChild.objects.create(child_data=37, parent_data=42)
+        nonexistent_pk = connection.ops.get_nonexistent_pk(72)
         self.assertQuerySetEqual(
-            SelfRefParent.objects.exclude(self_data=72), [obj.pk], attrgetter("pk")
+            SelfRefParent.objects.exclude(self_data=nonexistent_pk),
+            [obj.pk],
+            attrgetter("pk"),
         )
         self.assertQuerySetEqual(
-            SelfRefChild.objects.exclude(self_data=72), [obj.pk], attrgetter("pk")
+            SelfRefChild.objects.exclude(self_data=nonexistent_pk),
+            [obj.pk],
+            attrgetter("pk"),
         )
 
     def test_concrete_abstract_concrete_pk(self):

--- a/tests/multiple_database/tests.py
+++ b/tests/multiple_database/tests.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.core import management
-from django.db import DEFAULT_DB_ALIAS, router, transaction
+from django.db import DEFAULT_DB_ALIAS, connection, router, transaction
 from django.db.models import signals
 from django.db.utils import ConnectionRouter
 from django.test import SimpleTestCase, TestCase, override_settings
@@ -1668,16 +1668,21 @@ class RouterTestCase(TestCase):
         "M2M relations can cross databases if the database share a source"
         # Create books and authors on the inverse to the usual database
         pro = Book.objects.using("other").create(
-            pk=1, title="Pro Django", published=datetime.date(2008, 12, 16)
+            title="Pro Django", published=datetime.date(2008, 12, 16)
         )
 
-        marty = Person.objects.using("other").create(pk=1, name="Marty Alchin")
+        marty = Person.objects.using("other").create(name="Marty Alchin")
 
         dive = Book.objects.using("default").create(
-            pk=2, title="Dive into Python", published=datetime.date(2009, 5, 4)
+            pk=connection.ops.get_nonexistent_pk(pro.pk),
+            title="Dive into Python",
+            published=datetime.date(2009, 5, 4),
         )
 
-        mark = Person.objects.using("default").create(pk=2, name="Mark Pilgrim")
+        mark = Person.objects.using("default").create(
+            pk=connection.ops.get_nonexistent_pk(marty.pk),
+            name="Mark Pilgrim",
+        )
 
         # Now save back onto the usual database.
         # This simulates primary/replica - the objects exist on both database,
@@ -1760,7 +1765,9 @@ class RouterTestCase(TestCase):
         # If you create an object through a M2M relation, it will be
         # written to the write database, even if the original object
         # was on the read database
-        alice = dive.authors.create(name="Alice", pk=3)
+        alice = dive.authors.create(
+            name="Alice", pk=connection.ops.get_nonexistent_pk(mark.pk)
+        )
         self.assertEqual(alice._state.db, "default")
 
         # Same goes for get_or_create, regardless of whether getting or
@@ -1768,7 +1775,9 @@ class RouterTestCase(TestCase):
         alice, created = dive.authors.get_or_create(name="Alice")
         self.assertEqual(alice._state.db, "default")
 
-        bob, created = dive.authors.get_or_create(name="Bob", defaults={"pk": 4})
+        bob, created = dive.authors.get_or_create(
+            name="Bob", defaults={"pk": connection.ops.get_nonexistent_pk(alice.pk)}
+        )
         self.assertEqual(bob._state.db, "default")
 
     def test_o2o_cross_database_protection(self):

--- a/tests/or_lookups/tests.py
+++ b/tests/or_lookups/tests.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from operator import attrgetter
 
+from django.db import connection
 from django.db.models import Q
 from django.test import TestCase
 
@@ -94,8 +95,9 @@ class OrLookupsTests(TestCase):
             attrgetter("headline"),
         )
 
+        nonexistent_pk = connection.ops.get_nonexistent_pk(40000)
         self.assertQuerySetEqual(
-            Article.objects.filter(pk__in=[self.a1, self.a2, self.a3, 40000]),
+            Article.objects.filter(pk__in=[self.a1, self.a2, self.a3, nonexistent_pk]),
             ["Hello", "Goodbye", "Hello and goodbye"],
             attrgetter("headline"),
         )

--- a/tests/prefetch_related/tests.py
+++ b/tests/prefetch_related/tests.py
@@ -177,11 +177,12 @@ class PrefetchRelatedTests(TestDataMixin, TestCase):
                 self.assertEqual(author.name, author.bio.author.name)
 
     def test_survives_clone(self):
+        nonexistent_pk = connection.ops.get_nonexistent_pk(1000)
         with self.assertNumQueries(2):
             [
                 list(b.first_time_authors.all())
                 for b in Book.objects.prefetch_related("first_time_authors").exclude(
-                    id=1000
+                    id=nonexistent_pk
                 )
             ]
 

--- a/tests/prefetch_related/tests.py
+++ b/tests/prefetch_related/tests.py
@@ -1749,15 +1749,16 @@ class MultiDbTests(TestCase):
 class Ticket19607Tests(TestCase):
     @classmethod
     def setUpTestData(cls):
+        pk = connection.ops.get_hardcoded_pk
         LessonEntry.objects.bulk_create(
-            LessonEntry(id=id_, name1=name1, name2=name2)
+            LessonEntry(id=pk(id_), name1=name1, name2=name2)
             for id_, name1, name2 in [
                 (1, "einfach", "simple"),
                 (2, "schwierig", "difficult"),
             ]
         )
         WordEntry.objects.bulk_create(
-            WordEntry(id=id_, lesson_entry_id=lesson_entry_id, name=name)
+            WordEntry(id=pk(id_), lesson_entry_id=pk(lesson_entry_id), name=name)
             for id_, lesson_entry_id, name in [
                 (1, 1, "einfach"),
                 (2, 1, "simple"),

--- a/tests/prefetch_related/tests.py
+++ b/tests/prefetch_related/tests.py
@@ -1751,15 +1751,16 @@ class MultiDbTests(TestCase):
 class Ticket19607Tests(TestCase):
     @classmethod
     def setUpTestData(cls):
+        pk = connection.ops.get_hardcoded_pk
         LessonEntry.objects.bulk_create(
-            LessonEntry(id=id_, name1=name1, name2=name2)
+            LessonEntry(id=pk(id_), name1=name1, name2=name2)
             for id_, name1, name2 in [
                 (1, "einfach", "simple"),
                 (2, "schwierig", "difficult"),
             ]
         )
         WordEntry.objects.bulk_create(
-            WordEntry(id=id_, lesson_entry_id=lesson_entry_id, name=name)
+            WordEntry(id=pk(id_), lesson_entry_id=pk(lesson_entry_id), name=name)
             for id_, lesson_entry_id, name in [
                 (1, 1, "einfach"),
                 (2, 1, "simple"),

--- a/tests/prefetch_related/tests.py
+++ b/tests/prefetch_related/tests.py
@@ -179,11 +179,12 @@ class PrefetchRelatedTests(TestDataMixin, TestCase):
                 self.assertEqual(author.name, author.bio.author.name)
 
     def test_survives_clone(self):
+        nonexistent_pk = connection.ops.get_nonexistent_pk(1000)
         with self.assertNumQueries(2):
             [
                 list(b.first_time_authors.all())
                 for b in Book.objects.prefetch_related("first_time_authors").exclude(
-                    id=1000
+                    id=nonexistent_pk
                 )
             ]
 

--- a/tests/proxy_models/tests.py
+++ b/tests/proxy_models/tests.py
@@ -2,7 +2,7 @@ from django.contrib import admin
 from django.contrib.auth.models import User as AuthUser
 from django.contrib.contenttypes.models import ContentType
 from django.core import checks, management
-from django.db import DEFAULT_DB_ALIAS, models, transaction
+from django.db import DEFAULT_DB_ALIAS, connection, models, transaction
 from django.db.models import signals
 from django.test import TestCase, override_settings
 from django.test.utils import isolate_apps
@@ -398,7 +398,7 @@ class ProxyModelTests(TestCase):
 
     def test_proxy_load_from_fixture(self):
         management.call_command("loaddata", "mypeople.json", verbosity=0)
-        p = MyPerson.objects.get(pk=100)
+        p = MyPerson.objects.get(pk=connection.ops.get_hardcoded_pk(100))
         self.assertEqual(p.name, "Elvis Presley")
 
     def test_select_related_only(self):
@@ -408,7 +408,8 @@ class ProxyModelTests(TestCase):
         self.assertEqual(qs.get(), issue)
 
     def test_eq(self):
-        self.assertEqual(MyPerson(id=100), Person(id=100))
+        id_ = connection.ops.get_hardcoded_pk(100)
+        self.assertEqual(MyPerson(id=id_), Person(id=id_))
 
 
 @override_settings(ROOT_URLCONF="proxy_models.urls")

--- a/tests/queries/test_bulk_update.py
+++ b/tests/queries/test_bulk_update.py
@@ -213,7 +213,7 @@ class BulkUpdateTests(TestCase):
         )
 
     def test_falsey_pk_value(self):
-        order = Order.objects.create(pk=0, name="test")
+        order = Order.objects.create(pk=connection.ops.get_hardcoded_pk(0), name="test")
         order.name = "updated"
         Order.objects.bulk_update([order], ["name"])
         order.refresh_from_db()

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -186,7 +186,7 @@ class Queries1Tests(TestCase):
         cls.c2 = Cover.objects.create(title="second", item=cls.i2)
 
     def test_subquery_condition(self):
-        qs1 = Tag.objects.filter(pk__lte=0)
+        qs1 = Tag.objects.filter(pk__lte=connection.ops.get_hardcoded_pk(0))
         qs2 = Tag.objects.filter(parent__in=qs1)
         qs3 = Tag.objects.filter(parent__in=qs2)
         self.assertEqual(qs3.query.subq_aliases, {"T", "U", "V"})
@@ -449,9 +449,11 @@ class Queries1Tests(TestCase):
         self.assertNotIn("order by", captured_queries[0]["sql"].lower())
 
     def test_tickets_4088_4306(self):
+        pk = connection.ops.get_hardcoded_pk
+        # Without a chained lookup, the ForeignKey's to_field, num, is queried.
         self.assertSequenceEqual(Report.objects.filter(creator=1001), [self.r1])
         self.assertSequenceEqual(Report.objects.filter(creator__num=1001), [self.r1])
-        self.assertSequenceEqual(Report.objects.filter(creator__id=1001), [])
+        self.assertSequenceEqual(Report.objects.filter(creator__id=pk(1001)), [])
         self.assertSequenceEqual(
             Report.objects.filter(creator__id=self.a1.id), [self.r1]
         )
@@ -552,7 +554,7 @@ class Queries1Tests(TestCase):
         self.assertSequenceEqual(Item.objects.filter(tags__in=[t]), [self.i4])
 
     def test_avoid_infinite_loop_on_too_many_subqueries(self):
-        x = Tag.objects.filter(pk=1)
+        x = Tag.objects.filter(pk=connection.ops.get_hardcoded_pk(1))
         local_recursion_limit = sys.getrecursionlimit() // 16
         msg = "Maximum recursion depth exceeded: too many subqueries."
         with self.assertRaisesMessage(RecursionError, msg):
@@ -560,7 +562,7 @@ class Queries1Tests(TestCase):
                 x = Tag.objects.filter(pk__in=x)
 
     def test_reasonable_number_of_subq_aliases(self):
-        x = Tag.objects.filter(pk=1)
+        x = Tag.objects.filter(pk=connection.ops.get_hardcoded_pk(1))
         for _ in range(20):
             x = Tag.objects.filter(pk__in=x)
         self.assertEqual(
@@ -893,11 +895,12 @@ class Queries1Tests(TestCase):
         # An EmptyQuerySet should not raise exceptions if it is filtered.
         Eaten.objects.create(meal="m")
         q = Eaten.objects.none()
+        pk = connection.ops.get_hardcoded_pk
         with self.assertNumQueries(0):
             self.assertSequenceEqual(q.all(), [])
             self.assertSequenceEqual(q.filter(meal="m"), [])
             self.assertSequenceEqual(q.exclude(meal="m"), [])
-            self.assertSequenceEqual(q.complex_filter({"pk": 1}), [])
+            self.assertSequenceEqual(q.complex_filter({"pk": pk(1)}), [])
             self.assertSequenceEqual(q.select_related("food"), [])
             self.assertSequenceEqual(q.annotate(Count("food")), [])
             self.assertSequenceEqual(q.order_by("meal", "food"), [])
@@ -2148,12 +2151,12 @@ class Queries6Tests(TestCase):
         # Incorrect SQL was being generated for certain types of exclude()
         # queries that crossed multi-valued relations (#8921, #9188 and some
         # preemptively discovered cases).
-
+        id_ = connection.ops.get_hardcoded_pk(1)
         self.assertSequenceEqual(
-            PointerA.objects.filter(connection__pointerb__id=1), []
+            PointerA.objects.filter(connection__pointerb__id=id_), []
         )
         self.assertSequenceEqual(
-            PointerA.objects.exclude(connection__pointerb__id=1), []
+            PointerA.objects.exclude(connection__pointerb__id=id_), []
         )
 
         self.assertSequenceEqual(
@@ -3937,9 +3940,10 @@ class JoinReuseTest(TestCase):
 
 class DisjunctionPromotionTests(TestCase):
     def test_disjunction_promotion_select_related(self):
+        pk = connection.ops.get_hardcoded_pk
         fk1 = FK1.objects.create(f1="f1", f2="f2")
         basea = BaseA.objects.create(a=fk1)
-        qs = BaseA.objects.filter(Q(a=fk1) | Q(b=2))
+        qs = BaseA.objects.filter(Q(a=fk1) | Q(b=pk(2)))
         self.assertEqual(str(qs.query).count(" JOIN "), 0)
         qs = qs.select_related("a", "b")
         self.assertEqual(str(qs.query).count(" INNER JOIN "), 0)
@@ -3995,7 +3999,8 @@ class DisjunctionPromotionTests(TestCase):
         self.assertEqual(str(qs.query).count("LEFT OUTER JOIN"), 1)
 
     def test_disjunction_promotion4_demote(self):
-        qs = BaseA.objects.filter(Q(a=1) | Q(a=2))
+        pk = connection.ops.get_hardcoded_pk
+        qs = BaseA.objects.filter(Q(a=pk(1)) | Q(a=pk(2)))
         self.assertEqual(str(qs.query).count("JOIN"), 0)
         # Demote needed for the "a" join. It is marked as outer join by
         # above filter (even if it is trimmed away).
@@ -4003,13 +4008,15 @@ class DisjunctionPromotionTests(TestCase):
         self.assertEqual(str(qs.query).count("INNER JOIN"), 1)
 
     def test_disjunction_promotion4(self):
+        pk = connection.ops.get_hardcoded_pk
         qs = BaseA.objects.filter(a__f1="foo")
         self.assertEqual(str(qs.query).count("INNER JOIN"), 1)
-        qs = qs.filter(Q(a=1) | Q(a=2))
+        qs = qs.filter(Q(a=pk(1)) | Q(a=pk(2)))
         self.assertEqual(str(qs.query).count("INNER JOIN"), 1)
 
     def test_disjunction_promotion5_demote(self):
-        qs = BaseA.objects.filter(Q(a=1) | Q(a=2))
+        pk = connection.ops.get_hardcoded_pk
+        qs = BaseA.objects.filter(Q(a=pk(1)) | Q(a=pk(2)))
         # Note that the above filters on a force the join to an
         # inner join even if it is trimmed.
         self.assertEqual(str(qs.query).count("JOIN"), 0)
@@ -4021,12 +4028,13 @@ class DisjunctionPromotionTests(TestCase):
         qs = BaseA.objects.filter(Q(a__f1="foo") | Q(b__f1="foo"))
         # Now the join to a is created as LOUTER
         self.assertEqual(str(qs.query).count("LEFT OUTER JOIN"), 2)
-        qs = qs.filter(Q(a=1) | Q(a=2))
+        qs = qs.filter(Q(a=pk(1)) | Q(a=pk(2)))
         self.assertEqual(str(qs.query).count("INNER JOIN"), 1)
         self.assertEqual(str(qs.query).count("LEFT OUTER JOIN"), 1)
 
     def test_disjunction_promotion6(self):
-        qs = BaseA.objects.filter(Q(a=1) | Q(a=2))
+        pk = connection.ops.get_hardcoded_pk
+        qs = BaseA.objects.filter(Q(a=pk(1)) | Q(a=pk(2)))
         self.assertEqual(str(qs.query).count("JOIN"), 0)
         qs = BaseA.objects.filter(Q(a__f1="foo") & Q(b__f1="foo"))
         self.assertEqual(str(qs.query).count("INNER JOIN"), 2)
@@ -4035,12 +4043,13 @@ class DisjunctionPromotionTests(TestCase):
         qs = BaseA.objects.filter(Q(a__f1="foo") & Q(b__f1="foo"))
         self.assertEqual(str(qs.query).count("LEFT OUTER JOIN"), 0)
         self.assertEqual(str(qs.query).count("INNER JOIN"), 2)
-        qs = qs.filter(Q(a=1) | Q(a=2))
+        qs = qs.filter(Q(a=pk(1)) | Q(a=pk(2)))
         self.assertEqual(str(qs.query).count("INNER JOIN"), 2)
         self.assertEqual(str(qs.query).count("LEFT OUTER JOIN"), 0)
 
     def test_disjunction_promotion7(self):
-        qs = BaseA.objects.filter(Q(a=1) | Q(a=2))
+        pk = connection.ops.get_hardcoded_pk
+        qs = BaseA.objects.filter(Q(a=pk(1)) | Q(a=pk(2)))
         self.assertEqual(str(qs.query).count("JOIN"), 0)
         qs = BaseA.objects.filter(Q(a__f1="foo") | (Q(b__f1="foo") & Q(a__f1="bar")))
         self.assertEqual(str(qs.query).count("INNER JOIN"), 1)
@@ -4066,7 +4075,8 @@ class DisjunctionPromotionTests(TestCase):
             Q(a__f1=F("b__f1")) | Q(a__f2=F("b__f2")) | Q(c__f1="foo")
         )
         self.assertEqual(str(qs.query).count("LEFT OUTER JOIN"), 3)
-        qs = BaseA.objects.filter(Q(a__f1=F("c__f1")) | (Q(pk=1) & Q(pk=2)))
+        pk = connection.ops.get_hardcoded_pk
+        qs = BaseA.objects.filter(Q(a__f1=F("c__f1")) | (Q(pk=pk(1)) & Q(pk=pk(2))))
         self.assertEqual(str(qs.query).count("LEFT OUTER JOIN"), 2)
         self.assertEqual(str(qs.query).count("INNER JOIN"), 0)
 
@@ -4422,13 +4432,14 @@ class ValuesJoinPromotionTests(TestCase):
         self.assertIn(" INNER JOIN ", str(qs.query))
 
     def test_ticket_21376(self):
+        pk = connection.ops.get_hardcoded_pk
         a = ObjectA.objects.create()
         ObjectC.objects.create(objecta=a)
         qs = ObjectC.objects.filter(
             Q(objecta=a) | Q(objectb__objecta=a),
         )
         qs = qs.filter(
-            Q(objectb=1) | Q(objecta=a),
+            Q(objectb=pk(1)) | Q(objecta=a),
         )
         self.assertEqual(qs.count(), 1)
         tblname = connection.ops.quote_name(ObjectB._meta.db_table)

--- a/tests/queryset_pickle/tests.py
+++ b/tests/queryset_pickle/tests.py
@@ -2,7 +2,7 @@ import datetime
 import pickle
 
 import django
-from django.db import models
+from django.db import connection, models
 from django.test import TestCase
 
 from .models import (
@@ -50,7 +50,8 @@ class PickleabilityTestCase(TestCase):
         self.assert_pickles(Happening.objects.filter(number2=1))
 
     def test_filter_reverse_fk(self):
-        self.assert_pickles(Group.objects.filter(event=1))
+        event_id = connection.ops.get_hardcoded_pk(1)
+        self.assert_pickles(Group.objects.filter(event=event_id))
 
     def test_doesnotexist_exception(self):
         # Ticket #17776
@@ -93,7 +94,7 @@ class PickleabilityTestCase(TestCase):
         """
         A model not defined on module level is picklable.
         """
-        original = Container.SomeModel(pk=1)
+        original = Container.SomeModel(pk=connection.ops.get_hardcoded_pk(1))
         dumped = pickle.dumps(original)
         reloaded = pickle.loads(dumped)
         self.assertEqual(original, reloaded)
@@ -172,7 +173,8 @@ class PickleabilityTestCase(TestCase):
             models.Prefetch("event_set", queryset=Event.objects.order_by("id"))
         )
         groups2 = pickle.loads(pickle.dumps(groups))
-        self.assertSequenceEqual(groups2.filter(id__gte=0), [g])
+        zero = connection.ops.get_hardcoded_pk(0)
+        self.assertSequenceEqual(groups2.filter(id__gte=zero), [g])
 
     def test_pickle_prefetch_queryset_not_evaluated(self):
         Group.objects.create(name="foo")
@@ -323,7 +325,7 @@ class PickleabilityTestCase(TestCase):
     def test_filter_deferred(self):
         qs = Happening.objects.all()
         qs._defer_next_filter = True
-        qs = qs.filter(id=0)
+        qs = qs.filter(id=connection.ops.get_hardcoded_pk(0))
         self.assert_pickles(qs)
 
     def test_missing_django_version_unpickling(self):

--- a/tests/signals/tests.py
+++ b/tests/signals/tests.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 from django import dispatch
 from django.apps.registry import Apps
-from django.db import models
+from django.db import connection, models
 from django.db.models import signals
 from django.dispatch import receiver
 from django.test import SimpleTestCase, TestCase
@@ -111,7 +111,8 @@ class SignalTests(BaseSignalSetup, TestCase):
             data[:] = []
 
             p2 = Person(first_name="James", last_name="Jones")
-            p2.id = 99999
+            new_pk1 = connection.ops.get_nonexistent_pk(99999)
+            p2.id = new_pk1
             p2.save()
             self.assertEqual(
                 data,
@@ -121,7 +122,7 @@ class SignalTests(BaseSignalSetup, TestCase):
                 ],
             )
             data[:] = []
-            p2.id = 99998
+            p2.id = connection.ops.get_nonexistent_pk(99998)
             p2.save()
             self.assertEqual(
                 data,
@@ -178,9 +179,10 @@ class SignalTests(BaseSignalSetup, TestCase):
             data[:] = []
 
             p2 = Person(first_name="James", last_name="Jones")
-            p2.id = 99999
+            new_pk1 = connection.ops.get_nonexistent_pk(99999)
+            p2.id = new_pk1
             p2.save()
-            p2.id = 99998
+            p2.id = connection.ops.get_nonexistent_pk(99998)
             p2.save()
             p2.delete()
             self.assertEqual(

--- a/tests/sites_tests/tests.py
+++ b/tests/sites_tests/tests.py
@@ -10,6 +10,7 @@ from django.contrib.sites.requests import RequestSite
 from django.contrib.sites.shortcuts import get_current_site
 from django.core import checks
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.db import connection
 from django.db.models.signals import post_migrate
 from django.http import HttpRequest, HttpResponse
 from django.test import SimpleTestCase, TestCase, modify_settings, override_settings
@@ -203,7 +204,7 @@ class SitesFrameworkTests(TestCase):
         self.assertEqual(Site.objects.get_by_natural_key(self.site.domain), self.site)
         self.assertEqual(self.site.natural_key(), (self.site.domain,))
 
-    @override_settings(SITE_ID="1")
+    @override_settings(SITE_ID=str(connection.ops.get_hardcoded_pk(1)))
     def test_check_site_id_incorrect_type(self):
         self.assertEqual(
             check_site_id(None),
@@ -229,7 +230,7 @@ class SitesFrameworkTests(TestCase):
         )
 
     def test_valid_site_id(self):
-        for site_id in [1, None]:
+        for site_id in [connection.ops.get_hardcoded_pk(1), None]:
             with self.subTest(site_id=site_id), self.settings(SITE_ID=site_id):
                 self.assertEqual(check_site_id(None), [])
 
@@ -330,13 +331,14 @@ class CreateDefaultSiteTests(TestCase):
         )
         self.assertTrue(Site.objects.exists())
 
-    @override_settings(SITE_ID=35696)
     def test_custom_site_id(self):
         """
         #23945 - The configured ``SITE_ID`` should be respected.
         """
-        create_default_site(self.app_config, verbosity=0)
-        self.assertEqual(Site.objects.get().pk, 35696)
+        custom_site_id = connection.ops.get_hardcoded_pk(35696)
+        with self.settings(SITE_ID=custom_site_id):
+            create_default_site(self.app_config, verbosity=0)
+        self.assertEqual(Site.objects.get().pk, custom_site_id)
 
     @override_settings()  # Restore original ``SITE_ID`` afterward.
     def test_no_site_id(self):

--- a/tests/syndication_tests/tests.py
+++ b/tests/syndication_tests/tests.py
@@ -4,6 +4,7 @@ from xml.dom import minidom
 from django.contrib.sites.models import Site
 from django.contrib.syndication import views
 from django.core.exceptions import ImproperlyConfigured
+from django.db import connection
 from django.templatetags.static import static
 from django.test import TestCase, override_settings
 from django.test.utils import requires_tz_support
@@ -848,5 +849,6 @@ class SyndicationFeedTest(FeedTestCase):
         )
 
     def test_get_non_existent_object(self):
-        response = self.client.get("/syndication/rss2/articles/0/")
+        pk = connection.ops.get_nonexistent_pk(-1)
+        response = self.client.get(f"/syndication/rss2/articles/{pk}/")
         self.assertEqual(response.status_code, 404)

--- a/tests/validation/test_unique.py
+++ b/tests/validation/test_unique.py
@@ -3,7 +3,7 @@ import unittest
 
 from django.apps.registry import Apps
 from django.core.exceptions import ValidationError
-from django.db import models
+from django.db import connection, models
 from django.test import TestCase
 
 from .models import (
@@ -135,8 +135,9 @@ class PerformUniqueChecksTest(TestCase):
 
     def test_primary_key_unique_check_performed_when_adding_and_pk_specified(self):
         # Regression test for #12560
+        id_ = connection.ops.get_hardcoded_pk(123)
         with self.assertNumQueries(1):
-            mtv = ModelToValidate(number=10, name="Some Name", id=123)
+            mtv = ModelToValidate(number=10, name="Some Name", id=id_)
             setattr(mtv, "_adding", True)
             mtv.full_clean()
 

--- a/tests/validation/test_unique.py
+++ b/tests/validation/test_unique.py
@@ -3,7 +3,7 @@ import unittest
 
 from django.apps.registry import Apps
 from django.core.exceptions import ValidationError
-from django.db import models
+from django.db import connection, models
 from django.test import TestCase, skipUnlessDBFeature
 
 from .models import (
@@ -137,8 +137,9 @@ class PerformUniqueChecksTest(TestCase):
 
     def test_primary_key_unique_check_performed_when_adding_and_pk_specified(self):
         # Regression test for #12560
+        id_ = connection.ops.get_hardcoded_pk(123)
         with self.assertNumQueries(1):
-            mtv = ModelToValidate(number=10, name="Some Name", id=123)
+            mtv = ModelToValidate(number=10, name="Some Name", id=id_)
             setattr(mtv, "_adding", True)
             mtv.full_clean()
 

--- a/tests/validation/tests.py
+++ b/tests/validation/tests.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.core.exceptions import NON_FIELD_ERRORS
+from django.db import connection
 from django.test import TestCase
 from django.utils.functional import lazy
 
@@ -27,7 +28,8 @@ class BaseModelValidationTests(ValidationAssertions, TestCase):
         self.assertFailsValidation(mtv.full_clean, [NON_FIELD_ERRORS, "name"])
 
     def test_wrong_FK_value_raises_error(self):
-        mtv = ModelToValidate(number=10, name="Some Name", parent_id=3)
+        parent_id = connection.ops.get_hardcoded_pk(3)
+        mtv = ModelToValidate(number=10, name="Some Name", parent_id=parent_id)
         self.assertFieldFailsValidationWithMessage(
             mtv.full_clean,
             "parent",


### PR DESCRIPTION
First, I removed all unnecessary hardcoded pks (#21364).

The patch has been tested with the CockroachDB (does not use the new APIs, but uses monotonically increasing, non-sequential integer primary keys)  and MongoDB third-party backends.

ticket-37175