### PR TITLE
Fixed typos in docs configuration and linting script.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -566,6 +566,7 @@ answer newbie questions, and generally made Django that much better:
     Jonny Park <jonnythebard9@gmail.com>
     Jordan Bae <qoentlr37@gmail.com>
     Jordan Dimov <s3x3y1@gmail.com>
+    Jordhy Louzolo <mpassilouzolo@gmail.com>
     Jordi J. Tablada <jordi.joan@gmail.com>
     Jorge Bastida <me@jorgebastida.com>
     Jorge Gajon <gajon@gajon.org>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,7 @@ sys.path.insert(1, dirname(dirname(abspath(__file__))))
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.append(abspath(join(dirname(__file__), "_ext")))
 
-# Use the module to GitHub url resolver, but import it after the _ext directoy
+# Use the module to GitHub url resolver, but import it after the _ext directory
 # it lives in has been added to sys.path.
 import github_links  # NOQA
 

--- a/docs/lint.py
+++ b/docs/lint.py
@@ -124,7 +124,7 @@ _PYTHON_DOMAIN = re.compile(f":py:{SIMPLENAME}:`{_ROLE_BODY}`")
 @sphinxlint_checker(".rst", enabled=False, rst_only=True)
 def check_python_domain_in_roles(file, lines, options=None):
     """
-    :py: indicates the Python language domain. This means code writen in
+    :py: indicates the Python language domain. This means code written in
     Python, not Python built-ins in particular.
 
     Bad:    :py:class:`email.message.EmailMessage`


### PR DESCRIPTION
Trivial documentation typo fixes (directoy → directory, writen → written). No ticket, per Django's policy on trivial doc changes.