### PR TITLE
Fixed #37205 -- Asserted exact HttpResponse types in tests.

### DIFF
--- a/tests/async/tests.py
+++ b/tests/async/tests.py
@@ -118,7 +118,7 @@ class ViewTests(SimpleTestCase):
                 if is_coroutine:
                     response = asyncio.run(response)
 
-                self.assertIsInstance(response, HttpResponse)
+                self.assertIs(type(response), HttpResponse)
 
     def test_http_method_not_allowed_responds_correctly(self):
         request_factory = RequestFactory()
@@ -137,7 +137,7 @@ class ViewTests(SimpleTestCase):
                 if is_coroutine:
                     response = asyncio.run(response)
 
-                self.assertIsInstance(response, HttpResponseNotAllowed)
+                self.assertIs(type(response), HttpResponseNotAllowed)
 
     def test_base_view_class_is_sync(self):
         """

--- a/tests/decorators/test_common.py
+++ b/tests/decorators/test_common.py
@@ -26,7 +26,7 @@ class NoAppendSlashTests(SimpleTestCase):
             return HttpResponse()
 
         self.assertIs(sync_view.should_append_slash, False)
-        self.assertIsInstance(sync_view(HttpRequest()), HttpResponse)
+        self.assertIs(type(sync_view(HttpRequest())), HttpResponse)
 
     async def test_no_append_slash_decorator_async_view(self):
         @no_append_slash
@@ -34,4 +34,4 @@ class NoAppendSlashTests(SimpleTestCase):
             return HttpResponse()
 
         self.assertIs(async_view.should_append_slash, False)
-        self.assertIsInstance(await async_view(HttpRequest()), HttpResponse)
+        self.assertIs(type(await async_view(HttpRequest())), HttpResponse)

--- a/tests/decorators/test_csrf.py
+++ b/tests/decorators/test_csrf.py
@@ -182,7 +182,7 @@ class CsrfExemptTests(SimpleTestCase):
             return HttpResponse()
 
         self.assertIs(sync_view.csrf_exempt, True)
-        self.assertIsInstance(sync_view(HttpRequest()), HttpResponse)
+        self.assertIs(type(sync_view(HttpRequest())), HttpResponse)
 
     async def test_csrf_exempt_decorator_async_view(self):
         @csrf_exempt
@@ -190,4 +190,4 @@ class CsrfExemptTests(SimpleTestCase):
             return HttpResponse()
 
         self.assertIs(async_view.csrf_exempt, True)
-        self.assertIsInstance(await async_view(HttpRequest()), HttpResponse)
+        self.assertIs(type(await async_view(HttpRequest())), HttpResponse)

--- a/tests/decorators/test_http.py
+++ b/tests/decorators/test_http.py
@@ -33,15 +33,15 @@ class RequireHttpMethodsTest(SimpleTestCase):
 
         request = HttpRequest()
         request.method = "GET"
-        self.assertIsInstance(my_view(request), HttpResponse)
+        self.assertIs(type(my_view(request)), HttpResponse)
         request.method = "PUT"
-        self.assertIsInstance(my_view(request), HttpResponse)
+        self.assertIs(type(my_view(request)), HttpResponse)
         request.method = "HEAD"
-        self.assertIsInstance(my_view(request), HttpResponseNotAllowed)
+        self.assertIs(type(my_view(request)), HttpResponseNotAllowed)
         request.method = "POST"
-        self.assertIsInstance(my_view(request), HttpResponseNotAllowed)
+        self.assertIs(type(my_view(request)), HttpResponseNotAllowed)
         request.method = "DELETE"
-        self.assertIsInstance(my_view(request), HttpResponseNotAllowed)
+        self.assertIs(type(my_view(request)), HttpResponseNotAllowed)
 
     async def test_require_http_methods_methods_async_view(self):
         @require_http_methods(["GET", "PUT"])
@@ -50,15 +50,15 @@ class RequireHttpMethodsTest(SimpleTestCase):
 
         request = HttpRequest()
         request.method = "GET"
-        self.assertIsInstance(await my_view(request), HttpResponse)
+        self.assertIs(type(await my_view(request)), HttpResponse)
         request.method = "PUT"
-        self.assertIsInstance(await my_view(request), HttpResponse)
+        self.assertIs(type(await my_view(request)), HttpResponse)
         request.method = "HEAD"
-        self.assertIsInstance(await my_view(request), HttpResponseNotAllowed)
+        self.assertIs(type(await my_view(request)), HttpResponseNotAllowed)
         request.method = "POST"
-        self.assertIsInstance(await my_view(request), HttpResponseNotAllowed)
+        self.assertIs(type(await my_view(request)), HttpResponseNotAllowed)
         request.method = "DELETE"
-        self.assertIsInstance(await my_view(request), HttpResponseNotAllowed)
+        self.assertIs(type(await my_view(request)), HttpResponseNotAllowed)
 
 
 class RequireSafeDecoratorTest(SimpleTestCase):
@@ -69,15 +69,15 @@ class RequireSafeDecoratorTest(SimpleTestCase):
         my_safe_view = require_safe(my_view)
         request = HttpRequest()
         request.method = "GET"
-        self.assertIsInstance(my_safe_view(request), HttpResponse)
+        self.assertIs(type(my_safe_view(request)), HttpResponse)
         request.method = "HEAD"
-        self.assertIsInstance(my_safe_view(request), HttpResponse)
+        self.assertIs(type(my_safe_view(request)), HttpResponse)
         request.method = "POST"
-        self.assertIsInstance(my_safe_view(request), HttpResponseNotAllowed)
+        self.assertIs(type(my_safe_view(request)), HttpResponseNotAllowed)
         request.method = "PUT"
-        self.assertIsInstance(my_safe_view(request), HttpResponseNotAllowed)
+        self.assertIs(type(my_safe_view(request)), HttpResponseNotAllowed)
         request.method = "DELETE"
-        self.assertIsInstance(my_safe_view(request), HttpResponseNotAllowed)
+        self.assertIs(type(my_safe_view(request)), HttpResponseNotAllowed)
 
     async def test_require_safe_accepts_only_safe_methods_async_view(self):
         @require_safe
@@ -86,15 +86,15 @@ class RequireSafeDecoratorTest(SimpleTestCase):
 
         request = HttpRequest()
         request.method = "GET"
-        self.assertIsInstance(await async_view(request), HttpResponse)
+        self.assertIs(type(await async_view(request)), HttpResponse)
         request.method = "HEAD"
-        self.assertIsInstance(await async_view(request), HttpResponse)
+        self.assertIs(type(await async_view(request)), HttpResponse)
         request.method = "POST"
-        self.assertIsInstance(await async_view(request), HttpResponseNotAllowed)
+        self.assertIs(type(await async_view(request)), HttpResponseNotAllowed)
         request.method = "PUT"
-        self.assertIsInstance(await async_view(request), HttpResponseNotAllowed)
+        self.assertIs(type(await async_view(request)), HttpResponseNotAllowed)
         request.method = "DELETE"
-        self.assertIsInstance(await async_view(request), HttpResponseNotAllowed)
+        self.assertIs(type(await async_view(request)), HttpResponseNotAllowed)
 
 
 class ConditionDecoratorTest(SimpleTestCase):


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37205

#### Branch description
Tests using `assertIsInstance()` will pass if the expected is a superclass of the returned object. Replaced these asserts with an `assertEquals` comparison of response status codes.
 
I only looked through the codebase for usages of `assertIsInstance()` with `HttpResponse` objects. Tests that checked against a class that is _not_ currently used as a superclass were also changed for consistency. There are some examples in these files that I chose to leave as is:
* [tests/middleware/tests.py](../tree/main/tests/middleware/tests.py)
* [tests/urlpatterns_reverse/tests.py](../tree/main/tests/urlpatterns_reverse/tests.py)
* [tests/cache/tests.py](../tree/main/tests/cache/tests.py)
* [tests/shortcuts/tests.py](../tree/main/tests/shortcuts/tests.py)
* [tests/view_tests/tests/test_static.py](../tree/main/tests/view_tests/tests/test_static.py)


#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
