### PR TITLE
Fixed concurrency in labels.yml GitHub Action.

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -7,7 +7,8 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Avoid github.ref, which is always main for the pull_request_target trigger.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
Under pull_request_target, github.ref is always main. So, any edit on any PR could cause another PR's label workflow to quit.

Follow-up to 5244ecbd2259365ecd6bbf96747285a673b2ee69.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Incidental finding while doing other work with Claude.