### PR TITLE
Refs #35870 -- Mentioned transitional setting in BLANK_CHOICE_DASH release note.

### DIFF
--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -657,8 +657,9 @@ Miscellaneous
   the top-level value. :lookup:`Key and index lookups <jsonfield.key>` are
   unaffected by this deprecation.
 
-* The ``django.db.models.fields.BLANK_CHOICE_DASH`` constant is deprecated
-  in favor of the new constant ``django.db.models.fields.BLANK_CHOICE_LABEL``.
+* The undocumented ``django.db.models.fields.BLANK_CHOICE_DASH`` constant is
+  deprecated. See the :setting:`USE_BLANK_CHOICE_DASH` transitional setting for
+  migration advice.
 
 * The :setting:`USE_BLANK_CHOICE_DASH` transitional setting is deprecated.
 


### PR DESCRIPTION
See discussion in https://github.com/adamchainz/django-upgrade/issues/653#issuecomment-4785081974. This release note is similar to wording we've used before for equivalent constants, however these two constants are not equivalent.

Instead, @nessita had an idea to link to the transitional setting.