### PR TITLE
Fixed #36998 -- Raised TemplateSyntaxError for {% firstof as var %} with no arguments.

### DIFF
--- a/django/template/defaulttags.py
+++ b/django/template/defaulttags.py
@@ -801,6 +801,8 @@ def firstof(parser, token):
     if len(bits) >= 2 and bits[-2] == "as":
         asvar = bits[-1]
         bits = bits[:-2]
+    if not bits:
+        raise TemplateSyntaxError("'firstof' statement requires at least one argument")
     return FirstOfNode([parser.compile_filter(bit) for bit in bits], asvar)
 
 

--- a/tests/template_tests/syntax_tests/test_firstof.py
+++ b/tests/template_tests/syntax_tests/test_firstof.py
@@ -50,6 +50,11 @@ class FirstOfTagTests(SimpleTestCase):
         with self.assertRaises(TemplateSyntaxError):
             self.engine.get_template("firstof09")
 
+    @setup({"firstof_asvar_no_args": "{% firstof as myvar %}"})
+    def test_firstof_asvar_no_args(self):
+        with self.assertRaises(TemplateSyntaxError):
+            self.engine.get_template("firstof_asvar_no_args")
+
     @setup({"firstof10": "{% firstof a %}"})
     def test_firstof10(self):
         output = self.engine.render_to_string("firstof10", {"a": "<"})


### PR DESCRIPTION
#### Trac ticket number

ticket-36998

#### Branch description

The `{% firstof as myvar %}` syntax was silently accepted without raising
a `TemplateSyntaxError`, producing a `FirstOfNode` with an empty vars list.

The initial emptiness check ran before the `as` suffix was stripped.
After `as varname` was removed, `bits` became `[]` but was never
re-validated. Added a second emptiness check after the `as` parsing block
and a regression test (`test_firstof_asvar_no_args`) that confirms the
error is raised. All 17 firstof tests pass.

#### AI Assistance Disclosure (REQUIRED)
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.