### PR TITLE
Fixed #37177 -- Reduced per-middleware context switching under ASGI.

### DIFF
--- a/django/contrib/auth/middleware.py
+++ b/django/contrib/auth/middleware.py
@@ -27,6 +27,8 @@ async def auser(request):
 
 
 class AuthenticationMiddleware(MiddlewareMixin):
+    async_capable = False
+
     def process_request(self, request):
         if not hasattr(request, "session"):
             raise ImproperlyConfigured(

--- a/django/contrib/flatpages/middleware.py
+++ b/django/contrib/flatpages/middleware.py
@@ -5,6 +5,8 @@ from django.utils.deprecation import MiddlewareMixin
 
 
 class FlatpageFallbackMiddleware(MiddlewareMixin):
+    async_capable = False
+
     def process_response(self, request, response):
         if response.status_code != 404:
             return response  # No need to check for a flatpage for non-404 responses.

--- a/django/contrib/flatpages/middleware.py
+++ b/django/contrib/flatpages/middleware.py
@@ -5,6 +5,8 @@ from django.middleware import MiddlewareMixin
 
 
 class FlatpageFallbackMiddleware(MiddlewareMixin):
+    async_capable = False
+
     def process_response(self, request, response):
         if response.status_code != 404:
             return response  # No need to check for a flatpage for non-404 responses.

--- a/django/contrib/messages/middleware.py
+++ b/django/contrib/messages/middleware.py
@@ -8,6 +8,8 @@ class MessageMiddleware(MiddlewareMixin):
     Middleware that handles temporary messages.
     """
 
+    async_capable = False
+
     def process_request(self, request):
         request._messages = default_storage(request)
 

--- a/django/contrib/redirects/middleware.py
+++ b/django/contrib/redirects/middleware.py
@@ -8,6 +8,8 @@ from django.utils.deprecation import MiddlewareMixin
 
 
 class RedirectFallbackMiddleware(MiddlewareMixin):
+    async_capable = False
+
     # Defined as class-level attributes to be subclassing-friendly.
     response_gone_class = HttpResponseGone
     response_redirect_class = HttpResponsePermanentRedirect

--- a/django/contrib/redirects/middleware.py
+++ b/django/contrib/redirects/middleware.py
@@ -8,6 +8,8 @@ from django.middleware import MiddlewareMixin
 
 
 class RedirectFallbackMiddleware(MiddlewareMixin):
+    async_capable = False
+
     # Defined as class-level attributes to be subclassing-friendly.
     response_gone_class = HttpResponseGone
     response_redirect_class = HttpResponsePermanentRedirect

--- a/django/contrib/sessions/middleware.py
+++ b/django/contrib/sessions/middleware.py
@@ -10,6 +10,8 @@ from django.utils.http import http_date
 
 
 class SessionMiddleware(MiddlewareMixin):
+    async_capable = False
+
     def __init__(self, get_response):
         super().__init__(get_response)
         engine = import_module(settings.SESSION_ENGINE)

--- a/django/contrib/sites/middleware.py
+++ b/django/contrib/sites/middleware.py
@@ -8,5 +8,7 @@ class CurrentSiteMiddleware(MiddlewareMixin):
     Middleware that sets `site` attribute to request object.
     """
 
+    async_capable = False
+
     def process_request(self, request):
         request.site = get_current_site(request)

--- a/django/middleware/cache.py
+++ b/django/middleware/cache.py
@@ -71,6 +71,8 @@ class UpdateCacheMiddleware(MiddlewareMixin):
     so that it'll get called last during the response phase.
     """
 
+    async_capable = False
+
     def __init__(self, get_response):
         super().__init__(get_response)
         self.cache_timeout = settings.CACHE_MIDDLEWARE_SECONDS
@@ -156,6 +158,8 @@ class FetchFromCacheMiddleware(MiddlewareMixin):
     FetchFromCacheMiddleware must be the last piece of middleware in MIDDLEWARE
     so that it'll get called last during the request phase.
     """
+
+    async_capable = False
 
     def __init__(self, get_response):
         super().__init__(get_response)

--- a/django/middleware/cache.py
+++ b/django/middleware/cache.py
@@ -71,6 +71,8 @@ class UpdateCacheMiddleware(MiddlewareMixin):
     so that it'll get called last during the response phase.
     """
 
+    async_capable = False
+
     def __init__(self, get_response):
         super().__init__(get_response)
         self.cache_timeout = settings.CACHE_MIDDLEWARE_SECONDS
@@ -152,6 +154,8 @@ class FetchFromCacheMiddleware(MiddlewareMixin):
     FetchFromCacheMiddleware must be the last piece of middleware in MIDDLEWARE
     so that it'll get called last during the request phase.
     """
+
+    async_capable = False
 
     def __init__(self, get_response):
         super().__init__(get_response)

--- a/django/middleware/clickjacking.py
+++ b/django/middleware/clickjacking.py
@@ -22,6 +22,8 @@ class XFrameOptionsMiddleware(MiddlewareMixin):
     X_FRAME_OPTIONS in your project's Django settings to 'SAMEORIGIN'.
     """
 
+    async_capable = False
+
     def process_response(self, request, response):
         # Don't set it if it's already in the response
         if response.get("X-Frame-Options") is not None:

--- a/django/middleware/common.py
+++ b/django/middleware/common.py
@@ -29,6 +29,7 @@ class CommonMiddleware(MiddlewareMixin):
           overriding the response_redirect_class attribute.
     """
 
+    async_capable = False
     response_redirect_class = HttpResponsePermanentRedirect
 
     def process_request(self, request):
@@ -118,6 +119,7 @@ class CommonMiddleware(MiddlewareMixin):
 
 
 class BrokenLinkEmailsMiddleware(MiddlewareMixin):
+    async_capable = False
     # Set to override the mail.mailers alias used for sending the email.
     using = None
 

--- a/django/middleware/csp.py
+++ b/django/middleware/csp.py
@@ -8,6 +8,8 @@ def get_nonce(request):
 
 
 class ContentSecurityPolicyMiddleware(MiddlewareMixin):
+    async_capable = False
+
     def process_request(self, request):
         request._csp_nonce = LazyNonce()
 

--- a/django/middleware/csrf.py
+++ b/django/middleware/csrf.py
@@ -171,6 +171,8 @@ class CsrfViewMiddleware(MiddlewareMixin):
     template tag.
     """
 
+    async_capable = False
+
     @cached_property
     def csrf_trusted_origins_hosts(self):
         return [

--- a/django/middleware/gzip.py
+++ b/django/middleware/gzip.py
@@ -13,6 +13,7 @@ class GZipMiddleware(MiddlewareMixin):
     on the Accept-Encoding header.
     """
 
+    async_capable = False
     max_random_bytes = 100
 
     def process_response(self, request, response):

--- a/django/middleware/http.py
+++ b/django/middleware/http.py
@@ -11,6 +11,8 @@ class ConditionalGetMiddleware(MiddlewareMixin):
     header if needed.
     """
 
+    async_capable = False
+
     def process_response(self, request, response):
         # It's too late to prevent an unsafe request with a 412 response, and
         # for a HEAD request, the response body is always empty so computing

--- a/django/middleware/locale.py
+++ b/django/middleware/locale.py
@@ -14,6 +14,7 @@ class LocaleMiddleware(MiddlewareMixin):
     the language the user desires (if the language is available).
     """
 
+    async_capable = False
     response_redirect_class = HttpResponseRedirect
 
     def process_request(self, request):

--- a/django/middleware/security.py
+++ b/django/middleware/security.py
@@ -6,6 +6,8 @@ from django.utils.deprecation import MiddlewareMixin
 
 
 class SecurityMiddleware(MiddlewareMixin):
+    async_capable = False
+
     def __init__(self, get_response):
         super().__init__(get_response)
         self.sts_seconds = settings.SECURE_HSTS_SECONDS

--- a/django/middleware/security.py
+++ b/django/middleware/security.py
@@ -6,6 +6,8 @@ from django.middleware import MiddlewareMixin
 
 
 class SecurityMiddleware(MiddlewareMixin):
+    async_capable = False
+
     def __init__(self, get_response):
         super().__init__(get_response)
         self.sts_seconds = settings.SECURE_HSTS_SECONDS

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -493,6 +493,22 @@ Models
   using :class:`.RawSQL`, might have to be adjusted to also make use of
   quoting.
 
+Requests and responses
+----------------------
+
+* Most Django-provided middleware now set ``async_capable = False`` to
+  avoid repetitive context switching in ``MiddlewareMixin.__acall__()`` under
+  ASGI. For atypical use cases — high in-process concurrency over non-ORM I/O,
+  where no thread is otherwise held — the repetitive context switching may be
+  preferable to pinning a thread per request (see :ref:`async_performance`).
+  Such deployments can restore the prior behavior by setting
+  ``async_capable = True``; see :ref:`MiddlewareMixin <upgrading-middleware>`.
+  :class:`~django.contrib.auth.middleware.RemoteUserMiddleware` is unaffected,
+  because it does not use ``MiddlewareMixin``. Neither is
+  :class:`~django.contrib.auth.middleware.LoginRequiredMiddleware` nor
+  ``django.contrib.admindocs.middleware.XViewMiddleware`` affected, as they did
+  not implement ``process_request()`` or ``process_response()``.
+
 System checks
 -------------
 

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -286,6 +286,22 @@ backends.
   :meth:`~django.contrib.gis.gdal.Field.as_datetime` is now a ``c_float``
   rather than a ``c_int``.
 
+Requests and responses
+----------------------
+
+* Most Django-provided middleware now set ``async_capable = False`` to
+  avoid repetitive context switching in ``MiddlewareMixin.__acall__()`` under
+  ASGI. For atypical use cases — high in-process concurrency over non-ORM I/O,
+  where no thread is otherwise held — the repetitive context switching may be
+  preferable to pinning a thread per request (see :ref:`async_performance`).
+  Such deployments can restore the prior behavior by setting
+  ``async_capable = True``; see :ref:`MiddlewareMixin <upgrading-middleware>`.
+  :class:`~django.contrib.auth.middleware.RemoteUserMiddleware` is unaffected,
+  because it does not use ``MiddlewareMixin``. Neither is
+  :class:`~django.contrib.auth.middleware.LoginRequiredMiddleware` nor
+  ``django.contrib.admindocs.middleware.XViewMiddleware`` affected, as they did
+  not implement ``process_request()`` or ``process_response()``.
+
 Tests
 -----
 

--- a/docs/topics/http/middleware.txt
+++ b/docs/topics/http/middleware.txt
@@ -414,9 +414,23 @@ The ``__call__()`` method:
 #. Calls ``self.process_response(request, response)`` (if defined).
 #. Returns the response.
 
-If used with ``MIDDLEWARE_CLASSES``, the ``__call__()`` method will
-never be used; Django calls ``process_request()`` and ``process_response()``
-directly.
+The ``__acall__()`` method adapts sync ``process_request()`` and
+``process_response()`` methods to the async context, which is usually something
+to avoid, as it causes repetitive context switching (via
+:func:`asgiref.sync.sync_to_async`) for each middleware. For this reason,
+Django's built-in middlewares that lack an ``__acall__()`` implementation set
+``async_capable = False``. Views tuned for high in-process concurrency over
+non-ORM I/O (see :ref:`async_performance`) and only light CPU-bound work in
+sync middleware may find this repetitive context switching preferable to the
+alternative -- pinning a thread per request in sync mode -- and may wish to set
+``async_capable`` to ``True``.
+
+.. versionchanged:: 6.1
+
+    In earlier versions, each of Django's middlewares without their own
+    ``__acall__()`` inherited the default value of
+    ``MiddlewareMixin.async_capable`` (``True``), making them subject to the
+    repetitive context switching described above.
 
 In most cases, inheriting from this mixin will be sufficient to make an
 old-style middleware compatible with the new system with sufficient

--- a/docs/topics/http/middleware.txt
+++ b/docs/topics/http/middleware.txt
@@ -414,9 +414,23 @@ The ``__call__()`` method:
 #. Calls ``self.process_response(request, response)`` (if defined).
 #. Returns the response.
 
-If used with ``MIDDLEWARE_CLASSES``, the ``__call__()`` method will
-never be used; Django calls ``process_request()`` and ``process_response()``
-directly.
+The ``__acall__()`` method adapts sync ``process_request()`` and
+``process_response()`` methods to the async context, which is usually something
+to avoid, as it causes repetitive context switching (via
+:func:`asgiref.sync.sync_to_async`) for each middleware. For this reason,
+Django's built-in middlewares that lack an ``__acall__()`` implementation set
+``async_capable = False``. Views tuned for high in-process concurrency over
+non-ORM I/O (see :ref:`async_performance`) and only light CPU-bound work in
+sync middleware may find this repetitive context switching preferable to the
+alternative -- pinning a thread per request in sync mode -- and may wish to set
+``async_capable`` to ``True``.
+
+.. versionchanged:: 6.2
+
+    In earlier versions, each of Django's middlewares without their own
+    ``__acall__()`` inherited the default value of
+    ``MiddlewareMixin.async_capable`` (``True``), making them subject to the
+    repetitive context switching described above.
 
 In most cases, inheriting from this mixin will be sufficient to make an
 old-style middleware compatible with the new system with sufficient

--- a/tests/middleware_exceptions/tests.py
+++ b/tests/middleware_exceptions/tests.py
@@ -7,7 +7,6 @@ from django.conf import settings
 from django.core.exceptions import MiddlewareNotUsed
 from django.http import HttpResponse
 from django.test import RequestFactory, SimpleTestCase, TestCase, override_settings
-from django.test.client import AsyncClient
 from django.utils.deprecation import MiddlewareMixin
 from django.utils.module_loading import import_string
 
@@ -391,11 +390,6 @@ class MiddlewareSyncAsyncTransitionTests(TestCase):
         self.assertEqual(base_adapter.call_count, 1)
 
     async def test_sync_middleware_adaptation_grouping_isolation(self):
-        real_acall = MiddlewareMixin.__acall__
-
-        async def spy_acall(self, request):
-            return await real_acall(self, request)
-
         for middleware in [
             # From startproject template.
             "django.middleware.security.SecurityMiddleware",
@@ -419,31 +413,14 @@ class MiddlewareSyncAsyncTransitionTests(TestCase):
             "django.middleware.locale.LocaleMiddleware",
         ]:
             with (
-                self.subTest(middleware=middleware),
-                self.settings(MIDDLEWARE=[middleware]),
-                (
-                    self.modify_settings(
-                        INSTALLED_APPS={"append": middleware.split(".middleware")[0]}
-                    )
-                    if middleware.startswith("django.contrib.")
-                    else nullcontext()
-                ),
-                # Patch out any ImproperlyConfigured from testing in isolation.
-                (
-                    mock.patch(
-                        f"{middleware}.process_request",
-                        side_effect=lambda request: None,
-                    )
-                    if hasattr(import_string(middleware), "process_request")
-                    else nullcontext()
-                ),
-                mock.patch.object(
-                    MiddlewareMixin, "__acall__", autospec=True, side_effect=spy_acall
-                ) as acall,
+                self.modify_settings(
+                    INSTALLED_APPS={"append": middleware.split(".middleware")[0]}
+                )
+                if middleware.startswith("django.contrib.")
+                else nullcontext()
             ):
-                client = AsyncClient()
-                await client.get("/middleware_exceptions/async_view/")
-                acall.assert_not_called()
+                klass = import_string(middleware)
+                self.assertIs(klass.async_capable, False)
 
 
 @override_settings(ROOT_URLCONF="middleware_exceptions.urls")

--- a/tests/middleware_exceptions/tests.py
+++ b/tests/middleware_exceptions/tests.py
@@ -1,7 +1,13 @@
+from contextlib import nullcontext
+from unittest import mock
+
+from asgiref.sync import sync_to_async
+
 from django.conf import settings
 from django.core.exceptions import MiddlewareNotUsed
 from django.http import HttpResponse
 from django.test import RequestFactory, SimpleTestCase, override_settings
+from django.utils.module_loading import import_string
 
 from . import middleware as mw
 
@@ -344,6 +350,77 @@ class MiddlewareSyncAsyncTests(SimpleTestCase):
         response = self.client.get("/middleware_exceptions/view/")
         self.assertEqual(response.content, b"OK")
         self.assertEqual(response.status_code, 200)
+
+    async def test_sync_middleware_adaptation_grouping(self):
+        with (
+            mock.patch(
+                "django.utils.deprecation.sync_to_async", side_effect=sync_to_async
+            ) as mixin_adapter,
+            mock.patch(
+                "django.core.handlers.base.sync_to_async", side_effect=sync_to_async
+            ) as base_adapter,
+            # This middleware requires a second adaptation for process_view(),
+            # making it a little harder to see what's happening.
+            self.modify_settings(
+                MIDDLEWARE={"remove": "django.middleware.csrf.CsrfViewMiddleware"}
+            ),
+        ):
+            await self.async_client.get("/middleware_exceptions/async_view/")
+        # No sync-to-async adaptation via MiddlewareMixin.
+        self.assertEqual(mixin_adapter.call_count, 0)
+        # O(1) sync-to-async adaptation via BaseHandler.
+        self.assertEqual(base_adapter.call_count, 1)
+
+    async def test_sync_middleware_adaptation_grouping_isolation(self):
+        for middleware in [
+            # From startproject template.
+            "django.middleware.security.SecurityMiddleware",
+            "django.contrib.sessions.middleware.SessionMiddleware",
+            "django.middleware.common.CommonMiddleware",
+            "django.middleware.csrf.CsrfViewMiddleware",
+            "django.contrib.auth.middleware.AuthenticationMiddleware",
+            "django.contrib.messages.middleware.MessageMiddleware",
+            "django.middleware.clickjacking.XFrameOptionsMiddleware",
+            # Other subclasses of MiddlewareMixin implementing either
+            # process_response() or process_request().
+            "django.contrib.flatpages.middleware.FlatpageFallbackMiddleware",
+            "django.contrib.redirects.middleware.RedirectFallbackMiddleware",
+            "django.contrib.sites.middleware.CurrentSiteMiddleware",
+            "django.middleware.cache.FetchFromCacheMiddleware",
+            "django.middleware.cache.UpdateCacheMiddleware",
+            "django.middleware.common.BrokenLinkEmailsMiddleware",
+            "django.middleware.csp.ContentSecurityPolicyMiddleware",
+            "django.middleware.gzip.GZipMiddleware",
+            "django.middleware.http.ConditionalGetMiddleware",
+            "django.middleware.locale.LocaleMiddleware",
+        ]:
+            with (
+                self.subTest(middleware=middleware),
+                self.settings(MIDDLEWARE=[middleware]),
+                (
+                    self.modify_settings(
+                        INSTALLED_APPS={"append": middleware.split(".middleware")[0]}
+                    )
+                    if middleware.startswith("django.contrib.")
+                    else nullcontext()
+                ),
+                mock.patch(
+                    "django.utils.deprecation.sync_to_async", side_effect=sync_to_async
+                ) as mocked_adapter,
+                # Patch out any ImproperlyConfigured from testing in isolation.
+                (
+                    mock.patch(
+                        f"{middleware}.process_request",
+                        side_effect=lambda request: None,
+                    )
+                    if hasattr(import_string(middleware), "process_request")
+                    else nullcontext()
+                ),
+            ):
+                self.async_client.handler.load_middleware(is_async=True)
+                await self.async_client.get("/middleware_exceptions/async_view/")
+                # No sync-to-async adaptation via MiddlewareMixin.
+                self.assertEqual(mocked_adapter.call_count, 0)
 
 
 @override_settings(ROOT_URLCONF="middleware_exceptions.urls")

--- a/tests/middleware_exceptions/tests.py
+++ b/tests/middleware_exceptions/tests.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.core.exceptions import MiddlewareNotUsed
 from django.http import HttpResponse
 from django.test import RequestFactory, SimpleTestCase, TestCase, override_settings
+from django.test.client import AsyncClient
 from django.utils.deprecation import MiddlewareMixin
 from django.utils.module_loading import import_string
 
@@ -440,9 +441,9 @@ class MiddlewareSyncAsyncTransitionTests(TestCase):
                     MiddlewareMixin, "__acall__", autospec=True, side_effect=spy_acall
                 ) as acall,
             ):
-                self.async_client.handler.load_middleware(is_async=True)
-                await self.async_client.get("/middleware_exceptions/async_view/")
-                self.assertEqual(acall.call_count, 0)
+                client = AsyncClient()
+                await client.get("/middleware_exceptions/async_view/")
+                acall.assert_not_called()
 
 
 @override_settings(ROOT_URLCONF="middleware_exceptions.urls")

--- a/tests/middleware_exceptions/tests.py
+++ b/tests/middleware_exceptions/tests.py
@@ -6,7 +6,8 @@ from asgiref.sync import sync_to_async
 from django.conf import settings
 from django.core.exceptions import MiddlewareNotUsed
 from django.http import HttpResponse
-from django.test import RequestFactory, SimpleTestCase, override_settings
+from django.test import RequestFactory, SimpleTestCase, TestCase, override_settings
+from django.utils.deprecation import MiddlewareMixin
 from django.utils.module_loading import import_string
 
 from . import middleware as mw
@@ -351,27 +352,49 @@ class MiddlewareSyncAsyncTests(SimpleTestCase):
         self.assertEqual(response.content, b"OK")
         self.assertEqual(response.status_code, 200)
 
+
+@override_settings(
+    DEBUG=True,
+    ROOT_URLCONF="middleware_exceptions.urls",
+)
+class MiddlewareSyncAsyncTransitionTests(TestCase):
     async def test_sync_middleware_adaptation_grouping(self):
+        real_acall = MiddlewareMixin.__acall__
+
+        async def spy_acall(self, request):
+            return await real_acall(self, request)
+
         with (
-            mock.patch(
-                "django.utils.deprecation.sync_to_async", side_effect=sync_to_async
-            ) as mixin_adapter,
-            mock.patch(
-                "django.core.handlers.base.sync_to_async", side_effect=sync_to_async
-            ) as base_adapter,
             # This middleware requires a second adaptation for process_view(),
             # making it a little harder to see what's happening.
             self.modify_settings(
                 MIDDLEWARE={"remove": "django.middleware.csrf.CsrfViewMiddleware"}
             ),
+            mock.patch.object(
+                MiddlewareMixin,
+                "__acall__",
+                autospec=True,
+                side_effect=spy_acall,
+            ) as acall,
         ):
+            with mock.patch(
+                "django.core.handlers.base.sync_to_async", wraps=sync_to_async
+            ) as base_adapter:
+                self.async_client.handler.load_middleware(is_async=True)
+            # Exit the mock of sync_to_async before issuing a request.
             await self.async_client.get("/middleware_exceptions/async_view/")
-        # No sync-to-async adaptation via MiddlewareMixin.
-        self.assertEqual(mixin_adapter.call_count, 0)
+
+        # No sync-to-async adaptation via MiddlewareMixin.__acall__().
+        acall.assert_not_called()
         # O(1) sync-to-async adaptation via BaseHandler.
         self.assertEqual(base_adapter.call_count, 1)
 
     async def test_sync_middleware_adaptation_grouping_isolation(self):
+        real_acall = MiddlewareMixin.__acall__
+
+        async def spy_acall(self, request):
+            return await real_acall(self, request)
+
         for middleware in [
             # From startproject template.
             "django.middleware.security.SecurityMiddleware",
@@ -404,9 +427,6 @@ class MiddlewareSyncAsyncTests(SimpleTestCase):
                     if middleware.startswith("django.contrib.")
                     else nullcontext()
                 ),
-                mock.patch(
-                    "django.utils.deprecation.sync_to_async", side_effect=sync_to_async
-                ) as mocked_adapter,
                 # Patch out any ImproperlyConfigured from testing in isolation.
                 (
                     mock.patch(
@@ -416,11 +436,13 @@ class MiddlewareSyncAsyncTests(SimpleTestCase):
                     if hasattr(import_string(middleware), "process_request")
                     else nullcontext()
                 ),
+                mock.patch.object(
+                    MiddlewareMixin, "__acall__", autospec=True, side_effect=spy_acall
+                ) as acall,
             ):
                 self.async_client.handler.load_middleware(is_async=True)
                 await self.async_client.get("/middleware_exceptions/async_view/")
-                # No sync-to-async adaptation via MiddlewareMixin.
-                self.assertEqual(mocked_adapter.call_count, 0)
+                self.assertEqual(acall.call_count, 0)
 
 
 @override_settings(ROOT_URLCONF="middleware_exceptions.urls")

--- a/tests/middleware_exceptions/tests.py
+++ b/tests/middleware_exceptions/tests.py
@@ -1,7 +1,15 @@
+from contextlib import nullcontext
+from unittest import mock
+
+from asgiref.sync import sync_to_async
+
 from django.conf import settings
 from django.core.exceptions import MiddlewareNotUsed
 from django.http import HttpResponse
-from django.test import RequestFactory, SimpleTestCase, override_settings
+from django.middleware import MiddlewareMixin
+from django.test import RequestFactory, SimpleTestCase, TestCase, override_settings
+from django.test.client import AsyncClient
+from django.utils.module_loading import import_string
 
 from . import middleware as mw
 
@@ -344,6 +352,98 @@ class MiddlewareSyncAsyncTests(SimpleTestCase):
         response = self.client.get("/middleware_exceptions/view/")
         self.assertEqual(response.content, b"OK")
         self.assertEqual(response.status_code, 200)
+
+
+@override_settings(
+    DEBUG=True,
+    ROOT_URLCONF="middleware_exceptions.urls",
+)
+class MiddlewareSyncAsyncTransitionTests(TestCase):
+    async def test_sync_middleware_adaptation_grouping(self):
+        real_acall = MiddlewareMixin.__acall__
+
+        async def spy_acall(self, request):
+            return await real_acall(self, request)
+
+        with (
+            # This middleware requires a second adaptation for process_view(),
+            # making it a little harder to see what's happening.
+            self.modify_settings(
+                MIDDLEWARE={"remove": "django.middleware.csrf.CsrfViewMiddleware"}
+            ),
+            mock.patch.object(
+                MiddlewareMixin,
+                "__acall__",
+                autospec=True,
+                side_effect=spy_acall,
+            ) as acall,
+        ):
+            with mock.patch(
+                "django.core.handlers.base.sync_to_async", wraps=sync_to_async
+            ) as base_adapter:
+                self.async_client.handler.load_middleware(is_async=True)
+            # Exit the mock of sync_to_async before issuing a request.
+            await self.async_client.get("/middleware_exceptions/async_view/")
+
+        # No sync-to-async adaptation via MiddlewareMixin.__acall__().
+        acall.assert_not_called()
+        # O(1) sync-to-async adaptation via BaseHandler.
+        self.assertEqual(base_adapter.call_count, 1)
+
+    async def test_sync_middleware_adaptation_grouping_isolation(self):
+        real_acall = MiddlewareMixin.__acall__
+
+        async def spy_acall(self, request):
+            return await real_acall(self, request)
+
+        for middleware in [
+            # From startproject template.
+            "django.middleware.security.SecurityMiddleware",
+            "django.contrib.sessions.middleware.SessionMiddleware",
+            "django.middleware.common.CommonMiddleware",
+            "django.middleware.csrf.CsrfViewMiddleware",
+            "django.contrib.auth.middleware.AuthenticationMiddleware",
+            "django.contrib.messages.middleware.MessageMiddleware",
+            "django.middleware.clickjacking.XFrameOptionsMiddleware",
+            # Other subclasses of MiddlewareMixin implementing either
+            # process_response() or process_request().
+            "django.contrib.flatpages.middleware.FlatpageFallbackMiddleware",
+            "django.contrib.redirects.middleware.RedirectFallbackMiddleware",
+            "django.contrib.sites.middleware.CurrentSiteMiddleware",
+            "django.middleware.cache.FetchFromCacheMiddleware",
+            "django.middleware.cache.UpdateCacheMiddleware",
+            "django.middleware.common.BrokenLinkEmailsMiddleware",
+            "django.middleware.csp.ContentSecurityPolicyMiddleware",
+            "django.middleware.gzip.GZipMiddleware",
+            "django.middleware.http.ConditionalGetMiddleware",
+            "django.middleware.locale.LocaleMiddleware",
+        ]:
+            with (
+                self.subTest(middleware=middleware),
+                self.settings(MIDDLEWARE=[middleware]),
+                (
+                    self.modify_settings(
+                        INSTALLED_APPS={"append": middleware.split(".middleware")[0]}
+                    )
+                    if middleware.startswith("django.contrib.")
+                    else nullcontext()
+                ),
+                # Patch out any ImproperlyConfigured from testing in isolation.
+                (
+                    mock.patch(
+                        f"{middleware}.process_request",
+                        side_effect=lambda request: None,
+                    )
+                    if hasattr(import_string(middleware), "process_request")
+                    else nullcontext()
+                ),
+                mock.patch.object(
+                    MiddlewareMixin, "__acall__", autospec=True, side_effect=spy_acall
+                ) as acall,
+            ):
+                client = AsyncClient()
+                await client.get("/middleware_exceptions/async_view/")
+                acall.assert_not_called()
 
 
 @override_settings(ROOT_URLCONF="middleware_exceptions.urls")

--- a/tests/middleware_exceptions/urls.py
+++ b/tests/middleware_exceptions/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     path("middleware_exceptions/exception_in_render/", views.exception_in_render),
     path("middleware_exceptions/template_response/", views.template_response),
     # Async views.
+    path("middleware_exceptions/async_view/", views.async_normal_view),
     path(
         "middleware_exceptions/async_exception_in_render/",
         views.async_exception_in_render,

--- a/tests/middleware_exceptions/views.py
+++ b/tests/middleware_exceptions/views.py
@@ -8,6 +8,10 @@ def normal_view(request):
     return HttpResponse("OK")
 
 
+async def async_normal_view(request):
+    return HttpResponse("OK")
+
+
 def template_response(request):
     template = engines["django"].from_string(
         "template_response OK{% for m in mw %}\n{{ m }}{% endfor %}"


### PR DESCRIPTION
#### Trac ticket number
ticket-37177

#### Branch description
Relying on `MiddlewareMixin.__acall__()` to handle async requests imposed per-middleware context switching, defeating `BaseHandler`'s intent to transition only once per middleware chain.

To minimize breaking changes, `MiddlewareMixin`'s default value did not change: only the values on Django's own subclasses. Use cases where the prior behavior is preferable (in order to avoid pinning a thread per request) are fleshed out in docs.

See alternatives considered, below

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

I double-checked my understanding of the cases where the prior behavior would be preferable with Claude, and workshopped the release note & commit message.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.

#### Alternatives considered
* Flipping the value on `MiddlewareMixin` itself
  - This only gives DRY benefits, at the expense of possible silent breaking changes (user subclassed `MiddlewareMixin`, overrode `__acall__()`)
  - We could DRY this out later, with a deprecation path, see below, but I'm leaving that out of this first push to keep backporting into 6.1 on the table.
* Deprecating `MiddlewareMixin.__acall__()`
  - This does seem useful for some cases (see docs where I fleshed this out: some users may legitimately prefer the extra transitions!)
  - The future instead for Django's built-in middlewares is probably closer to https://github.com/django/new-features/issues/102#issuecomment-4587612916, where there's a sketch of writing out explicit `__acall__()` methods.
  - Separate discussion IMO
* Making `async_capable` a property that introspects whether the hooks are coroutines (mentioned on ticket):
  - There cannot be coroutines on those hooks in the wild; they're unconditionally run through `sync_to_async()`.

/cc @Arfey @carltongibson @nessita