### PR TITLE
Fixed #37179 -- Optimized slicing GDAL layer without random read.

### DIFF
--- a/django/contrib/gis/gdal/layer.py
+++ b/django/contrib/gis/gdal/layer.py
@@ -51,7 +51,13 @@ class Layer(GDALBase):
         elif isinstance(index, slice):
             # A slice was given
             start, stop, stride = index.indices(self.num_feat)
-            return [self._make_feature(fid) for fid in range(start, stop, stride)]
+            feature_ids = range(start, stop, stride)
+            if self._random_read:
+                return [self._make_feature(fid) for fid in feature_ids]
+            # Without random-read support, _make_feature() rescans the
+            # Layer from the beginning for every requested id. Make a
+            # single pass over the Layer instead of one pass per id.
+            return self._make_features(feature_ids)
         else:
             raise TypeError(
                 "Integers and slices may only be used when indexing OGR Layers."
@@ -93,6 +99,26 @@ class Layer(GDALBase):
                     return feat
         # Should have returned a Feature, raise an IndexError.
         raise IndexError("Invalid feature id: %s." % feat_id)
+
+    def _make_features(self, feature_ids):
+        """
+        Helper routine for __getitem__ slicing on Layers that do not
+        support random-access reading. Collects the requested Features in
+        a single pass over the Layer, rather than rescanning it from the
+        beginning for each feature id.
+        """
+        remaining = set(feature_ids)
+        found = {}
+        for feature in self:
+            if feature.fid in remaining:
+                found[feature.fid] = feature
+                remaining.discard(feature.fid)
+                if not remaining:
+                    break
+        try:
+            return [found[feature_id] for feature_id in feature_ids]
+        except KeyError as e:
+            raise IndexError("Invalid feature id: %s." % e.args[0]) from e
 
     # #### Layer properties ####
     @property

--- a/tests/gis_tests/gdal_tests/test_ds.py
+++ b/tests/gis_tests/gdal_tests/test_ds.py
@@ -2,9 +2,11 @@ import os
 import re
 from datetime import datetime
 from pathlib import Path
+from unittest import mock
 
 from django.contrib.gis.gdal import DataSource, Envelope, GDALException, OGRGeometry
 from django.contrib.gis.gdal.field import OFTDateTime, OFTInteger, OFTReal, OFTString
+from django.contrib.gis.gdal.prototypes import ds as capi
 from django.contrib.gis.geos import GEOSGeometry
 from django.test import SimpleTestCase
 
@@ -225,6 +227,31 @@ class DataSourceTest(SimpleTestCase):
             test_vals = [feat.get(fld_name) for feat in feats]
             control_vals = source.field_values[fld_name][sl]
             self.assertEqual(control_vals, test_vals)
+
+    def test03b_layer_slice_no_random_read(self):
+        """
+        Slicing a Layer that doesn't support random reads must scan the
+        Layer once, regardless of the size of the slice.
+        """
+        source = ds_list[0]
+        ds = DataSource(source.ds)
+        layer = ds[0]
+        # Force the code path taken by layers without random-read support
+        # (e.g. CSV, GeoJSON in older GDAL versions), independent of what
+        # the driver used in this test actually supports.
+        layer._random_read = False
+
+        with mock.patch(
+            "django.contrib.gis.gdal.prototypes.ds.get_next_feature",
+            wraps=capi.get_next_feature,
+        ) as mock_get_next_feature:
+            feats = layer[0 : source.nfeat]
+
+        # A single scan of the layer reads each feature once. Without the
+        # fix, re-scanning from the start for every requested id reads
+        # nfeat * (nfeat + 1) / 2 features instead.
+        self.assertEqual(mock_get_next_feature.call_count, source.nfeat)
+        self.assertEqual([feat.fid for feat in feats], list(source.fids))
 
     def test03c_layer_references(self):
         """


### PR DESCRIPTION
#### Trac ticket number
ticket-37179

#### Branch description
This PR optimizes slicing GDAL layers when the layer does not support random-access reads. Instead of scanning the entire layer from the beginning for every single item in the slice (which has O(N * K) complexity), this change implements a helper that collects all requested features in a single scan, reducing complexity to O(N).

#### AI Assistance Disclosure (REQUIRED)
- [ ] No AI tools were used in preparing this PR.
- [ ] - [x] If AI tools were used, I have disclosed which ones, and fully reviewed and verified their output.
- [ ] I used Gemini Code Assist to help identify the relevant GDAL layer methods and locate the previous proposed solution by the ticket reporter.
#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [ ] - [x] This PR does not disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [ ] - [x] This PR targets the main branch. 
- [ ] - [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [ ] - [x] I have not requested, and will not request, an automated AI review for this PR. 
- [ ] - [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] - [x] I have added or updated relevant tests.
- [ ] - [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] - [x] I have attached screenshots in both light and dark modes for any UI changes.