### PR TITLE
Clarified "plaintext" vs. "plain-text" in password hashers docs.

### DIFF
--- a/django/contrib/auth/hashers.py
+++ b/django/contrib/auth/hashers.py
@@ -98,8 +98,7 @@ async def acheck_password(password, encoded, setter=None, preferred="default"):
 
 
 def make_password(password, salt=None, hasher="default"):
-    """
-    Turn a plain-text password into a hash for database storage
+    """Turn a plaintext password into a hash for database storage.
 
     Same as encode() but generate a new random salt. If password is None then
     return a concatenation of UNUSABLE_PASSWORD_PREFIX and a random string,

--- a/docs/topics/auth/passwords.txt
+++ b/docs/topics/auth/passwords.txt
@@ -488,10 +488,10 @@ from the ``User`` model.
 
     *Asynchronous version*: ``acheck_password()``
 
-    If you'd like to manually authenticate a user by comparing a plain-text
+    If you'd like to manually authenticate a user by comparing a plaintext
     password to the hashed password in the database, use the convenience
     function :func:`check_password`. It takes two mandatory arguments: the
-    plain-text password to check, and the full value of a user's ``password``
+    plaintext password to check, and the full value of a user's ``password``
     field in the database to check against. It returns ``True`` if they match,
     ``False`` otherwise. Optionally, you can pass a callable ``setter`` that
     takes the password and will be called when you need to regenerate it. You
@@ -502,7 +502,7 @@ from the ``User`` model.
 .. function:: make_password(password, salt=None, hasher='default')
 
     Creates a hashed password in the format used by this application. It takes
-    one mandatory argument: the password in plain-text (string or bytes).
+    one mandatory argument: the plaintext password (string or bytes).
     Optionally, you can provide a salt and a hashing algorithm to use, if you
     don't want to use the defaults (first entry of ``PASSWORD_HASHERS``
     setting). See :ref:`auth-included-hashers` for the algorithm name of each


### PR DESCRIPTION
#### Trac ticket number
N/A - typo

#### Branch description
Replaced "plain-text" with "plaintext" where it is used to describe the unencrypted input to a password hashing function. This reduces ambiguity about whether `make_password()` expects UTF-8 encoded Unicode text ("plain-text bytes") or the unencrypted material for the user's password ("plaintext bytes"). (See ticket-37184.)

"Plaintext" is already used that way in [elsewhere in Django's docs](https://docs.djangoproject.com/en/6.1/search/?q=plaintext&category=).) All other current uses of "plain text" and "plain-text" in the docs (including the one elsewhere in passwords.txt) are describing text that is plain (unformatted; not rich text).

In a cryptography context, "plaintext" is the preferred spelling. ([Merriam-Webster](https://www.merriam-webster.com/dictionary/plain-text) redirects "plain-text" to "plaintext." The [OED](https://www.oed.com/dictionary/plain-text_n)[^1] notes "frequently as one word" for the encryption sense, and has no quotations newer than 1918 that use "plain text" in that sense.)

[^1]: paywall; your public library may provide access

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] (n/a) I have checked the "Has patch" ticket flag in the Trac system.
- [x] (n/a) I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] (n/a) I have attached screenshots in both light and dark modes for any UI changes.
