### PR TITLE
Refs #36984 -- Preserved translator comment on separator string.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -2798,9 +2798,9 @@ class InlineModelAdmin(BaseModelAdmin):
                             len(collector.protected) - delete_confirmation_max_display
                         )
                         if remaining_object_count > 0:
-                            # Translators: This string is used as a separator
-                            # between list elements
                             related = (
+                                # Translators: This string is used as a
+                                # separator between list elements.
                                 _(", ").join(str(i) for i in objs)
                                 + _(", ")
                                 + ngettext(


### PR DESCRIPTION
#### Trac ticket number
ticket-36984 (needs backport to 6.1)

#### Branch description
The inclusion of the comment in the .po file only works if the comment line is directly above.

Now, when the message is extracted with `django-admin makemessages -l en --domain=django`, the comment appears:

```
#. Translators: This string is used as a
#. separator between list elements.
#: contrib/admin/options.py:2804 contrib/admin/options.py:2805
msgid ", "
msgstr ""
```

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.