### PR TITLE
Relaxed StringAgg assertions to account for the lack of order_by.

### DIFF
--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -2485,13 +2485,16 @@ class AggregateTestCase(TestCase):
         values = Publisher.objects.aggregate(
             stringagg=StringAgg("name", delimiter=Value("'"))
         )
-
-        self.assertEqual(
-            values,
-            {
-                "stringagg": "Apress'Sams'Prentice Hall'Morgan Kaufmann'Jonno's House "
-                "of Books",
-            },
+        self.assertCountEqual(
+            values["stringagg"].split("'"),
+            [
+                "Apress",
+                "Sams",
+                "Prentice Hall",
+                "Morgan Kaufmann",
+                "Jonno",
+                "s House of Books",
+            ],
         )
 
     @skipUnlessDBFeature("supports_aggregate_order_by_clause")
@@ -2546,13 +2549,15 @@ class AggregateTestCase(TestCase):
                 filter=Q(name__startswith="P"),
             )
         )
-
-        expected_values = {
-            "stringagg": "Practical Django Projects;"
-            "Python Web Development with Django;Paradigms of Artificial "
-            "Intelligence Programming: Case Studies in Common Lisp",
-        }
-        self.assertEqual(values, expected_values)
+        self.assertCountEqual(
+            values["stringagg"].split(";"),
+            [
+                "Practical Django Projects",
+                "Python Web Development with Django",
+                "Paradigms of Artificial Intelligence Programming: Case "
+                "Studies in Common Lisp",
+            ],
+        )
 
     @skipUnlessDBFeature("supports_aggregate_order_by_clause")
     def test_string_agg_filter_outerref(self):
@@ -2623,16 +2628,24 @@ class AggregateTestCase(TestCase):
             ).values_list("agg", flat=True)
         )
 
-        expected_values = [
-            "Adrian Holovaty",
-            "Brad Dayley",
-            "Paul Bissex;Wesley J. Chun",
-            "Peter Norvig;Stuart Russell",
-            "Peter Norvig",
-            "" if connection.features.interprets_empty_strings_as_nulls else None,
-        ]
+        def normalize(v):
+            # Sort values for a normalized comparison since STRING_AGG() with
+            # ORDER BY isn't guaranteed to return results in a defined order.
+            if not v:  # Don't sort None or ""
+                return v
+            return ";".join(sorted(v.split(";")))
 
-        self.assertQuerySetEqual(expected_values, values, ordered=False)
+        self.assertCountEqual(
+            [normalize(v) for v in values],
+            [
+                "Adrian Holovaty",
+                "Brad Dayley",
+                "Paul Bissex;Wesley J. Chun",
+                "Peter Norvig;Stuart Russell",
+                "Peter Norvig",
+                "" if connection.features.interprets_empty_strings_as_nulls else None,
+            ],
+        )
 
     @skipUnlessDBFeature("supports_aggregate_order_by_clause")
     def test_order_by_in_subquery(self):


### PR DESCRIPTION
While developing a `StringAgg` emulation for MongoDB, `test_string_agg_filter_in_subquery` didn't pass. Without an `ORDER BY` clause, the order in which `STRING_AGG` concatenates values isn't guaranteed.

AI disclosure: Claude made these changes after I suggested splitting on the delimiter and comparing sets.