### PR TITLE
Fix batch_size parameter handling in bulk_create to use min() logic

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1209,7 +1209,9 @@ class QuerySet:
         if ignore_conflicts and not connections[self.db].features.supports_ignore_conflicts:
             raise NotSupportedError('This database backend does not support ignoring conflicts.')
         ops = connections[self.db].ops
-        batch_size = (batch_size or max(ops.bulk_batch_size(fields, objs), 1))
+        max_batch_size = ops.bulk_batch_size(fields, objs)
+        batch_size = min(batch_size, max_batch_size) if batch_size else max_batch_size
+        batch_size = max(batch_size, 1)
         inserted_rows = []
         bulk_return = connections[self.db].features.can_return_rows_from_bulk_insert
         for item in [objs[i:i + batch_size] for i in range(0, len(objs), batch_size)]:


### PR DESCRIPTION
When a user provides a batch_size parameter to bulk_create() that is larger than the compatible batch size calculated by ops.bulk_batch_size(), the user-provided value was being used directly, which could cause issues.

This change makes bulk_create consistent with bulk_update by using:
    batch_size = min(batch_size, max_batch_size) if batch_size else max_batch_size

This ensures that the batch_size never exceeds the database-compatible batch size while still respecting user-provided smaller values.