### PR TITLE
Fixed #37184 -- Allowed non-UTF-8 bytes passwords in the password hashers.

### DIFF
--- a/django/contrib/auth/hashers.py
+++ b/django/contrib/auth/hashers.py
@@ -330,7 +330,6 @@ class PBKDF2PasswordHasher(BasePasswordHasher):
     def encode(self, password, salt, iterations=None):
         self._check_encode_args(password, salt)
         iterations = iterations or self.iterations
-        password = force_str(password)
         salt = force_str(salt)
         hash = pbkdf2(password, salt, iterations, digest=self.digest)
         hash = base64.b64encode(hash).decode("ascii").strip()

--- a/docs/releases/6.0.7.txt
+++ b/docs/releases/6.0.7.txt
@@ -9,4 +9,6 @@ Django 6.0.7 fixes several bugs in 6.0.6.
 Bugfixes
 ========
 
-* ...
+* Fixed a regression in Django 6.0 by removing the forced string conversion in
+  ``PBKDF2PasswordHasher`` added for consistency, as it caused failures when
+  passwords were provided as non-UTF-8 bytes (:ticket:`37184`).

--- a/tests/auth_tests/test_hashers.py
+++ b/tests/auth_tests/test_hashers.py
@@ -104,6 +104,13 @@ class TestUtilsHashPass(SimpleTestCase):
         encoded_strong_salt = make_password("lètmein", hasher.salt(), "pbkdf2_sha256")
         self.assertIs(hasher.must_update(encoded_weak_salt), True)
         self.assertIs(hasher.must_update(encoded_strong_salt), False)
+        # Bytes password check.
+        non_utf8_bytes_password = b"\xc0\xc1\xfe\xff"
+        encoded_bytes = make_password(
+            non_utf8_bytes_password, "seasalt", "pbkdf2_sha256"
+        )
+        self.assertTrue(check_password(non_utf8_bytes_password, encoded_bytes))
+        self.assertFalse(check_password(b"wrong", encoded_bytes))
 
     @override_settings(
         PASSWORD_HASHERS=["django.contrib.auth.hashers.MD5PasswordHasher"]
@@ -169,6 +176,11 @@ class TestUtilsHashPass(SimpleTestCase):
         self.assertTrue(is_password_usable(blank_encoded))
         self.assertTrue(check_password("", blank_encoded))
         self.assertFalse(check_password(" ", blank_encoded))
+        # Bytes password check.
+        non_utf8_bytes_password = b"\xc0\xc1\xfe\xff"
+        encoded_bytes = make_password(non_utf8_bytes_password, hasher="bcrypt")
+        self.assertTrue(check_password(non_utf8_bytes_password, encoded_bytes))
+        self.assertFalse(check_password(b"wrong", encoded_bytes))
 
     @skipUnless(bcrypt, "bcrypt not installed")
     @override_settings(
@@ -674,6 +686,11 @@ class TestUtilsHashPassArgon2(SimpleTestCase):
         encoded_strong_salt = make_password("lètmein", hasher.salt(), "argon2")
         self.assertIs(hasher.must_update(encoded_weak_salt), True)
         self.assertIs(hasher.must_update(encoded_strong_salt), False)
+        # Bytes password check.
+        non_utf8_bytes_password = b"\xc0\xc1\xfe\xff"
+        encoded_bytes = make_password(non_utf8_bytes_password, "iodizedsalt", "argon2")
+        self.assertTrue(check_password(non_utf8_bytes_password, encoded_bytes))
+        self.assertFalse(check_password(b"wrong", encoded_bytes))
 
     def test_argon2_decode(self):
         salt = "abcdefghijk"
@@ -767,6 +784,11 @@ class TestUtilsHashPassScrypt(SimpleTestCase):
         self.assertIs(is_password_usable(blank_encoded), True)
         self.assertIs(check_password("", blank_encoded), True)
         self.assertIs(check_password(" ", blank_encoded), False)
+        # Bytes password check.
+        non_utf8_bytes_password = b"\xc0\xc1\xfe\xff"
+        encoded_bytes = make_password(non_utf8_bytes_password, "seasalt", "scrypt")
+        self.assertTrue(check_password(non_utf8_bytes_password, encoded_bytes))
+        self.assertFalse(check_password(b"wrong", encoded_bytes))
 
     def test_scrypt_decode(self):
         encoded = make_password("lètmein", "seasalt", "scrypt")


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37184

#### Branch description
Removed the unnecessary forced string conversion of passwords in `PBKDF2PasswordHasher`.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
