### PR TITLE
Fixed #37167 -- Allowed Address objects as email addresses.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1094,6 +1094,7 @@ answer newbie questions, and generally made Django that much better:
     Vibhu Agarwal <vibhu-agarwal.github.io>
     Victor Andrée
     viestards.lists@gmail.com
+    Vignesh A <https://github.com/VIZZARD-X>
     Viktor Danyliuk <v.v.danyliuk@gmail.com>
     Viktor Grabov <viktor@grabov.ru>
     Ville Säävuori <https://www.unessa.net/>

--- a/django/core/mail/__init__.py
+++ b/django/core/mail/__init__.py
@@ -3,6 +3,7 @@ Tools for sending email.
 """
 
 import warnings
+from email.headerregistry import Address
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -303,10 +304,11 @@ def _send_server_message(
         recipients = [a[1] for a in recipients]
 
     if not isinstance(recipients, (list, tuple)) or not all(
-        isinstance(address, (str, Promise)) for address in recipients
+        isinstance(address, (str, Promise, Address)) for address in recipients
     ):
         raise ImproperlyConfigured(
-            f"The {setting_name} setting must be a list of email address strings."
+            f"The {setting_name} setting must be a list of email address "
+            "strings or Address objects."
         )
 
     mail = EmailMultiAlternatives(

--- a/django/core/mail/message.py
+++ b/django/core/mail/message.py
@@ -342,7 +342,12 @@ class EmailMessage:
         self._add_attachments(msg)
 
         msg["Subject"] = str(self.subject)
-        msg["From"] = str(self.extra_headers.get("From", self.from_email))
+
+        from_header = self.extra_headers.get("From", self.from_email)
+        msg["From"] = (
+            from_header if isinstance(from_header, Address) else str(from_header)
+        )
+
         self._set_list_header_if_not_empty(msg, "To", self.to)
         self._set_list_header_if_not_empty(msg, "Cc", self.cc)
         self._set_list_header_if_not_empty(msg, "Reply-To", self.reply_to)
@@ -563,7 +568,11 @@ class EmailMessage:
             msg[header] = self.extra_headers[header]
         except KeyError:
             if values:
-                msg[header] = ", ".join(str(v) for v in values)
+                msg[header] = (
+                    tuple(values)
+                    if all(isinstance(v, Address) for v in values)
+                    else ", ".join(str(v) for v in values)
+                )
 
     def _idna_encode_address_header_domains(self, msg):
         """

--- a/django/core/mail/message.py
+++ b/django/core/mail/message.py
@@ -342,7 +342,12 @@ class EmailMessage:
         self._add_attachments(msg)
 
         msg["Subject"] = str(self.subject)
-        msg["From"] = str(self.extra_headers.get("From", self.from_email))
+
+        from_header = self.extra_headers.get("From", self.from_email)
+        msg["From"] = (
+            from_header if isinstance(from_header, Address) else str(from_header)
+        )
+
         self._set_list_header_if_not_empty(msg, "To", self.to)
         self._set_list_header_if_not_empty(msg, "Cc", self.cc)
         self._set_list_header_if_not_empty(msg, "Reply-To", self.reply_to)
@@ -563,7 +568,11 @@ class EmailMessage:
             msg[header] = self.extra_headers[header]
         except KeyError:
             if values:
-                msg[header] = ", ".join(str(v) for v in values)
+                msg[header] = (
+                    values
+                    if all(isinstance(v, Address) for v in values)
+                    else ", ".join(str(v) for v in values)
+                )
 
     def _idna_encode_address_header_domains(self, msg):
         """

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -58,8 +58,11 @@ Each item in the list should be an email address string. Example::
 
 To safely build an address with a display name from variable content, see
 :ref:`formatting-addresses`, which recommends using
-:class:`~email.headerregistry.Address` over string formatting, but since this
-setting requires a list of strings, wrap each ``Address`` in ``str(...)``.
+:class:`~email.headerregistry.Address` over string formatting.
+
+.. versionchanged:: 6.0
+
+    Support for :class:`email.headerregistry.Address` objects was added.
 
 .. setting:: ALLOWED_HOSTS
 
@@ -1359,6 +1362,10 @@ This doesn't affect error messages sent to :setting:`ADMINS` and
 To build an address with a display name from variable content, see
 :ref:`formatting-addresses`.
 
+.. versionchanged:: 6.0
+
+    Support for :class:`email.headerregistry.Address` objects was added.
+
 .. setting:: DEFAULT_INDEX_TABLESPACE
 
 ``DEFAULT_INDEX_TABLESPACE``
@@ -2246,6 +2253,10 @@ A list in the same format as :setting:`ADMINS` that specifies who should get
 broken link notifications when
 :class:`~django.middleware.common.BrokenLinkEmailsMiddleware` is enabled.
 
+.. versionchanged:: 6.0
+
+    Support for :class:`email.headerregistry.Address` objects was added.
+
 .. setting:: MEDIA_ROOT
 
 ``MEDIA_ROOT``
@@ -2813,6 +2824,10 @@ To build an address with a display name from variable content, see
     This address is used only for error messages. It is *not* the address that
     regular email messages sent with :func:`~django.core.mail.send_mail`
     come from; for that, see :setting:`DEFAULT_FROM_EMAIL`.
+
+.. versionchanged:: 6.0
+
+    Support for :class:`email.headerregistry.Address` objects was added.
 
 .. setting:: SHORT_DATE_FORMAT
 

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -52,14 +52,17 @@ A list of all the people who get code error notifications. When
 is configured in :setting:`LOGGING` (done by default), Django emails these
 people the details of exceptions raised in the request/response cycle.
 
-Each item in the list should be an email address string. Example::
+Each item in the list should be an email address string or
+:class:`~email.headerregistry.Address` object. Example::
 
     ADMINS = ["john@example.com", '"Ng, Mary" <mary@example.com>']
 
 To safely build an address with a display name from variable content, see
-:ref:`formatting-addresses`, which recommends using
-:class:`~email.headerregistry.Address` over string formatting, but since this
-setting requires a list of strings, wrap each ``Address`` in ``str(...)``.
+:ref:`formatting-addresses`.
+
+.. versionchanged:: 6.2
+
+    Support for :class:`email.headerregistry.Address` objects was added.
 
 .. setting:: ALLOWED_HOSTS
 
@@ -1359,6 +1362,10 @@ This doesn't affect error messages sent to :setting:`ADMINS` and
 To build an address with a display name from variable content, see
 :ref:`formatting-addresses`.
 
+.. versionchanged:: 6.2
+
+    Support for :class:`email.headerregistry.Address` objects was added.
+
 .. setting:: DEFAULT_INDEX_TABLESPACE
 
 ``DEFAULT_INDEX_TABLESPACE``
@@ -2246,6 +2253,10 @@ A list in the same format as :setting:`ADMINS` that specifies who should get
 broken link notifications when
 :class:`~django.middleware.common.BrokenLinkEmailsMiddleware` is enabled.
 
+.. versionchanged:: 6.2
+
+    Support for :class:`email.headerregistry.Address` objects was added.
+
 .. setting:: MEDIA_ROOT
 
 ``MEDIA_ROOT``
@@ -2813,6 +2824,10 @@ To build an address with a display name from variable content, see
     This address is used only for error messages. It is *not* the address that
     regular email messages sent with :func:`~django.core.mail.send_mail`
     come from; for that, see :setting:`DEFAULT_FROM_EMAIL`.
+
+.. versionchanged:: 6.2
+
+    Support for :class:`email.headerregistry.Address` objects was added.
 
 .. setting:: SHORT_DATE_FORMAT
 

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -135,7 +135,9 @@ Decorators
 Email
 ~~~~~
 
-* ...
+* The :setting:`ADMINS`, :setting:`DEFAULT_FROM_EMAIL`, :setting:`MANAGERS`,
+  and :setting:`SERVER_EMAIL` settings now support
+  :class:`~email.headerregistry.Address` objects.
 
 Error Reporting
 ~~~~~~~~~~~~~~~

--- a/docs/topics/email.txt
+++ b/docs/topics/email.txt
@@ -499,6 +499,11 @@ email backend API :ref:`provides an alternative
       :ref:`formatting-addresses`). If omitted, the
       :setting:`DEFAULT_FROM_EMAIL` setting is used.
 
+      .. versionchanged:: 6.0
+
+          The ``from_email`` parameter now officially supports
+          :class:`email.headerregistry.Address` objects.
+
     * ``to``: A list or tuple of recipient addresses.
 
     The following parameters must be given as keyword arguments if used:
@@ -511,6 +516,12 @@ email backend API :ref:`provides an alternative
 
     * ``reply_to``: A list or tuple of recipient addresses used in the
       "Reply-To" header when sending the email.
+
+      .. versionchanged:: 6.0
+
+          The recipient lists (``to``, ``cc``, ``bcc``, and ``reply_to``) now
+          officially support :class:`email.headerregistry.Address` objects
+          mixed with standard email strings.
 
     * ``attachments``: A list of attachments to put on the message. Each can
       be an instance of :class:`~email.message.MIMEPart` or

--- a/docs/topics/email.txt
+++ b/docs/topics/email.txt
@@ -223,11 +223,13 @@ are required.
 
 * ``subject``: A string.
 * ``message``: A string.
-* ``from_email``: A string. If ``None``, Django will use the value of the
+* ``from_email``: A string or :class:`~email.headerregistry.Address` object.
+  If ``None``, Django will use the value of the
   :setting:`DEFAULT_FROM_EMAIL` setting.
-* ``recipient_list``: A list of strings, each an email address. Each
-  member of ``recipient_list`` will see the other recipients in the "To:"
-  field of the email message.
+* ``recipient_list``: A list of strings or
+  :class:`~email.headerregistry.Address` objects, each an email address.
+  Each member of ``recipient_list`` will see the other recipients in the
+  "To:" field of the email message.
 
 The following parameters are optional, and must be given as keyword arguments
 if used.
@@ -494,12 +496,19 @@ email backend API :ref:`provides an alternative
 
     * ``body``: The body text. This should be a plain text message.
 
-    * ``from_email``: The sender's address. Both ``fred@example.com`` and
-      ``"Fred" <fred@example.com>`` forms are supported (see
+    * ``from_email``: The sender's address, as a string or
+      :class:`~email.headerregistry.Address` object. Both ``fred@example.com``
+      and ``"Fred" <fred@example.com>`` forms are supported (see
       :ref:`formatting-addresses`). If omitted, the
       :setting:`DEFAULT_FROM_EMAIL` setting is used.
 
-    * ``to``: A list or tuple of recipient addresses.
+      .. versionchanged:: 6.2
+
+          The ``from_email`` now supports using an
+          :class:`~email.headerregistry.Address` object in place of a string.
+
+    * ``to``: A list or tuple of recipient addresses, each a string or
+      :class:`~email.headerregistry.Address` object.
 
     The following parameters must be given as keyword arguments if used:
 
@@ -511,6 +520,12 @@ email backend API :ref:`provides an alternative
 
     * ``reply_to``: A list or tuple of recipient addresses used in the
       "Reply-To" header when sending the email.
+
+      .. versionchanged:: 6.2
+
+          The address lists (``to``, ``cc``, ``bcc``, and ``reply_to``) now
+          support using :class:`~email.headerregistry.Address` objects in
+          place of strings.
 
     * ``attachments``: A list of attachments to put on the message. Each can
       be an instance of :class:`~email.message.MIMEPart` or

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -464,6 +464,40 @@ class EmailMessageTests(MailTestsMixin, SimpleTestCase):
                 with self.assertRaisesMessage(TypeError, message):
                     EmailMessage(**params)
 
+    def test_email_message_with_address_objects(self):
+        email = EmailMessage(
+            "Subject",
+            "Content",
+            from_email=Address("From Name", "from", "example.com"),
+            to=[Address("To Name", "to", "example.com")],
+            cc=[Address("Cc Name", "cc", "example.com")],
+            bcc=[Address("Bcc Name", "bcc", "example.com")],
+            reply_to=[Address("Reply Name", "reply", "example.com")],
+        )
+        message = email.message()
+
+        self.assertEqual(message["From"], "From Name <from@example.com>")
+        self.assertEqual(message["To"], "To Name <to@example.com>")
+        self.assertEqual(message["Cc"], "Cc Name <cc@example.com>")
+        self.assertEqual(message["Reply-To"], "Reply Name <reply@example.com>")
+        self.assertEqual(
+            email.recipients(),
+            [
+                Address("To Name", "to", "example.com"),
+                Address("Cc Name", "cc", "example.com"),
+                Address("Bcc Name", "bcc", "example.com"),
+            ],
+        )
+
+    def test_email_message_mixed_address_and_str(self):
+        email = EmailMessage(
+            "Subject",
+            "Content",
+            to=[Address("Jane", "jane", "example.com"), "john@example.com"],
+        )
+        message = email.message()
+        self.assertEqual(message["To"], "Jane <jane@example.com>, john@example.com")
+
     def test_header_injection(self):
         msg = "Header values may not contain linefeed or carriage return characters"
         cases = [
@@ -557,6 +591,15 @@ class EmailMessageTests(MailTestsMixin, SimpleTestCase):
         )
         message = email.message()
         self.assertEqual(message.get_all("From"), ["from@example.com"])
+
+    def test_default_from_email_with_address_object(self):
+        address = Address("Default Sender", "default", "example.com")
+        with self.settings(DEFAULT_FROM_EMAIL=address):
+            email = EmailMessage("Subject", "Content", to=["to@example.com"])
+            message = email.message()
+            self.assertEqual(
+                message.get_all("From"), ["Default Sender <default@example.com>"]
+            )
 
     def test_to_header(self):
         """
@@ -2394,6 +2437,28 @@ class MailAdminsAndManagersTests(SimpleTestCase, MailTestsMixin):
                     expected_to = ", ".join([str(address) for address in value])
                     self.assertEqual(message.get_all("to"), [expected_to])
 
+    def test_mail_admins_and_managers_with_address_objects(self):
+        address = Address("Admin Name", "admin", "example.com")
+        for setting, mail_func in (
+            ("ADMINS", mail_admins),
+            ("MANAGERS", mail_managers),
+        ):
+            mail.outbox = []
+            with self.subTest(setting=setting), self.settings(**{setting: [address]}):
+                mail_func("subject", "content")
+                message = self.get_outbox_message()
+                self.assertEqual(
+                    message.get_all("To"), ["Admin Name <admin@example.com>"]
+                )
+
+    def test_server_email_with_address_object(self):
+        address = Address("Server", "server", "example.com")
+        with self.settings(SERVER_EMAIL=address, ADMINS=["admin@example.com"]):
+            mail.outbox = []
+            mail_admins("subject", "content")
+            message = self.get_outbox_message()
+            self.assertEqual(message.get_all("From"), ["Server <server@example.com>"])
+
     @override_settings(MANAGERS=["nobody@example.com"])
     def test_html_mail_managers(self):
         """Test html_message argument to mail_managers"""
@@ -2513,7 +2578,10 @@ class MailAdminsAndManagersTests(SimpleTestCase, MailTestsMixin):
             ("ADMINS", mail_admins),
             ("MANAGERS", mail_managers),
         ):
-            msg = f"The {setting} setting must be a list of email address strings."
+            msg = (
+                f"The {setting} setting must be a list of email address "
+                "strings or Address objects."
+            )
             for value in tests:
                 mail.outbox = []
                 with (


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37167

#### Branch description
Introduced official support for ``email.headerregistry.Address`` objects across Django's core email functions and settings. It updates ``_send_server_message()`` to accept ``Address`` objects for ``ADMINS`` and ``MANAGERS``, and removes unnecessary string casting in ``EmailMessage`` to let Python's native ``email`` library parse them directly, even when mixed with standard strings. All corresponding tests and documentation updates have been included. Used Gemini to generate boilerplate and evaluate any missing test cases.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [X] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [X] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [X] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [X] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
