### PR TITLE
Fixed #37199 -- Fixed typo in bulk_update code example in docs/ref/models/querysets.txt.

### DIFF
--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -2542,7 +2542,7 @@ them, but it has a few caveats:
     batch_size = 100
     ids_iter = iter(range(1000))
     while ids := list(islice(ids_iter, batch_size)):
-        batch = Entry.objects.filter(ids__in=ids)
+        batch = Entry.objects.filter(id__in=ids)
         for entry in batch:
             entry.headline = f"Updated headline {entry.pk}"
         Entry.objects.bulk_update(batch, ["headline"], batch_size=batch_size)


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37199

#### Branch description

Fix a typo in the `bulk_update()` reference docs which referenced an `Entry.ids` field in a query --- I think that `Entry.id` was intended.

This example also uses `entry.pk` so I was tempted to make it consistent (either use `pk__in` or change `entry.pk` to `entry.id`), but I've stuck with the minimal typo fix here. As this is a typo fix I don't believe that the tests or release notes require an update, but I'd be happy to -- please advise.

Previously: #21571 (I can't reopen that one)

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
