### PR TITLE
Fixed #37203 -- Used normalized field names in inspectdb composite primary keys.

### DIFF
--- a/django/core/management/commands/inspectdb.py
+++ b/django/core/management/commands/inspectdb.py
@@ -123,8 +123,8 @@ class Command(BaseCommand):
                         cursor, table_name
                     )
                 except Exception as e:
-                    yield "# Unable to inspect table '%s'" % table_name
-                    yield "# The error was: %s" % e
+                    yield "# Unable to inspect table %r" % table_name
+                    yield "# The error was: %r" % str(e)
                     continue
 
                 model_name = self.normalize_table_name(table_name)
@@ -133,12 +133,9 @@ class Command(BaseCommand):
                 yield "class %s(models.Model):" % model_name
                 known_models.append(model_name)
 
-                if len(primary_key_columns) > 1:
-                    fields = ", ".join([f"'{col}'" for col in primary_key_columns])
-                    yield f"    pk = models.CompositePrimaryKey({fields})"
-
                 used_column_names = []  # Holds column names used in the table so far
                 column_to_field_name = {}  # Maps column names to names of model fields
+                field_lines = []
                 used_relations = set()  # Holds foreign relations used in the table.
                 for row in table_description:
                     comment_notes = (
@@ -252,7 +249,14 @@ class Command(BaseCommand):
                     field_desc += ")"
                     if comment_notes:
                         field_desc += "  # " + " ".join(comment_notes)
-                    yield "    %s" % field_desc
+                    field_lines.append("    %s" % field_desc)
+                if len(primary_key_columns) > 1:
+                    fields = ", ".join(
+                        repr(column_to_field_name.get(col, col))
+                        for col in primary_key_columns
+                    )
+                    yield f"    pk = models.CompositePrimaryKey({fields})"
+                yield from field_lines
                 comment = None
                 if info := table_info.get(table_name):
                     is_view = info.type == "v"

--- a/tests/inspectdb/tests.py
+++ b/tests/inspectdb/tests.py
@@ -5,7 +5,7 @@ from unittest import mock, skipUnless
 from django.core.management import CommandError, call_command
 from django.core.management.commands import inspectdb
 from django.db import connection
-from django.db.backends.base.introspection import TableInfo
+from django.db.backends.base.introspection import FieldInfo, TableInfo
 from django.test import (
     TestCase,
     TransactionTestCase,
@@ -515,6 +515,26 @@ class InspectDBTestCase(TestCase):
         # The error message depends on the backend
         self.assertIn("# The error was:", output)
 
+    def test_introspection_errors_escape_table_name_and_message(self):
+        table_name = "table_name\ncontinued"
+        error_message = "error\ncontinued"
+        out = StringIO()
+        with (
+            mock.patch(
+                "django.db.connection.introspection.get_table_list",
+                return_value=[TableInfo(name=table_name, type="t")],
+            ),
+            mock.patch(
+                "django.db.connection.introspection.get_relations",
+                side_effect=RuntimeError(error_message),
+            ),
+        ):
+            call_command("inspectdb", stdout=out)
+        output = out.getvalue()
+        self.assertIn(f"# Unable to inspect table {table_name!r}", output)
+        self.assertIn(f"# The error was: {error_message!r}", output)
+        self.assertNotIn("\ncontinued", output)
+
     def test_same_relations(self):
         out = StringIO()
         call_command("inspectdb", "inspectdb_message", stdout=out)
@@ -673,6 +693,62 @@ class InspectDBTransactionalTests(TransactionTestCase):
         )
         self.assertIn(f"column_1 = models.{field_type}()", output)
         self.assertIn(f"column_2 = models.{field_type}()", output)
+
+    def test_composite_primary_key_uses_normalized_column_names(self):
+        class_column = "class"
+        order_column = "order-line"
+        table_name = "inspectdb_compositepk_normalized_columns"
+        out = StringIO()
+        field_info = FieldInfo(
+            name=class_column,
+            type_code=None,
+            display_size=None,
+            internal_size=None,
+            precision=None,
+            scale=None,
+            null_ok=False,
+            default=None,
+            collation=None,
+        )
+        order_field_info = field_info._replace(name=order_column)
+        with (
+            mock.patch.object(
+                connection.introspection,
+                "get_table_list",
+                return_value=[TableInfo(name=table_name, type="t")],
+            ),
+            mock.patch.object(
+                connection.introspection, "get_relations", return_value={}
+            ),
+            mock.patch.object(
+                connection.introspection, "get_constraints", return_value={}
+            ),
+            mock.patch.object(
+                connection.introspection,
+                "get_primary_key_columns",
+                return_value=[class_column, order_column],
+            ),
+            mock.patch.object(
+                connection.introspection,
+                "get_table_description",
+                return_value=[field_info, order_field_info],
+            ),
+            mock.patch.object(
+                connection.introspection, "get_field_type", return_value="IntegerField"
+            ),
+            mock.patch.object(connection.features, "supports_comments", False),
+        ):
+            call_command("inspectdb", table_name, stdout=out)
+        output = out.getvalue()
+        self.assertIn(
+            "pk = models.CompositePrimaryKey('class_field', 'order_line')",
+            output,
+        )
+        self.assertIn("class_field = models.IntegerField(db_column='class')", output)
+        self.assertIn(
+            "order_line = models.IntegerField(db_column='order-line')",
+            output,
+        )
 
     def test_composite_primary_key_not_unique_together(self):
         out = StringIO()


### PR DESCRIPTION
#### Trac ticket number

ticket-37203

#### Branch description

`inspectdb` builds `models.CompositePrimaryKey(...)` from the database column names returned by introspection. Some of those column names are later rewritten by `normalize_col_name()` so they can be used as model field names. In those cases, the generated composite primary key can refer to the original database column name instead of the generated model field name.

This patch delays emitting `CompositePrimaryKey(...)` until after the model fields have been processed, then uses the same `column_to_field_name` mapping that `inspectdb` already uses for other generated model metadata.

It also keeps the related literal-rendering cleanups found along the way:

- Uses `repr()` for field names emitted into `models.CompositePrimaryKey(...)`.
- Uses `%r`/`repr(str(...))` for table names and exception messages emitted in introspection-error comments.

The patch includes focused regression tests for composite primary-key fields whose database column names are normalized, and for introspection-error comments containing newlines. No documentation changes are needed because this only affects generated `inspectdb` model source.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

OpenAI Codex assisted in finding and preparing this patch. I reviewed the generated diff and verified the behavior with focused regression tests.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.

#### Tests

```bash
env PYTHONPATH=. /tmp/django-patch-venv/bin/python tests/runtests.py inspectdb --verbosity 2
env PYTHONPATH=. /tmp/django-patch-venv/bin/python -m py_compile django/core/management/commands/inspectdb.py tests/inspectdb/tests.py
env PYTHONPATH=. /tmp/django-patch-venv/bin/python -m black --check --diff django/core/management/commands/inspectdb.py tests/inspectdb/tests.py
env PYTHONPATH=. /tmp/django-patch-venv/bin/python -m flake8 django/core/management/commands/inspectdb.py tests/inspectdb/tests.py
git diff --check
```

All passed.
