### PR TITLE
Fixed typo and versionadded locations in email docs.

### DIFF
--- a/docs/topics/email.txt
+++ b/docs/topics/email.txt
@@ -1282,6 +1282,8 @@ backends.
 
 .. data:: mailers
 
+    .. versionadded:: 6.1
+
     You can access the mailers configured in the :setting:`MAILERS` setting
     through a dict-like object: ``django.core.mail.mailers``:
 
@@ -1293,9 +1295,9 @@ backends.
     If the named key is not defined, a ``MailerDoesNotExist`` error will be
     raised. Other configuration problems will raise an ``InvalidMailer`` error.
 
-    .. versionadded:: 6.1
-
 .. data:: mailers.default
+
+    .. versionadded:: 6.1
 
     As a shortcut, the default mailer can be accessed through
     ``django.core.mail.mailers.default``:
@@ -1348,7 +1350,7 @@ backends.
 
     .. deprecated:: 6.0
 
-        Passing ``fail_silently`` as positional argument is deprecated.
+        Passing ``fail_silently`` as a positional argument is deprecated.
 
     .. deprecated:: 6.1
 


### PR DESCRIPTION

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

N/A - typo

#### Branch description

* Moved versionadded annotation to top of `mailers` section ("[prefacing the features’ documentation](https://docs.djangoproject.com/en/dev/internals/contributing/writing-documentation/#documenting-new-features)").
* Added versionadded to `mailers.default` to help avoid confusion over the deprecated annotation in same entry.
* Added missing "a" in `get_connection()`'s 6.0 deprecation note.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] (n/a) I have checked the "Has patch" ticket flag in the Trac system.
- [x] (n/a) I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] (n/a) I have attached screenshots in both light and dark modes for any UI changes.
