### PR TITLE
Refs #32670 -- Revealed warning in GDAL virtual filesystem reference.

### DIFF
--- a/docs/ref/contrib/gis/gdal.txt
+++ b/docs/ref/contrib/gis/gdal.txt
@@ -2091,9 +2091,9 @@ supported. You can use them by prepending the provided path with the
 appropriate ``/vsi*/`` prefix. See the `GDAL Virtual Filesystems
 documentation`_ for more details.
 
-.. warning:
+.. warning::
 
-    Rasters with names starting with `/vsi*/` will be treated as rasters from
+    Rasters with names starting with ``/vsi*/`` will be treated as rasters from
     the GDAL virtual filesystems. Django doesn't perform any extra validation.
 
 Compressed rasters

--- a/docs/ref/contrib/gis/gdal.txt
+++ b/docs/ref/contrib/gis/gdal.txt
@@ -2099,8 +2099,8 @@ documentation`_ for more details.
 Compressed rasters
 ^^^^^^^^^^^^^^^^^^
 
-Instead decompressing the file and instantiating the resulting raster, GDAL can
-directly access compressed files using the ``/vsizip/``, ``/vsigzip/``, or
+Instead of decompressing the file and instantiating the resulting raster, GDAL
+can directly access compressed files using the ``/vsizip/``, ``/vsigzip/``, or
 ``/vsitar/`` virtual filesystems:
 
 .. code-block:: pycon


### PR DESCRIPTION
See [docs](https://docs.djangoproject.com/en/dev/ref/contrib/gis/gdal/#using-other-virtual-filesystems), this box was missing.

Related typo fix also.