### PR TITLE
Removed additional versionchanged notices for 6.0.

### DIFF
--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -448,11 +448,6 @@ Methods
 
     See :doc:`cryptographic signing </topics/signing>` for more information.
 
-    .. versionchanged:: 5.2.15
-
-        In older versions, cookies signed with distinct ``(key, salt)`` pairs
-        that concatenate to the same string could be used interchangeably.
-
 .. method:: HttpRequest.is_secure()
 
     Returns ``True`` if the request is secure; that is, if it was made with

--- a/docs/topics/cache.txt
+++ b/docs/topics/cache.txt
@@ -1429,11 +1429,6 @@ For more on Vary headers, see the :rfc:`official Vary spec
     responses, Django's ``CacheMiddleware`` adds ``Authorization`` to the
     ``Vary`` header to simplify construction of cache keys.
 
-.. versionchanged:: 6.0.6
-
-    Previously, ``UpdateCacheMiddleware`` did not vary on ``Authorization`` for
-    requests bearing that header.
-
 Controlling cache: Using other headers
 ======================================
 


### PR DESCRIPTION
Some recent security releases came with versionchanged notices, but `main` has already advanced to 6.2 and removed those notices for 6.0 and below (see c17e494866024304da7f49a8ac3a43ac53bec93e).