### PR TITLE
Fixed #37166 -- Added system check for non-production EmailBackend.

### DIFF
--- a/django/core/checks/mail.py
+++ b/django/core/checks/mail.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.core.checks import Tags, Warning, register
+from django.core.checks import Error, Tags, Warning, register
 from django.core.mail import DEFAULT_MAILER_ALIAS
 
 
@@ -25,5 +25,39 @@ def check_mailers_default_alias(app_configs, **kwargs):
             "email without a valid mailer will fail.",
             hint=hint,
             id="mail.W001",
+        )
+    ]
+
+
+NON_PRODUCTION_EMAIL_BACKENDS = {
+    "django.core.mail.backends.console.EmailBackend",
+    "django.core.mail.backends.dummy.EmailBackend",
+    "django.core.mail.backends.filebased.EmailBackend",
+    "django.core.mail.backends.locmem.EmailBackend",
+}
+
+
+@register(Tags.mail, deploy=True)
+def check_mailers_production_backend(app_configs, **kwargs):
+    try:
+        backend = settings.MAILERS[DEFAULT_MAILER_ALIAS]["BACKEND"]
+    except (AttributeError, KeyError):
+        # There is no "default" backend to inspect: either MAILERS is not
+        # defined, or there is no "default" entry, or no "BACKEND" key in it.
+        # An omitted BACKEND defaults to SMTP, which is fine.
+        return []
+
+    if backend not in NON_PRODUCTION_EMAIL_BACKENDS:
+        return []
+
+    return [
+        Error(
+            f"Your MAILERS setting uses a development-only email backend in the "
+            f"'{DEFAULT_MAILER_ALIAS}' entry ({backend}).",
+            hint=(
+                "Use a production-ready email backend, such as the SMTP backend, "
+                "otherwise email will not be sent."
+            ),
+            id="mail.E001",
         )
     ]

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -158,6 +158,9 @@ Mail
 The following checks verify that your :setting:`MAILERS` setting is correctly
 configured:
 
+* **mail.E001**: Your :setting:`MAILERS` setting uses a development-only email
+  backend in the ``'default'`` entry (``<backend>``). (Only checked when the
+  :option:`check --deploy` option is used.)
 * **mail.W001**: Your :setting:`MAILERS` setting has no ``'default'`` entry.
   Sending email without a valid mailer will fail.
 

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -240,6 +240,10 @@ CSP
 Email
 ~~~~~
 
+* A new ``mail.E001`` deployment-only system check prevents using one of
+  Django's email backends that is not intended for production use in the
+  ``'default'`` :setting:`MAILERS` entry.
+
 * A new ``mail.W001`` system check warns when :setting:`MAILERS` is defined but
   does not include a ``'default'`` entry.
 

--- a/tests/check_framework/test_mail.py
+++ b/tests/check_framework/test_mail.py
@@ -1,5 +1,8 @@
-from django.core.checks import Warning
-from django.core.checks.mail import check_mailers_default_alias
+from django.core.checks import Error, Warning, registry
+from django.core.checks.mail import (
+    check_mailers_default_alias,
+    check_mailers_production_backend,
+)
 from django.test import SimpleTestCase, override_settings
 
 
@@ -52,4 +55,61 @@ class MailersDefaultAliasCheckTests(SimpleTestCase):
                     id="mail.W001",
                 )
             ],
+        )
+
+
+class MailersProductionBackendTests(SimpleTestCase):
+    def test_is_deployment_only(self):
+        self.assertIn(
+            check_mailers_production_backend, registry.registry.deployment_checks
+        )
+        self.assertNotIn(
+            check_mailers_production_backend, registry.registry.registered_checks
+        )
+
+    def test_mailers_not_defined(self):
+        self.assertEqual(check_mailers_production_backend(None), [])
+
+    def test_production_backends(self):
+        production_backends = [
+            "django.core.mail.backends.smtp.EmailBackend",
+            "any.third.party.EmailBackend",
+        ]
+        for backend in production_backends:
+            with (
+                self.subTest(backend=backend),
+                self.settings(MAILERS={"default": {"BACKEND": backend}}),
+            ):
+                self.assertEqual(check_mailers_production_backend(None), [])
+
+    def test_non_production_backends(self):
+        hint = (
+            "Use a production-ready email backend, such as the SMTP backend, "
+            "otherwise email will not be sent."
+        )
+        for backend_type in ["console", "dummy", "filebased", "locmem"]:
+            backend = f"django.core.mail.backends.{backend_type}.EmailBackend"
+            msg = (
+                f"Your MAILERS setting uses a development-only email backend in "
+                f"the 'default' entry ({backend})."
+            )
+            with (
+                self.subTest(backend=backend),
+                self.settings(MAILERS={"default": {"BACKEND": backend}}),
+            ):
+                self.assertEqual(
+                    check_mailers_production_backend(None),
+                    [Error(msg, hint=hint, id="mail.E001")],
+                )
+
+    @override_settings(
+        MAILERS={
+            "default": {"BACKEND": "django.core.mail.backends.smtp.EmailBackend"},
+            "secondary": {"BACKEND": "django.core.mail.backends.console.EmailBackend"},
+        }
+    )
+    def test_only_applies_to_default_mailer(self):
+        self.assertEqual(
+            check_mailers_production_backend(None),
+            [],
         )


### PR DESCRIPTION
#### Trac ticket number

ticket-37166

#### Branch description
Added `mail.E001` deployment-only system check to detect one of Django's not-for-production-use email backends in the "default" `MAILERS` entry.


#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
   * PyCharm AI Assistant "next edit suggestions": general coding
   * Gemini cloud (Google search): testing that a system check is registered as deployment only

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] (n/a) I have attached screenshots in both light and dark modes for any UI changes.
