### PR TITLE
Fixed broken link in uvicorn deployment docs.

### DIFF
--- a/docs/howto/deployment/asgi/uvicorn.txt
+++ b/docs/howto/deployment/asgi/uvicorn.txt
@@ -56,5 +56,5 @@ Then start Gunicorn using the Uvicorn worker class like this:
 
     python -m gunicorn myproject.asgi:application -k uvicorn_worker.UvicornWorker
 
-.. _Uvicorn: https://www.uvicorn.org/
+.. _Uvicorn: https://www.uvicorn.dev/
 .. _Gunicorn: https://gunicorn.org/


### PR DESCRIPTION
Looks like this moved in late 2025.