### PR TITLE
Updated howto-release-django.txt with reminder to bump asgiref.

### DIFF
--- a/docs/internals/howto-release-django.txt
+++ b/docs/internals/howto-release-django.txt
@@ -782,6 +782,13 @@ You're almost done! All that's left to do now is:
    #. Forward port the updated source translations to the ``main`` branch
       (:commit:`example commit <aed303aff57ac990894b6354af001b0e8ea55f71>`).
 
+#. If this was an ``alpha`` pre-release, coordinate with the maintainer of
+   :pypi:`asgiref` to determine when to raise the minimum version before the
+   final release. For the backport, add an upper bound on the next major
+   version (example commits:
+   :commit:`main <df35cf578f99522dd1ba864d513be95d47bab7a5>`,
+   :commit:`backport <e5d2664908164d51d2daa46e375da8b6a93def03>`).
+
 #. If this was an ``rc`` pre-release, call for translations for the upcoming
    release in the `Django Forum - Internationalization category
    <https://forum.djangoproject.com/c/internals/i18n/14>`_.


### PR DESCRIPTION
Update how-to-release section with reminder to bump asgiref.

We're likely to do this for 6.1 in July.

We could also start adding stuff like:
- bump GitHub action dependencies, which doesn't depend on the python version support (like our other dependencies)

... but that might bloat this section a bit.

Also appreciate advice on whether to copy this over to the checklist generator.