### PR TITLE
Refs #36983 -- Skipped GC specific tests when GIL disabled.

### DIFF
--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -787,6 +787,17 @@ requires_tz_support = skipUnless(
 )
 
 
+requires_gil = skipUnless(
+    # sys._is_gil_enabled() is available on Python 3.13+, and only returns
+    # False on a free-threaded build with the GIL disabled. Assume the GIL is
+    # enabled otherwise.
+    getattr(sys, "_is_gil_enabled", lambda: True)(),
+    "This test relies on CPython's reference counting to free objects as soon "
+    "as they become unreachable, which isn't guaranteed on a free-threaded "
+    "build where the cyclic garbage collector may reclaim them instead.",
+)
+
+
 @contextmanager
 def extend_sys_path(*paths):
     """Context manager to temporarily add paths to sys.path."""

--- a/tests/backends/base/test_base.py
+++ b/tests/backends/base/test_base.py
@@ -10,7 +10,7 @@ from django.test import (
     skipUnlessDBFeature,
 )
 from django.test.runner import DebugSQLTextTestResult
-from django.test.utils import CaptureQueriesContext, override_settings
+from django.test.utils import CaptureQueriesContext, override_settings, requires_gil
 
 from ..models import Person, Square
 
@@ -62,6 +62,7 @@ class DatabaseWrapperTests(SimpleTestCase):
         with patch.object(connection.features, "minimum_database_version", None):
             connection.check_database_version_supported()
 
+    @requires_gil
     def test_release_memory_without_garbage_collection(self):
         # Schedule the restore of the garbage collection settings.
         self.addCleanup(gc.set_debug, 0)

--- a/tests/model_regress/test_state.py
+++ b/tests/model_regress/test_state.py
@@ -2,7 +2,7 @@ import gc
 
 from django.db.models.base import ModelState, ModelStateFieldsCacheDescriptor
 from django.test import SimpleTestCase
-from django.test.utils import garbage_collect
+from django.test.utils import garbage_collect, requires_gil
 
 from .models import Worker, WorkerProfile
 
@@ -11,6 +11,7 @@ class ModelStateTests(SimpleTestCase):
     def test_fields_cache_descriptor(self):
         self.assertIsInstance(ModelState.fields_cache, ModelStateFieldsCacheDescriptor)
 
+    @requires_gil
     def test_one_to_one_field_cycle_collection(self):
         self.addCleanup(gc.set_debug, gc.get_debug())
         gc.set_debug(gc.DEBUG_SAVEALL)

--- a/tests/select_related/tests.py
+++ b/tests/select_related/tests.py
@@ -3,7 +3,7 @@ import gc
 from django.core.exceptions import FieldError
 from django.db.models import FETCH_PEERS
 from django.test import SimpleTestCase, TestCase
-from django.test.utils import garbage_collect, ignore_warnings
+from django.test.utils import garbage_collect, ignore_warnings, requires_gil
 from django.utils.deprecation import RemovedInDjango70Warning
 
 from .models import (
@@ -62,15 +62,19 @@ class SelectRelatedTests(TestCase):
         )
 
     def setup_gc_debug(self):
+        self.addCleanup(gc.garbage.clear)
         self.addCleanup(gc.set_debug, 0)
         self.addCleanup(gc.enable)
         gc.disable()
         garbage_collect()
         gc.set_debug(gc.DEBUG_SAVEALL)
 
-    def assert_no_memory_leaks(self):
+    def assert_no_local_function_leaks(self):
         garbage_collect()
-        self.assertEqual(gc.garbage, [])
+        local_functions_leaked = [
+            obj for obj in gc.garbage if "<locals>" in getattr(obj, "__qualname__", "")
+        ]
+        self.assertEqual(local_functions_leaked, [])
 
     def test_access_fks_without_select_related(self):
         """
@@ -157,10 +161,11 @@ class SelectRelatedTests(TestCase):
         )
         self.assertEqual(s.id + 10, s.a)
 
+    @requires_gil
     def test_select_related_memory_leak(self):
         self.setup_gc_debug()
         list(Species.objects.select_related("genus"))
-        self.assert_no_memory_leaks()
+        self.assert_no_local_function_leaks()
 
     def test_certain_fields(self):
         """


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-36983

#### Branch description

Running the test suite with python3.14t — the free-threading build — 5 tests failed. 

Two are asgiref (`Local`) related, and I will resolve those there. 

The other three are about GC behaviour, which is different with the GIL disabled. So added a skip. 

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

I used Claude to help me understand the failures. 

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
