### PR TITLE
Fixed #37198 -- Used end-of-string anchor in content_disposition_header quotable check.

### DIFF
--- a/django/utils/http.py
+++ b/django/utils/http.py
@@ -420,7 +420,7 @@ def content_disposition_header(as_attachment, filename):
         # characters from 0x21 to 0x7e, except 0x22 (`"`) and 0x5C (`\`) which
         # can still be expressed but must be escaped with their own `\`.
         # https://datatracker.ietf.org/doc/html/rfc9110#name-quoted-strings
-        quotable_characters = r"^[\t \x21-\x7e]*$"
+        quotable_characters = r"^[\t \x21-\x7e]*\Z"
         if is_ascii and re.match(quotable_characters, filename):
             file_expr = 'filename="{}"'.format(
                 filename.replace("\\", "\\\\").replace('"', r"\"")

--- a/tests/utils_tests/test_http.py
+++ b/tests/utils_tests/test_http.py
@@ -644,6 +644,11 @@ class ContentDispositionHeaderTests(unittest.TestCase):
                 "attachment; filename*=utf-8''%22esp%C3%A9cimen%22%20filename",
             ),
             ((True, "some\nfile"), "attachment; filename*=utf-8''some%0Afile"),
+            (
+                (True, "report.pdf\n"),
+                "attachment; filename*=utf-8''report.pdf%0A",
+            ),
+            ((True, "\n"), "attachment; filename*=utf-8''%0A"),
         )
 
         for (is_attachment, filename), expected in tests:


### PR DESCRIPTION
#### Trac ticket number

ticket-37198

#### Branch description

`content_disposition_header()` used `$` in its quotable-character regex, which
matches before a trailing newline in Python. Filenames ending with `\n` were
incorrectly emitted as quoted strings containing a raw newline, causing
`BadHeaderError` or `ValueError` when set as response headers.

Changed the anchor to `\Z` (consistent with the fix for CVE-2021-32052 in
URLValidator). Added regression test cases for trailing-newline filenames.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Used Grok (xAI) for ticket research, applying the regex fix (`$` to `\Z`),
adding regression test cases, and drafting this PR description. I manually
reviewed the diff, ran `runtests.py utils_tests.test_http.ContentDispositionHeaderTests`
locally (all passed), and confirmed trailing-newline filenames use the
`filename*=utf-8''` branch as expected.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability.
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have added or updated relevant tests.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.