### PR TITLE
Added or moved deprecation notes in docs/internals/deprecation.txt.

### DIFF
--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -38,9 +38,6 @@ details on these changes.
 
 * The ``URLIZE_ASSUME_HTTPS`` transitional setting will be removed.
 
-* The ``SIGNED_COOKIE_LEGACY_SALT_FALLBACK`` transitional setting will be
-  removed.
-
 * Using a percent sign in a column alias or annotation will raise
   ``ValueError``.
 
@@ -80,6 +77,9 @@ details on these changes.
 * The ``django.db.models.fields.BLANK_CHOICE_DASH`` constant will be removed.
 
 * The ``USE_BLANK_CHOICE_DASH`` transitional setting will be removed.
+
+* The ``SIGNED_COOKIE_LEGACY_SALT_FALLBACK`` transitional setting will be
+  removed.
 
 * The ``Field.get_placeholder_sql`` shim over the deprecated
   ``get_placeholder`` method will be removed.

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -120,6 +120,9 @@ details on these changes.
   ``django.core.signing.base64_hmac()`` will change from ``"sha1"`` to
   ``"sha256"``.
 
+* Calling :meth:`.QuerySet.select_related` without arguments will raise
+  :exc:`TypeError`.
+
 * :meth:`.QuerySet.select_related` will raise :exc:`TypeError` if passed
   ``True`` rather than :exc:`AttributeError`.
 

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -15,6 +15,8 @@ about each item can often be found in the release notes of two versions prior.
 See the :ref:`Django 6.2 release notes <deprecated-features-6.2>` for more
 details on these changes.
 
+* The ``safe`` parameter of :class:`~django.http.JsonResponse` will be removed.
+
 .. _deprecation-removed-in-7.0:
 
 7.0


### PR DESCRIPTION
#### Trac ticket number
ticket-36905
ticket-36593
CVE-2026-6873

Two of these should be backported to 6.1.x.