### PR TITLE
Fixed #37200 -- Fixed get_signed_cookie() crash with base Signer.

### DIFF
--- a/django/core/signing.py
+++ b/django/core/signing.py
@@ -131,11 +131,14 @@ def _cookie_signer_legacy_salt(cookie_name, salt=""):
 
 
 def _unsign_cookie(signed_value, *, cookie_name, salt="", max_age=None):
+    kwargs = {}
+    if max_age is not None:
+        kwargs["max_age"] = max_age
     try:
         # RemovedInDjango70Warning: When the deprecation ends, replace the
         # whole function body with this single return statement.
         return get_cookie_signer(salt=_cookie_signer_salt(cookie_name, salt)).unsign(
-            signed_value, max_age=max_age
+            signed_value, **kwargs
         )
     except BadSignature as exc:
         if settings.SIGNED_COOKIE_LEGACY_SALT_FALLBACK and not isinstance(
@@ -143,7 +146,7 @@ def _unsign_cookie(signed_value, *, cookie_name, salt="", max_age=None):
         ):
             return get_cookie_signer(
                 salt=_cookie_signer_legacy_salt(cookie_name, salt)
-            ).unsign(signed_value, max_age=max_age)
+            ).unsign(signed_value, **kwargs)
         raise
 
 

--- a/tests/signed_cookies_tests/tests.py
+++ b/tests/signed_cookies_tests/tests.py
@@ -18,6 +18,15 @@ class SignedCookieTest(SimpleTestCase):
         value = request.get_signed_cookie("c")
         self.assertEqual(value, "hello")
 
+    @override_settings(SIGNING_BACKEND="django.core.signing.Signer")
+    def test_get_signed_cookie_works_with_plain_signer_backend(self):
+        response = HttpResponse()
+        response.set_signed_cookie("c", "hello")
+        request = HttpRequest()
+        request.COOKIES["c"] = response.cookies["c"].value
+        self.assertEqual(request.get_signed_cookie("c"), "hello")
+        self.assertEqual(request.get_signed_cookie("c", default=None), "hello")
+
     def test_can_use_salt(self):
         response = HttpResponse()
         response.set_signed_cookie("a", "hello", salt="one")


### PR DESCRIPTION
#### Trac ticket number
ticket-37200

#### Branch description
This PR fixes an abstraction leak where `HttpRequest.get_signed_cookie()` (via the internal `_unsign_cookie()` function) unconditionally passed the `max_age` argument to the configured signer's `unsign()` method. 

This caused a `TypeError` when a plain `django.core.signing.Signer` was used as the `SIGNING_BACKEND` (which is a valid and documented configuration), because the base `Signer.unsign()` does not accept a `max_age` argument. 

**Changes:**
- Conditionally pass `max_age` to the signer's `unsign()` method using `**kwargs` only when it is not `None`.
- Applied the same `**kwargs` logic to the legacy salt fallback block to prevent similar crashes.
- Added a regression test `test_get_signed_cookie_works_with_plain_signer_backend` to ensure plain signers work smoothly with signed cookies.

#### AI Assistance Disclosure (REQUIRED)
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. 
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR. 
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.