### PR TITLE
Fixed #37184 -- Allowed non-UTF-8 bytes passwords in the PBKDF2 and MD5 password hashers.

### DIFF
--- a/django/contrib/auth/hashers.py
+++ b/django/contrib/auth/hashers.py
@@ -330,7 +330,6 @@ class PBKDF2PasswordHasher(BasePasswordHasher):
     def encode(self, password, salt, iterations=None):
         self._check_encode_args(password, salt)
         iterations = iterations or self.iterations
-        password = force_str(password)
         salt = force_str(salt)
         hash = pbkdf2(password, salt, iterations, digest=self.digest)
         hash = base64.b64encode(hash).decode("ascii").strip()
@@ -664,10 +663,8 @@ class MD5PasswordHasher(BasePasswordHasher):
 
     def encode(self, password, salt):
         self._check_encode_args(password, salt)
-        password = force_str(password)
-        salt = force_str(salt)
-        hash = hashlib.md5((salt + password).encode()).hexdigest()
-        return "%s$%s$%s" % (self.algorithm, salt, hash)
+        hash = hashlib.md5(force_bytes(salt) + force_bytes(password)).hexdigest()
+        return "%s$%s$%s" % (self.algorithm, force_str(salt), hash)
 
     def decode(self, encoded):
         algorithm, salt, hash = encoded.split("$", 2)

--- a/docs/releases/6.0.7.txt
+++ b/docs/releases/6.0.7.txt
@@ -9,4 +9,7 @@ Django 6.0.7 fixes several bugs in 6.0.6.
 Bugfixes
 ========
 
-* ...
+* Fixed a regression in Django 6.0 where the PBKDF2 and MD5 password hashers
+  raised :exc:`UnicodeDecodeError` for :class:`bytes` passwords that were not
+  valid UTF-8. Passwords supplied as :class:`str` or as UTF-8 :class:`bytes`
+  are unaffected (:ticket:`37184`).

--- a/tests/auth_tests/test_hashers.py
+++ b/tests/auth_tests/test_hashers.py
@@ -522,6 +522,30 @@ class TestUtilsHashPass(SimpleTestCase):
                     with self.assertRaisesMessage(ValueError, msg):
                         hasher.encode("password", salt)
 
+    def assertHasherVerifiesStrAndBytes(self, hasher, salts):
+        """
+        If a string representation exists for a bytes password, then both
+        representations will verify against whichever form was stored.
+        Otherwise, only the bytes representation will verify.
+        """
+        for pass_str, pass_bytes in [
+            ("password", b"password"),
+            # Valid UTF-8, but not ASCII.
+            ("Lösenord", "Lösenord".encode()),
+            # Not UTF-8.
+            ("", b"non-utf-8-\xc0"),
+        ]:
+            with self.subTest(hasher=hasher.__class__.__name__, password=pass_bytes):
+                for password in (pass_str, pass_bytes):
+                    if not password:
+                        continue
+                    for salt in salts:
+                        encoded = hasher.encode(password, salt)
+                        self.assertIs(hasher.verify(pass_bytes, encoded), True)
+                        if not pass_str:
+                            continue
+                        self.assertIs(hasher.verify(pass_str, encoded), True)
+
     def test_password_and_salt_in_str_and_bytes(self):
         hasher_classes = [
             MD5PasswordHasher,
@@ -531,25 +555,16 @@ class TestUtilsHashPass(SimpleTestCase):
         ]
         for hasher_class in hasher_classes:
             hasher = hasher_class()
-            with self.subTest(hasher_class.__name__):
-                passwords = ["password", b"password"]
-                for password in passwords:
-                    for salt in [hasher.salt(), hasher.salt().encode()]:
-                        encoded = hasher.encode(password, salt)
-                        for password_to_verify in passwords:
-                            self.assertIs(
-                                hasher.verify(password_to_verify, encoded), True
-                            )
+            self.assertHasherVerifiesStrAndBytes(
+                hasher, [hasher.salt(), hasher.salt().encode()]
+            )
 
     @skipUnless(argon2, "argon2-cffi not installed")
     def test_password_and_salt_in_str_and_bytes_argon2(self):
         hasher = Argon2PasswordHasher()
-        passwords = ["password", b"password"]
-        for password in passwords:
-            for salt in [hasher.salt(), hasher.salt().encode()]:
-                encoded = hasher.encode(password, salt)
-                for password_to_verify in passwords:
-                    self.assertIs(hasher.verify(password_to_verify, encoded), True)
+        self.assertHasherVerifiesStrAndBytes(
+            hasher, [hasher.salt(), hasher.salt().encode()]
+        )
 
     @skipUnless(bcrypt, "bcrypt not installed")
     def test_password_and_salt_in_str_and_bytes_bcrypt(self):
@@ -559,16 +574,9 @@ class TestUtilsHashPass(SimpleTestCase):
         ]
         for hasher_class in hasher_classes:
             hasher = hasher_class()
-            with self.subTest(hasher_class.__name__):
-                passwords = ["password", b"password"]
-                for password in passwords:
-                    salts = [hasher.salt().decode(), hasher.salt()]
-                    for salt in salts:
-                        encoded = hasher.encode(password, salt)
-                        for password_to_verify in passwords:
-                            self.assertIs(
-                                hasher.verify(password_to_verify, encoded), True
-                            )
+            self.assertHasherVerifiesStrAndBytes(
+                hasher, [hasher.salt().decode(), hasher.salt()]
+            )
 
     def test_encode_password_required(self):
         hasher_classes = [


### PR DESCRIPTION
#### Trac ticket number
ticket-37184

#### Branch description
An unnecessary `force_str()` call in the `PBKDF2` hasher raised `UnicodeDecodeError` on perfectly valid password values, by introducing a UTF-8-encodability constraint.

The MD5 hasher had a similar issue, however the same commit that introduced the bug also happened to allow bytes in general, so preserve the support while removing the constraint on UTF-8 validity by concatenating like:
```py
    force_bytes(salt) + force_bytes(password)
```
Regression in 78fac1b0473ed8960ecd2a30aca4fa8420d150b8.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

I used Claude to verify my understanding and check for subtle bugs, including in the MD5 tweaks. I hope no one is using the MD5 hasher, but let's not leave it degraded.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.