### PR TITLE
Fixed #37187, #37190 -- Added qualnames to ModelAdmin deprecations.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -88,6 +88,11 @@ IS_FACETS_VAR = "_facets"
 EMPTY_VALUE_STRING = "-"
 
 
+# RemovedInDjango70Warning.
+def _fqname(bound_method):
+    return f"{bound_method.__module__}.{bound_method.__func__.__qualname__}"
+
+
 class ShowFacets(enum.Enum):
     NEVER = "NEVER"
     ALLOW = "ALLOW"
@@ -929,6 +934,7 @@ class ModelAdmin(BaseModelAdmin):
             # below 'if' clause and raise a ValueError here.
             if self.list_select_related is not True:
                 warnings.warn(
+                    f"{_fqname(self.get_list_select_related)}: "
                     "Returning True from ModelAdmin.get_list_select_related() is "
                     "deprecated. Return False or a list or tuple of fields to "
                     "fetch instead.",
@@ -1133,11 +1139,11 @@ class ModelAdmin(BaseModelAdmin):
             return self.get_actions(request, action_location=action_location)
         else:
             warnings.warn(
+                f"{_fqname(self.get_actions)}: "
                 "Overriding get_actions() without the 'action_location' parameter is "
                 "deprecated. Update the signature to get_actions(self, request, "
                 "action_location=ActionLocation.CHANGE_LIST).",
                 RemovedInDjango70Warning,
-                skip_file_prefixes=django_file_prefixes(),
             )
             if action_location == ActionLocation.CHANGE_FORM:
                 # Disable adding actions on change form when get_actions is
@@ -1173,12 +1179,12 @@ class ModelAdmin(BaseModelAdmin):
             )
         else:
             warnings.warn(
+                f"{_fqname(self.get_action_choices)}: "
                 "Overriding get_action_choices() without the 'action_location' "
                 "parameter is deprecated. Update the signature to "
                 "get_action_choices(self, request, default_choices=None, "
                 "action_location=ActionLocation.CHANGE_LIST).",
                 RemovedInDjango70Warning,
-                skip_file_prefixes=django_file_prefixes(),
             )
             return self.get_action_choices(request, default_choices=default_choices)
 

--- a/tests/admin_views/test_actions.py
+++ b/tests/admin_views/test_actions.py
@@ -872,6 +872,7 @@ class AdminDetailActionsTest(TestCase):
         obj = ModelAction.objects.create()
         change_url = reverse("admin:admin_views_modelaction_change", args=[obj.pk])
         get_actions_overridden_msg = (
+            "admin_views.admin.OverriddenActionAdmin.get_actions: "
             "Overriding get_actions() without the 'action_location' parameter is "
             "deprecated. Update the signature to get_actions(self, request, "
             "action_location=ActionLocation.CHANGE_LIST)."
@@ -891,6 +892,7 @@ class AdminDetailActionsTest(TestCase):
             message_warnings = [str(warning.message) for warning in warning_list]
             expected_warnings = {
                 get_actions_overridden_msg,
+                "admin_views.admin.OverriddenActionAdmin.get_action_choices: "
                 "Overriding get_action_choices() without the 'action_location' "
                 "parameter is deprecated. Update the signature to "
                 "get_action_choices(self, request, default_choices=None, "
@@ -909,6 +911,7 @@ class AdminDetailActionsTest(TestCase):
             "index": 0,
         }
         get_actions_overridden_msg = (
+            "admin_views.admin.OverriddenActionAdmin.get_actions: "
             "Overriding get_actions() without the 'action_location' parameter is "
             "deprecated. Update the signature to get_actions(self, request, "
             "action_location=ActionLocation.CHANGE_LIST)."

--- a/tests/modeladmin/tests.py
+++ b/tests/modeladmin/tests.py
@@ -1057,6 +1057,8 @@ class ModelAdminTests(TestCase):
     # RemovedInDjango70Warning: when the deprecation ends, rename.
     def test_get_list_select_related_returns_true_deprecated(self):
         msg = (
+            "modeladmin.tests.ModelAdminTests.test_get_list_select_related_returns"
+            "_true_deprecated.<locals>.TestModelAdmin.get_list_select_related: "
             "Returning True from ModelAdmin.get_list_select_related() is "
             "deprecated. Return False or a list or tuple of fields to fetch "
             "instead."


### PR DESCRIPTION

#### Trac ticket number

ticket-37187
ticket-37190

#### Branch description
\[This is a minimal-change alternative to PR 21553. I don't really think this is the best long-term approach, but I think it would be acceptable for 6.1. See https://github.com/django/django/pull/21553#issuecomment-4812629858 for details.]

Added the fully qualified name of a `ModelAdmin` method exhibiting deprecated behavior to its deprecation warning. Because the method is not on the stack when the warning is issued, `warnings.warn()` isn't able to point to the filename with the deprecated code. Showing the method's module and qualname helps identify the source of the problem.

Also removed `skip_file_prefixes=django_file_prefixes()` from these warnings. (That made the warning point into wsgiref/handler.py or similar, which is not helpful.) The warnings will now be issued against django/contrib/admin/options.py.

(This isn't necessary for the warning in `ModelAdmin.__init_subclass__`. The subclass with a deprecated property value _is_ on the stack at that point, so `warnings.warn(skip_file_prefixes=django)` will show the subclass's filename.)

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] (n/a) I have added or updated relevant docs, including release notes if applicable.
- [x] (n/a) I have attached screenshots in both light and dark modes for any UI changes.
