### PR TITLE
Fixed #37181 -- Corrected assertion in SeleniumTests.test_pagination.

### DIFF
--- a/tests/admin_views/test_history_view.py
+++ b/tests/admin_views/test_history_view.py
@@ -99,7 +99,7 @@ class SeleniumTests(AdminSeleniumTestCase):
         self.assertEqual(current_page_link.text, "1")
         # The last page.
         last_page_link = self.selenium.find_element(By.XPATH, "//ul/li[last()]/a")
-        self.assertTrue(last_page_link.text, "20")
+        self.assertEqual(last_page_link.text, "11")
         # Select the second page.
         pages = paginator.find_elements(By.TAG_NAME, "a")
         second_page_link = pages[1]


### PR DESCRIPTION
https://code.djangoproject.com/ticket/37181

in admin_views.test_history_view.SeleniumTests.test_pagination,

there is an assertion that check last page pagination number.

self.assertTrue(last_page_link.text, "20")

but, seems like it is intended to be assertEqual()

also, setUp creates 1100 records. with admin page size of 100, the last page should be "11", not "20".