### PR TITLE
Fixed #37140 -- Advised against filtering on iterables containing NULL.

### DIFF
--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -265,6 +265,12 @@ Note the second example is more restrictive.
 If you need to execute more complex queries (for example, queries with ``OR``
 statements), you can use :class:`Q objects <django.db.models.Q>` (``*args``).
 
+.. note::
+
+    See the warning under the :lookup:`in` lookup for unexpected behavior
+    when using ``exclude()`` with subqueries or lists of values that contain
+    ``NULL`` values.
+
 ``annotate()``
 ~~~~~~~~~~~~~~
 
@@ -3379,6 +3385,34 @@ extract two field values, where only one is expected::
     Note the ``list()`` call around the Blog ``QuerySet`` to force execution of
     the first query. Without it, a nested query would be executed, because
     :ref:`querysets-are-lazy`.
+
+.. warning::
+
+    **NULL values and three-valued logic**
+
+    If the right-hand side of an ``__in`` lookup (either a subquery or a list
+    of values) contains ``NULL`` (or ``None``), it can produce unexpected or
+    empty query results due to SQL's three-valued logic.
+
+    For example, when using ``exclude(field__in=...)``, if the right-hand side
+    contains even a single ``NULL`` value, the SQL ``NOT IN`` comparison
+    evaluates to ``UNKNOWN`` for all rows, resulting in an empty queryset.
+
+    To avoid this, filter out ``NULL`` values from the right-hand side:
+
+    .. code-block:: python
+
+        # For a subquery
+        inner_qs = Blog.objects.filter(name__isnull=False).values("pk")
+        entries = Entry.objects.exclude(blog__in=inner_qs)
+
+        # For a list of values
+        values = [1, 2, None]
+        non_null_values = [v for v in values if v is not None]
+        entries = Entry.objects.exclude(blog__in=non_null_values)
+
+    Alternatively, rewrite the query to use a NULL-safe
+    :class:`~django.db.models.Exists` subquery.
 
 .. fieldlookup:: gt
 

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -265,6 +265,11 @@ Note the second example is more restrictive.
 If you need to execute more complex queries (for example, queries with ``OR``
 statements), you can use :class:`Q objects <django.db.models.Q>` (``*args``).
 
+.. note::
+
+    See the warning under the :lookup:`in` lookup for unexpected behavior
+    when using ``exclude()`` with an iterable containing ``NULL`` values.
+
 ``annotate()``
 ~~~~~~~~~~~~~~
 
@@ -3379,6 +3384,34 @@ extract two field values, where only one is expected::
     Note the ``list()`` call around the Blog ``QuerySet`` to force execution of
     the first query. Without it, a nested query would be executed, because
     :ref:`querysets-are-lazy`.
+
+.. warning::
+
+    **NULL values and three-valued logic**
+
+    If the right-hand side of an ``__in`` lookup contains ``NULL`` (or
+    ``None``), it can produce unexpected or empty query results due to SQL's
+    three-valued logic.
+
+    For example, when using ``exclude(field__in=...)``, if the right-hand side
+    contains even a single ``NULL`` value, the SQL ``NOT IN`` comparison
+    evaluates to ``UNKNOWN`` for all rows, resulting in an empty queryset.
+
+    To avoid this, filter out ``NULL`` values from the right-hand side:
+
+    .. code-block:: python
+
+        # For a subquery
+        inner_qs = Blog.objects.filter(name__isnull=False).values("pk")
+        entries = Entry.objects.exclude(blog__in=inner_qs)
+
+        # For a list of values
+        values = [1, 2, None]
+        non_null_values = [v for v in values if v is not None]
+        entries = Entry.objects.exclude(blog__in=non_null_values)
+
+    Alternatively, rewrite the query to use a NULL-safe
+    :class:`~django.db.models.Exists` subquery.
 
 .. fieldlookup:: gt
 


### PR DESCRIPTION

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37140

#### Branch description
This PR documents a pitfall when using subqueries on the right-hand side of `__in` lookups. Due to SQL's three-valued logic, if the subquery returns any `NULL` values, executing `exclude(field__in=subquery)` translates to `NOT IN` in SQL and will evaluate to `UNKNOWN` for all rows, silently returning an empty queryset.

Following feedback from core ORM developers on the ticket, this PR:
* Adds a warning under the `in` lookup reference in `docs/ref/models/querysets.txt` describing the `NULL` logic pitfall.
* Documents the recommended workaround: explicitly excluding `NULL` values from the subquery using `filter(inner_field__isnull=False)`.
* Adds a cross-reference note under the `exclude()` method documentation pointing to the new warning.
* Followes Django's 80-character documentation line-wrapping guidelines.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
