### PR TITLE
Refs #36277 -- Added missing release note for Postgres 18+ virtual column.

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -1346,8 +1346,8 @@ materialized view.
 
     .. versionchanged:: 6.1
 
-        Support for stored ``GeneratedField``\s was added on Oracle 23ai/26ai
-        (23.7+).
+        Support for virtual ``GeneratedField``\s was added on Postgres 18+ and
+        for stored ones on Oracle 23ai/26ai (23.7+).
 
 .. admonition:: Database limitations
 

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -311,7 +311,9 @@ Models
 * The new :class:`~django.db.models.functions.UUID4` and
   :class:`~django.db.models.functions.UUID7` database functions were added.
 
-* :class:`~django.db.models.GeneratedField` now supports stored columns
+* :class:`~django.db.models.GeneratedField` now supports virtual columns
+  (:attr:`~django.db.models.GeneratedField.db_persist` set to ``False``) on
+  Postgres 18+ and stored columns
   (:attr:`~django.db.models.GeneratedField.db_persist` set to ``True``) on
   Oracle 23ai/26ai (23.7+).
 


### PR DESCRIPTION
#### Trac ticket number

ticket-36277

#### Branch description

A release note was added for Oracle support of stored columns in 0174a85770356fd12e4c8daa42a4f1c752ae00e6 but one was lacking for Postgres 18+ support of virtual ones in e8190b370e508648b0f0ee9b86876f97d3997e14.

Discovered when [triaging a ticket](https://code.djangoproject.com/ticket/37208#comment:2) and trying to point at release notes.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
