### PR TITLE
Fixed #37187, #37190 -- Pointed ModelAdmin warnings to the deprecated code.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -63,7 +63,7 @@ from django.http.response import HttpResponseBase
 from django.template.response import SimpleTemplateResponse, TemplateResponse
 from django.urls import reverse
 from django.utils.decorators import method_decorator
-from django.utils.deprecation import RemovedInDjango70Warning
+from django.utils.deprecation import RemovedInDjango70Warning, warn_about_implementation
 from django.utils.html import format_html
 from django.utils.http import urlencode
 from django.utils.inspect import get_func_args
@@ -928,11 +928,12 @@ class ModelAdmin(BaseModelAdmin):
             # RemovedInDjango70Warning: when the deprecation ends, remove the
             # below 'if' clause and raise a ValueError here.
             if self.list_select_related is not True:
-                warnings.warn(
+                warn_about_implementation(
                     "Returning True from ModelAdmin.get_list_select_related() is "
                     "deprecated. Return False or a list or tuple of fields to "
                     "fetch instead.",
                     RemovedInDjango70Warning,
+                    self.get_list_select_related,
                 )
         return ChangeList(
             request,
@@ -1132,12 +1133,12 @@ class ModelAdmin(BaseModelAdmin):
         if "action_location" in get_func_args(self.get_actions):
             return self.get_actions(request, action_location=action_location)
         else:
-            warnings.warn(
+            warn_about_implementation(
                 "Overriding get_actions() without the 'action_location' parameter is "
                 "deprecated. Update the signature to get_actions(self, request, "
                 "action_location=ActionLocation.CHANGE_LIST).",
                 RemovedInDjango70Warning,
-                skip_file_prefixes=django_file_prefixes(),
+                self.get_actions,
             )
             if action_location == ActionLocation.CHANGE_FORM:
                 # Disable adding actions on change form when get_actions is
@@ -1172,13 +1173,13 @@ class ModelAdmin(BaseModelAdmin):
                 action_location=action_location,
             )
         else:
-            warnings.warn(
+            warn_about_implementation(
                 "Overriding get_action_choices() without the 'action_location' "
                 "parameter is deprecated. Update the signature to "
                 "get_action_choices(self, request, default_choices=None, "
                 "action_location=ActionLocation.CHANGE_LIST).",
                 RemovedInDjango70Warning,
-                skip_file_prefixes=django_file_prefixes(),
+                self.get_action_choices,
             )
             return self.get_action_choices(request, default_choices=default_choices)
 

--- a/django/utils/deprecation.py
+++ b/django/utils/deprecation.py
@@ -1,5 +1,6 @@
 import functools
 import inspect
+import sys
 import warnings
 from collections import Counter
 from inspect import iscoroutinefunction, markcoroutinefunction
@@ -99,6 +100,58 @@ def warn_about_external_use(
 
     if not is_internal:
         warnings.warn(message, category=category, stacklevel=level + 1)
+
+
+def warn_about_implementation(message, category, target):
+    """Issue a warning about a specific function, class, or method definition.
+
+    The warning will point to the source filename and line number where
+    'target' is _defined_ (not where it is being _called_ as with other warning
+    helpers). Use this to warn about code that isn't currently on the call
+    stack, e.g., deprecation based on the return value of a called method or
+    inspecting a function's signature to see if it supports an updated API.
+
+    Supported usage:
+    warn_about_implementation(message, category, some_function)
+    warn_about_implementation(message, category, SomeClass)
+    warn_about_implementation(message, category, SomeClass.method)
+    warn_about_implementation(message, category, self.method) [a bound method]
+
+    To warn about a property without invoking its descriptor, call with
+    'target' set to inspect.getattr_static(class_or_instance, "property_name").
+    """
+    if inspect.ismethod(target) or isinstance(target, (classmethod, staticmethod)):
+        function = target.__func__
+    elif inspect.isfunction(target) or inspect.isclass(target):
+        function = target
+    elif isinstance(target, property):
+        function = target.fget
+    else:
+        raise TypeError(
+            "target must be a function, class, bound method, or unbound descriptor "
+            "(classmethod, staticmethod, or property)."
+        )
+
+    function = inspect.unwrap(function)
+
+    try:
+        filename = inspect.getsourcefile(function)
+        _, lineno = inspect.getsourcelines(function)
+    except (AttributeError, OSError, TypeError):
+        # Can't identify the source. Issue the warning generically.
+        warnings.warn(message, category, skip_file_prefixes=django_file_prefixes())
+        return
+
+    # Find or create the module's warning registry so warning filters work.
+    module = function.__module__
+    try:
+        registry = sys.modules[module].__dict__.setdefault("__warningregistry__", {})
+    except (AttributeError, KeyError):
+        registry = None
+
+    warnings.warn_explicit(
+        message, category, filename, lineno, module=module, registry=registry
+    )
 
 
 class warn_about_renamed_method:

--- a/tests/admin_views/test_actions.py
+++ b/tests/admin_views/test_actions.py
@@ -15,6 +15,7 @@ from django.urls import reverse
 from django.utils.deprecation import RemovedInDjango70Warning
 
 from .admin import SubscriberAdmin
+from .admin import __file__ as admin_filename
 from .forms import MediaActionForm
 from .models import (
     Actor,
@@ -878,14 +879,14 @@ class AdminDetailActionsTest(TestCase):
         )
         with self.assertWarnsMessage(
             RemovedInDjango70Warning, get_actions_overridden_msg
-        ):
+        ) as warning:
             response = self.client.get(change_url)
+        self.assertEqual(warning.filename, admin_filename)
         self.assertNotContains(response, "<div class='actions'>", html=True)
 
         changelist_url = reverse("admin:admin_views_modelaction_changelist")
         with warnings.catch_warnings(record=True) as warning_list:
             warnings.simplefilter("always", RemovedInDjango70Warning)
-            warnings.filterwarnings("always", category=RemovedInDjango70Warning)
             response = self.client.get(changelist_url)
 
             message_warnings = [str(warning.message) for warning in warning_list]
@@ -901,6 +902,9 @@ class AdminDetailActionsTest(TestCase):
                 "Use Action attributes instead.",
             }
             self.assertEqual(set(message_warnings), expected_warnings)
+            self.assertEqual(
+                {warning.filename for warning in warning_list}, {admin_filename}
+            )
         self.assertContains(response, "Delete selected model actions (extra)")
 
         action_data = {
@@ -915,10 +919,11 @@ class AdminDetailActionsTest(TestCase):
         )
         with self.assertWarnsMessage(
             RemovedInDjango70Warning, get_actions_overridden_msg
-        ):
+        ) as warning:
             response = self.client.post(
                 reverse("admin:admin_views_modelaction_changelist"), action_data
             )
+        self.assertEqual(warning.filename, admin_filename)
         self.assertContains(
             response, "Are you sure you want to delete the selected model action?"
         )

--- a/tests/deprecation/test_warn_about_implementation.py
+++ b/tests/deprecation/test_warn_about_implementation.py
@@ -1,0 +1,231 @@
+import inspect
+import sys
+import warnings
+from contextlib import contextmanager
+
+from django.test import SimpleTestCase
+from django.utils.deprecation import warn_about_implementation
+from django.views.decorators import csrf
+
+
+class WarnAboutImplementationTests(SimpleTestCase):
+    @contextmanager
+    def assertWarnsAboutLine(self, category, message, *, offset):
+        caller_frame = inspect.currentframe().f_back.f_back
+        with self.assertWarnsMessage(category, message) as warning:
+            yield
+        self.assertEqual(warning.filename, caller_frame.f_code.co_filename)
+        self.assertEqual(warning.lineno, caller_frame.f_lineno + offset)
+
+    def test_function(self):
+        def some_function():
+            pass
+
+        with self.assertWarnsAboutLine(Warning, "deprecated", offset=-3):
+            warn_about_implementation("deprecated", Warning, some_function)
+
+    def test_class(self):
+        class SomeClass:
+            pass
+
+        with self.assertWarnsAboutLine(Warning, "deprecated", offset=-3):
+            warn_about_implementation("deprecated", Warning, SomeClass)
+
+    def test_class_init(self):
+        class SomeClass:
+            def __init__(self):
+                pass
+
+        with self.assertWarnsAboutLine(Warning, "deprecated", offset=-3):
+            warn_about_implementation("deprecated", Warning, SomeClass.__init__)
+
+    def test_method(self):
+        class SomeClass:
+            def some_method(self):
+                pass
+
+        for case, target in [
+            ("unbound", SomeClass.some_method),
+            ("bound", SomeClass().some_method),
+        ]:
+            with (
+                self.subTest(case),
+                self.assertWarnsAboutLine(Warning, "deprecated", offset=-9),
+            ):
+                warn_about_implementation("deprecated", Warning, target)
+
+    def test_subclass_method(self):
+        class BaseClass:
+            def some_method(self):
+                pass
+
+            def issue_warning(self):
+                warn_about_implementation("deprecated", Warning, self.some_method)
+
+        class SubClass(BaseClass):
+            def some_method(self):
+                pass
+
+        with self.assertWarnsAboutLine(Warning, "deprecated", offset=-3):
+            SubClass().issue_warning()
+
+    def test_my_own_method(self):
+        with self.assertWarnsAboutLine(Warning, "deprecated", offset=-1):
+            warn_about_implementation("deprecated", Warning, self.test_my_own_method)
+
+    def test_classmethod(self):
+        class SomeClass:
+            @classmethod
+            def some_classmethod(cls):
+                pass
+
+        for case, target in [
+            ("unbound", SomeClass.some_classmethod),
+            ("bound", SomeClass().some_classmethod),
+        ]:
+            with (
+                self.subTest(case),
+                self.assertWarnsAboutLine(Warning, "deprecated", offset=-10),
+            ):
+                warn_about_implementation("deprecated", Warning, target)
+
+    def test_staticmethod(self):
+        class SomeClass:
+            @staticmethod
+            def some_staticmethod():
+                pass
+
+        with self.assertWarnsAboutLine(Warning, "deprecated", offset=-4):
+            warn_about_implementation(
+                "deprecated", Warning, SomeClass.some_staticmethod
+            )
+
+    def test_property(self):
+        class SomeClass:
+            @property
+            def some_property(self):
+                return None
+
+        with self.assertWarnsAboutLine(Warning, "deprecated", offset=-4):
+            warn_about_implementation(
+                "deprecated",
+                Warning,
+                inspect.getattr_static(SomeClass(), "some_property"),
+            )
+
+    def test_decorated_function(self):
+        @csrf.csrf_exempt
+        @csrf.ensure_csrf_cookie
+        def some_view(request):
+            pass
+
+        with self.assertWarnsAboutLine(Warning, "deprecated", offset=-5):
+            warn_about_implementation("deprecated", Warning, some_view)
+
+    def test_decorated_method(self):
+        class SomeClass:
+            @csrf.csrf_exempt
+            @csrf.ensure_csrf_cookie
+            def some_method(self):
+                pass
+
+        for case, target in [
+            ("unbound", SomeClass.some_method),
+            ("bound", SomeClass().some_method),
+        ]:
+            with (
+                self.subTest(case),
+                self.assertWarnsAboutLine(Warning, "deprecated", offset=-11),
+            ):
+                warn_about_implementation("deprecated", Warning, target)
+
+    def test_decorated_staticmethod(self):
+        class SomeClass:
+            @staticmethod
+            @csrf.csrf_exempt
+            @csrf.ensure_csrf_cookie
+            def some_staticmethod():
+                pass
+
+        with self.assertWarnsAboutLine(Warning, "deprecated", offset=-6):
+            warn_about_implementation(
+                "deprecated", Warning, SomeClass.some_staticmethod
+            )
+
+    def test_no_source_file(self):
+        # When the source file can't be determined, falls back to warning about
+        # the caller. (Builtins like `dict` have no source file.)
+        with self.assertWarnsAboutLine(Warning, "deprecated", offset=1):
+            warn_about_implementation("deprecated", Warning, dict)
+
+    def test_rejects_invalid_target(self):
+        msg = (
+            "target must be a function, class, bound method, or unbound descriptor "
+            "(classmethod, staticmethod, or property)."
+        )
+        for invalid in ["string", object(), 123, None]:
+            with self.subTest(target=invalid), self.assertRaisesMessage(TypeError, msg):
+                warn_about_implementation("deprecated", Warning, invalid)
+
+    def test_respects_warning_registry(self):
+        def some_function():
+            pass
+
+        # The "default" action only works correctly when warn_explicit() is
+        # called with the correct module and warning registry. (This test must
+        # use "default" or "module", not "once". CPython has an undocumented
+        # optimization for "once" that uses a global registry.)
+        with warnings.catch_warnings(record=True, action="default") as captured:
+            warn_about_implementation("deprecated", Warning, some_function)
+            self.assertEqual(len(captured), 1)
+
+            captured.clear()
+            warn_about_implementation("deprecated", Warning, some_function)
+            self.assertEqual(len(captured), 0)
+
+    def test_creates_warning_registry_if_needed(self):
+        def some_function():
+            pass
+
+        module = sys.modules[some_function.__module__]
+        if hasattr(module, "__warningregistry__"):
+            old_registry = module.__warningregistry__
+            del module.__warningregistry__
+        else:
+            old_registry = None
+
+        try:
+            with warnings.catch_warnings(record=True, action="default") as captured:
+                warn_about_implementation("deprecated", Warning, some_function)
+                warn_about_implementation("deprecated", Warning, some_function)
+
+            self.assertEqual(len(captured), 1)
+            self.assertIsInstance(module.__warningregistry__, dict)
+            self.assertNotEqual(module.__warningregistry__, {})
+        finally:
+            if old_registry is not None:
+                module.__warningregistry__ = old_registry
+            elif hasattr(module, "__warningregistry__"):
+                del module.__warningregistry__
+
+    def test_missing_module(self):
+        def some_function():
+            pass
+
+        some_function.__module__ = "not_a_module"
+
+        with self.assertWarnsAboutLine(Warning, "deprecated", offset=-5):
+            warn_about_implementation("deprecated", Warning, some_function)
+
+    def test_non_standard_module(self):
+        sys.modules["sealed_module"] = type("SealedModule", (), {"__slots__": ()})()
+        self.addCleanup(sys.modules.pop, "sealed_module")
+
+        def some_function():
+            pass
+
+        some_function.__module__ = "sealed_module"
+
+        with self.assertWarnsAboutLine(Warning, "deprecated", offset=2):
+            # Module is not inspectable, so the warning is issued generically.
+            warn_about_implementation("deprecated", Warning, some_function)

--- a/tests/modeladmin/tests.py
+++ b/tests/modeladmin/tests.py
@@ -1035,10 +1035,12 @@ class ModelAdminTests(TestCase):
         )
         # RemovedInDjango70Warning:
         # with self.assertRaisesMessage(ValueError, msg)
-        with self.assertWarnsMessage(RemovedInDjango70Warning, msg):
+        with self.assertWarnsMessage(RemovedInDjango70Warning, msg) as warning:
 
             class TestModelAdmin(ModelAdmin):
                 list_select_related = True
+
+        self.assertEqual(warning.filename, __file__)
 
     # RemovedInDjango70Warning: when the deprecation ends, remove.
     def test_list_select_related_true_deprecated_subclass(self):
@@ -1073,8 +1075,9 @@ class ModelAdminTests(TestCase):
 
         # RemovedInDjango70Warning:
         # with self.assertRaisesMessage(ValueError, msg)
-        with self.assertWarnsMessage(RemovedInDjango70Warning, msg):
+        with self.assertWarnsMessage(RemovedInDjango70Warning, msg) as warning:
             TestModelAdmin(Band, self.site).get_changelist_instance(request)
+        self.assertEqual(warning.filename, __file__)
 
 
 class ModelAdminPermissionTests(SimpleTestCase):


### PR DESCRIPTION
#### Trac ticket number

ticket-37187
ticket-37190

#### Branch description
Created `warn_about_implementation()` utility for issuing warnings about particular code that isn't currently on the call stack.

Used `warn_about_implementation()` for `ModelAdmin` deprecation warnings on `get_list_select_related()` return value and missing `action_location` parameters in `get_actions()` and `get_action_choices()`. Fixes a problem where the warnings would point to `wsgiref` rather than the `ModelAdmin` subclass using deprecated functionality.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
   * PyCharm AI Assistant "next edit suggestions": general editing
   * GPT-5.5: discussing approaches to `warn_about_implementation()` and correct use of Python's `inspect` module
   * Gemini cloud (Google search version): understanding and testing Python's `__warningregistry__`.
   * Claude 4.6 Sonnet: code review, simplification

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] (n/a) I have added or updated relevant docs, including release notes if applicable.
- [x] (n/a) I have attached screenshots in both light and dark modes for any UI changes.
