### PR TITLE
Fixed #27734 -- Made parallel test workers reuse database clones of exited workers.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -34,6 +34,7 @@ answer newbie questions, and generally made Django that much better:
     Ahmad Alhashemi <trans@ahmadh.com>
     Ahmad Al-Ibrahim
     Ahmed Eltawela <https://github.com/ahmedabt>
+    Ahmed Mohamed <https://github.com/ahmed5145>
     Ahmed Nassar <https://ahmednassar7.github.io/>
     Aina Anjary Fenomamy R. <anja1catus@gmail.com>
     ajs <adi@sieker.info>

--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -12,6 +12,7 @@ import pickle
 import random
 import sys
 import textwrap
+import time
 import unittest
 import unittest.suite
 from collections import defaultdict
@@ -418,8 +419,59 @@ def parallel_type(value):
 _worker_id = 0
 
 
+def _claim_database_clone_slot(worker_slots, timeout=5):
+    """
+    Claim a database clone slot (1-based index) for this worker process.
+
+    Each slot of the shared worker_slots array stores the pid of the worker
+    process that owns it, or 0 if the slot is free. When multiprocessing.Pool
+    spawns a replacement for an exited worker, the replacement waits for the
+    parent process to release the dead worker's slot instead of being assigned
+    an index that has no matching database clone.
+    """
+    pid = os.getpid()
+    deadline = time.monotonic() + timeout
+    while True:
+        with worker_slots.get_lock():
+            free_index = None
+            for index, owner in enumerate(worker_slots):
+                # Prefer a slot this pid already owns over a free one, so that
+                # a pid reused by the OS for a replacement worker can never
+                # hold two slots at once (which would leave the exited
+                # worker's slot stuck until the replacement finishes).
+                if owner == pid:
+                    return index + 1
+                if owner == 0 and free_index is None:
+                    free_index = index
+            if free_index is not None:
+                worker_slots[free_index] = pid
+                return free_index + 1
+        if time.monotonic() > deadline:
+            raise RuntimeError(
+                f"Test worker (pid {pid}) could not acquire a test database "
+                f"clone within {timeout} seconds because all "
+                f"{len(worker_slots)} clones are assigned to running workers."
+            )
+        time.sleep(0.05)
+
+
+def _release_dead_worker_slots(worker_slots):
+    """
+    Release database clone slots owned by worker processes that exited, so
+    that replacement workers spawned by multiprocessing.Pool can reuse them.
+
+    This runs in the parent process, where pool workers are visible as active
+    children.
+    """
+    with worker_slots.get_lock():
+        alive_pids = {child.pid for child in multiprocessing.active_children()}
+        for index, owner in enumerate(worker_slots):
+            if owner and owner not in alive_pids:
+                worker_slots[index] = 0
+
+
 def _init_worker(
-    counter,
+    worker_slots,
     initial_settings=None,
     serialized_contents=None,
     process_setup=None,
@@ -436,9 +488,7 @@ def _init_worker(
 
     global _worker_id
 
-    with counter.get_lock():
-        counter.value += 1
-        _worker_id = counter.value
+    _worker_id = _claim_database_clone_slot(worker_slots)
 
     is_spawn_or_forkserver = multiprocessing.get_start_method() in {
         "forkserver",
@@ -474,13 +524,11 @@ def _init_worker(
         )
 
 
-def _safe_init_worker(init_worker, counter, *args, **kwargs):
+def _safe_init_worker(init_worker, init_failed, *args, **kwargs):
     try:
-        init_worker(counter, *args, **kwargs)
+        init_worker(*args, **kwargs)
     except Exception:
-        with counter.get_lock():
-            # Set a value that will not increment above zero any time soon.
-            counter.value = -1000
+        init_failed.value = True
         raise
 
 
@@ -554,7 +602,9 @@ class ParallelTestSuite(unittest.TestSuite):
         exception classes which cannot be unpickled.
         """
         self.initialize_suite()
-        counter = multiprocessing.Value(ctypes.c_int, 0)
+        # One slot per db clone, holding the pid of the worker process (or 0).
+        worker_slots = multiprocessing.Array(ctypes.c_longlong, self.processes)
+        init_failed = multiprocessing.Value(ctypes.c_bool, False)
         args = [
             (self.runner_class, index, subsuite, self.failfast, self.buffer)
             for index, subsuite in enumerate(self.subsuites)
@@ -566,7 +616,8 @@ class ParallelTestSuite(unittest.TestSuite):
             processes=self.processes,
             initializer=functools.partial(_safe_init_worker, self.init_worker.__func__),
             initargs=[
-                counter,
+                init_failed,
+                worker_slots,
                 self.initial_settings,
                 self.serialized_contents,
                 self.process_setup.__func__,
@@ -582,10 +633,14 @@ class ParallelTestSuite(unittest.TestSuite):
                     pool.terminate()
                     break
 
+                # Return the database clones of exited workers to the pool of
+                # available slots so that replacement workers can reuse them.
+                _release_dead_worker_slots(worker_slots)
+
                 try:
                     subsuite_index, events = test_results.next(timeout=0.1)
                 except multiprocessing.TimeoutError as err:
-                    if counter.value < 0:
+                    if init_failed.value:
                         err.add_note("ERROR: _init_worker failed, see prior traceback")
                         raise
                     continue

--- a/tests/test_runner/test_parallel.py
+++ b/tests/test_runner/test_parallel.py
@@ -1,12 +1,21 @@
+import ctypes
+import multiprocessing
+import os
 import pickle
 import sys
 import unittest
+from unittest import mock
 from unittest.case import TestCase
 from unittest.result import TestResult
 from unittest.suite import TestSuite, _ErrorHolder
 
 from django.test import SimpleTestCase
-from django.test.runner import ParallelTestSuite, RemoteTestResult
+from django.test.runner import (
+    ParallelTestSuite,
+    RemoteTestResult,
+    _claim_database_clone_slot,
+    _release_dead_worker_slots,
+)
 
 from . import models
 
@@ -224,6 +233,59 @@ class RemoteTestResultTest(SimpleTestCase):
         result = RemoteTestResult()
         result.addDuration(None, 2.3)
         self.assertEqual(result.collectedDurations, [("None", 2.3)])
+
+
+class DatabaseCloneSlotTests(SimpleTestCase):
+    def make_slots(self, *owners):
+        slots = multiprocessing.Array(ctypes.c_longlong, len(owners))
+        for index, owner in enumerate(owners):
+            slots[index] = owner
+        return slots
+
+    def test_claims_first_free_slot(self):
+        slots = self.make_slots(101, 0, 0)
+        self.assertEqual(_claim_database_clone_slot(slots), 2)
+        self.assertEqual(slots[1], os.getpid())
+
+    def test_reclaims_slot_owned_by_own_pid(self):
+        # The OS may reuse the pid of an exited worker whose slot was not
+        # released yet.
+        slots = self.make_slots(101, os.getpid(), 0)
+        self.assertEqual(_claim_database_clone_slot(slots), 2)
+
+    def test_prefers_own_slot_over_earlier_free_slot(self):
+        # A pid already owning a slot must reclaim it rather than take an
+        # earlier free slot, otherwise a pid reused by the OS could hold two
+        # slots at once and strand the old one.
+        slots = self.make_slots(0, os.getpid())
+        self.assertEqual(_claim_database_clone_slot(slots), 2)
+        # The earlier free slot is left untouched for another worker.
+        self.assertEqual(slots[0], 0)
+
+    def test_times_out_when_no_slot_is_free(self):
+        slots = self.make_slots(101, 102)
+        msg = "could not acquire a test database clone"
+        with self.assertRaisesMessage(RuntimeError, msg):
+            _claim_database_clone_slot(slots, timeout=0)
+
+    def test_release_dead_worker_slots(self):
+        alive_worker = mock.Mock(pid=103)
+        slots = self.make_slots(101, 0, 103)
+        with mock.patch.object(
+            multiprocessing, "active_children", return_value=[alive_worker]
+        ):
+            _release_dead_worker_slots(slots)
+        self.assertEqual(list(slots), [0, 0, 103])
+
+    def test_released_slot_is_claimed_by_replacement_worker(self):
+        dead_worker_pid = 101
+        slots = self.make_slots(dead_worker_pid, 102)
+        with mock.patch.object(
+            multiprocessing, "active_children", return_value=[mock.Mock(pid=102)]
+        ):
+            _release_dead_worker_slots(slots)
+        self.assertEqual(_claim_database_clone_slot(slots), 1)
+        self.assertEqual(slots[0], os.getpid())
 
 
 class ParallelTestSuiteTest(SimpleTestCase):

--- a/tests/test_runner/tests.py
+++ b/tests/test_runner/tests.py
@@ -744,9 +744,9 @@ class TestRunnerInitializerTests(SimpleTestCase):
         self.assertIsInstance(initializer, functools.partial)
         self.assertIs(initializer.args[0], _init_worker)
         initargs = mocked_pool.call_args.kwargs["initargs"]
-        self.assertEqual(len(initargs), 7)
-        self.assertEqual(initargs[5], True)  # debug_mode
-        self.assertEqual(initargs[6], {db.DEFAULT_DB_ALIAS})  # Used database aliases.
+        self.assertEqual(len(initargs), 8)
+        self.assertEqual(initargs[6], True)  # debug_mode
+        self.assertEqual(initargs[7], {db.DEFAULT_DB_ALIAS})  # Used database aliases.
 
 
 class Ticket17477RegressionTests(AdminScriptTestCase):


### PR DESCRIPTION
#### Trac ticket number

ticket-27734

#### Branch description

`ParallelTestSuite` assigned worker IDs from a monotonically increasing shared
counter. When `multiprocessing.Pool` respawned a worker after one exited
(segfault, OOM, resource contention), the replacement incremented the counter
past N and tried to connect to a database clone that doesn't exist
(`FATAL: database "test_db_5" does not exist`), aborting the whole run.

As suggested by Jacob Walls in
[comment 15](https://code.djangoproject.com/ticket/27734#comment:15), database
clones are now a pool of slots that workers acquire on initialization. Each
slot records the owning worker's PID; the parent process releases slots of
exited workers on each tick of the existing result-polling loop in
`ParallelTestSuite.run()`, so replacement workers reuse the freed clones. If no
slot becomes free, the worker fails with an explicit error message. A stale
slot is also reclaimed if the OS reuses the PID of an exited worker. Worker
initialization failures are now signaled through a dedicated shared flag
instead of poisoning the counter.

Verified with the reproduction from comment 15 (`maxtasksperchild=1`, then
`runtests.py queries --parallel=4`) on Windows / Python 3.14 / SQLite (spawn
start method): crashes on main, passes with this patch even with every worker
respawning after each subsuite. Also ran
`runtests.py queries test_runner test_utils --parallel=4` in normal mode
(890 tests OK) and Black, isort, and flake8 on the changed files.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
Cursor (Claude) was used while developing this patch. I reviewed the
changes, reproduced the failure on main before applying the fix, and
verified the behaviour with the ticket’s reproduction recipe and the
relevant test suites.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable. (No docs/release-note changes needed: this fixes internal, private test-runner machinery.)
- [x] I have attached screenshots in both light and dark modes for any UI changes. (N/A: no UI changes.)