### PR TITLE
Fixed #36770 -- Fixed SQLite parallel test flakiness in forkserver.

### DIFF
--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -426,6 +426,7 @@ def _init_worker(
     process_setup_args=None,
     debug_mode=None,
     used_aliases=None,
+    processes=None,
 ):
     """
     Switch to databases dedicated to this worker and run system checks.
@@ -438,7 +439,10 @@ def _init_worker(
 
     with counter.get_lock():
         counter.value += 1
-        _worker_id = counter.value
+        if processes:
+            _worker_id = ((counter.value - 1) % processes) + 1
+        else:
+            _worker_id = counter.value
 
     is_spawn_or_forkserver = multiprocessing.get_start_method() in {
         "forkserver",
@@ -573,6 +577,7 @@ class ParallelTestSuite(unittest.TestSuite):
                 self.process_setup_args,
                 self.debug_mode,
                 self.used_aliases,
+                self.processes,
             ],
         ) as pool:
             test_results = pool.imap_unordered(self.run_subsuite.__func__, args)

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -1819,6 +1819,8 @@ class LiveServerTestCase(TransactionTestCase):
     @classmethod
     def _make_connections_override(cls):
         connections_override = {}
+        for alias in cls.databases:
+            connections[alias].ensure_connection()
         for conn in connections.all():
             # If using in-memory sqlite databases, pass the connections to
             # the server thread.

--- a/tests/servers/tests.py
+++ b/tests/servers/tests.py
@@ -106,7 +106,6 @@ class LiveServerTestCloseConnectionTest(LiveServerBase):
         self.assertIsNone(conn.connection)
 
 
-@unittest.skip("Flaky test as described in https://code.djangoproject.com/ticket/36770")
 @unittest.skipUnless(connection.vendor == "sqlite", "SQLite specific test.")
 class LiveServerInMemoryDatabaseLockTest(LiveServerBase):
     def test_in_memory_database_lock(self):


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-36770

#### Branch description
This PR resolves Ticket #36770, addressing flakiness and deadlocks in SQLite threading/locking tests under the parallel test runner when using forkserver or spawn multiprocessing start methods (default in Python 3.14+).

Connection Override Initialization: In LiveServerTestCase, the database connections override dictionary is built during the setUpClass stage. However, if a test database has not yet been initialized in the current worker process, it is omitted from the override list. The live server is then forced to establish a brand-new connection rather than sharing the main connection. Under SQLite's shared cache concurrency model, concurrent write attempts while the main test thread holds an active transaction cause deadlocks or database-locked errors. We resolve this by ensuring all database connections defined for the test case are initialized via ensure_connection() before creating the override dictionary.

Parallel Process Counter Bounding: During parallel execution with recycled or restarted worker processes, worker ID increments can exceed the process pool size (processes), leading to worker processes attempting to access non-existent cloned database files (e.g. default_3.sqlite3 when only two clones were created). We resolve this by passing the pool size processes down to _init_worker() and mapping _worker_id modulo processes

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have used used Google's Antigravity agent to help diagnose the SQLite parallel test runner race conditions and run the local verification test suites under my supervision.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
