### PR TITLE
Fixed #37198 -- Fixed content_disposition_header() quoting of filenames ending with newlines.

### DIFF
--- a/django/utils/http.py
+++ b/django/utils/http.py
@@ -420,7 +420,7 @@ def content_disposition_header(as_attachment, filename):
         # characters from 0x21 to 0x7e, except 0x22 (`"`) and 0x5C (`\`) which
         # can still be expressed but must be escaped with their own `\`.
         # https://datatracker.ietf.org/doc/html/rfc9110#name-quoted-strings
-        quotable_characters = r"^[\t \x21-\x7e]*$"
+        quotable_characters = r"^[\t \x21-\x7e]*\Z"
         if is_ascii and re.match(quotable_characters, filename):
             file_expr = 'filename="{}"'.format(
                 filename.replace("\\", "\\\\").replace('"', r"\"")

--- a/tests/utils_tests/test_http.py
+++ b/tests/utils_tests/test_http.py
@@ -644,6 +644,8 @@ class ContentDispositionHeaderTests(unittest.TestCase):
                 "attachment; filename*=utf-8''%22esp%C3%A9cimen%22%20filename",
             ),
             ((True, "some\nfile"), "attachment; filename*=utf-8''some%0Afile"),
+            ((True, "\n"), "attachment; filename*=utf-8''%0A"),
+            ((True, "example\n"), "attachment; filename*=utf-8''example%0A"),
         )
 
         for (is_attachment, filename), expected in tests:


### PR DESCRIPTION
#### Trac ticket number

ticket-37198

#### Branch description
Currently, regex in `content_disposition_header` excludes the trailing new line at the end of a filename — leading to introduction of new line in the resulting header. Hence, replaced the `$` with `\Z` to capture till the very end of a string, to avoid such evading.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
