### PR TITLE
Refs #35638 -- Added coverage for updating a model instance with a db_default.

### DIFF
--- a/tests/field_defaults/tests.py
+++ b/tests/field_defaults/tests.py
@@ -98,6 +98,17 @@ class DefaultTests(TestCase):
         obj2 = DBDefaults.objects.create()
         self.assertEqual(obj2.both, 1)
 
+    def test_db_default_blind_overwrite(self):
+        """
+        Perform a blind overwrite: instantiate an object with a known pk
+        without fetching it, and overwrite some values. The db_default is used.
+        """
+        obj1 = DBDefaults.objects.create(null=1.2)
+        unfetched_instance = DBDefaults(pk=obj1.pk)
+        unfetched_instance.save()
+        obj1.refresh_from_db()
+        self.assertEqual(obj1.null, 1.1)
+
     def test_pk_db_default(self):
         obj1 = DBDefaultsPK.objects.create()
         if not connection.features.can_return_columns_from_insert:


### PR DESCRIPTION
We noticed this line wasn't covered:

https://github.com/django/django/blob/cf889381ffec9220ca9d7a8eccef0e06b903fa38/django/db/models/expressions.py#L1341-L1343

In [discussion](https://github.com/django/django/pull/20526#discussion_r2682809720):

> I'm not sure what calls `DatabaseDefault.resolve_expression` anymore to be honest, maybe some logic in `Model.save` prior to calling `sql.Query._insert`? [The coverage report](https://djangoci.com/view/%C2%ADCoverage/job/django-coverage/HTML_20Coverage_20Report/z_d81526da7cfdb7e4_expressions_py.html#t1295) points at the `not for_save` branch being completely dead so I guess we could prune it and raise a `ValueError` if `not for_save`?



 Instead, I wrote a test to cover it.