### PR TITLE
Fixed #33091 -- Raised FieldError for MTI parent updates using child F() refs.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -34,6 +34,7 @@ answer newbie questions, and generally made Django that much better:
     Ahmad Alhashemi <trans@ahmadh.com>
     Ahmad Al-Ibrahim
     Ahmed Eltawela <https://github.com/ahmedabt>
+    Ahmed Mohamed <https://github.com/ahmed5145>
     Ahmed Nassar <https://ahmednassar7.github.io/>
     Aina Anjary Fenomamy R. <anja1catus@gmail.com>
     ajs <adi@sieker.info>

--- a/django/db/models/sql/subqueries.py
+++ b/django/db/models/sql/subqueries.py
@@ -3,7 +3,7 @@ Query subclasses which provide extra functionality beyond simple data
 retrieval.
 """
 
-from django.core.exceptions import FieldError
+from django.core.exceptions import FieldDoesNotExist, FieldError
 from django.db.models.sql.constants import (
     GET_ITERATOR_CHUNK_SIZE,
     NO_RESULTS,
@@ -98,10 +98,35 @@ class UpdateQuery(Query):
                     % field
                 )
             if model is not self.get_meta().concrete_model:
+                # Parent MTI table update: expression refs are resolved later
+                # against the parent model, which cannot see child-only fields
+                # (#33091). Detect those joins here and raise the same error as
+                # child-field updates that reference parent columns (#30044).
+                self._check_related_update_expressions(model, val)
                 self.add_related_update(model, field, val)
                 continue
             values_seq.append((field, model, val))
         return self.add_update_fields(values_seq)
+
+    def _check_related_update_expressions(self, model, val):
+        """
+        Ensure F() (and similar) references used when updating a parent table
+        are local to that parent. Child-only fields require a join.
+        """
+        joined_msg = "Joined field references are not permitted in this query"
+        local_names = {"pk"}
+        for f in model._meta.local_concrete_fields:
+            local_names.add(f.name)
+            local_names.add(f.attname)
+        for field_name, *lookups in self.model._get_expr_references(val):
+            if lookups or field_name not in local_names:
+                try:
+                    self.get_meta().get_field(field_name)
+                except FieldDoesNotExist:
+                    # Unknown name: leave for the related UpdateQuery to raise
+                    # its usual "Cannot resolve keyword … Choices are: …".
+                    continue
+                raise FieldError(joined_msg)
 
     def add_update_fields(self, values_seq):
         """

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -493,6 +493,14 @@ class BasicExpressionsTests(TestCase):
         with self.assertRaisesMessage(FieldError, msg):
             RemoteEmployee.objects.update(adjusted_salary=F("salary") * 5)
 
+    def test_update_set_inherited_field_from_child(self):
+        # Converse of test_update_inherited_field_value / #30044.
+        # Updating a parent-table field with F() to a child-only field also
+        # requires a join and must raise the same FieldError (#33091).
+        msg = "Joined field references are not permitted in this query"
+        with self.assertRaisesMessage(FieldError, msg):
+            RemoteEmployee.objects.update(salary=F("adjusted_salary") / 5)
+
     def test_object_update_unsaved_objects(self):
         # F expressions cannot be used to update attributes on objects which do
         # not yet exist in the database


### PR DESCRIPTION
#### Trac ticket number

ticket-33091

#### Branch description

``ChildModel.objects.update(parent_field=F("child_field"))`` raised a confusing
``Cannot resolve keyword`` error. Related (parent-table) updates resolve
expressions against the parent model, which cannot see child-only fields.

This change validates expression field references in
``UpdateQuery.add_update_values`` before ``add_related_update`` and raises the
same ``FieldError`` as #30044: ``Joined field references are not permitted in
this query``. Adds regression test
``test_update_set_inherited_field_from_child``.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Cursor (Composer) was used while developing this patch. I reviewed the
changes, reproduced the failure before applying the fix, and verified the
behaviour with the ticket’s regression test and the expressions/update suites.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable. (N/A: error-message cleanup only.)
- [x] I have attached screenshots in both light and dark modes for any UI changes. (N/A: no UI changes.)