### PR TITLE
Added step to install gettext in Github Actions workflows.

### DIFF
--- a/.github/workflows/coverage_tests.yml
+++ b/.github/workflows/coverage_tests.yml
@@ -47,10 +47,10 @@ jobs:
           cache: 'pip'
           cache-dependency-path: 'tests/requirements/py3.txt'
 
-      - name: Update apt repo
-        run: sudo apt update
-      - name: Install libmemcached-dev for pylibmc
-        run: sudo apt install -y libmemcached-dev
+      - name: Install system packages
+        run: |
+          sudo apt update
+          xargs -a .github/workflows/data/apt-packages.txt sudo apt install -y --no-install-recommends
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel

--- a/.github/workflows/data/apt-packages.txt
+++ b/.github/workflows/data/apt-packages.txt
@@ -1,0 +1,1 @@
+libmemcached-dev

--- a/.github/workflows/data/apt-packages.txt
+++ b/.github/workflows/data/apt-packages.txt
@@ -1,1 +1,2 @@
+gettext
 libmemcached-dev

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
           cache: 'pip'
           cache-dependency-path: 'docs/requirements.txt'
       - name: Install system spell checker
-        run: sudo apt update && sudo apt install -y aspell aspell-en
+        run: sudo apt update && sudo apt install -y --no-install-recommends aspell aspell-en
       - run: python -m pip install -r requirements.txt
       - name: Lint
         run: make lint

--- a/.github/workflows/postgis.yml
+++ b/.github/workflows/postgis.yml
@@ -42,8 +42,10 @@ jobs:
           activate-environment: geodjango
           environment-file: ${{ matrix.conda-environment-file }}
           channel-priority: strict
-      - name: Install libmemcached-dev for pylibmc
-        run: sudo apt install -y libmemcached-dev
+      - name: Install system packages
+        run: |
+          sudo apt update
+          xargs -a .github/workflows/data/apt-packages.txt sudo apt install -y --no-install-recommends
       - name: Install and upgrade packaging tools
         run: python -m pip install --upgrade pip wheel
       - run: python -m pip install -r tests/requirements/py3.txt -r tests/requirements/postgres.txt -e .

--- a/.github/workflows/python_matrix.yml
+++ b/.github/workflows/python_matrix.yml
@@ -49,8 +49,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
           cache-dependency-path: 'tests/requirements/py3.txt'
-      - name: Install libmemcached-dev for pylibmc
-        run: sudo apt-get install libmemcached-dev
+      - name: Install system packages
+        run: |
+          sudo apt update
+          xargs -a .github/workflows/data/apt-packages.txt sudo apt install -y --no-install-recommends
       - name: Install and upgrade packaging tools
         run: python -m pip install --upgrade pip wheel
       - run: python -m pip install -r tests/requirements/py3.txt -e .

--- a/.github/workflows/schedule_tests.yml
+++ b/.github/workflows/schedule_tests.yml
@@ -54,8 +54,10 @@ jobs:
         with:
           python-version: '3.14'
           cache: 'pip'
-      - name: Install libmemcached-dev for pylibmc
-        run: sudo apt-get install libmemcached-dev
+      - name: Install system packages
+        run: |
+          sudo apt update
+          xargs -a .github/workflows/data/apt-packages.txt sudo apt install -y --no-install-recommends
       - name: Install and upgrade packaging tools
         run: python -m pip install --upgrade pip wheel
       - run: python -m pip install .
@@ -104,8 +106,10 @@ jobs:
           python-version: '3.14'
           cache: 'pip'
           cache-dependency-path: 'tests/requirements/py3.txt'
-      - name: Install libmemcached-dev for pylibmc
-        run: sudo apt-get install libmemcached-dev
+      - name: Install system packages
+        run: |
+          sudo apt update
+          xargs -a .github/workflows/data/apt-packages.txt sudo apt install -y --no-install-recommends
       - name: Install and upgrade packaging tools
         run: python -m pip install --upgrade pip wheel
       - run: python -m pip install -r tests/requirements/py3.txt -e .
@@ -143,8 +147,10 @@ jobs:
           python-version: '3.14'
           cache: 'pip'
           cache-dependency-path: 'tests/requirements/py3.txt'
-      - name: Install libmemcached-dev for pylibmc
-        run: sudo apt-get install libmemcached-dev
+      - name: Install system packages
+        run: |
+          sudo apt update
+          xargs -a .github/workflows/data/apt-packages.txt sudo apt install -y --no-install-recommends
       - name: Install and upgrade packaging tools
         run: python -m pip install --upgrade pip wheel
       - run: python -m pip install -r tests/requirements/py3.txt -r tests/requirements/postgres.txt -e .
@@ -191,8 +197,10 @@ jobs:
           python-version: '3.14'
           cache: 'pip'
           cache-dependency-path: 'tests/requirements/py3.txt'
-      - name: Install libmemcached-dev for pylibmc
-        run: sudo apt-get install libmemcached-dev
+      - name: Install system packages
+        run: |
+          sudo apt update
+          xargs -a .github/workflows/data/apt-packages.txt sudo apt install -y --no-install-recommends
       - name: Install and upgrade packaging tools
         run: python -m pip install --upgrade pip wheel
       - run: python -m pip install -r tests/requirements/py3.txt -r tests/requirements/postgres.txt -e .

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -30,10 +30,10 @@ jobs:
           python-version: '3.14'
           cache: 'pip'
           cache-dependency-path: 'tests/requirements/py3.txt'
-      - name: Update apt repo
-        run: sudo apt update
-      - name: Install libmemcached-dev for pylibmc
-        run: sudo apt install -y libmemcached-dev
+      - name: Install system packages
+        run: |
+          sudo apt update
+          xargs -a .github/workflows/data/apt-packages.txt sudo apt install -y --no-install-recommends
       - name: Install and upgrade packaging tools
         run: python -m pip install --upgrade pip wheel
       - run: python -m pip install -r tests/requirements/py3.txt -e .

--- a/.github/workflows/selenium.yml
+++ b/.github/workflows/selenium.yml
@@ -30,8 +30,10 @@ jobs:
           python-version: '3.14'
           cache: 'pip'
           cache-dependency-path: 'tests/requirements/py3.txt'
-      - name: Install libmemcached-dev for pylibmc
-        run: sudo apt-get install libmemcached-dev
+      - name: Install system packages
+        run: |
+          sudo apt update
+          xargs -a .github/workflows/data/apt-packages.txt sudo apt install -y --no-install-recommends
       - name: Install and upgrade packaging tools
         run: python -m pip install --upgrade pip wheel
       - run: python -m pip install -r tests/requirements/py3.txt -e .
@@ -70,8 +72,10 @@ jobs:
           python-version: '3.14'
           cache: 'pip'
           cache-dependency-path: 'tests/requirements/py3.txt'
-      - name: Install libmemcached-dev for pylibmc
-        run: sudo apt-get install libmemcached-dev
+      - name: Install system packages
+        run: |
+          sudo apt update
+          xargs -a .github/workflows/data/apt-packages.txt sudo apt install -y --no-install-recommends
       - name: Install and upgrade packaging tools
         run: python -m pip install --upgrade pip wheel
       - run: python -m pip install -r tests/requirements/py3.txt -r tests/requirements/postgres.txt -e .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
           cache-dependency-path: 'tests/requirements/py3.txt'
+      - name: Install gettext
+        run: choco install gettext --no-progress -y
       - name: Install and upgrade packaging tools
         run: python -m pip install --upgrade pip wheel
       - run: python -m pip install -r tests/requirements/py3.txt -e .


### PR DESCRIPTION
We were seeing skips due to missing xgettext, e.g.:
```
18n.test_extraction.BasicExtractorTests.test_blocktranslate_trimmed ... skipped 'xgettext is mandatory for extraction tests'
```
#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Chatted w/ Claude to verify that installing gettext was sufficient to get `xgettext`, and to give me the `choco` command for Windows.
***
Add all the labels 🤣 