### PR TITLE
Fixed #37191 -- Prevented ValueError in FileBasedCache.touch() for expired keys

### DIFF
--- a/django/core/cache/backends/filebased.py
+++ b/django/core/cache/backends/filebased.py
@@ -73,7 +73,9 @@ class FileBasedCache(BaseCache):
                         self._write_content(f, timeout, previous_value)
                         return True
                 finally:
-                    locks.unlock(f)
+                    # Expired files are closed & unlocked by _is_expired().
+                    if not f.closed:
+                        locks.unlock(f)
         except FileNotFoundError:
             return False
 

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -1971,6 +1971,12 @@ class FileBasedCacheTests(BaseCacheTests, TestCase):
         ):
             super().test_touch()
 
+    def test_touch_expired_key_does_not_crash(self):
+        cache.set("expired_touch_key", "value", timeout=0.01)
+        time.sleep(0.05)
+        result = cache.touch("expired_touch_key", 60)
+        self.assertIs(result, False)
+
 
 @unittest.skipUnless(RedisCache_params, "Redis backend not configured")
 @override_settings(


### PR DESCRIPTION
#### Trac ticket number
ticket-37191

#### Branch description
This PR fixes a bug where `FileBasedCache.touch()` raises a `ValueError: I/O operation on closed file` when called on an expired cache key. 

The issue stems from the fact that `self._is_expired(f)` automatically closes the underlying file descriptor when the key's timeout has elapsed. However, the `finally` block still blindly executes `locks.unlock(f)`. Because the file descriptor is already closed, retrieving its file number in the unlock routing utilities triggers a `ValueError`. 

To resolve this, I wrapped the `locks.unlock(f)` statement in an `if not f.closed:` safety check to guarantee it only attempts to unlock file descriptors that are still active. A regression test verifying this scenario has also been added to `tests/cache/tests.py`.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
*Details: Used an AI assistant to help isolate the file descriptor behavior in `locks.py` and format the regression test within the native test runner suite.*

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.