### PR TITLE
Fixed #37191 -- Prevented ValueError in FileBasedCache.touch() for ex…

### DIFF
--- a/django/core/cache/backends/filebased.py
+++ b/django/core/cache/backends/filebased.py
@@ -73,7 +73,8 @@ class FileBasedCache(BaseCache):
                         self._write_content(f, timeout, previous_value)
                         return True
                 finally:
-                    locks.unlock(f)
+                    if not f.closed:
+                        locks.unlock(f)
         except FileNotFoundError:
             return False
 

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -1970,7 +1970,23 @@ class FileBasedCacheTests(BaseCacheTests, TestCase):
             mock.patch("cache.tests.time", new=mocked_time),
         ):
             super().test_touch()
-
+        
+    def test_touch_expired_key_does_not_crash(self):
+        """
+        Touching an expired key in FileBasedCache should safely return False
+        instead of raising a ValueError due to an unlocked closed file.
+        """
+        import time
+        
+        # Set a cache key with a very short timeout
+        cache.set("expired_touch_key", "value", timeout=0.01)
+        
+        # Wait a moment to ensure it is natively expired
+        time.sleep(0.05)
+        
+        # Attempt to touch the key (this will crash without the fix)
+        result = cache.touch("expired_touch_key", 60)
+        self.assertIs(result, False)
 
 @unittest.skipUnless(RedisCache_params, "Redis backend not configured")
 @override_settings(


### PR DESCRIPTION
This PR fixes ticket #37191. Added a check to ensure locks.unlock(f) is only called if the file descriptor is not already closed by self._is_expired(f). Included a regression test.