### PR TITLE
Fixed subject/verb agreement in DecimalValidator messages.

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -513,17 +513,17 @@ class DecimalValidator:
     messages = {
         "invalid": _("Enter a number."),
         "max_digits": ngettext_lazy(
-            "Ensure that there are no more than %(max)s digit in total.",
+            "Ensure that there is no more than %(max)s digit in total.",
             "Ensure that there are no more than %(max)s digits in total.",
             "max",
         ),
         "max_decimal_places": ngettext_lazy(
-            "Ensure that there are no more than %(max)s decimal place.",
+            "Ensure that there is no more than %(max)s decimal place.",
             "Ensure that there are no more than %(max)s decimal places.",
             "max",
         ),
         "max_whole_digits": ngettext_lazy(
-            "Ensure that there are no more than %(max)s digit before the decimal "
+            "Ensure that there is no more than %(max)s digit before the decimal "
             "point.",
             "Ensure that there are no more than %(max)s digits before the decimal "
             "point.",


### PR DESCRIPTION
#### Trac ticket number

N/A - typo

#### Branch description

"There are 1 digit" → "There is 1 digit". ("no more than" and "in total" don't change that.)

/cc typo fixes PR #21595. 

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
