### PR TITLE
Refs #32785 -- Fixed Sphinx reference in release note.

### DIFF
--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -108,10 +108,9 @@ Asynchronous views
 Cache
 ~~~~~
 
-* Subclasses of ``BaseDatabaseCache`` now support :ref:`
-  culling <_database-caching>` on a percentage of writes as an optimization.
-  The default is 10%, and may be configured using the ``CULL_PROBABILITY``
-  option.
+* Subclasses of ``BaseDatabaseCache`` now support :ref:`culling
+  <database-caching>` on a percentage of writes as an optimization. The
+  default is 10%, and may be configured using the ``CULL_PROBABILITY`` option.
 
 CSP
 ~~~


### PR DESCRIPTION
~I was under the mistaken belief that you could wrap after the backtick.~

I wrapped this line in the wrong place.