### PR TITLE
Fixed #37178 -- Moved MiddlewareMixin out of utils.deprecation.

### DIFF
--- a/django/contrib/admindocs/middleware.py
+++ b/django/contrib/admindocs/middleware.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponse
-from django.utils.deprecation import MiddlewareMixin
+from django.middleware import MiddlewareMixin
 
 from .utils import get_view_name
 

--- a/django/contrib/auth/middleware.py
+++ b/django/contrib/auth/middleware.py
@@ -10,7 +10,7 @@ from django.contrib.auth.views import redirect_to_login
 from django.core.exceptions import ImproperlyConfigured
 from django.core.handlers.asgi import ASGIRequest
 from django.shortcuts import resolve_url
-from django.utils.deprecation import MiddlewareMixin
+from django.middleware import MiddlewareMixin
 from django.utils.functional import SimpleLazyObject
 
 

--- a/django/contrib/flatpages/middleware.py
+++ b/django/contrib/flatpages/middleware.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.contrib.flatpages.views import flatpage
 from django.http import Http404
-from django.utils.deprecation import MiddlewareMixin
+from django.middleware import MiddlewareMixin
 
 
 class FlatpageFallbackMiddleware(MiddlewareMixin):

--- a/django/contrib/messages/middleware.py
+++ b/django/contrib/messages/middleware.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.contrib.messages.storage import default_storage
-from django.utils.deprecation import MiddlewareMixin
-
+from django.middleware import MiddlewareMixin
 
 class MessageMiddleware(MiddlewareMixin):
     """

--- a/django/contrib/redirects/middleware.py
+++ b/django/contrib/redirects/middleware.py
@@ -4,7 +4,7 @@ from django.contrib.redirects.models import Redirect
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponseGone, HttpResponsePermanentRedirect
-from django.utils.deprecation import MiddlewareMixin
+from django.middleware import MiddlewareMixin
 
 
 class RedirectFallbackMiddleware(MiddlewareMixin):

--- a/django/contrib/sessions/middleware.py
+++ b/django/contrib/sessions/middleware.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.contrib.sessions.backends.base import UpdateError
 from django.contrib.sessions.exceptions import SessionInterrupted
 from django.utils.cache import patch_vary_headers
-from django.utils.deprecation import MiddlewareMixin
+from django.middleware import MiddlewareMixin
 from django.utils.http import http_date
 
 

--- a/django/contrib/sites/middleware.py
+++ b/django/contrib/sites/middleware.py
@@ -1,4 +1,4 @@
-from django.utils.deprecation import MiddlewareMixin
+from django.middleware import MiddlewareMixin
 
 from .shortcuts import get_current_site
 

--- a/django/middleware/__init__.py
+++ b/django/middleware/__init__.py
@@ -1,0 +1,1 @@
+from django.middleware.base import MiddlewareMixin

--- a/django/middleware/base.py
+++ b/django/middleware/base.py
@@ -1,0 +1,60 @@
+from asgiref.sync import iscoroutinefunction, markcoroutinefunction, sync_to_async
+
+
+class MiddlewareMixin:
+    sync_capable = True
+    async_capable = True
+
+    def __init__(self, get_response):
+        if get_response is None:
+            raise ValueError("get_response must be provided.")
+        self.get_response = get_response
+        # If get_response is a coroutine function, turns us into async mode so
+        # a thread is not consumed during a whole request.
+        self.async_mode = iscoroutinefunction(self.get_response)
+        if self.async_mode:
+            # Mark the class as async-capable, but do the actual switch inside
+            # __call__ to avoid swapping out dunder methods.
+            markcoroutinefunction(self)
+        super().__init__()
+
+    def __repr__(self):
+        return "<%s get_response=%s>" % (
+            self.__class__.__qualname__,
+            getattr(
+                self.get_response,
+                "__qualname__",
+                self.get_response.__class__.__name__,
+            ),
+        )
+
+    def __call__(self, request):
+        # Exit out to async mode, if needed
+        if self.async_mode:
+            return self.__acall__(request)
+        response = None
+        if hasattr(self, "process_request"):
+            response = self.process_request(request)
+        response = response or self.get_response(request)
+        if hasattr(self, "process_response"):
+            response = self.process_response(request, response)
+        return response
+
+    async def __acall__(self, request):
+        """
+        Async version of __call__ that is swapped in when an async request
+        is running.
+        """
+        response = None
+        if hasattr(self, "process_request"):
+            response = await sync_to_async(
+                self.process_request,
+                thread_sensitive=True,
+            )(request)
+        response = response or await self.get_response(request)
+        if hasattr(self, "process_response"):
+            response = await sync_to_async(
+                self.process_response,
+                thread_sensitive=True,
+            )(request, response)
+        return response

--- a/django/middleware/cache.py
+++ b/django/middleware/cache.py
@@ -58,7 +58,7 @@ from django.utils.cache import (
     patch_vary_headers,
     split_header_value,
 )
-from django.utils.deprecation import MiddlewareMixin
+from django.middleware import MiddlewareMixin
 from django.utils.http import parse_http_date_safe
 
 

--- a/django/middleware/clickjacking.py
+++ b/django/middleware/clickjacking.py
@@ -6,7 +6,7 @@ malicious site loading resources from your site in a hidden frame.
 """
 
 from django.conf import settings
-from django.utils.deprecation import MiddlewareMixin
+from django.middleware import MiddlewareMixin
 
 
 class XFrameOptionsMiddleware(MiddlewareMixin):

--- a/django/middleware/common.py
+++ b/django/middleware/common.py
@@ -6,7 +6,7 @@ from django.core.exceptions import PermissionDenied
 from django.core.mail import MailerDoesNotExist, mail_managers, mailers
 from django.http import HttpResponsePermanentRedirect
 from django.urls import is_valid_path
-from django.utils.deprecation import MiddlewareMixin
+from django.middleware import MiddlewareMixin
 from django.utils.http import escape_leading_slashes
 
 

--- a/django/middleware/csp.py
+++ b/django/middleware/csp.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.utils.csp import CSP, LazyNonce, build_policy
-from django.utils.deprecation import MiddlewareMixin
+from django.middleware import MiddlewareMixin
 
 
 def get_nonce(request):

--- a/django/middleware/csrf.py
+++ b/django/middleware/csrf.py
@@ -16,7 +16,7 @@ from django.http import HttpHeaders, UnreadablePostError
 from django.urls import get_callable
 from django.utils.cache import patch_vary_headers
 from django.utils.crypto import constant_time_compare, get_random_string
-from django.utils.deprecation import MiddlewareMixin
+from django.middleware import MiddlewareMixin
 from django.utils.functional import cached_property
 from django.utils.http import is_same_domain
 from django.utils.log import log_response

--- a/django/middleware/gzip.py
+++ b/django/middleware/gzip.py
@@ -1,5 +1,5 @@
 from django.utils.cache import patch_vary_headers
-from django.utils.deprecation import MiddlewareMixin
+from django.middleware import MiddlewareMixin
 from django.utils.regex_helper import _lazy_re_compile
 from django.utils.text import acompress_sequence, compress_sequence, compress_string
 

--- a/django/middleware/http.py
+++ b/django/middleware/http.py
@@ -1,5 +1,5 @@
 from django.utils.cache import get_conditional_response, set_response_etag
-from django.utils.deprecation import MiddlewareMixin
+from django.middleware import MiddlewareMixin
 from django.utils.http import parse_http_date_safe, split_header_value
 
 

--- a/django/middleware/locale.py
+++ b/django/middleware/locale.py
@@ -4,7 +4,7 @@ from django.http import HttpResponseRedirect
 from django.urls import get_script_prefix, is_valid_path
 from django.utils import translation
 from django.utils.cache import patch_vary_headers
-from django.utils.deprecation import MiddlewareMixin
+from django.middleware import MiddlewareMixin
 
 
 class LocaleMiddleware(MiddlewareMixin):

--- a/django/middleware/security.py
+++ b/django/middleware/security.py
@@ -2,7 +2,7 @@ import re
 
 from django.conf import settings
 from django.http import HttpResponsePermanentRedirect
-from django.utils.deprecation import MiddlewareMixin
+from django.middleware import MiddlewareMixin
 
 
 class SecurityMiddleware(MiddlewareMixin):

--- a/django/utils/deprecation.py
+++ b/django/utils/deprecation.py
@@ -2,12 +2,16 @@ import functools
 import inspect
 import warnings
 from collections import Counter
-from inspect import iscoroutinefunction, markcoroutinefunction
+from inspect import iscoroutinefunction
 
-from asgiref.sync import sync_to_async
+
 
 from django.utils.inspect import signature
 from django.utils.warnings import django_file_prefixes
+
+# Retained for backward compactibility
+from django.middleware import MiddlewareMixin
+
 
 
 class RemovedInDjango70Warning(DeprecationWarning):
@@ -341,62 +345,3 @@ def deprecate_posargs(deprecation_warning, remappable_names, /):
         return wrapper
 
     return decorator
-
-
-class MiddlewareMixin:
-    sync_capable = True
-    async_capable = True
-
-    def __init__(self, get_response):
-        if get_response is None:
-            raise ValueError("get_response must be provided.")
-        self.get_response = get_response
-        # If get_response is a coroutine function, turns us into async mode so
-        # a thread is not consumed during a whole request.
-        self.async_mode = iscoroutinefunction(self.get_response)
-        if self.async_mode:
-            # Mark the class as async-capable, but do the actual switch inside
-            # __call__ to avoid swapping out dunder methods.
-            markcoroutinefunction(self)
-        super().__init__()
-
-    def __repr__(self):
-        return "<%s get_response=%s>" % (
-            self.__class__.__qualname__,
-            getattr(
-                self.get_response,
-                "__qualname__",
-                self.get_response.__class__.__name__,
-            ),
-        )
-
-    def __call__(self, request):
-        # Exit out to async mode, if needed
-        if self.async_mode:
-            return self.__acall__(request)
-        response = None
-        if hasattr(self, "process_request"):
-            response = self.process_request(request)
-        response = response or self.get_response(request)
-        if hasattr(self, "process_response"):
-            response = self.process_response(request, response)
-        return response
-
-    async def __acall__(self, request):
-        """
-        Async version of __call__ that is swapped in when an async request
-        is running.
-        """
-        response = None
-        if hasattr(self, "process_request"):
-            response = await sync_to_async(
-                self.process_request,
-                thread_sensitive=True,
-            )(request)
-        response = response or await self.get_response(request)
-        if hasattr(self, "process_response"):
-            response = await sync_to_async(
-                self.process_response,
-                thread_sensitive=True,
-            )(request, response)
-        return response

--- a/docs/topics/http/middleware.txt
+++ b/docs/topics/http/middleware.txt
@@ -395,10 +395,10 @@ instances are correctly marked as coroutine functions::
 Upgrading pre-Django 1.10-style middleware
 ==========================================
 
-.. class:: django.utils.deprecation.MiddlewareMixin
+.. class:: django.middleware.MiddlewareMixin
     :module:
 
-Django provides ``django.utils.deprecation.MiddlewareMixin`` to ease creating
+Django provides ``django.middleware.MiddlewareMixin`` to ease creating
 middleware classes that are compatible with both :setting:`MIDDLEWARE` and the
 old ``MIDDLEWARE_CLASSES``, and support synchronous and asynchronous requests.
 All middleware classes included with Django are compatible with both settings.

--- a/tests/csrf_tests/views.py
+++ b/tests/csrf_tests/views.py
@@ -3,7 +3,7 @@ from django.middleware.csrf import get_token, rotate_token
 from django.template import Context, RequestContext, Template
 from django.template.context_processors import csrf
 from django.utils.decorators import decorator_from_middleware
-from django.utils.deprecation import MiddlewareMixin
+from django.middleware import MiddlewareMixin
 from django.views.decorators.csrf import csrf_protect, ensure_csrf_cookie
 
 

--- a/tests/deprecation/test_middleware_mixin.py
+++ b/tests/deprecation/test_middleware_mixin.py
@@ -29,7 +29,8 @@ from django.middleware.http import ConditionalGetMiddleware
 from django.middleware.locale import LocaleMiddleware
 from django.middleware.security import SecurityMiddleware
 from django.test import SimpleTestCase
-from django.utils.deprecation import MiddlewareMixin
+from django.middleware import MiddlewareMixin
+from django.utils.deprecation import MiddlewareMixin as DeprecationMiddlewareMixin
 
 
 class MiddlewareMixinTests(SimpleTestCase):
@@ -54,6 +55,9 @@ class MiddlewareMixinTests(SimpleTestCase):
         XFrameOptionsMiddleware,
         XViewMiddleware,
     ]
+
+    def test_deprecation_import_compatibility(self):
+        self.assertIs(DeprecationMiddlewareMixin, MiddlewareMixin)
 
     def test_repr(self):
         class GetResponse:

--- a/tests/urlpatterns_reverse/middleware.py
+++ b/tests/urlpatterns_reverse/middleware.py
@@ -1,6 +1,6 @@
 from django.http import HttpResponse, StreamingHttpResponse
 from django.urls import reverse
-from django.utils.deprecation import MiddlewareMixin
+from django.middleware import MiddlewareMixin
 
 from . import urlconf_inner
 


### PR DESCRIPTION
#### Trac ticket number

ticket-37178

#### Branch description

Moved `MiddlewareMixin` out of `django.utils.deprecation` and into the middleware package.

This updates Django’s internal middleware imports to use `django.middleware.MiddlewareMixin` while keeping the old `django.utils.deprecation.MiddlewareMixin` import path working for backward compatibility.

Also updated the middleware documentation and added a test to ensure the old import path still points to the same class.

Tests run:

```bash
PYTHONPATH=. python tests/runtests.py deprecation.test_middleware_mixin
```

Release notes are not applicable because this change keeps the old import path working for backward compatibility.

#### AI Assistance Disclosure (REQUIRED)

* [ ] **No AI tools were used** in preparing this PR.
* [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

I used ChatGPT to help understand the ticket, contribution workflow, and review the implementation steps. I manually verified the final changes and ran the targeted test listed above.

#### Checklist

* [x] This PR follows the [[contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/)](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
* [x] This PR **does not** disclose a security vulnerability (see [[vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)](https://docs.djangoproject.com/en/stable/internals/security/)).
* [x] This PR targets the `main` branch.
* [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
* [x] I have not requested, and will not request, an automated AI review for this PR.
* [x] I have checked the "Has patch" ticket flag in the Trac system.
* [x] I have added or updated relevant tests.
* [x] I have added or updated relevant docs, including release notes if applicable.
* [x] I have attached screenshots in both light and dark modes for any UI changes. N/A, no UI changes.