### PR TITLE
Fixed #26722 -- Django silently discards user provided on_delete for GenericRelation

### DIFF
--- a/django/contrib/contenttypes/fields.py
+++ b/django/contrib/contenttypes/fields.py
@@ -8,9 +8,9 @@ from django.contrib.contenttypes.models import ContentType
 from django.core import checks
 from django.core.exceptions import FieldDoesNotExist, ObjectDoesNotExist
 from django.db import DEFAULT_DB_ALIAS, models, router, transaction
-from django.db.models import DO_NOTHING, ForeignObject, ForeignObjectRel
+from django.db.models import ForeignObject, ForeignObjectRel
 from django.db.models.base import ModelBase, make_foreign_order_accessors
-from django.db.models.deletion import DatabaseOnDelete
+from django.db.models.deletion import GENERIC_ON_DELETE, DatabaseOnDelete
 from django.db.models.fields import Field
 from django.db.models.fields.mixins import FieldCacheMixin
 from django.db.models.fields.related import (
@@ -317,6 +317,7 @@ class GenericRel(ForeignObjectRel):
         related_name=None,
         related_query_name=None,
         limit_choices_to=None,
+        on_delete=models.CASCADE,
     ):
         super().__init__(
             field,
@@ -324,7 +325,7 @@ class GenericRel(ForeignObjectRel):
             related_name=related_query_name or "+",
             related_query_name=related_query_name,
             limit_choices_to=limit_choices_to,
-            on_delete=DO_NOTHING,
+            on_delete=on_delete,
         )
 
 
@@ -356,20 +357,25 @@ class GenericRelation(ForeignObject):
         limit_choices_to=None,
         **kwargs,
     ):
+        on_delete = kwargs.get("on_delete", models.CASCADE)
+        if on_delete not in GENERIC_ON_DELETE:
+            raise NotImplementedError(f"{on_delete} is not supported")
+
         kwargs["rel"] = self.rel_class(
             self,
             to,
             related_query_name=related_query_name,
             limit_choices_to=limit_choices_to,
+            on_delete=on_delete,
         )
 
         # Reverse relations are always nullable (Django can't enforce that a
         # foreign key on the related model points to this model).
         kwargs["null"] = True
         kwargs["blank"] = True
-        kwargs["on_delete"] = models.CASCADE
         kwargs["editable"] = False
         kwargs["serialize"] = False
+        kwargs["on_delete"] = on_delete
 
         # This construct is somewhat of an abuse of ForeignObject. This field
         # represents a relation from pk to object_id field. But, this relation

--- a/django/db/models/deletion.py
+++ b/django/db/models/deletion.py
@@ -101,6 +101,7 @@ DB_SET_DEFAULT = DatabaseOnDelete("SET DEFAULT", "DB_SET_DEFAULT")
 DB_SET_NULL = DatabaseOnDelete("SET NULL", "DB_SET_NULL")
 
 SKIP_COLLECTION = frozenset([DO_NOTHING, DB_CASCADE, DB_SET_DEFAULT, DB_SET_NULL])
+GENERIC_ON_DELETE = frozenset([CASCADE, DO_NOTHING])
 
 
 def get_candidate_relations_to_delete(opts):
@@ -399,10 +400,11 @@ class Collector:
         for field in model._meta.private_fields:
             if hasattr(field, "bulk_related_objects"):
                 # It's something like generic foreign key.
-                sub_objs = field.bulk_related_objects(new_objs, self.using)
-                self.collect(
-                    sub_objs, source=model, nullable=True, fail_on_restricted=False
-                )
+                if field.remote_field.on_delete == CASCADE:
+                    sub_objs = field.bulk_related_objects(new_objs, self.using)
+                    self.collect(
+                        sub_objs, source=model, nullable=True, fail_on_restricted=False
+                    )
 
         if fail_on_restricted:
             # Raise an error if collected restricted objects (RESTRICT) aren't

--- a/docs/ref/contrib/contenttypes.txt
+++ b/docs/ref/contrib/contenttypes.txt
@@ -512,13 +512,9 @@ pointing at it will be deleted as well. In the example above, this means that
 if a ``Bookmark`` object were deleted, any ``TaggedItem`` objects pointing at
 it would be deleted at the same time.
 
-Unlike :class:`~django.db.models.ForeignKey`,
-:class:`~django.contrib.contenttypes.fields.GenericForeignKey` does not accept
+:class:`~django.contrib.contenttypes.fields.GenericForeignKey` accepts
 an :attr:`~django.db.models.ForeignKey.on_delete` argument to customize this
-behavior; if desired, you can avoid the cascade-deletion by not using
-:class:`~django.contrib.contenttypes.fields.GenericRelation`, and alternate
-behavior can be provided via the :data:`~django.db.models.signals.pre_delete`
-signal.
+behavior; however only DO_NOTHING and CASCADE is currently supported.
 
 Generic relations and aggregation
 ---------------------------------

--- a/tests/generic_relations/models.py
+++ b/tests/generic_relations/models.py
@@ -85,6 +85,16 @@ class Vegetable(models.Model):
         return self.name
 
 
+class DoNothingVegetable(models.Model):
+    name = models.CharField(max_length=150)
+    is_yucky = models.BooleanField(default=True)
+
+    tags = GenericRelation(TaggedItem, on_delete=models.DO_NOTHING)
+
+    def __str__(self):
+        return self.name
+
+
 class Carrot(Vegetable):
     pass
 

--- a/tests/generic_relations/tests.py
+++ b/tests/generic_relations/tests.py
@@ -1,6 +1,7 @@
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes.prefetch import GenericPrefetch
 from django.core.exceptions import FieldError, FieldFetchBlocked
+from django.db import models
 from django.db.models import Q, prefetch_related_objects
 from django.db.models.fetch_modes import FETCH_PEERS, RAISE
 from django.test import SimpleTestCase, TestCase, skipUnlessDBFeature
@@ -11,6 +12,7 @@ from .models import (
     Carrot,
     Comparison,
     ConcreteRelatedModel,
+    DoNothingVegetable,
     ForConcreteModelModel,
     ForProxyModelModel,
     Gecko,
@@ -23,6 +25,45 @@ from .models import (
     ValuableTaggedItem,
     Vegetable,
 )
+
+
+class GenericRelationsOnDeleteTests(TestCase):
+    """
+    Tests related to on_delete, where on_delete issomething else
+    other than CASCADE
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.vegetable = DoNothingVegetable.objects.create(name="Eggplant")
+        cls.vegetable.tags.create(tag="yellow")
+        cls.vegetable.tags.create(tag="yummy")
+
+    def comp_func(self, obj):
+        # Original list of tags:
+        return obj.tag, obj.content_type.model_class(), obj.object_id
+
+    def test_deleting_vegetable_does_not_delete_tags(self):
+        pk = self.vegetable.pk
+        self.assertQuerySetEqual(
+            TaggedItem.objects.all(),
+            [
+                ("yellow", DoNothingVegetable, pk),
+                ("yummy", DoNothingVegetable, pk),
+            ],
+            self.comp_func,
+        )
+
+        self.vegetable.delete()
+
+        self.assertQuerySetEqual(
+            TaggedItem.objects.all(),
+            [
+                ("yellow", DoNothingVegetable, pk),
+                ("yummy", DoNothingVegetable, pk),
+            ],
+            self.comp_func,
+        )
 
 
 class GenericRelationsTests(TestCase):
@@ -289,6 +330,17 @@ class GenericRelationsTests(TestCase):
             ],
             self.comp_func,
         )
+
+    def test_generic_relation_has_correct_remote_field(self):
+        """
+        GenericRelation field should correctly tell you that it's using cascade
+        """
+
+        fields = self.lion._meta.get_fields()
+        tag_field = fields[-2]
+
+        self.assertEqual(tag_field.verbose_name, "tags")
+        self.assertEqual(tag_field.remote_field.on_delete, models.CASCADE)
 
     def test_object_deletion_without_generic_relation(self):
         """


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-26722

#### Branch description
When a user provides on_delete it is silently discarded, instead it will always use a python driven cascade behaviour. This mitigates this footgun by allowing the user to change the behaviour to DO_NOTHING.

on_delete is required in ForeignKey fields, but making it required here would be a backward incompatible change. So the best we can do mitigate this surprising footgun is to allow the user to change on_delete to DO_NOTHING.

Further work to implement other on_delete behaviour is outside the scope of this particular ticket. It would be desirable to move towards a required on_delete for GenericRelations as well.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
