### PR TITLE
Fixed #37180 -- Fixed admin SelectBox height tests to verify available/chosen box heights.

### DIFF
--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -6674,19 +6674,11 @@ class SeleniumTests(AdminSeleniumTestCase):
         url = self.live_server_url + reverse("admin7:admin_views_pizza_add")
         self.selenium.get(url)
         self.selenium.find_elements(By.TAG_NAME, "summary")[0].click()
-        from_filter_box = self.selenium.find_element(By.ID, "id_toppings_filter")
-        from_box = self.selenium.find_element(By.ID, "id_toppings_from")
-        to_filter_box = self.selenium.find_element(By.ID, "id_toppings_filter_selected")
-        to_box = self.selenium.find_element(By.ID, "id_toppings_to")
+        available_box = self.selenium.find_element(By.CLASS_NAME, "selector-available")
+        chosen_box = self.selenium.find_element(By.CLASS_NAME, "selector-chosen")
         self.assertEqual(
-            (
-                to_filter_box.get_property("offsetHeight")
-                + to_box.get_property("offsetHeight")
-            ),
-            (
-                from_filter_box.get_property("offsetHeight")
-                + from_box.get_property("offsetHeight")
-            ),
+            available_box.get_property("offsetHeight"),
+            chosen_box.get_property("offsetHeight"),
         )
         self.take_screenshot("selectbox-collapsible")
 
@@ -6701,23 +6693,11 @@ class SeleniumTests(AdminSeleniumTestCase):
         )
         url = self.live_server_url + reverse("admin7:admin_views_question_add")
         self.selenium.get(url)
-        from_filter_box = self.selenium.find_element(
-            By.ID, "id_related_questions_filter"
-        )
-        from_box = self.selenium.find_element(By.ID, "id_related_questions_from")
-        to_filter_box = self.selenium.find_element(
-            By.ID, "id_related_questions_filter_selected"
-        )
-        to_box = self.selenium.find_element(By.ID, "id_related_questions_to")
+        available_box = self.selenium.find_element(By.CLASS_NAME, "selector-available")
+        chosen_box = self.selenium.find_element(By.CLASS_NAME, "selector-chosen")
         self.assertEqual(
-            (
-                to_filter_box.get_property("offsetHeight")
-                + to_box.get_property("offsetHeight")
-            ),
-            (
-                from_filter_box.get_property("offsetHeight")
-                + from_box.get_property("offsetHeight")
-            ),
+            available_box.get_property("offsetHeight"),
+            chosen_box.get_property("offsetHeight"),
         )
         self.take_screenshot("selectbox-non-collapsible")
 


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37180

#### Branch description
these tests compare the height of the inner <select> boxes (from_box and to_box)

since, the UI was updated to use CSS Flexbox, Flexbox makes the outer containers (.selector-available and .selector-chosen) equal in height, not the inner <select> boxes.

The current Selenium tests are passing mostly by luck. But if the test runs in a different window size, it could fail.

We should update the test to compare the heights of the outer flex containers only.



#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [X] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
