### PR TITLE
Fixed #37198 -- Used \Z anchor in content_disposition_header() regex.

### DIFF
--- a/django/utils/http.py
+++ b/django/utils/http.py
@@ -420,7 +420,7 @@ def content_disposition_header(as_attachment, filename):
         # characters from 0x21 to 0x7e, except 0x22 (`"`) and 0x5C (`\`) which
         # can still be expressed but must be escaped with their own `\`.
         # https://datatracker.ietf.org/doc/html/rfc9110#name-quoted-strings
-        quotable_characters = r"^[\t \x21-\x7e]*$"
+        quotable_characters = r"^[\t \x21-\x7e]*\Z"
         if is_ascii and re.match(quotable_characters, filename):
             file_expr = 'filename="{}"'.format(
                 filename.replace("\\", "\\\\").replace('"', r"\"")

--- a/tests/utils_tests/test_http.py
+++ b/tests/utils_tests/test_http.py
@@ -644,6 +644,10 @@ class ContentDispositionHeaderTests(unittest.TestCase):
                 "attachment; filename*=utf-8''%22esp%C3%A9cimen%22%20filename",
             ),
             ((True, "some\nfile"), "attachment; filename*=utf-8''some%0Afile"),
+            # Trailing newline must not slip through the quoted-string branch
+            # ($ matches before trailing \n in Python regex). Refs #37198.
+            ((True, "report.pdf\n"), "attachment; filename*=utf-8''report.pdf%0A"),
+            ((True, "\n"), "attachment; filename*=utf-8''%0A"),
         )
 
         for (is_attachment, filename), expected in tests:


### PR DESCRIPTION
#### Trac ticket number
ticket-37198

#### Branch description
`content_disposition_header()` uses a regex to determine if a filename can be safely expressed as an RFC 9110 quoted-string. The regex on line 423 of `django/utils/http.py` was:

```python
quotable_characters = r"^[\t \x21-\x7e]*$"
```

**The bug:** Python's `$` regex anchor matches at the end of the string *or immediately before a trailing `\n`*. This means a filename like `"report.pdf\n"` (ending in a newline) incorrectly passes the quotable-character check and takes the quoted-string branch, producing:

```python
>>> content_disposition_header(True, "report.pdf\n")
'attachment; filename="report.pdf\n"'  # ← raw newline in the header!
```

This causes `BadHeaderError` on Django responses and `ValueError("Invalid header value ...")` in `boto3`/`http.client` — an uncaught 500 for anyone serving a user-supplied filename that ends in a newline.

This is the same class of bug as **CVE-2021-32052** (URLValidator `$` accepting a trailing newline), after which Django validators were systematically switched to `\Z`.

**Fix:** Anchored with `\Z` (matches only the true end of string).
**Tests:** Added two regression test cases to `ContentDispositionHeaderTests.test_basic` in `tests/utils_tests/test_http.py` for `\n` and `report.pdf\n`. Both now correctly route to the percent-encoded `filename*=utf-8''` branch.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

I used Google Gemini to trace the codebase, identify the bug pattern, formulate the regex fix, and write the regression tests. I have fully reviewed the logic, verified the output, and successfully executed the test suite locally.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
