### PR TITLE
Fixed #37213 -- Made ForeignKeyRawIdWidget honor the field's queryset.

### DIFF
--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
 from django.db.models import CASCADE, UUIDField
+from django.forms.models import ModelChoiceIterator
 from django.forms.widgets import Select
 from django.urls import reverse
 from django.urls.exceptions import NoReverseMatch
@@ -210,8 +211,18 @@ class ForeignKeyRawIdWidget(forms.TextInput):
 
     def label_and_url_for_value(self, value):
         key = self.rel.get_related_field().name
+        # Resolve the value through the form field's queryset, which may be
+        # narrowed (e.g. via ModelAdmin.formfield_for_foreignkey()), so that
+        # labels and change links aren't exposed for objects outside it. Fall
+        # back to the default manager when the widget isn't bound to a
+        # ModelChoiceField (and therefore has no queryset to consult).
+        choices = getattr(self, "choices", None)
+        if isinstance(choices, ModelChoiceIterator) and choices.queryset is not None:
+            manager = choices.queryset
+        else:
+            manager = self.rel.model._default_manager
         try:
-            obj = self.rel.model._default_manager.using(self.db).get(**{key: value})
+            obj = manager.using(self.db).get(**{key: value})
         except (ValueError, self.rel.model.DoesNotExist, ValidationError):
             return "", ""
 

--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -787,6 +787,27 @@ class ForeignKeyRawIdWidgetTest(TestCase):
             "Hidden</a></strong></div>" % {"pk": hidden.pk},
         )
 
+    def test_label_and_url_for_value_respects_field_queryset(self):
+        # A narrowed form field queryset (e.g. set via
+        # ModelAdmin.formfield_for_foreignkey()) must also restrict the label
+        # and change link rendered by the widget, so a value outside the
+        # queryset isn't exposed (#37213).
+        apple = Inventory.objects.create(barcode=86, name="Apple")
+        pear = Inventory.objects.create(barcode=22, name="Pear")
+        rel = Inventory._meta.get_field("parent").remote_field
+        # The field copies the widget and sets its queryset, so read the label
+        # back from field.widget (as the admin does when rendering).
+        field = forms.ModelChoiceField(
+            queryset=Inventory._default_manager.exclude(pk=pear.pk),
+            widget=widgets.ForeignKeyRawIdWidget(rel, widget_admin_site),
+        )
+        widget = field.widget
+        self.assertEqual(
+            widget.label_and_url_for_value(apple.barcode),
+            ("Apple", "/admin_widgets/inventory/%s/change/" % apple.pk),
+        )
+        self.assertEqual(widget.label_and_url_for_value(pear.barcode), ("", ""))
+
     def test_render_unsafe_limit_choices_to(self):
         rel = UnsafeLimitChoicesTo._meta.get_field("band").remote_field
         w = widgets.ForeignKeyRawIdWidget(rel, widget_admin_site)


### PR DESCRIPTION
#### Trac ticket number
[ticket-37213](https://code.djangoproject.com/ticket/37213)

#### Branch description
`ForeignKeyRawIdWidget.label_and_url_for_value()` resolved the submitted value through the related model's **default manager**, so it rendered the label and change link for any valid primary key even when the form field's queryset was narrowed (e.g. via `ModelAdmin.formfield_for_foreignkey()`). A staff user could therefore view the label and change URL of related objects outside the allowed queryset via a query-string value, even though POST validation already rejected them.

The fix resolves the value through the **field's queryset** — which the field already shares with the widget as its `choices` (a `ModelChoiceIterator`) — and falls back to the default manager when the widget isn't bound to a `ModelChoiceField`.

Added a regression test in `admin_widgets` that fails without the fix and passes with it. The `admin_widgets` suite passes and `black`/`isort`/`flake8` are clean.

#### AI Assistance Disclosure (REQUIRED)
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Codex was used to help write the code and for feedback. I have reviewed and verified the output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (the issue was reported and accepted publicly on Trac).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.
