### PR TITLE
Cosmetic edits to docs/topics/signals.txt

### DIFF
--- a/docs/topics/signals.txt
+++ b/docs/topics/signals.txt
@@ -219,7 +219,8 @@ connecting the same receiver more than once has no effect::
     def my_handler(sender, **kwargs): ...
 
 
-    my_signal.connect(my_handler)  # Running this code again is a no-op.
+    my_signal.connect(my_handler)
+    my_signal.connect(my_handler)  # This line is a no-op.
 
 Bound methods, which take a ``self`` argument, are different. Their identity
 is tied to the specific instance, so connecting the same method from a new
@@ -230,7 +231,8 @@ instance registers it as an additional receiver::
         my_signal.connect(backend.my_handler)  # A distinct receiver.
 
 
-    connect_signals()  # Running this code again registers another receiver.
+    connect_signals()
+    connect_signals()  # Registers two receivers, handler fires twice
 
 When using a bound method as a receiver, multiple registrations can be
 prevented by supplying a unique ``dispatch_uid``. This identifier will usually


### PR DESCRIPTION
Cosmetic edits to docs/topics/signals.txt

#### Branch description
This change adds an explicit noop line rather than explaining it. While I was reading this documentation I was confused by the phrasing `Running this code again is a no-op.`. For some reason my tired brain was thinking about running the handler multiple times rather than the registration of the handler. Anyways, it's a tiny change but it makes the explanation easier to grok.

#### AI Assistance Disclosure (REQUIRED)
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
