### PR TITLE
Fixed #37161 -- Added system check for "default" entry in MAILERS setting.

### DIFF
--- a/django/core/checks/__init__.py
+++ b/django/core/checks/__init__.py
@@ -20,6 +20,7 @@ import django.core.checks.commands  # NOQA isort:skip
 import django.core.checks.compatibility.django_4_0  # NOQA isort:skip
 import django.core.checks.database  # NOQA isort:skip
 import django.core.checks.files  # NOQA isort:skip
+import django.core.checks.mail  # NOQA isort:skip
 import django.core.checks.model_checks  # NOQA isort:skip
 import django.core.checks.security.base  # NOQA isort:skip
 import django.core.checks.security.csrf  # NOQA isort:skip

--- a/django/core/checks/mail.py
+++ b/django/core/checks/mail.py
@@ -1,0 +1,29 @@
+from django.conf import settings
+from django.core.checks import Tags, Warning, register
+from django.core.mail import DEFAULT_MAILER_ALIAS
+
+
+@register(Tags.mail)
+def check_mailers_default_alias(app_configs, **kwargs):
+    if not settings.is_overridden("MAILERS"):
+        return []
+
+    if DEFAULT_MAILER_ALIAS in settings.MAILERS:
+        return []
+
+    if settings.MAILERS:
+        hint = (
+            f"Add a '{DEFAULT_MAILER_ALIAS}' entry to MAILERS, or pass 'using' when "
+            "sending email."
+        )
+    else:
+        hint = f"Add a '{DEFAULT_MAILER_ALIAS}' entry to MAILERS."
+
+    return [
+        Warning(
+            f"Your MAILERS setting has no '{DEFAULT_MAILER_ALIAS}' entry. Sending "
+            "email without a valid mailer will fail.",
+            hint=hint,
+            id="mail.W001",
+        )
+    ]

--- a/django/core/checks/registry.py
+++ b/django/core/checks/registry.py
@@ -17,6 +17,7 @@ class Tags:
     compatibility = "compatibility"
     database = "database"
     files = "files"
+    mail = "mail"
     models = "models"
     security = "security"
     signals = "signals"

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -84,6 +84,7 @@ Django's system checks are organized using the following tags:
   or if you specify configured database aliases using the ``--database`` option
   when calling the :djadmin:`check` command.
 * ``files``: Checks files related configuration.
+* ``mail``: Checks email related configuration.
 * ``models``: Checks of model, field, and manager definitions.
 * ``security``: Checks security related configuration.
 * ``signals``: Checks on signal declarations and handler registrations.
@@ -150,6 +151,15 @@ If you're using MySQL or MariaDB, the following checks will be performed:
   ``<alias>``. See also :ref:`mysql-sql-mode`.
 * **mysql.W003**: MySQL/MariaDB may not allow unique ``CharField``\s to have a
   ``max_length`` > 255.
+
+Mail
+----
+
+The following checks verify that your :setting:`MAILERS` setting is correctly
+configured:
+
+* **mail.W001**: Your :setting:`MAILERS` setting has no ``'default'`` entry.
+  Sending email without a valid mailer will fail.
 
 Managing files
 --------------

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -237,6 +237,12 @@ CSP
   :func:`~django.template.context_processors.csp` context processor is
   configured. See :ref:`csp-nonce-config` for setup instructions.
 
+Email
+~~~~~
+
+* A new ``mail.W001`` system check warns when :setting:`MAILERS` is defined but
+  does not include a ``'default'`` entry.
+
 Forms
 ~~~~~
 

--- a/tests/check_framework/test_mail.py
+++ b/tests/check_framework/test_mail.py
@@ -1,0 +1,55 @@
+from django.core.checks import Warning
+from django.core.checks.mail import check_mailers_default_alias
+from django.test import SimpleTestCase, override_settings
+
+
+class MailersDefaultAliasCheckTests(SimpleTestCase):
+    def test_mailers_not_defined(self):
+        self.assertEqual(check_mailers_default_alias(None), [])
+
+    @override_settings(
+        MAILERS={
+            "default": {
+                "BACKEND": "django.core.mail.backends.smtp.EmailBackend",
+            }
+        }
+    )
+    def test_mailers_default_alias_configured(self):
+        self.assertEqual(check_mailers_default_alias(None), [])
+
+    @override_settings(MAILERS={})
+    def test_mailers_empty(self):
+        self.assertEqual(
+            check_mailers_default_alias(None),
+            [
+                Warning(
+                    "Your MAILERS setting has no 'default' entry. Sending email "
+                    "without a valid mailer will fail.",
+                    hint="Add a 'default' entry to MAILERS.",
+                    id="mail.W001",
+                )
+            ],
+        )
+
+    @override_settings(
+        MAILERS={
+            "secondary": {
+                "BACKEND": "django.core.mail.backends.smtp.EmailBackend",
+            }
+        }
+    )
+    def test_mailers_without_default_alias(self):
+        self.assertEqual(
+            check_mailers_default_alias(None),
+            [
+                Warning(
+                    "Your MAILERS setting has no 'default' entry. Sending email "
+                    "without a valid mailer will fail.",
+                    hint=(
+                        "Add a 'default' entry to MAILERS, or pass 'using' when "
+                        "sending email."
+                    ),
+                    id="mail.W001",
+                )
+            ],
+        )


### PR DESCRIPTION
Thanks Mike Edmunds for reviews.

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37161

#### Branch description
See https://github.com/django/django/pull/21478

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [X] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [X] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [X] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [X] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
