### PR TITLE
Refs #36560, CVE-2026-35193 -- Recognized qualified cache-control directives.

### DIFF
--- a/django/middleware/cache.py
+++ b/django/middleware/cache.py
@@ -56,10 +56,9 @@ from django.utils.cache import (
     learn_cache_key,
     patch_response_headers,
     patch_vary_headers,
-    split_header_value,
 )
 from django.utils.deprecation import MiddlewareMixin
-from django.utils.http import parse_http_date_safe
+from django.utils.http import parse_http_date_safe, split_directive_names
 
 
 class UpdateCacheMiddleware(MiddlewareMixin):
@@ -105,17 +104,12 @@ class UpdateCacheMiddleware(MiddlewareMixin):
             return response
 
         # Don't cache responses when the Cache-Control header is set to
-        # private, no-cache, or no-store.
-        cache_control = response.get("Cache-Control", "").lower()
-        cache_control_parts = list(split_header_value(cache_control))
-        if cache_control and any(
-            directive in cache_control_parts
-            for directive in (
-                "private",
-                "no-cache",
-                "no-store",
-            )
-        ):
+        # private, no-cache, or no-store. Qualified forms like
+        # `private="Set-Cookie"` reduce to their directive name and match too.
+        cache_control_parts = set(
+            split_directive_names(response.get("Cache-Control", ""))
+        )
+        if cache_control_parts.intersection({"private", "no-cache", "no-store"}):
             return response
 
         # Don't cache responses when the Vary header contains '*'.

--- a/django/middleware/http.py
+++ b/django/middleware/http.py
@@ -1,6 +1,6 @@
 from django.utils.cache import get_conditional_response, set_response_etag
 from django.utils.deprecation import MiddlewareMixin
-from django.utils.http import parse_http_date_safe, split_header_value
+from django.utils.http import parse_http_date_safe, split_directive_names
 
 
 class ConditionalGetMiddleware(MiddlewareMixin):
@@ -37,5 +37,5 @@ class ConditionalGetMiddleware(MiddlewareMixin):
 
     def needs_etag(self, response):
         """Return True if an ETag header should be added to response."""
-        cache_control_headers = split_header_value(response.get("Cache-Control", ""))
-        return all(header.lower() != "no-store" for header in cache_control_headers)
+        directives = split_directive_names(response.get("Cache-Control", ""))
+        return "no-store" not in directives

--- a/django/utils/cache.py
+++ b/django/utils/cache.py
@@ -50,7 +50,7 @@ def patch_cache_control(response, **kwargs):
     def dictitem(s):
         t = s.split("=", 1)
         if len(t) > 1:
-            return (t[0].lower(), t[1])
+            return (t[0].strip().lower(), t[1])
         else:
             return (t[0].lower(), True)
 

--- a/django/utils/http.py
+++ b/django/utils/http.py
@@ -209,6 +209,20 @@ def split_header_value(value, sep=","):
             yield stripped
 
 
+def split_directive_names(value):
+    """Yield the lowercased directive names from an HTTP header value.
+
+    Any qualified value is discarded, so that qualified forms permitted by
+    RFC 9111 (e.g. `private="Set-Cookie"`) reduce to their directive name
+    ("private").
+
+    Use to check for the presence of a directive when its value is not needed;
+    use `split_header_value()` when the value matters (e.g. `max-age`).
+    """
+    for part in split_header_value(value):
+        yield part.split("=", 1)[0].strip().lower()
+
+
 def parse_etags(etag_str):
     """
     Parse a string of ETags given in an If-None-Match or If-Match header as

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -2466,6 +2466,17 @@ class CacheUtils(SimpleTestCase):
                 parts = {cc for cc in response.headers["Cache-Control"].split(", ")}
                 self.assertEqual(parts, expected_cc)
 
+    def test_patch_cache_control_whitespace_around_equals(self):
+        # Whitespace around "=" must not be retained in the directive name;
+        # otherwise no_cache=True fails to collapse the qualified field-list
+        # form (i.e. dictitem() lacks a strip()).
+        for initial_cc in ('no-cache ="Set-Cookie"', 'no-cache = "Set-Cookie"'):
+            with self.subTest(initial_cc=initial_cc):
+                response = HttpResponse(headers={"Cache-Control": initial_cc})
+                patch_cache_control(response, no_cache=True)
+                parts = {cc for cc in response.headers["Cache-Control"].split(", ")}
+                self.assertEqual(parts, {"no-cache"})
+
     def test_has_vary_header(self):
         tests = [
             ("*", "*", True),
@@ -3060,6 +3071,40 @@ class CacheMiddlewareTest(SimpleTestCase):
         self.assertEqual(response.content, b"Hello World 1")
         response = view(request, "2")
         self.assertEqual(response.content, b"Hello World 1")
+
+    def test_qualified_cache_control_value_not_cached(self):
+        for cc in (
+            'private="Set-Cookie"',
+            'no-cache="Set-Cookie"',
+            'no-store="Set-Cookie"',
+            # Malformed whitespace around "=" still fails safe.
+            'private ="Set-Cookie"',
+            'no-cache = "Set-Cookie"',
+        ):
+            with self.subTest(cache_control=cc):
+
+                @cache_page(3)
+                def view(request, value):
+                    return HttpResponse(
+                        f"Hello World {value}", headers={"Cache-Control": cc}
+                    )
+
+                request = self.factory.get("/view/")
+                response = view(request, "1")
+                self.assertEqual(response.content, b"Hello World 1")
+                response = view(request, "2")
+                self.assertEqual(response.content, b"Hello World 2")
+
+    def test_authorization_header_exception_qualified_public_directive(self):
+        @cache_page(3)
+        def view(request, value):
+            return HttpResponse(
+                f"Hello World {value}", headers={"Cache-Control": 'public="abc"'}
+            )
+
+        request = self.factory.get("/view/", headers={"Authorization": "token"})
+        response = view(request, "1")
+        self.assertIs(has_vary_header(response, "Authorization"), False)
 
     def test_vary_asterisk_not_cached(self):
         views_with_cache = (

--- a/tests/middleware/tests.py
+++ b/tests/middleware/tests.py
@@ -614,6 +614,15 @@ class ConditionalGetMiddlewareTest(SimpleTestCase):
             ConditionalGetMiddleware(self.get_response)(self.req).has_header("ETag")
         )
 
+    def test_no_etag_no_store_qualified(self):
+        # A qualified no-store directive (including whitespace around "=")
+        # reduces to its name and must still prevent ETag generation.
+        for cc in ('no-store="x"', 'no-store ="x"', "no-store = x"):
+            with self.subTest(cache_control=cc):
+                self.resp_headers["Cache-Control"] = cc
+                response = ConditionalGetMiddleware(self.get_response)(self.req)
+                self.assertIs(response.has_header("ETag"), False)
+
     def test_if_none_match_and_no_etag(self):
         self.req.META["HTTP_IF_NONE_MATCH"] = "spam"
         resp = ConditionalGetMiddleware(self.get_response)(self.req)

--- a/tests/utils_tests/test_http.py
+++ b/tests/utils_tests/test_http.py
@@ -18,6 +18,7 @@ from django.utils.http import (
     parse_header_parameters,
     parse_http_date,
     quote_etag,
+    split_directive_names,
     split_header_value,
     url_has_allowed_host_and_scheme,
     urlencode,
@@ -355,6 +356,29 @@ class SplitHeaderValueTests(unittest.TestCase):
         for value, expected in tests:
             with self.subTest(value=value):
                 self.assertEqual(list(split_header_value(value, sep=";")), expected)
+
+
+class SplitDirectiveNamesTests(unittest.TestCase):
+    def test_basic(self):
+        tests = [
+            ("", []),
+            ("no-store", ["no-store"]),
+            # Names are lowercased.
+            ("No-Store, PRIVATE", ["no-store", "private"]),
+            # Qualified values are dropped, leaving the directive name.
+            ('private="Set-Cookie"', ["private"]),
+            ('no-cache="Set-Cookie", max-age=0', ["no-cache", "max-age"]),
+            # Whitespace around the "=" is stripped from the name.
+            ('private ="Set-Cookie"', ["private"]),
+            ("no-cache = foo", ["no-cache"]),
+            # Superstrings are preserved (not confused for shorter names).
+            ("myprivate", ["myprivate"]),
+            # A nameless directive yields an empty name.
+            ('="Set-Cookie"', [""]),
+        ]
+        for value, expected in tests:
+            with self.subTest(value=value):
+                self.assertEqual(list(split_directive_names(value)), expected)
 
 
 class ETagProcessingTests(unittest.TestCase):


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-36560
CVE-2026-35193

#### Branch description

The switch from substring matching to exact token membership in 142b881cecaddc334cabec139e701c0e4b9798da caused qualified directive forms permitted by RFC 9111 (e.g. `Cache-Control: private="Set-Cookie"`) to be missed, allowing such responses to be stored in a shared cache.

This work added a new `split_directive_names()` helper that yields the lowercased directive name from each token, dropping any qualified value and stripping whitespace around "=", so qualified forms reduce to their directive name. `UpdateCacheMiddleware` now uses it so `private`, `no-cache`, and `no-store` (and the `public` exception for `Authorization`) match regardless of qualified form.

Aligned `ConditionalGetMiddleware.needs_etag()` to use the same helper, since it relied on the same brittle exact-token check. Sharing one helper keeps the two directive lookups consistent and means malformed input (e.g. `no-store="x"`) now correctly suppresses the `ETag` instead of being silently ignored.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [X] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude Code (Opus 4.8) was used to inspect the code and find other instances that may require attention.

#### Checklist
- [X] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [X] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [X] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
