### PR TITLE
Refs #36593, #37187 -- Avoided spurious select_related() warning in ModelAdmin.

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -37,7 +37,11 @@ from django.db.models.utils import (
     resolve_callables,
 )
 from django.utils import timezone
-from django.utils.deprecation import RemovedInDjango70Warning, RemovedInDjango71Warning
+from django.utils.deprecation import (
+    RemovedInDjango70Warning,
+    RemovedInDjango71Warning,
+    warn_about_external_use,
+)
 from django.utils.functional import cached_property
 from django.utils.warnings import django_file_prefixes
 
@@ -1795,11 +1799,11 @@ class QuerySet(AltersData):
         else:
             # RemovedInDjango70Warning: when the deprecation ends, raise a
             # TypeError instead.
-            warnings.warn(
+            warn_about_external_use(
                 "Calling select_related() with no arguments is deprecated. "
                 "Specify the fields to fetch instead.",
                 category=RemovedInDjango70Warning,
-                skip_file_prefixes=django_file_prefixes(),
+                skip_name_prefixes=("django.db.models",),
             )
             obj.query.select_related = True
         return obj


### PR DESCRIPTION
#### Trac ticket number

ticket-37187

#### Branch description
This is the quick-fix for "problem B" in ticket-37187, and can be reviewed/cherry-picked separately. (I'm also working on a fix for "problem A" and the related ticket-37190.)

Changed QuerySet.select_related() "called with no arguments" deprecation warning to be issued only when called from outside Django. This prevents a confusing, cascading warning when ModelAdmin issues its own warning for list_select_related=True (see 122f0b62) and then calls QuerySet.select_related() to implement the deprecated behavior.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] ??? I have added or updated relevant tests.
- [x] (n/a) I have added or updated relevant docs, including release notes if applicable.
- [x] (n/a) I have attached screenshots in both light and dark modes for any UI changes.
