### PR TITLE
Fixed grammatical errors and typos in the 'submitting patches' documentation

### DIFF
--- a/docs/internals/contributing/writing-code/submitting-patches.txt
+++ b/docs/internals/contributing/writing-code/submitting-patches.txt
@@ -15,7 +15,7 @@ If you are fixing a really trivial issue, for example changing a word in the
 documentation, the preferred way to provide the patch is using GitHub pull
 requests without a Trac ticket.
 
-See the :doc:`/internals/contributing/writing-code/working-with-git` for more
+See :doc:`/internals/contributing/writing-code/working-with-git` for more
 details on how to use pull requests.
 
 .. _claiming-tickets:
@@ -34,7 +34,7 @@ If you have identified a contribution you want to make and you're capable of
 fixing it (as measured by your coding ability, knowledge of Django internals
 and time availability), claim it by following these steps:
 
-* `Login using your GitHub account`_ or `create an account`_ in our ticket
+* `Log in using your GitHub account`_ or `create an account`_ in our ticket
   system. If you have an account but have forgotten your password, you can
   reset it using the `password reset page`_.
 
@@ -59,7 +59,7 @@ and time availability), claim it by following these steps:
 * Claim the ticket by clicking the "assign to" radio button in the "Action"
   section. Your username will be filled in the text box by default.
 
-* Finally click the "Submit changes" button at the bottom to save.
+* Finally, click the "Submit changes" button at the bottom to save.
 
 .. note::
     If your change is not :ref:`trivial <trivial-change>`, you have the option
@@ -67,7 +67,7 @@ and time availability), claim it by following these steps:
     of your contribution. This ensures that the Django Software Foundation has
     clear license to your contribution.
 
-.. _Login using your GitHub account: https://code.djangoproject.com/github/login
+.. _Log in using your GitHub account: https://code.djangoproject.com/github/login
 .. _Create an account: https://www.djangoproject.com/accounts/register/
 .. _password reset page: https://www.djangoproject.com/accounts/password/reset/
 .. _Contributor License Agreement: https://www.djangoproject.com/foundation/cla/
@@ -99,8 +99,8 @@ In the case of small changes, such as typos in the documentation or small bugs
 that will only take a few minutes to fix, you don't need to jump through the
 hoops of claiming tickets. Submit your changes directly and you're done!
 
-It is *always* acceptable, regardless whether someone has claimed it or not, to
-link proposals to a ticket if you happen to have the changes ready.
+It is *always* acceptable, regardless of whether someone has claimed it or not,
+to link proposals to a ticket if you happen to have the changes ready.
 
 .. _patch-style:
 
@@ -271,7 +271,7 @@ mechanism for proposing and collecting community input on major new features.
 Before considering writing a DEP, it is recommended to first open a discussion
 following the :ref:`process for suggesting new features <requesting-features>`.
 This allows the community to provide feedback and helps refine the proposal.
-Once the DEP is ready the :ref:`Steering Council <steering-council>` votes on
+Once the DEP is ready, the :ref:`Steering Council <steering-council>` votes on
 whether to accept it.
 
 Some examples of DEPs that have been approved and fully implemented:
@@ -451,7 +451,7 @@ set the "Triage Stage" on the corresponding Trac ticket to "Ready for checkin".
 If you've left comments for improvement on the pull request, please tick the
 appropriate flags on the Trac ticket based on the results of your review:
 "Patch needs improvement", "Needs documentation", and/or "Needs tests". As time
-and interest permits, mergers do final reviews of "Ready for checkin" tickets
+and interest permit, mergers do final reviews of "Ready for checkin" tickets
 and will either commit the changes or bump it back to "Accepted" if further
 work needs to be done.
 


### PR DESCRIPTION
Didn't create the ticket as the typo is trivial : https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/submitting-patches/#typo-fixes-and-trivial-documentation-changes

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

N/A - typo

#### Branch description
Corrects several minor grammatical errors and typos in `submitting-patches.txt`. Ran `make html` to test the HTML generated and looks good.
<img width="681" height="832" alt="Screenshot 2026-06-27 at 20 19 23" src="https://github.com/user-attachments/assets/33e3de4c-e93a-4ffa-aa59-a8aa3f6e1892" />

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
