### PR TITLE
Fixed #37183 -- Prevented writing unserializable attributes in syndication entries.

### DIFF
--- a/django/core/serializers/xml_serializer.py
+++ b/django/core/serializers/xml_serializer.py
@@ -63,7 +63,13 @@ class Serializer(base.Serializer):
             if obj_pk is not None:
                 attrs["pk"] = obj._meta.pk.value_to_string(obj)
 
-        self.xml.startElement("object", attrs)
+        try:
+            self.xml.startElement("object", attrs)
+        except UnserializableContentError:
+            raise ValueError(
+                "%s (pk:%s) contains unserializable characters"
+                % (obj.__class__.__name__, obj.pk)
+            )
 
     def end_object(self, obj):
         """

--- a/django/utils/xmlutils.py
+++ b/django/utils/xmlutils.py
@@ -2,12 +2,16 @@
 Utilities for XML generation/parsing.
 """
 
-import re
 from xml.sax.saxutils import XMLGenerator
+
+from django.utils.regex_helper import _lazy_re_compile
+
+_xml_control_chars_re = _lazy_re_compile(r"[\x00-\x08\x0B-\x0C\x0E-\x1F]")
 
 
 class UnserializableContentError(ValueError):
-    pass
+    def __init__(self, msg="Control characters are not supported in XML 1.0"):
+        super().__init__(msg)
 
 
 class SimplerXMLGenerator(XMLGenerator):
@@ -21,15 +25,16 @@ class SimplerXMLGenerator(XMLGenerator):
         self.endElement(name)
 
     def characters(self, content):
-        if content and re.search(r"[\x00-\x08\x0B-\x0C\x0E-\x1F]", content):
+        if content and _xml_control_chars_re.search(content):
             # Fail loudly when content has control chars (unsupported in XML
             # 1.0) See https://www.w3.org/International/questions/qa-controls
-            raise UnserializableContentError(
-                "Control characters are not supported in XML 1.0"
-            )
+            raise UnserializableContentError
         XMLGenerator.characters(self, content)
 
     def startElement(self, name, attrs):
+        for value in attrs.values():
+            if isinstance(value, str) and _xml_control_chars_re.search(value):
+                raise UnserializableContentError
         # Sort attrs for a deterministic output.
         sorted_attrs = dict(sorted(attrs.items())) if attrs else attrs
         super().startElement(name, sorted_attrs)

--- a/tests/serializers/test_xml.py
+++ b/tests/serializers/test_xml.py
@@ -4,6 +4,7 @@ from django.core import serializers
 from django.core.serializers.xml_serializer import DTDForbidden
 from django.test import TestCase, TransactionTestCase
 
+from .models import Actor
 from .tests import SerializersTestBase, SerializersTransactionTestBase
 
 
@@ -78,6 +79,12 @@ class XmlSerializerTestCase(SerializersTestBase, TestCase):
             "HT \t, LF \n, and CR \r are allowed",
             serializers.serialize(self.serializer_name, [self.a1]),
         )
+
+    def test_control_char_failure_attribute(self):
+        actor = Actor.objects.create(pk="\u0001")
+        msg = "Actor (pk:%s) contains unserializable characters" % actor.pk
+        with self.assertRaisesMessage(ValueError, msg):
+            serializers.serialize(self.serializer_name, [actor])
 
     def test_no_dtd(self):
         """

--- a/tests/syndication_tests/feeds.py
+++ b/tests/syndication_tests/feeds.py
@@ -321,3 +321,9 @@ class TestMultipleEnclosureAtomFeed(TestAtomFeed):
             feedgenerator.Enclosure("http://example.com/hello.png", "0", "image/png"),
             feedgenerator.Enclosure("http://example.com/goodbye.png", "0", "image/png"),
         ]
+
+
+class TestInvalidAtomFeed(TestAtomFeed):
+    def item_categories(self):
+        # This control character is not serializable.
+        return ["\x00"]

--- a/tests/syndication_tests/tests.py
+++ b/tests/syndication_tests/tests.py
@@ -17,6 +17,7 @@ from django.utils.feedgenerator import (
     rfc2822_date,
     rfc3339_date,
 )
+from django.utils.xmlutils import UnserializableContentError
 
 from .models import Article, Entry
 
@@ -525,6 +526,11 @@ class SyndicationFeedTest(FeedTestCase):
             if link.firstChild.wholeText == "http://example.com/blog/4/":
                 title = item.getElementsByTagName("title")[0]
                 self.assertEqual(title.firstChild.wholeText, "A &amp; B &lt; C &gt; D")
+
+    def test_no_control_chars_in_attributes(self):
+        msg = "Control characters are not supported in XML 1.0"
+        with self.assertRaisesMessage(UnserializableContentError, msg):
+            self.client.get("/syndication/atom/invalid/")
 
     def test_naive_datetime_conversion(self):
         """

--- a/tests/syndication_tests/urls.py
+++ b/tests/syndication_tests/urls.py
@@ -41,6 +41,7 @@ urlpatterns = [
     path("syndication/rss2/multiple-enclosure/", feeds.TestMultipleEnclosureRSSFeed()),
     path("syndication/atom/single-enclosure/", feeds.TestSingleEnclosureAtomFeed()),
     path("syndication/atom/multiple-enclosure/", feeds.TestMultipleEnclosureAtomFeed()),
+    path("syndication/atom/invalid/", feeds.TestInvalidAtomFeed()),
     path(
         "syndication/stylesheet.xsl",
         lambda request: None,


### PR DESCRIPTION
#### Trac ticket number
ticket-37183

#### Branch description
To match the behavior of the XML serializers, when writing syndication feed entries and encountering a control character not allowed by the XML spec, raise a `ValueError` instead of silently writing unparseable XML.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.