### PR TITLE
Fixed #37194 -- Updated ChoiceWidget docs section title and description.

### DIFF
--- a/docs/ref/forms/widgets.txt
+++ b/docs/ref/forms/widgets.txt
@@ -79,13 +79,14 @@ widget on the field. In the following example, the
 See the :ref:`built-in widgets` for more information about which widgets
 are available and which arguments they accept.
 
-Widgets inheriting from the ``Select`` widget
-=============================================
+Widgets with choices
+====================
 
-Widgets inheriting from the :class:`Select` widget deal with choices. They
-present the user with a list of options to choose from. The different widgets
-present this choice differently; the :class:`Select` widget itself uses a
-``<select>`` HTML list representation, while :class:`RadioSelect` uses radio
+There are a group of widgets which deal with choices and present the
+user with a list of options to choose from. These widgets inherit from
+:class:`ChoiceWidget`. The different widgets present this choice
+differently; the :class:`Select` widget itself uses a ``<select>``
+HTML list representation, while :class:`RadioSelect` uses radio
 buttons.
 
 :class:`Select` widgets are used by default on :class:`ChoiceField` fields. The


### PR DESCRIPTION
ticket-37194

#### Branch description
Updated the "Widgets inheriting from the Select widget" section title
and description to reflect the current class hierarchy, where both
Select and RadioSelect inherit from ChoiceWidget, not from Select.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, Claude (Anthropic) was used for guidance. I have disclosed which ones, and fully reviewed and verified their output.
Claude (Anthropic) was used for guidance on Django's contribution workflow, finding the correct file to edit, and reviewing the diff. All changes were manually reviewed and verified by me.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.