### PR TITLE
Fixed #37210 -- Logged cached_db session cache delete failures.

### DIFF
--- a/django/contrib/sessions/backends/cached_db.py
+++ b/django/contrib/sessions/backends/cached_db.py
@@ -109,7 +109,10 @@ class SessionStore(DBStore):
             if self.session_key is None:
                 return
             session_key = self.session_key
-        self._cache.delete(self.cache_key_prefix + session_key)
+        try:
+            self._cache.delete(self.cache_key_prefix + session_key)
+        except Exception:
+            logger.exception("Error deleting from cache (%s)", self._cache)
 
     async def adelete(self, session_key=None):
         await super().adelete(session_key)
@@ -117,7 +120,10 @@ class SessionStore(DBStore):
             if self.session_key is None:
                 return
             session_key = self.session_key
-        await self._cache.adelete(self.cache_key_prefix + session_key)
+        try:
+            await self._cache.adelete(self.cache_key_prefix + session_key)
+        except Exception:
+            logger.exception("Error deleting from cache (%s)", self._cache)
 
     def flush(self):
         """

--- a/docs/topics/http/sessions.txt
+++ b/docs/topics/http/sessions.txt
@@ -77,9 +77,9 @@ cache or a non-persistent cache.
 
 The cached database backend (``cached_db``) uses a write-through cache --
 session writes are applied to both the database and cache, in that order. If
-writing to the cache fails, the exception is handled and logged via the
-:ref:`sessions logger <django-contrib-sessions-logger>`, to avoid failing an
-otherwise successful write operation.
+writing to the cache (or deleting from it) fails, the exception is handled and
+logged via the :ref:`sessions logger <django-contrib-sessions-logger>`, to
+avoid failing an otherwise successful write or delete operation.
 
 Session reads use the cache, or the database if the data has been evicted from
 the cache. To use this backend, set :setting:`SESSION_ENGINE` to
@@ -97,6 +97,11 @@ The cache backend can be made persistent by using a persistent cache, such as
 Redis with appropriate configuration. But unless your cache is definitely
 configured for sufficient persistence, opt for the cached database backend.
 This avoids edge cases caused by unreliable data storage in production.
+
+.. versionchanged:: 6.2
+
+  In earlier versions, only failed writes were caught and logged rather than
+  failed deletes.
 
 Using file-based sessions
 -------------------------

--- a/tests/cache/failing_cache.py
+++ b/tests/cache/failing_cache.py
@@ -8,3 +8,9 @@ class CacheClass(LocMemCache):
 
     async def aset(self, *args, **kwargs):
         raise Exception("Faked exception saving to cache")
+
+    def delete(self, *args, **kwargs):
+        raise Exception("Faked exception deleting from cache")
+
+    async def adelete(self, *args, **kwargs):
+        raise Exception("Faked exception deleting from cache")

--- a/tests/sessions_tests/tests.py
+++ b/tests/sessions_tests/tests.py
@@ -845,6 +845,23 @@ class CacheDBSessionTests(SessionTestsMixin, TestCase):
     @override_settings(
         CACHES={"default": {"BACKEND": "cache.failing_cache.CacheClass"}}
     )
+    def test_cache_delete_failure_non_fatal(self):
+        """Failing to delete from the cache does not raise errors."""
+        session = self.backend()
+        session.save()
+        session_key = session.session_key
+
+        with self.assertLogs("django.contrib.sessions", "ERROR") as cm:
+            session.delete(session_key)
+
+        # A proper ERROR log message was recorded.
+        log = cm.records[-1]
+        self.assertEqual(log.message, f"Error deleting from cache ({session._cache})")
+        self.assertEqual(str(log.exc_info[1]), "Faked exception deleting from cache")
+
+    @override_settings(
+        CACHES={"default": {"BACKEND": "cache.failing_cache.CacheClass"}}
+    )
     async def test_cache_async_set_failure_non_fatal(self):
         """Failing to write to the cache does not raise errors."""
         session = self.backend()
@@ -857,6 +874,23 @@ class CacheDBSessionTests(SessionTestsMixin, TestCase):
         log = cm.records[-1]
         self.assertEqual(log.message, f"Error saving to cache ({session._cache})")
         self.assertEqual(str(log.exc_info[1]), "Faked exception saving to cache")
+
+    @override_settings(
+        CACHES={"default": {"BACKEND": "cache.failing_cache.CacheClass"}}
+    )
+    async def test_cache_async_delete_failure_non_fatal(self):
+        """Failing to delete from the cache does not raise errors."""
+        session = self.backend()
+        await session.asave()
+        session_key = session.session_key
+
+        with self.assertLogs("django.contrib.sessions", "ERROR") as cm:
+            await session.adelete(session_key)
+
+        # A proper ERROR log message was recorded.
+        log = cm.records[-1]
+        self.assertEqual(log.message, f"Error deleting from cache ({session._cache})")
+        self.assertEqual(str(log.exc_info[1]), "Faked exception deleting from cache")
 
 
 @override_settings(USE_TZ=True)


### PR DESCRIPTION
#### Trac ticket number

ticket-37210

#### Branch description

The `cached_db` session backend already handles and logs cache write failures in `save()` and `asave()`, but cache delete failures from `delete()` and `adelete()` were still allowed to propagate.

This makes cache delete failures non-fatal and logs them through the sessions logger, matching the existing write-failure behavior. It also adds sync and async regression tests for the delete paths.

Local verification:

- Reproduced the failure with the new regression tests before the implementation change.
- `./runtests.py sessions_tests.tests.CacheDBSessionTests.test_cache_delete_failure_non_fatal sessions_tests.tests.CacheDBSessionTests.test_cache_async_delete_failure_non_fatal -v 2`
- `./runtests.py sessions_tests.tests.CacheDBSessionTests -v 2`
- `./runtests.py sessions_tests -v 1`
- `python -m black --check django/contrib/sessions/backends/cached_db.py tests/sessions_tests/tests.py`
- `git diff --check`

#### AI Assistance Disclosure (REQUIRED)

- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

AI tools were used: OpenAI Codex (GPT-5) helped inspect the ticket/code path, draft the small code and test changes, and run local verification commands. The resulting diff and test output were reviewed before submission.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable. No docs or release notes are needed; the existing docs already describe the intended behavior.
- [x] I have attached screenshots in both light and dark modes for any UI changes. Not applicable; this is not a UI change.