### PR TITLE
Fixed #37213 -- Made ForeignKeyRawIdWidget honor the field's queryset.

### DIFF
--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
 from django.db.models import CASCADE, UUIDField
+from django.forms.models import ModelChoiceIterator
 from django.forms.widgets import Select
 from django.urls import reverse
 from django.urls.exceptions import NoReverseMatch
@@ -210,8 +211,18 @@ class ForeignKeyRawIdWidget(forms.TextInput):
 
     def label_and_url_for_value(self, value):
         key = self.rel.get_related_field().name
+        # Resolve the value through the form field's queryset, which may be
+        # narrowed (e.g. via ModelAdmin.formfield_for_foreignkey()), so that
+        # labels and change links aren't exposed for objects outside it. Fall
+        # back to the default manager when the widget isn't bound to a
+        # ModelChoiceField (and therefore has no queryset to consult).
+        choices = getattr(self, "choices", None)
+        if isinstance(choices, ModelChoiceIterator) and choices.queryset is not None:
+            manager = choices.queryset
+        else:
+            manager = self.rel.model._default_manager
         try:
-            obj = self.rel.model._default_manager.using(self.db).get(**{key: value})
+            obj = manager.using(self.db).get(**{key: value})
         except (ValueError, self.rel.model.DoesNotExist, ValidationError):
             return "", ""
 

--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -221,8 +221,13 @@ class ForeignKeyRawIdWidget(forms.TextInput):
             manager = choices.queryset
         else:
             manager = self.rel.model._default_manager
+        # Only override the database when the widget is bound to one, so that a
+        # queryset which already selected its own (e.g. via
+        # Model.objects.using()) isn't reset to the default routing.
+        if self.db is not None:
+            manager = manager.using(self.db)
         try:
-            obj = manager.using(self.db).get(**{key: value})
+            obj = manager.get(**{key: value})
         except (ValueError, self.rel.model.DoesNotExist, ValidationError):
             return "", ""
 

--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -787,6 +787,27 @@ class ForeignKeyRawIdWidgetTest(TestCase):
             "Hidden</a></strong></div>" % {"pk": hidden.pk},
         )
 
+    def test_label_and_url_for_value_respects_field_queryset(self):
+        # A narrowed form field queryset (e.g. set via
+        # ModelAdmin.formfield_for_foreignkey()) must also restrict the label
+        # and change link rendered by the widget, so a value outside the
+        # queryset isn't exposed (#37213).
+        apple = Inventory.objects.create(barcode=86, name="Apple")
+        pear = Inventory.objects.create(barcode=22, name="Pear")
+        rel = Inventory._meta.get_field("parent").remote_field
+        # The field copies the widget and sets its queryset, so read the label
+        # back from field.widget (as the admin does when rendering).
+        field = forms.ModelChoiceField(
+            queryset=Inventory._default_manager.exclude(pk=pear.pk),
+            widget=widgets.ForeignKeyRawIdWidget(rel, widget_admin_site),
+        )
+        widget = field.widget
+        self.assertEqual(
+            widget.label_and_url_for_value(apple.barcode),
+            ("Apple", "/admin_widgets/inventory/%s/change/" % apple.pk),
+        )
+        self.assertEqual(widget.label_and_url_for_value(pear.barcode), ("", ""))
+
     def test_render_unsafe_limit_choices_to(self):
         rel = UnsafeLimitChoicesTo._meta.get_field("band").remote_field
         w = widgets.ForeignKeyRawIdWidget(rel, widget_admin_site)

--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -831,6 +831,26 @@ class ForeignKeyRawIdWidgetTest(TestCase):
 
 
 @override_settings(ROOT_URLCONF="admin_widgets.urls")
+class ForeignKeyRawIdWidgetMultiDbTest(TestCase):
+    databases = {"default", "other"}
+
+    def test_label_and_url_for_value_preserves_queryset_database(self):
+        # A form field queryset that selected its own database (e.g. via
+        # using()) keeps it when the widget isn't bound to one, instead of
+        # falling back to the default routing (#37213).
+        apple = Inventory.objects.using("other").create(barcode=86, name="Apple")
+        rel = Inventory._meta.get_field("parent").remote_field
+        field = forms.ModelChoiceField(
+            queryset=Inventory.objects.using("other"),
+            widget=widgets.ForeignKeyRawIdWidget(rel, widget_admin_site),
+        )
+        self.assertEqual(
+            field.widget.label_and_url_for_value(apple.barcode),
+            ("Apple", "/admin_widgets/inventory/%s/change/" % apple.pk),
+        )
+
+
+@override_settings(ROOT_URLCONF="admin_widgets.urls")
 class ManyToManyRawIdWidgetTest(TestCase):
     def test_render(self):
         band = Band.objects.create(name="Linkin Park")


### PR DESCRIPTION
#### Trac ticket number

ticket-37213

#### Branch description

`ForeignKeyRawIdWidget.label_and_url_for_value()` resolved the submitted value through the related model's **default manager**, so it rendered the label and change link for any valid primary key even when the form field's queryset was narrowed (e.g. via `ModelAdmin.formfield_for_foreignkey()`). A staff user could therefore view the label and change URL of related objects outside the allowed queryset via a query-string value, even though POST validation already rejected them.

This resolves the value through the **field's queryset** — which the field already shares with the widget as its `choices` (a `ModelChoiceIterator`) — and falls back to the default manager when the widget isn't bound to a `ModelChoiceField`. It also adds a regression test for the narrowed-queryset case.

Local verification:

- Confirmed the new regression test fails before the implementation change and passes after.
- `./runtests.py admin_widgets.tests.ForeignKeyRawIdWidgetTest admin_widgets.tests.AdminForeignKeyRawIdWidget --parallel=1`
- `./runtests.py admin_widgets --parallel=1`
- `python -m black --check django/contrib/admin/widgets.py tests/admin_widgets/tests.py`
- `python -m isort --check-only django/contrib/admin/widgets.py tests/admin_widgets/tests.py`
- `python -m flake8 django/contrib/admin/widgets.py tests/admin_widgets/tests.py`
- `git diff --check`

#### AI Assistance Disclosure (REQUIRED)

- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

AI tools were used: OpenAI Codex helped inspect the ticket and code path, draft the small code and test changes, and run the local verification commands. The resulting diff and test output were reviewed and verified before submission.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)). The issue was reported and accepted publicly on Trac.
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.

