### PR TITLE
Fixed #26372 -- Used admin_order_field when a list_display method shadows a reverse relation.

### DIFF
--- a/django/contrib/admin/views/main.py
+++ b/django/contrib/admin/views/main.py
@@ -17,6 +17,8 @@ from django.contrib.admin.options import (
     ShowFacets,
 )
 from django.contrib.admin.utils import (
+    FieldIsAForeignKeyColumnName,
+    _get_non_gfk_field,
     build_q_object_from_lookup_parameters,
     get_fields_from_path,
     lookup_spawns_duplicates,
@@ -352,9 +354,13 @@ class ChangeList:
         attribute. Return None if no proper model field name can be matched.
         """
         try:
-            field = self.lookup_opts.get_field(field_name)
+            # Use the same field resolution as lookup_field() does for
+            # rendering, so that e.g. a method shadowing a reverse relation
+            # sorts by its admin_order_field rather than by the relation
+            # (#26372).
+            field = _get_non_gfk_field(self.lookup_opts, field_name)
             return field.name
-        except FieldDoesNotExist:
+        except (FieldDoesNotExist, FieldIsAForeignKeyColumnName):
             # See whether field_name is a name of a non-field
             # that allows sorting.
             if callable(field_name):

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -18,7 +18,7 @@ from django.contrib.admin.views.main import (
 from django.contrib.auth.models import User
 from django.contrib.messages.storage.cookie import CookieStorage
 from django.db import DatabaseError, connection
-from django.db.models import F, Field, IntegerField
+from django.db.models import Count, F, Field, IntegerField
 from django.db.models.functions import Upper
 from django.db.models.lookups import Contains, Exact
 from django.template import Context, Template, TemplateSyntaxError
@@ -140,6 +140,41 @@ class ChangeListTests(TestCase):
         request.user = self.superuser
         cl = m.get_changelist_instance(request)
         self.assertEqual(cl.get_ordering_field_columns(), {3: "asc", 2: "asc"})
+
+    def test_admin_order_field_on_method_shadowing_reverse_relation(self):
+        """
+        A list_display method whose name shadows a reverse relation is
+        ordered by its admin_order_field, matching how the column is
+        rendered (#26372).
+        """
+
+        class ShadowingChildAdmin(admin.ModelAdmin):
+            list_display = ["name", "child"]
+
+            @admin.display(ordering="child_count")
+            def child(self, obj):
+                return obj.child_count
+
+            def get_queryset(self, request):
+                return (
+                    super().get_queryset(request).annotate(child_count=Count("child"))
+                )
+
+        parent_two = Parent.objects.create(name="two children")
+        Child.objects.create(parent=parent_two)
+        Child.objects.create(parent=parent_two)
+        parent_zero = Parent.objects.create(name="no children")
+
+        m = ShadowingChildAdmin(Parent, custom_site)
+        request = self._mocked_authenticated_request("/parent/", self.superuser)
+        cl = m.get_changelist_instance(request)
+        self.assertEqual(cl.get_ordering_field("child"), "child_count")
+
+        # Sorting on the column orders by the annotation without duplicating
+        # rows for each related object.
+        request = self._mocked_authenticated_request("/parent/?o=2", self.superuser)
+        cl = m.get_changelist_instance(request)
+        self.assertEqual(list(cl.queryset), [parent_zero, parent_two])
 
     def test_select_related_preserved(self):
         """


### PR DESCRIPTION
#### Trac ticket number

ticket-26372

#### Branch description

`ChangeList.get_ordering_field()` resolves `list_display` names with `Options.get_field()`, which also matches reverse relations and `GenericForeignKey`s. Rendering, however, goes through `lookup_field()`/`_get_non_gfk_field()`, which explicitly excludes those (per the helper's own docstring: "Reverse relations should also be excluded as these aren't attributes of the model").

So for the ticket's scenario — a `list_display` method whose name shadows a reverse relation (e.g. a method `child` with `@admin.display(ordering="child_count")` on a model with a reverse `child` relation) — the column is *rendered* with the method, but *sorted* by the relation. Ordering by a reverse relation joins the related table and produces one changelist row per related object (the duplicated results described in the ticket), while the method's `admin_order_field` is silently ignored.

**Fix:** resolve ordering names with the same `_get_non_gfk_field()` helper used for rendering, so names matching reverse relations/GFKs fall through to the `admin_order_field` resolution. Ordering by concrete fields, including forward relations, is unchanged — in particular, the concrete-field-shadowing behavior Tim raised backwards-compatibility concerns about in the ticket is untouched; only the non-concrete cases change, where the previous behavior produced duplicated rows.

Verified with a regression test that fails on `main` (`'child' != 'child_count'`) and passes with this change; the `admin_changelist`, `admin_views`, `admin_ordering`, `admin_utils`, `modeladmin`, `admin_filters` and `admin_checks` suites all pass, and `black`/`isort`/`flake8` are clean.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

AI tool used: Claude Code (Anthropic), for code analysis, drafting the patch and the regression test. I have reviewed and verified the change and all test results, and I take responsibility for the contribution.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
