### PR TITLE
Refs #34118 -- Removed further asgiref coroutine detection shims in tests.

### DIFF
--- a/tests/deprecation/test_middleware_mixin.py
+++ b/tests/deprecation/test_middleware_mixin.py
@@ -1,6 +1,7 @@
 import threading
+from inspect import iscoroutinefunction
 
-from asgiref.sync import async_to_sync, iscoroutinefunction
+from asgiref.sync import async_to_sync
 
 from django.contrib.admindocs.middleware import XViewMiddleware
 from django.contrib.auth.middleware import (

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -5,11 +5,12 @@ import re
 import sys
 import tempfile
 import threading
+from inspect import iscoroutinefunction
 from io import StringIO
 from pathlib import Path
 from unittest import mock, skipIf
 
-from asgiref.sync import async_to_sync, iscoroutinefunction
+from asgiref.sync import async_to_sync
 
 from django.core import mail
 from django.core.files.uploadedfile import SimpleUploadedFile


### PR DESCRIPTION
Follow-up to 4a52533329a03207c1c4592a13fbb12b9ec5ef9e.

There were a few more 😅 