### PR TITLE
Fixed #37182 -- Corrected property typo in skip link to content test.

### DIFF
--- a/tests/admin_views/test_skip_link_to_content.py
+++ b/tests/admin_views/test_skip_link_to_content.py
@@ -123,7 +123,7 @@ class SeleniumTests(AdminSeleniumTestCase):
                 "return arguments[0].scrollHeight > arguments[0].offsetHeight;", body
             )
             is_horizontal_scrolleable = self.selenium.execute_script(
-                "return arguments[0].scrollWeight > arguments[0].offsetWeight;", body
+                "return arguments[0].scrollWidth > arguments[0].offsetWidth;", body
             )
             self.assertTrue(is_vertical_scrolleable)
             self.assertFalse(is_horizontal_scrolleable)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/37182

in admin_views.test_skip_link_to_content.PlaywrightTests.test_skip_link_with_RTL_language_doesnt_create_horizontal_scrolling

horizontal scroll check uses non-existent DOM properties (scrollWeight / offsetWeight) instead of scrollWidth / offsetWidth.

            is_vertical_scrolleable = self.selenium.execute_script(
                "return arguments[0].scrollHeight > arguments[0].offsetHeight;", body
            )
            is_horizontal_scrolleable = self.selenium.execute_script(
                "return arguments[0].scrollWeight > arguments[0].offsetWeight;", body
            )
            self.assertTrue(is_vertical_scrolleable)
            self.assertFalse(is_horizontal_scrolleable)
undefined > undefined is always false. so, assertFalse always passes