### PR TITLE
Fixed #36658 -- Deprecated template variables led by numeric literals.

### DIFF
--- a/django/template/base.py
+++ b/django/template/base.py
@@ -57,7 +57,7 @@ import warnings
 from enum import Enum
 
 from django.template.context import BaseContext
-from django.utils.deprecation import RemovedInDjango70Warning
+from django.utils.deprecation import RemovedInDjango70Warning, RemovedInDjango71Warning
 from django.utils.formats import localize
 from django.utils.html import conditional_escape
 from django.utils.inspect import getfullargspec, signature
@@ -937,6 +937,28 @@ class Variable:
                             "Invalid character ('%s') in variable name: '%s'" % (c, var)
                         )
                 self.lookups = tuple(var.split(VARIABLE_ATTRIBUTE_SEPARATOR))
+                first_lookup = self.lookups[0]
+                try:
+                    (
+                        float(first_lookup)
+                        if "e" in first_lookup.lower()
+                        else int(first_lookup)
+                    )
+                except ValueError:
+                    pass
+                else:
+                    warnings.warn(
+                        "Support for using a numeric literal as the first "
+                        "component of a template variable is deprecated. This "
+                        "will raise a TemplateSyntaxError in Django 7.1.",
+                        RemovedInDjango71Warning,
+                        skip_file_prefixes=django_file_prefixes(),
+                    )
+                    # RemovedInDjango71Warning: when the deprecation ends,
+                    # replace the warning above with:
+                    # raise TemplateSyntaxError(
+                    #     "Invalid numeric literal: '%s'" % var
+                    # )
 
     def resolve(self, context):
         """Resolve this variable against a given context."""

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -19,6 +19,8 @@ details on these changes.
 
 * Calling ``QuerySet.aiterator()`` after ``prefetch_related()`` without
   providing a ``chunk_size`` will raise :exc:`ValueError`.
+* Using a numeric literal as the first component of a template variable will
+  raise ``TemplateSyntaxError``.
 
 .. _deprecation-removed-in-7.0:
 

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -273,6 +273,13 @@ Miscellaneous
 Features deprecated in 6.2
 ==========================
 
+Templates
+---------
+
+* Using a numeric literal as the first component of a template variable, such
+  as ``{{ 1.2.3 }}``, is deprecated. Such variables currently resolve as a
+  lookup, but will raise a ``TemplateSyntaxError`` in Django 7.1.
+
 Miscellaneous
 -------------
 

--- a/tests/template_tests/syntax_tests/test_basic.py
+++ b/tests/template_tests/syntax_tests/test_basic.py
@@ -3,7 +3,7 @@ from django.template.base import Origin, Template, TemplateSyntaxError
 from django.template.context import Context
 from django.template.loader_tags import BlockContext, BlockNode
 from django.test import SimpleTestCase, ignore_warnings
-from django.utils.deprecation import RemovedInDjango70Warning
+from django.utils.deprecation import RemovedInDjango70Warning, RemovedInDjango71Warning
 from django.views.debug import ExceptionReporter
 
 from ..utils import SilentAttrClass, SilentGetItemClass, SomeClass, setup
@@ -259,6 +259,8 @@ class BasicSyntaxTests(SimpleTestCase):
 
     # Something that starts like a number but has an extra lookup works
     # as a lookup.
+    # RemovedInDjango71Warning: When the deprecation ends, remove this test.
+    @ignore_warnings(category=RemovedInDjango71Warning)
     @setup({"basic-syntax30": "{{ 1.2.3 }}"})
     def test_basic_syntax30(self):
         output = self.engine.render_to_string(
@@ -266,6 +268,8 @@ class BasicSyntaxTests(SimpleTestCase):
         )
         self.assertEqual(output, "d")
 
+    # RemovedInDjango71Warning: When the deprecation ends, remove this test.
+    @ignore_warnings(category=RemovedInDjango71Warning)
     @setup({"basic-syntax31": "{{ 1.2.3 }}"})
     def test_basic_syntax31(self):
         output = self.engine.render_to_string(
@@ -274,6 +278,8 @@ class BasicSyntaxTests(SimpleTestCase):
         )
         self.assertEqual(output, "d")
 
+    # RemovedInDjango71Warning: When the deprecation ends, remove this test.
+    @ignore_warnings(category=RemovedInDjango71Warning)
     @setup({"basic-syntax32": "{{ 1.2.3 }}"})
     def test_basic_syntax32(self):
         output = self.engine.render_to_string(
@@ -282,6 +288,8 @@ class BasicSyntaxTests(SimpleTestCase):
         )
         self.assertEqual(output, "d")
 
+    # RemovedInDjango71Warning: When the deprecation ends, remove this test.
+    @ignore_warnings(category=RemovedInDjango71Warning)
     @setup({"basic-syntax33": "{{ 1.2.3 }}"})
     def test_basic_syntax33(self):
         output = self.engine.render_to_string(
@@ -290,12 +298,23 @@ class BasicSyntaxTests(SimpleTestCase):
         )
         self.assertEqual(output, "d")
 
+    # RemovedInDjango71Warning: When the deprecation ends, remove this test.
+    @ignore_warnings(category=RemovedInDjango71Warning)
     @setup({"basic-syntax34": "{{ 1.2.3 }}"})
     def test_basic_syntax34(self):
         output = self.engine.render_to_string(
             "basic-syntax34", {"1": ({"x": "x"}, {"y": "y"}, {"z": "z", "3": "d"})}
         )
         self.assertEqual(output, "d")
+
+    # RemovedInDjango71Warning: When the deprecation ends, add the following
+    # test in place of the five removed above.
+    # @setup({"basic-syntax-numeric": "{{ 1.2.3 }}"})
+    # def test_numeric_literal_first_component(self):
+    #     with self.assertRaisesMessage(
+    #         TemplateSyntaxError, "Invalid numeric literal: '1.2.3'"
+    #     ):
+    #         self.engine.get_template("basic-syntax-numeric")
 
     # Numbers are numbers even if their digits are in the context.
     @setup({"basic-syntax35": "{{ 1 }}"})

--- a/tests/template_tests/test_base.py
+++ b/tests/template_tests/test_base.py
@@ -1,6 +1,7 @@
 from django.template import Context, Template, Variable, VariableDoesNotExist
 from django.template.base import DebugLexer, Lexer, TokenType
 from django.test import SimpleTestCase
+from django.utils.deprecation import RemovedInDjango71Warning
 from django.utils.translation import gettext_lazy
 
 
@@ -81,3 +82,24 @@ class VariableTests(SimpleTestCase):
         for var in ["inf", "infinity", "iNFiniTy", "nan"]:
             with self.subTest(var=var):
                 self.assertIsNone(Variable(var).literal)
+
+    def test_numeric_literal_lookup_deprecated(self):
+        msg = (
+            "Support for using a numeric literal as the first component of a "
+            "template variable is deprecated. This will raise a "
+            "TemplateSyntaxError in Django 7.1."
+        )
+        for name in ["1.2.3", "1e2.", "1e2.0"]:
+            with self.subTest(name=name):
+                with self.assertWarnsMessage(RemovedInDjango71Warning, msg):
+                    Variable(name)
+
+    # RemovedInDjango71Warning: When the deprecation ends, replace the above
+    # test with the following.
+    # def test_numeric_literal_lookup_error(self):
+    #     for name in ["1.2.3", "1e2.", "1e2.0"]:
+    #         with self.subTest(name=name):
+    #             with self.assertRaisesMessage(
+    #                 TemplateSyntaxError, f"Invalid numeric literal: '{name}'"
+    #             ):
+    #                 Variable(name)

--- a/tests/template_tests/test_parser.py
+++ b/tests/template_tests/test_parser.py
@@ -16,7 +16,8 @@ from django.template.base import (
     VariableDoesNotExist,
 )
 from django.template.defaultfilters import register as filter_library
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, ignore_warnings
+from django.utils.deprecation import RemovedInDjango71Warning
 from django.utils.version import PY314
 
 
@@ -184,6 +185,7 @@ class ParserTests(SimpleTestCase):
         ):
             FilterExpression(expr, parser)
 
+    @ignore_warnings(category=RemovedInDjango71Warning)
     def test_filter_numeric_argument_parsing(self):
         p = Parser("", builtins=[filter_library])
 
@@ -216,6 +218,9 @@ class ParserTests(SimpleTestCase):
             "1e",
             "e400",
             "1e.2",
+            # RemovedInDjango71Warning: When the deprecation ends, move "1e2."
+            # and "1e2.0" to invalid_numbers_and_var_names below (they will
+            # raise TemplateSyntaxError).
             "1e2.",
             "1e2.0",
             "1e2a",


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-36658

#### Branch description
`{{ 1.2.3 }}` currently parse as lookup chains instead of erroring. Per django/new-features#116 this deprecates that to raise `TemplateSyntaxError`.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
