### PR TITLE
Fixed #37204 -- Rendered console directives as plain code in epub docs builds.

### DIFF
--- a/docs/_ext/djangodocs.py
+++ b/docs/_ext/djangodocs.py
@@ -212,7 +212,14 @@ def depart_console_dummy(self, node):
 
 def visit_console_html(self, node):
     """Generate HTML for the console directive."""
-    if self.builder.format == "html" and node["win_console_text"]:
+    # The epub builder uses the HTML format but produces XHTML for e-readers,
+    # where the CSS-driven tabs neither work nor validate as XML, so fall back
+    # to a plain literal block there (as the non-HTML formats already do).
+    if (
+        self.builder.format == "html"
+        and self.builder.name != "epub"
+        and node["win_console_text"]
+    ):
         # Put a mark on the document object signaling the fact the directive
         # has been used on it.
         self.document._console_directive_used_flag = True


### PR DESCRIPTION
The console directive renders its Unix/Windows tabs with browser-only markup: hidden radio inputs toggled via CSS. The epub builder shares the HTML format, so it copied that markup into the ebook, where the tabs cannot work (e-readers do not support the driving CSS) and the raw HTML is not well-formed XHTML, so strict readers fail to parse the page.

Skipped the tab markup for the epub builder and fell back to a plain literal block, matching what the non-HTML builders already do.

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37204

#### Branch description
Provide a concise overview of the issue or rationale behind the proposed changes.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [X] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [X] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [X] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [X] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
