### PR TITLE
Refs #32539 -- Fixed flaky facet filter tests.

### DIFF
--- a/tests/admin_filters/tests.py
+++ b/tests/admin_filters/tests.py
@@ -3,6 +3,7 @@ import sys
 import unittest
 
 from django.contrib.admin import (
+    AdminSite,
     AllValuesFieldListFilter,
     BooleanFieldListFilter,
     EmptyFieldListFilter,
@@ -10,7 +11,6 @@ from django.contrib.admin import (
     ModelAdmin,
     RelatedOnlyFieldListFilter,
     SimpleListFilter,
-    site,
 )
 from django.contrib.admin.filters import FacetsMixin
 from django.contrib.admin.options import IncorrectLookupParameters, ShowFacets
@@ -21,6 +21,9 @@ from django.db import connection, models
 from django.test import RequestFactory, SimpleTestCase, TestCase, override_settings
 
 from .models import Book, Bookmark, Department, Employee, ImprovedBook, TaggedItem
+
+site = AdminSite(name="test_adminfilters")
+site.register(User, UserAdmin)
 
 
 def select_by(dictlist, key, value):


### PR DESCRIPTION
#### Trac ticket number
ticket-32539

#### Branch description
Because the default admin site was used in this test module, `UserAdmin` was never registered, meaning the username ordering was never applied. This meant order-sensitive assertions could fail.

```py
  File "/home/runner/work/django/django/tests/admin_filters/tests.py", line 1524, in test_facets_filter
    self.assertChoicesDisplay(choices, expected_displays)
    ^^^^^^^
  File "/home/runner/work/django/django/tests/admin_filters/tests.py", line 415, in assertChoicesDisplay
    self.assertEqual(choice["display"], expected_display)
    ^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.14.6/x64/lib/python3.14/unittest/case.py", line 925, in assertEqual
    assertion_func(first, second, msg=msg)
    ^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.14.6/x64/lib/python3.14/unittest/case.py", line 1291, in assertMultiLineEqual
    self.fail(self._formatMessage(msg, standardMsg))
    ^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.14.6/x64/lib/python3.14/unittest/case.py", line 750, in fail
    raise self.failureException(msg)
    ^^^^^^^^^^^^^^^
AssertionError: 'lisa (0)' != 'bob (0)'
- lisa (0)
+ bob (0)
```
#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude pointed me at the missing UserAdmin registration.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.