### PR TITLE
Fixed #34034 -- Allow setting HTML attributes on Select widget options.

### DIFF
--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -524,12 +524,21 @@ class AutocompleteMixin:
 
     url_name = "%s:autocomplete"
 
-    def __init__(self, field, admin_site, attrs=None, choices=(), using=None):
+    def __init__(
+        self,
+        field,
+        admin_site,
+        attrs=None,
+        choices=(),
+        using=None,
+        option_attrs=None,
+    ):
         self.field = field
         self.admin_site = admin_site
         self.db = using
         self.choices = choices
         self.attrs = {} if attrs is None else attrs.copy()
+        self.option_attrs = {} if option_attrs is None else option_attrs.copy()
         self.i18n_name = get_select2_language()
 
     def get_url(self):

--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -737,13 +737,15 @@ class ChoiceWidget(Widget):
     checked_attribute = {"checked": True}
     option_inherits_attrs = True
 
-    def __init__(self, attrs=None, choices=()):
+    def __init__(self, attrs=None, choices=(), option_attrs=None):
         super().__init__(attrs)
         self.choices = choices
+        self.option_attrs = {} if option_attrs is None else option_attrs.copy()
 
     def __deepcopy__(self, memo):
         obj = copy.copy(self)
         obj.attrs = self.attrs.copy()
+        obj.option_attrs = self.option_attrs.copy()
         obj.choices = copy.copy(self.choices)
         memo[id(self)] = obj
         return obj
@@ -805,9 +807,13 @@ class ChoiceWidget(Widget):
         self, name, value, label, selected, index, subindex=None, attrs=None
     ):
         index = str(index) if subindex is None else "%s_%s" % (index, subindex)
-        option_attrs = (
-            self.build_attrs(self.attrs, attrs) if self.option_inherits_attrs else {}
-        )
+        if self.option_inherits_attrs:
+            option_attrs = self.build_attrs({**self.option_attrs, **self.attrs}, attrs)
+        elif self.option_attrs:
+            option_attrs = self.build_attrs(self.option_attrs)
+        else:
+            option_attrs = {}
+
         if selected:
             option_attrs.update(self.checked_attribute)
         if "id" in option_attrs:

--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -810,7 +810,7 @@ class ChoiceWidget(Widget):
         if self.option_inherits_attrs:
             option_attrs = self.build_attrs({**self.option_attrs, **self.attrs}, attrs)
         elif self.option_attrs:
-            option_attrs = {**self.option_attrs}
+            option_attrs = self.build_attrs(self.option_attrs)
         else:
             option_attrs = {}
 

--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -810,7 +810,7 @@ class ChoiceWidget(Widget):
         if self.option_inherits_attrs:
             option_attrs = self.build_attrs({**self.option_attrs, **self.attrs}, attrs)
         elif self.option_attrs:
-            option_attrs = self.build_attrs(self.option_attrs)
+            option_attrs = {**self.option_attrs}
         else:
             option_attrs = {}
 

--- a/docs/ref/forms/widgets.txt
+++ b/docs/ref/forms/widgets.txt
@@ -112,6 +112,20 @@ with fields which are not based on choice -- such as a :class:`CharField` --
 but it is recommended to use a :class:`ChoiceField`-based field when the
 choices are inherent to the model and not just the representational widget.
 
+.. versionchanged:: 6.2
+
+For widgets that have options on their own, like those inheriting from
+``ChoiceWidget``, you can also pass option-specific attributes using
+``option_attrs``. For example, if you wish to set custom CSS classes for a
+RadioSelect's options, you could do as follows:
+
+.. code-block:: pycon
+
+    >>> from django.forms.widgets import RadioSelect
+    >>> widget = RadioSelect(choices=(("J", "John"),), option_attrs={"class": "special"})
+    >>> widget.render(name="beatle", value=["J"])
+    '<div><div>\n    <label><input type="radio" name="beatle" value="J" class="special" checked>\n John</label>\n\n</div>\n</div>'
+
 Customizing widget instances
 ============================
 
@@ -767,6 +781,20 @@ that specifies the template used to render each choice. For example, for the
         This attribute is optional when the form field does not have a
         ``choices`` attribute. If it does, it will override anything you set
         here when the attribute is updated on the :class:`Field`.
+
+    .. attribute:: Select.option_attrs
+
+        .. versionadded:: 6.2
+
+        An optional dictionary containing option-specific HTML attributes to
+        be set on the options of the rendered widget.
+
+        .. code-block:: pycon
+
+            >>> from django.forms.widgets import Select
+            >>> widget = Select(choices=(("J", "John"),), option_attrs={"class": "special"})
+            >>> widget.render(name="beatle", value=["J"])
+            '<select name="beatle">\n  <option value="J" class="special" selected>John</option>\n\n</select>'
 
 ``NullBooleanSelect``
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/ref/forms/widgets.txt
+++ b/docs/ref/forms/widgets.txt
@@ -79,6 +79,39 @@ widget on the field. In the following example, the
 See the :ref:`built-in widgets` for more information about which widgets
 are available and which arguments they accept.
 
+Widgets inheriting from the ``Select`` widget
+=============================================
+
+Widgets inheriting from the :class:`Select` widget deal with choices. They
+present the user with a list of options to choose from. The different widgets
+present this choice differently; the :class:`Select` widget itself uses a
+``<select>`` HTML list representation, while :class:`RadioSelect` uses radio
+buttons.
+
+:class:`Select` widgets are used by default on :class:`ChoiceField` fields. The
+choices displayed on the widget are inherited from the :class:`ChoiceField` and
+changing :attr:`ChoiceField.choices` will update :attr:`Select.choices`. For
+example:
+
+.. code-block:: pycon
+
+    >>> from django import forms
+    >>> CHOICES = {"1": "First", "2": "Second"}
+    >>> choice_field = forms.ChoiceField(widget=forms.RadioSelect, choices=CHOICES)
+    >>> choice_field.choices
+    [('1', 'First'), ('2', 'Second')]
+    >>> choice_field.widget.choices
+    [('1', 'First'), ('2', 'Second')]
+    >>> choice_field.widget.choices = []
+    >>> choice_field.choices = [("1", "First and only")]
+    >>> choice_field.widget.choices
+    [('1', 'First and only')]
+
+Widgets which offer a :attr:`~Select.choices` attribute can however be used
+with fields which are not based on choice -- such as a :class:`CharField` --
+but it is recommended to use a :class:`ChoiceField`-based field when the
+choices are inherent to the model and not just the representational widget.
+
 Customizing widget instances
 ============================
 
@@ -325,7 +358,7 @@ foundation for custom widgets.
         all checkboxes to be checked instead of at least one.
 
         Override this method in custom widgets that aren't compatible with
-        browser validation. For example, a WYSIWYG text editor widget backed by
+        browser validation. For example, a WSYSIWG text editor widget backed by
         a hidden ``textarea`` element may want to always return ``False`` to
         avoid browser validation on the hidden field.
 
@@ -734,6 +767,20 @@ that specifies the template used to render each choice. For example, for the
         This attribute is optional when the form field does not have a
         ``choices`` attribute. If it does, it will override anything you set
         here when the attribute is updated on the :class:`Field`.
+
+    .. attribute:: Select.option_attrs
+
+        .. versionadded:: 6.2
+
+        An optional dictionary containing option-specific HTML attributes to
+        be set on the options of the rendered widget.
+
+        .. code-block:: pycon
+
+            >>> from django.forms.widgets import Select
+            >>> widget = Select(choices=(("J", "John"),), option_attrs={"class": "special"})
+            >>> widget.render(name="beatle", value=["J"])
+            '<select name="beatle">\n  <option value="J" class="special" selected>John</option>\n\n</select>'
 
 ``NullBooleanSelect``
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -155,7 +155,8 @@ File Uploads
 Forms
 ~~~~~
 
-* ...
+* The new :attr:`~django.forms.Select.option_attrs` attribute can be used to
+  specify option-specific HTML attributes.
 
 Generic Views
 ~~~~~~~~~~~~~

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -167,7 +167,8 @@ File Uploads
 Forms
 ~~~~~
 
-* ...
+* The new :attr:`~django.forms.Select.option_attrs` attribute can be used to
+  specify option-specific HTML attributes.
 
 Generic Views
 ~~~~~~~~~~~~~

--- a/tests/forms_tests/field_tests/test_choicefield.py
+++ b/tests/forms_tests/field_tests/test_choicefield.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.forms import ChoiceField, Form
+from django.forms import ChoiceField, Form, RadioSelect
 from django.test import SimpleTestCase
 
 from . import FormFieldAssertionsMixin
@@ -148,3 +148,46 @@ class ChoiceFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
         msg = "'Select a valid choice. 3 is not one of the available choices.'"
         with self.assertRaisesMessage(ValidationError, msg):
             f.clean("3")
+
+    def test_choicefield_adds_required_and_id_attributes(self):
+        class MyForm(Form):
+            select = ChoiceField(
+                choices=((None, "---"), ("1", "1"), ("2", "2")),
+                widget=RadioSelect(option_attrs={"option-attr": "test"}),
+            )
+
+        form = MyForm()
+        self.maxDiff = None
+        self.assertHTMLEqual(
+            str(form),
+            """
+            <div>
+            <fieldset>
+            <legend>Select:</legend>
+            <div id="id_select">
+            <div>
+            <label for="id_select_0">
+            <input type="radio" name="select" value="" required id="id_select_0"
+            option-attr="test" checked>
+                ---
+            </label>
+            </div>
+            <div>
+            <label for="id_select_1">
+            <input type="radio" name="select" value="1" required id="id_select_1"
+            option-attr="test">
+                1
+            </label>
+            </div>
+            <div>
+            <label for="id_select_2">
+            <input type="radio" name="select" value="2" required id="id_select_2"
+            option-attr="test">
+                2
+            </label>
+            </div>
+            </div>
+            </fieldset>
+            </div>
+            """,
+        )

--- a/tests/forms_tests/field_tests/test_choicefield.py
+++ b/tests/forms_tests/field_tests/test_choicefield.py
@@ -162,7 +162,7 @@ class ChoiceFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
             str(form),
             "<div><fieldset><legend>Select:</legend><div id=id_select><div><label "
             "for=id_select_0><input id=id_select_0 name=select option-attr=test "
-            "required type=radio value=""checked> ---</label></div><div><label "
+            'required type=radio value="" checked> ---</label></div><div><label '
             "for=id_select_1><input id=id_select_1 name=select option-attr=test "
             "required type=radio value=1> 1</label></div><div><label for=id_select_2>"
             "<input id=id_select_2 name=select option-attr=test required type=radio "
@@ -184,7 +184,7 @@ class ChoiceFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
             str(form),
             "<div><fieldset><legend>Select:</legend><div id=id_select><div><label "
             "for=id_select_0><input attr=attr-test id=id_select_0 name=select "
-            "option-attr=test required type=radio value=""checked> ---</label></div>"
+            'option-attr=test required type=radio value="" checked> ---</label></div>'
             "<div><label for=id_select_1><input attr=attr-test id=id_select_1 "
             "name=select option-attr=test required type=radio value=1> 1</label></div>"
             "<div><label for=id_select_2><input attr=attr-test id=id_select_2 "

--- a/tests/forms_tests/field_tests/test_choicefield.py
+++ b/tests/forms_tests/field_tests/test_choicefield.py
@@ -150,6 +150,7 @@ class ChoiceFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
             f.clean("3")
 
     def test_choicefield_adds_required_and_id_attributes(self):
+        # this test reaches if with option_attrs set
         class MyForm(Form):
             select = ChoiceField(
                 choices=((None, "---"), ("1", "1"), ("2", "2")),
@@ -157,37 +158,36 @@ class ChoiceFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
             )
 
         form = MyForm()
-        self.maxDiff = None
         self.assertHTMLEqual(
             str(form),
-            """
-            <div>
-            <fieldset>
-            <legend>Select:</legend>
-            <div id="id_select">
-            <div>
-            <label for="id_select_0">
-            <input type="radio" name="select" value="" required id="id_select_0"
-            option-attr="test" checked>
-                ---
-            </label>
-            </div>
-            <div>
-            <label for="id_select_1">
-            <input type="radio" name="select" value="1" required id="id_select_1"
-            option-attr="test">
-                1
-            </label>
-            </div>
-            <div>
-            <label for="id_select_2">
-            <input type="radio" name="select" value="2" required id="id_select_2"
-            option-attr="test">
-                2
-            </label>
-            </div>
-            </div>
-            </fieldset>
-            </div>
-            """,
+            "<div><fieldset><legend>Select:</legend><div id=id_select><div><label "
+            "for=id_select_0><input id=id_select_0 name=select option-attr=test "
+            "required type=radio value=""checked> ---</label></div><div><label "
+            "for=id_select_1><input id=id_select_1 name=select option-attr=test "
+            "required type=radio value=1> 1</label></div><div><label for=id_select_2>"
+            "<input id=id_select_2 name=select option-attr=test required type=radio "
+            "value=2> 2</label></div></div></fieldset></div>",
+        )
+
+    def test_choicefield_with_attrs_and_option_attrs(self):
+        # this test reaches if with both attrs and option_attrs set
+        class MyForm(Form):
+            select = ChoiceField(
+                choices=((None, "---"), ("1", "1"), ("2", "2")),
+                widget=RadioSelect(
+                    attrs={"attr": "attr-test"}, option_attrs={"option-attr": "test"}
+                ),
+            )
+
+        form = MyForm()
+        self.assertHTMLEqual(
+            str(form),
+            "<div><fieldset><legend>Select:</legend><div id=id_select><div><label "
+            "for=id_select_0><input attr=attr-test id=id_select_0 name=select "
+            "option-attr=test required type=radio value=""checked> ---</label></div>"
+            "<div><label for=id_select_1><input attr=attr-test id=id_select_1 "
+            "name=select option-attr=test required type=radio value=1> 1</label></div>"
+            "<div><label for=id_select_2><input attr=attr-test id=id_select_2 "
+            "name=select option-attr=test required type=radio value=2> 2</label></div>"
+            "</div></fieldset></div>",
         )

--- a/tests/forms_tests/widget_tests/test_choicewidget.py
+++ b/tests/forms_tests/widget_tests/test_choicewidget.py
@@ -41,6 +41,8 @@ class ChoiceWidgetTest(WidgetTest):
         self.assertIsNot(widget.choices, obj.choices)
         self.assertEqual(widget.attrs, obj.attrs)
         self.assertIsNot(widget.attrs, obj.attrs)
+        self.assertEqual(widget.option_attrs, obj.option_attrs)
+        self.assertIsNot(widget.option_attrs, obj.option_attrs)
 
     def test_options(self):
         options = list(

--- a/tests/forms_tests/widget_tests/test_radioselect.py
+++ b/tests/forms_tests/widget_tests/test_radioselect.py
@@ -184,6 +184,42 @@ class RadioSelectTest(ChoiceWidgetTest):
         """
         self.check_html(widget, "beatle", "J", html=html)
 
+    def test_constructor_option_attrs(self):
+        """
+        Attributes provided at instantiation are passed to the constituent
+        inputs.
+        """
+        widget = self.widget(
+            attrs={"id": "foo"},
+            option_attrs={"data-test": "custom", "class": "other"},
+            choices=self.beatles,
+        )
+        html = """
+        <div id="foo">
+          <div>
+            <label for="foo_0">
+            <input checked class="other" data-test="custom" type="radio"
+                   id="foo_0" value="J" name="beatle">John</label>
+          </div>
+          <div>
+            <label for="foo_1">
+            <input class="other" data-test="custom" type="radio"
+                   id="foo_1" value="P" name="beatle">Paul</label>
+          </div>
+          <div>
+            <label for="foo_2">
+            <input class="other" data-test="custom" type="radio"
+                   id="foo_2" value="G" name="beatle">George</label>
+          </div>
+          <div>
+            <label for="foo_3">
+            <input class="other" data-test="custom" type="radio"
+                   id="foo_3" value="R" name="beatle">Ringo</label>
+          </div>
+        </div>
+        """
+        self.check_html(widget, "beatle", "J", html=html)
+
     def test_compare_to_str(self):
         """
         The value is compared to its str().
@@ -494,6 +530,38 @@ class RadioSelectTest(ChoiceWidgetTest):
             "beatle",
             ["J", "Some text"],
             html=html,
+        )
+
+    def test_render_as_subwidget_with_option_attrs(self):
+        """We render option_attrs for the subwidget."""
+        choices = (("", "------"),) + self.beatles
+        widget_instance = self.widget(
+            choices=choices,
+            option_attrs={"class": "special"},
+        )
+        self.check_html(
+            MultiWidget([widget_instance]),
+            "beatle",
+            ["J"],
+            html="""
+            <div>
+            <div><label>
+            <input type="radio" name="beatle_0" value=""
+                class="special"> ------</label></div>
+            <div><label>
+            <input checked type="radio" name="beatle_0" value="J"
+                class="special"> John</label></div>
+            <div><label>
+            <input type="radio" name="beatle_0" value="P"
+                class="special"> Paul</label></div>
+            <div><label>
+            <input type="radio" name="beatle_0" value="G"
+                class="special"> George</label></div>
+            <div><label>
+            <input type="radio" name="beatle_0" value="R"
+                class="special"> Ringo</label></div>
+            </div>
+        """,
         )
 
     def test_fieldset(self):

--- a/tests/forms_tests/widget_tests/test_select.py
+++ b/tests/forms_tests/widget_tests/test_select.py
@@ -94,6 +94,26 @@ class SelectTest(ChoiceWidgetTest):
             </select>"""),
         )
 
+    def test_constructor_option_attrs(self):
+        """
+        Select options shouldn't inherit the parent widget attrs.
+        """
+        widget = Select(
+            attrs={"class": "super", "id": "super"},
+            option_attrs={"data-test": "custom", "class": "other"},
+            choices=[(1, 1), (2, 2), (3, 3)],
+        )
+        self.check_html(
+            widget,
+            "num",
+            2,
+            html=("""<select name="num" class="super" id="super">
+              <option value="1" data-test="custom" class="other">1</option>
+              <option value="2" data-test="custom" class="other" selected>2</option>
+              <option value="3" data-test="custom" class="other">3</option>
+            </select>"""),
+        )
+
     def test_compare_to_str(self):
         """
         The value is compared to its str().
@@ -389,6 +409,23 @@ class SelectTest(ChoiceWidgetTest):
         for choices in (choices_dict, choices_list, choices_nested_dict):
             with self.subTest(choices):
                 self._test_optgroups(choices)
+
+    def test_options_with_option_attrs(self):
+        options = list(
+            self.widget(choices=self.beatles, option_attrs={"class": "other"}).options(
+                "name",
+                ["J"],
+                attrs={"class": "super"},
+            )
+        )
+        self.assertEqual(len(options), 4)
+        for option, (i, (value, label)) in zip(options, enumerate(self.beatles)):
+            self.assertEqual(option["name"], "name")
+            self.assertEqual(option["value"], value)
+            self.assertEqual(option["label"], label)
+            self.assertEqual(option["index"], str(i))
+            self.assertEqual(option["attrs"]["class"], "other")
+            self.assertIs(option["selected"], value == "J")
 
     def test_doesnt_render_required_when_impossible_to_select_empty_field(self):
         widget = self.widget(choices=[("J", "John"), ("P", "Paul")])

--- a/tests/forms_tests/widget_tests/test_select.py
+++ b/tests/forms_tests/widget_tests/test_select.py
@@ -470,3 +470,30 @@ class SelectTest(ChoiceWidgetTest):
             '<option value="R">Ringo</option></select></div>',
             form.render(),
         )
+
+    def test_select_with_option_attrs(self):
+        # this test reaches the else
+        select = Select(
+            choices=((None, "---"), ("1", "1"), ("2", "2")),
+            option_attrs={"option-attr": "test"},
+        )
+        html_str = select.render(name="test_select", value=None)
+        self.assertHTMLEqual(
+            html_str,
+            '<select name=test_select><option option-attr="test" value="" selected>'
+            '---</option><option option-attr="test" value=1>1</option><option '
+            'option-attr="test" value=2>2</option></select>',
+        )
+
+    def test_select_without_option_attrs(self):
+        # this test reaches the elif
+        select = Select(
+            choices=((None, "---"), ("1", "1"), ("2", "2")),
+        )
+        html_str = select.render(name="test_select", value=None)
+        self.assertHTMLEqual(
+            html_str,
+            '<select name=test_select><option value="" selected>'
+            "---</option><option value=1>1</option><option "
+            "value=2>2</option></select>",
+        )


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-34034

#### Branch description
Extends #18146 
I added a test to check the desired behavior of `option` having `required` and `id` attribute as per the last comments in that PR. Moreover, I have fixed that particular issue by adding both `self.option_attrs` and `self.attrs` in the call to `build_attrs()`. The later is added conditionally if `self.option_inherits_attrs` is `True`.  

A little thing to report here, there were two tests which were failing already. Them being:
1. `test_avoids_sending_to_invalid_addresses` from `test_backends`
2. `test_strip_tags` from `utils_test`

And after these changes, there were some other tests failing as well. There is one more solution and that is to do it like this
```py
all_attrs = self.option_attrs | self.attrs
option_attrs = (
    self.build_attrs(all_attrs, attrs) if self.option_inherits_attrs else {}
)
```
This way, only 4 tests were failing and the way which is currently is `forms/widgets.py` makes around 40-50 tests to fail.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
