### PR TITLE
Fixed #36415 -- Added a public API to unregister model field lookups.

### DIFF
--- a/django/contrib/postgres/apps.py
+++ b/django/contrib/postgres/apps.py
@@ -32,16 +32,16 @@ def uninstall_if_needed(setting, value, enter, **kwargs):
         and "django.contrib.postgres" not in set(value)
     ):
         connection_created.disconnect(register_type_handlers)
-        CharField._unregister_lookup(Unaccent)
-        TextField._unregister_lookup(Unaccent)
-        CharField._unregister_lookup(SearchLookup)
-        TextField._unregister_lookup(SearchLookup)
-        CharField._unregister_lookup(TrigramSimilar)
-        TextField._unregister_lookup(TrigramSimilar)
-        CharField._unregister_lookup(TrigramWordSimilar)
-        TextField._unregister_lookup(TrigramWordSimilar)
-        CharField._unregister_lookup(TrigramStrictWordSimilar)
-        TextField._unregister_lookup(TrigramStrictWordSimilar)
+        CharField.unregister_lookup(Unaccent)
+        TextField.unregister_lookup(Unaccent)
+        CharField.unregister_lookup(SearchLookup)
+        TextField.unregister_lookup(SearchLookup)
+        CharField.unregister_lookup(TrigramSimilar)
+        TextField.unregister_lookup(TrigramSimilar)
+        CharField.unregister_lookup(TrigramWordSimilar)
+        TextField.unregister_lookup(TrigramWordSimilar)
+        CharField.unregister_lookup(TrigramStrictWordSimilar)
+        TextField.unregister_lookup(TrigramStrictWordSimilar)
         # Disconnect this receiver until the next time this app is installed
         # and ready() connects it again to prevent unnecessary processing on
         # each setting change.

--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -333,12 +333,22 @@ class RegisterLookupMixin:
         class_lookups = [
             parent.__dict__.get("class_lookups", {}) for parent in inspect.getmro(cls)
         ]
-        return cls.merge_dicts(class_lookups)
+        return {
+            lookup_name: lookup
+            for lookup_name, lookup in cls.merge_dicts(class_lookups).items()
+            if lookup is not None
+        }
 
     def get_instance_lookups(self):
         class_lookups = self.get_class_lookups()
         if instance_lookups := getattr(self, "instance_lookups", None):
-            return {**class_lookups, **instance_lookups}
+            lookups = {**class_lookups}
+            for lookup_name, lookup in instance_lookups.items():
+                if lookup is None:
+                    lookups.pop(lookup_name, None)
+                else:
+                    lookups[lookup_name] = lookup
+            return lookups
         return class_lookups
 
     get_lookups = class_or_instance_method(get_class_lookups, get_instance_lookups)
@@ -403,29 +413,53 @@ class RegisterLookupMixin:
     )
     register_class_lookup = classmethod(register_class_lookup)
 
-    def _unregister_class_lookup(cls, lookup, lookup_name=None):
+    def unregister_class_lookup(cls, lookup, lookup_name=None):
         """
-        Remove given lookup from cls lookups. For use in tests only as it's
-        not thread-safe.
+        Remove given lookup from cls lookups. Like lookup registration, this
+        isn't thread-safe and is intended to be used during setup, e.g. in
+        AppConfig.ready().
         """
         if lookup_name is None:
             lookup_name = lookup.lookup_name
-        del cls.class_lookups[lookup_name]
+        # Raise KeyError, as deleting from class_lookups used to, rather than
+        # silently ignoring a lookup that was never registered, as that would
+        # hide typos in the lookup name.
+        if lookup_name not in cls.get_class_lookups():
+            raise KeyError(lookup_name)
+        # Shadow the lookup with a None tombstone instead of deleting it, as
+        # class_lookups may belong to a parent class and deleting from it
+        # would unregister the lookup for the parent and all of its other
+        # subclasses.
+        if "class_lookups" not in cls.__dict__:
+            cls.class_lookups = {}
+        cls.class_lookups[lookup_name] = None
         cls._clear_cached_class_lookups()
 
-    def _unregister_instance_lookup(self, lookup, lookup_name=None):
+    def unregister_instance_lookup(self, lookup, lookup_name=None):
         """
-        Remove given lookup from instance lookups. For use in tests only as
-        it's not thread-safe.
+        Remove given lookup from instance lookups. Like lookup registration,
+        this isn't thread-safe and is intended to be used during setup, e.g.
+        in AppConfig.ready().
         """
         if lookup_name is None:
             lookup_name = lookup.lookup_name
-        del self.instance_lookups[lookup_name]
+        if lookup_name not in self.get_instance_lookups():
+            raise KeyError(lookup_name)
+        # Shadow class-level lookups with a None tombstone instead of deleting
+        # them, as they are shared with the class and its other instances.
+        if "instance_lookups" not in self.__dict__:
+            self.instance_lookups = {}
+        self.instance_lookups[lookup_name] = None
 
-    _unregister_lookup = class_or_instance_method(
-        _unregister_class_lookup, _unregister_instance_lookup
+    unregister_lookup = class_or_instance_method(
+        unregister_class_lookup, unregister_instance_lookup
     )
-    _unregister_class_lookup = classmethod(_unregister_class_lookup)
+    unregister_class_lookup = classmethod(unregister_class_lookup)
+    # The private name is kept as an alias for backwards compatibility with
+    # third-party code. Its semantics intentionally changed from deleting the
+    # lookup to shadowing it with a None tombstone, which is safe to use on
+    # subclasses of the class the lookup was registered on.
+    _unregister_lookup = unregister_lookup
 
 
 def select_related_descend(field, restricted, requested, select_mask):

--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -1010,8 +1010,19 @@ def register_lookup(field, *lookups, lookup_name=None):
             field.register_lookup(lookup, lookup_name)
         yield
     finally:
+        # Each lookup was registered by this context manager on this exact
+        # class or instance, so deleting it from that object's own dict
+        # restores the exact pre-registration state. The public
+        # unregister_lookup() isn't used as it would leave a None tombstone
+        # that shadows lookups registered later under the same name on
+        # ancestor classes, breaking test isolation.
         for lookup in lookups:
-            field._unregister_lookup(lookup, lookup_name)
+            name = lookup_name or lookup.lookup_name
+            if isinstance(field, type):
+                del field.class_lookups[name]
+                field._clear_cached_class_lookups()
+            else:
+                del field.instance_lookups[name]
 
 
 def garbage_collect():

--- a/tests/custom_lookups/tests.py
+++ b/tests/custom_lookups/tests.py
@@ -6,7 +6,7 @@ from django.core.exceptions import FieldError
 from django.db import connection, models
 from django.db.models.fields.related_lookups import RelatedGreaterThan
 from django.db.models.functions import Lower
-from django.db.models.lookups import EndsWith, StartsWith
+from django.db.models.lookups import EndsWith, GreaterThanOrEqual, StartsWith
 from django.test import SimpleTestCase, TestCase, override_settings
 from django.test.utils import register_lookup
 from django.utils import timezone
@@ -494,8 +494,7 @@ class YearLteTests(TestCase):
         cls.a4 = Author.objects.create(name="a4", birthdate=date(2012, 3, 1))
 
     def setUp(self):
-        models.DateField.register_lookup(YearTransform)
-        self.addCleanup(models.DateField._unregister_lookup, YearTransform)
+        self.enterContext(register_lookup(models.DateField, YearTransform))
 
     @unittest.skipUnless(
         connection.vendor == "postgresql", "PostgreSQL specific SQL used"
@@ -608,7 +607,7 @@ class YearLteTests(TestCase):
                 "CONCAT(", str(Author.objects.filter(birthdate__testyear=2012).query)
             )
         finally:
-            YearTransform._unregister_lookup(CustomYearExact)
+            YearTransform.unregister_lookup(CustomYearExact)
             YearTransform.register_lookup(YearExact)
 
 
@@ -774,3 +773,96 @@ class RegisterLookupTests(SimpleTestCase):
         with register_lookup(article_author, RelatedMoreThan):
             self.assertEqual(article_author.get_lookup("rmt"), RelatedMoreThan)
         self.assertIsNone(article_author.get_lookup("rmt"))
+
+    def test_unregister_class_lookup(self):
+        class CustomTextField(models.TextField):
+            pass
+
+        CustomTextField.register_lookup(CustomStartsWith)
+        self.assertIs(CustomTextField().get_lookup("sw"), CustomStartsWith)
+        CustomTextField.unregister_lookup(CustomStartsWith)
+        self.assertIsNone(CustomTextField().get_lookup("sw"))
+        self.assertNotIn("sw", CustomTextField.get_lookups())
+
+    def test_unregister_class_lookup_on_subclass(self):
+        class ParentField(models.TextField):
+            pass
+
+        class ChildField(ParentField):
+            pass
+
+        ChildField.unregister_lookup(GreaterThanOrEqual)
+        self.assertIsNone(ChildField().get_lookup("gte"))
+        self.assertNotIn("gte", ChildField.get_lookups())
+        # The parent class is unaffected.
+        self.assertIs(ParentField().get_lookup("gte"), GreaterThanOrEqual)
+        self.assertIn("gte", ParentField.get_lookups())
+        # Unregistering twice raises as the lookup is no longer visible.
+        with self.assertRaisesMessage(KeyError, "'gte'"):
+            ChildField.unregister_lookup(GreaterThanOrEqual)
+
+    def test_register_class_lookup_after_unregister(self):
+        class CustomTextField(models.TextField):
+            pass
+
+        CustomTextField.unregister_lookup(GreaterThanOrEqual)
+        self.assertIsNone(CustomTextField().get_lookup("gte"))
+        CustomTextField.register_lookup(GreaterThanOrEqual)
+        self.assertIs(CustomTextField().get_lookup("gte"), GreaterThanOrEqual)
+        self.assertIn("gte", CustomTextField.get_lookups())
+
+    def test_register_parent_class_lookup_after_unregister_on_subclass(self):
+        class ParentField(models.TextField):
+            pass
+
+        class ChildField(ParentField):
+            pass
+
+        ParentField.register_lookup(CustomStartsWith)
+        ChildField.unregister_lookup(CustomStartsWith)
+        ParentField.register_lookup(CustomEndsWith, lookup_name="sw")
+        self.assertIs(ParentField().get_lookup("sw"), CustomEndsWith)
+        self.assertIsNone(ChildField().get_lookup("sw"))
+        self.assertNotIn("sw", ChildField.get_lookups())
+
+    def test_unregister_missing_class_lookup(self):
+        class CustomTextField(models.TextField):
+            pass
+
+        with self.assertRaisesMessage(KeyError, "'sw'"):
+            CustomTextField.unregister_lookup(CustomStartsWith)
+
+    def test_unregister_instance_lookup(self):
+        field = models.TextField()
+        field.register_lookup(CustomStartsWith)
+        self.assertIs(field.get_lookup("sw"), CustomStartsWith)
+        field.unregister_lookup(CustomStartsWith)
+        self.assertIsNone(field.get_lookup("sw"))
+        self.assertNotIn("sw", field.get_lookups())
+
+    def test_unregister_class_registered_lookup_on_instance(self):
+        field = models.TextField()
+        field.unregister_lookup(GreaterThanOrEqual)
+        self.assertIsNone(field.get_lookup("gte"))
+        self.assertNotIn("gte", field.get_lookups())
+        # The class and other instances are unaffected.
+        self.assertIn("gte", models.TextField.get_lookups())
+        self.assertIs(models.TextField().get_lookup("gte"), GreaterThanOrEqual)
+        # Re-registering on the instance overrides the unregistration.
+        field.register_lookup(GreaterThanOrEqual)
+        self.assertIs(field.get_lookup("gte"), GreaterThanOrEqual)
+
+    def test_unregister_missing_instance_lookup(self):
+        field = models.TextField()
+        with self.assertRaisesMessage(KeyError, "'sw'"):
+            field.unregister_lookup(CustomStartsWith)
+
+    def test_register_lookup_context_manager_leaves_no_residue(self):
+        class CustomTextField(models.TextField):
+            pass
+
+        with register_lookup(CustomTextField, CustomStartsWith):
+            self.assertIs(CustomTextField().get_lookup("sw"), CustomStartsWith)
+        # The lookup name is removed entirely, not left as a None tombstone.
+        self.assertNotIn("sw", CustomTextField.class_lookups)
+        self.assertIsNone(CustomTextField().get_lookup("sw"))

--- a/tests/model_fields/test_jsonfield.py
+++ b/tests/model_fields/test_jsonfield.py
@@ -48,7 +48,7 @@ from django.test import (
     skipIfDBFeature,
     skipUnlessDBFeature,
 )
-from django.test.utils import CaptureQueriesContext
+from django.test.utils import CaptureQueriesContext, register_lookup
 from django.utils.deprecation import RemovedInDjango70Warning
 
 from .models import (
@@ -102,14 +102,13 @@ class TestMethods(SimpleTestCase):
         self.assertEqual(kwargs["decoder"], CustomJSONDecoder)
 
     def test_get_transforms(self):
-        @models.JSONField.register_lookup
         class MyTransform(Transform):
             lookup_name = "my_transform"
 
         field = models.JSONField()
-        transform = field.get_transform("my_transform")
-        self.assertIs(transform, MyTransform)
-        models.JSONField._unregister_lookup(MyTransform)
+        with register_lookup(models.JSONField, MyTransform):
+            transform = field.get_transform("my_transform")
+            self.assertIs(transform, MyTransform)
         transform = field.get_transform("my_transform")
         self.assertIsInstance(transform, KeyTransformFactory)
 


### PR DESCRIPTION
#### Trac ticket number

ticket-36415

#### Branch description
The previously private RegisterLookupMixin._unregister_lookup() deleted the lookup from class_lookups, which is resolved through the MRO and may belong to a parent class, so calling it on a subclass unregistered the lookup for the parent and all of its other subclasses. The public unregister_lookup() instead shadows the lookup with a None tombstone in the class's (or instance's) own dict, and lookup resolution filters tombstones out. The private name is kept as an alias for backwards compatibility.

The register_lookup() test helper deletes the registered key outright on exit rather than unregistering it, as a leftover tombstone would shadow lookups registered later under the same name on ancestor classes, breaking test isolation.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
