### PR TITLE
Fixed #37191 -- Prevented ValueError in FileBasedCache.touch() for expired keys.

### DIFF
--- a/django/core/cache/backends/filebased.py
+++ b/django/core/cache/backends/filebased.py
@@ -73,7 +73,8 @@ class FileBasedCache(BaseCache):
                         self._write_content(f, timeout, previous_value)
                         return True
                 finally:
-                    locks.unlock(f)
+                    if not f.closed:
+                        locks.unlock(f)
         except FileNotFoundError:
             return False
 

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -1970,6 +1970,20 @@ class FileBasedCacheTests(BaseCacheTests, TestCase):
             mock.patch("cache.tests.time", new=mocked_time),
         ):
             super().test_touch()
+        
+    def test_touch_expired_key_does_not_crash(self):
+        """
+        Touching an expired key in FileBasedCache should safely return False
+        instead of raising a ValueError due to an unlocked closed file.
+        """
+        import time
+        # Set a cache key with a very short timeout
+        cache.set("expired_touch_key", "value", timeout=0.01)
+        # Wait a moment to ensure it is natively expired
+        time.sleep(0.05)
+        # Attempt to touch the key (this will crash without the fix)
+        result = cache.touch("expired_touch_key", 60)
+        self.assertIs(result, False)
 
 
 @unittest.skipUnless(RedisCache_params, "Redis backend not configured")


### PR DESCRIPTION
## Trac Ticket
ticket-37191

## Description
This PR fixes a bug where `FileBasedCache.touch()` raises a `ValueError: I/O operation on closed file` when called on a key whose timeout has already elapsed. 

The issue occurred because `self._is_expired(f)` closes the file descriptor, but the `finally` block still blindly attempted to execute `locks.unlock(f)`. I wrapped the unlock call in an `if not f.closed:` check to ensure it only attempts to unlock open files. I also added a regression test in `tests/cache/tests.py` to prevent this from happening again.

## AI Assistance Disclosure
- [ ] No AI tools were used in preparing this PR.
- [x] If AI tools were used, I have disclosed which ones, and fully reviewed and verified their output.
*Details: Used an AI assistant to help understand the `locks.py` internal logic and for guidance on setting up the local Django test suite.*

## Checklist
- [x] I have read the [contributing guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/).
- [x] I have added tests for my changes.
- [x] I have added documentation for my changes (if applicable).
- [x] I have run the test suite and all tests pass.
- [x] I have run the formatting tools (e.g. `black`, `flake8`) and there are no errors.