### PR TITLE
Fixed #23054 -- Documented per-site cache limitations with Vary: Cookie responses.

### DIFF
--- a/docs/topics/cache.txt
+++ b/docs/topics/cache.txt
@@ -648,6 +648,31 @@ are cached separately. This middleware expects that a HEAD request is answered
 with the same response headers as the corresponding GET request; in which case
 it can return a cached GET response for HEAD request.
 
+.. warning::
+
+    As described in :ref:`using-vary-headers` below, the cache middleware
+    caches a separate version of a page for each combination of values of the
+    request headers named in the response's ``Vary`` header, and several of
+    Django's features add ``Vary: Cookie`` to the response. For example, this
+    happens whenever the :doc:`session </topics/http/sessions>` is accessed
+    (including on any page that displays content specific to the logged-in
+    user) and whenever a page uses a :doc:`CSRF token </ref/csrf>` (that is,
+    most pages containing forms).
+
+    Since cookies such as the session ID and the CSRF token differ for every
+    visitor -- as do any cookies set on your domain by third-party scripts,
+    such as analytics -- ``Vary: Cookie`` effectively turns the per-site cache
+    into a per-visitor cache for those pages. This can dramatically reduce the
+    cache hit ratio and increase the size of the cache. In addition, responses
+    that both set a cookie and vary on ``Cookie`` aren't cached at all.
+
+    Therefore, the per-site cache is most effective for sites that serve
+    mostly cookie-independent pages to anonymous users. If most of your pages
+    use sessions or CSRF tokens, consider caching only selected views with
+    `the per-view cache`_, or caching the cookie-independent parts of your
+    templates with :ref:`template fragment caching
+    <template-fragment-caching>`.
+
 Additionally, ``UpdateCacheMiddleware`` automatically sets a few headers in
 each :class:`~django.http.HttpResponse` which affect :ref:`downstream caches
 <downstream-caches>`:
@@ -770,6 +795,8 @@ Here's the same thing, with ``my_view`` wrapped in ``cache_page``::
     ]
 
 .. templatetag:: cache
+
+.. _template-fragment-caching:
 
 Template fragment caching
 =========================


### PR DESCRIPTION
#### Trac ticket number

ticket-23054

#### Branch description

The per-site cache documentation doesn't mention that pages are cached per
combination of the request headers named in the response's ``Vary`` header,
and that common Django features (sessions, CSRF tokens) add ``Vary: Cookie``.
On sites where most pages touch the session or render forms, the per-site
cache effectively becomes a per-visitor cache, with a much lower hit ratio
and larger size than expected — the limitation reported in the ticket.

This adds a warning to the per-site cache section explaining when
``Vary: Cookie`` is added, its consequences (per-visitor caching; responses
that set cookies while varying on ``Cookie`` are never cached), and points to
the per-view cache and template fragment caching as alternatives. A ref label
was added to the template fragment caching section for cross-referencing.

The behavior described was verified against
``django/middleware/cache.py``, ``django/middleware/csrf.py``, and
``django/contrib/sessions/middleware.py``. Docs build cleanly with Sphinx and
pass ``sphinx-lint``.

#### AI Assistance Disclosure (REQUIRED)
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

AI tools used: Claude Code (Anthropic). The patch was verified by checking the
documented behavior against the middleware source and by building the docs.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests. (N/A — documentation-only change.)
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes. (N/A)
