### PR TITLE
Fixed #37201 -- Raised ValueError when Prefetch to_attr targets a property without a setter.

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -2690,10 +2690,18 @@ def prefetch_related_objects(model_instances, *related_lookups):
             # premise of prefetch_related), so what applies to first object
             # applies to all.
             first_obj = next(iter(obj_list))
-            to_attr = lookup.get_current_to_attr(level)[0]
+            to_attr, as_attr = lookup.get_current_to_attr(level)
             prefetcher, descriptor, attr_found, is_fetched = get_prefetcher(
                 first_obj, through_attr, to_attr
             )
+
+            if as_attr:
+                to_attr_obj = getattr(first_obj.__class__, to_attr, None)
+                if isinstance(to_attr_obj, property) and to_attr_obj.fset is None:
+                    raise ValueError(
+                        "to_attr=%s cannot be used because %s defines a property "
+                        "without a setter." % (to_attr, first_obj.__class__.__name__)
+                    )
 
             if not attr_found:
                 raise AttributeError(
@@ -2794,14 +2802,22 @@ def get_prefetcher(instance, through_attr, to_attr):
     """
 
     def is_to_attr_fetched(model, to_attr):
+        to_attr_obj = getattr(model, to_attr, None)
         # Special case cached_property instances because hasattr() triggers
         # attribute computation and assignment.
-        if isinstance(getattr(model, to_attr, None), cached_property):
+        if isinstance(to_attr_obj, cached_property):
 
             def has_cached_property(instance):
                 return to_attr in instance.__dict__
 
             return has_cached_property
+
+        if isinstance(to_attr_obj, property) and to_attr_obj.fset is not None:
+
+            def has_property_value(instance):
+                return to_attr in instance.__dict__
+
+            return has_property_value
 
         def has_to_attr_attribute(instance):
             return hasattr(instance, to_attr)

--- a/tests/prefetch_related/tests.py
+++ b/tests/prefetch_related/tests.py
@@ -1127,6 +1127,18 @@ class CustomPrefetchTests(TestCase):
             with self.assertNumQueries(0):
                 self.assertEqual(person.cached_all_houses, all_houses)
 
+    def test_to_attr_property_without_setter(self):
+        msg = (
+            "to_attr=all_houses cannot be used because Person defines a property "
+            "without a setter."
+        )
+        with self.assertRaisesMessage(ValueError, msg):
+            list(
+                Person.objects.prefetch_related(
+                    Prefetch("houses", House.objects.all(), to_attr="all_houses"),
+                )
+            )
+
     def test_filter_deferred(self):
         """
         Related filtering of prefetched querysets is deferred until necessary.


### PR DESCRIPTION
#### Trac ticket number

ticket-37201

#### Branch description

`Prefetch(..., to_attr="name")` was silently ignored when the target model
already defined a read-only `@property` with the same name. Django treated the
property as an already-fetched attribute because `hasattr()` returns true for
properties on the class.

Per triage feedback, this now raises `ValueError` when `to_attr` targets a
property without a setter. Properties with a setter use `__dict__` bookkeeping,
matching the existing `cached_property` behavior.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Used Grok (xAI) for ticket research, implementing the fix, writing the
regression test, and preparing this PR description. I manually reviewed every
line of the diff and ran `runtests.py prefetch_related` locally (134 tests,
1 skipped).

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability.
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have added or updated relevant tests.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.