### PR TITLE
Fixed #37218 -- Doc'd that on-demand fetching is sync only.

### DIFF
--- a/docs/topics/db/queries.txt
+++ b/docs/topics/db/queries.txt
@@ -996,8 +996,10 @@ In there, you'll find the methods on QuerySets grouped into two sections:
 
 * *Methods that return new querysets*: These are the non-blocking ones,
   and don't have asynchronous versions. You're free to use these in any
-  situation, though read the notes on ``defer()`` and ``only()`` before you use
-  them.
+  situation, but understand the constraint of `no deferred queries`_ before
+  using :meth:`~django.db.models.query.QuerySet.defer`,
+  :meth:`~django.db.models.query.QuerySet.only`, or
+  :meth:`~django.db.models.query.QuerySet.fetch_mode`.
 
 * *Methods that do not return querysets*: These are the blocking ones, and
   have asynchronous versions - the asynchronous name for each is noted in its
@@ -1019,6 +1021,15 @@ the whole expression in order to call it in an asynchronous-friendly way.
     *"coroutine object has no attribute x"* or *"<coroutine …>"* strings in
     place of your model instances. If you ever see these, you are missing an
     ``await`` somewhere to turn that coroutine into a real value.
+
+No deferred queries
+-------------------
+
+Relations are deferred by default. If the ``blog`` relation is not prefetched,
+accessing ``entry.blog`` during asynchronous evaluation of a queryset attempts
+a blocking database query, raising ``SynchronousOnlyOperation``. (A similar
+limitation applies to fields deferred via ``defer()`` or ``only()``.) To avoid
+this, see the advice on prefetching in :ref:`topics-db-queries-related`.
 
 Transactions
 ------------


### PR DESCRIPTION
ticket-37218

#### Branch description
While we had a note in the async queries topic saying "beware defer() and only(), see those methods for caveats", and those methods explained why lazy fetches don't work under async, there was no note for relations, and no reference to the new `fetch_mode()` method.

This PR:
- adds `fetch_mode()` to the list of methods to _see for caveats_
- ~adds said caveat~
- adds a "No deferred queries" section to the async queries guide to explicitly mention relations instead of leaving it as an exercise for the reader

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.