### PR TITLE
Fix add_fields() method to handle None index when can_delete=True and can_delete_extra=False

### DIFF
--- a/django/forms/formsets.py
+++ b/django/forms/formsets.py
@@ -490,7 +490,9 @@ class BaseFormSet(RenderableFormMixin):
                     required=False,
                     widget=self.get_ordering_widget(),
                 )
-        if self.can_delete and (self.can_delete_extra or index < initial_form_count):
+        if self.can_delete and (
+            self.can_delete_extra or (index is not None and index < initial_form_count)
+        ):
             form.fields[DELETION_FIELD_NAME] = BooleanField(
                 label=_("Delete"),
                 required=False,


### PR DESCRIPTION
When a FormSet has can_delete=True and can_delete_extra=False, calling add_fields() with index=None (e.g., when calling empty_form()) would raise TypeError: '<' not supported between instances of 'NoneType' and 'int'.

This is fixed by checking if index is not None before comparing it to initial_form_count, consistent with the existing pattern used for the ordering field check on line 480.