### PR TITLE
Closed temporary files in GDALRasterTests.

### DIFF
--- a/tests/gis_tests/gdal_tests/test_raster.py
+++ b/tests/gis_tests/gdal_tests/test_raster.py
@@ -151,6 +151,7 @@ class GDALRasterTests(SimpleTestCase):
     def test_file_based_raster_creation(self):
         # Prepare tempfile
         rstfile = NamedTemporaryFile(suffix=".tif")
+        self.addCleanup(rstfile.close)
 
         # Create file-based raster from scratch
         GDALRaster(
@@ -273,6 +274,7 @@ class GDALRasterTests(SimpleTestCase):
 
     def test_vsi_vsizip_filesystem(self):
         rst_zipfile = NamedTemporaryFile(suffix=".zip")
+        self.addCleanup(rst_zipfile.close)
         with zipfile.ZipFile(rst_zipfile, mode="w") as zf:
             zf.write(self.rs_path, "raster.tif")
         rst_path = "/vsizip/" + os.path.join(rst_zipfile.name, "raster.tif")
@@ -416,6 +418,7 @@ class GDALRasterTests(SimpleTestCase):
 
     def test_compressed_file_based_raster_creation(self):
         rstfile = NamedTemporaryFile(suffix=".tif")
+        self.addCleanup(rstfile.close)
         # Make a compressed copy of an existing raster.
         compressed = self.rs.warp(
             {"papsz_options": {"compress": "packbits"}, "name": rstfile.name}
@@ -573,6 +576,7 @@ class GDALRasterTests(SimpleTestCase):
 
     def test_raster_clone(self):
         rstfile = NamedTemporaryFile(suffix=".tif")
+        self.addCleanup(rstfile.close)
         tests = [
             ("MEM", "", 23),  # In memory raster.
             ("tif", rstfile.name, 99),  # In file based raster.
@@ -619,6 +623,7 @@ class GDALRasterTests(SimpleTestCase):
             with self.subTest(srs=srs):
                 # Prepare tempfile and nodata value.
                 rstfile = NamedTemporaryFile(suffix=".tif")
+                self.addCleanup(rstfile.close)
                 ndv = 99
                 # Create in file based raster.
                 source = GDALRaster(
@@ -720,6 +725,7 @@ class GDALRasterTests(SimpleTestCase):
         with mock.patch.object(GDALRaster, "clone") as mocked_clone:
             # Create in file based raster.
             rstfile = NamedTemporaryFile(suffix=".tif")
+            self.addCleanup(rstfile.close)
             source = GDALRaster(
                 {
                     "datatype": 1,
@@ -748,6 +754,7 @@ class GDALRasterTests(SimpleTestCase):
     def test_raster_transform_clone_name(self):
         # Create in file based raster.
         rstfile = NamedTemporaryFile(suffix=".tif")
+        self.addCleanup(rstfile.close)
         source = GDALRaster(
             {
                 "datatype": 1,


### PR DESCRIPTION
Fixes the `ResourceWarning` mentioned in https://github.com/django/django/pull/21249#issuecomment-4409644296:

```py
ResourceWarning: Implicitly cleaning up <_TemporaryFileWrapper file=<_io.BufferedRandom name='/var/folders/_c/qsz9054d71v9z4wt9p38wc9c0000gn/T/django_d_xh6qt8/tmpx6fbr067.zip'>>
```
etc.