### PR TITLE
Fixed #35838 -- Supported chunked request bodies under WSGI via wsgi.input_terminated.

### DIFF
--- a/django/core/handlers/wsgi.py
+++ b/django/core/handlers/wsgi.py
@@ -53,6 +53,21 @@ class LimitedStream(IOBase):
         return line
 
 
+class TerminatedStream(IOBase):
+    """
+    Wrap a stream that the WSGI server terminates at the end of the request
+    body, as signaled by the de facto wsgi.input_terminated environ key.
+
+    Servers that decode Transfer-Encoding themselves (e.g. gunicorn and uWSGI
+    for chunked requests) cannot provide CONTENT_LENGTH, so the stream is read
+    until EOF instead of up to a known length.
+    """
+
+    def __init__(self, stream):
+        self.read = stream.read
+        self.readline = stream.readline
+
+
 class WSGIRequest(HttpRequest):
     def __init__(self, environ):
         script_name = get_script_name(environ)
@@ -74,8 +89,19 @@ class WSGIRequest(HttpRequest):
         try:
             content_length = int(environ.get("CONTENT_LENGTH"))
         except (ValueError, TypeError):
-            content_length = 0
-        self._stream = LimitedStream(self.environ["wsgi.input"], content_length)
+            content_length = None
+        if content_length is not None:
+            self._stream = LimitedStream(self.environ["wsgi.input"], content_length)
+        elif environ.get("wsgi.input_terminated"):
+            # CONTENT_LENGTH is absent or malformed, but the server decodes
+            # any Transfer-Encoding itself and terminates the stream at the
+            # end of the request body.
+            self._stream = TerminatedStream(self.environ["wsgi.input"])
+        else:
+            # The WSGI spec allows CONTENT_LENGTH to be absent, in which case
+            # reading past the end of the body isn't safe, so treat the body
+            # as empty.
+            self._stream = LimitedStream(self.environ["wsgi.input"], 0)
         self._read_started = False
         self.resolver_match = None
 

--- a/django/http/request.py
+++ b/django/http/request.py
@@ -425,7 +425,24 @@ class HttpRequest:
                 self._stream.seek(0)
 
             try:
-                self._body = self.read()
+                if (
+                    settings.DATA_UPLOAD_MAX_MEMORY_SIZE is not None
+                    and not content_length
+                    and not self._stream.seekable()
+                ):
+                    # The body length isn't known up front (e.g. a chunked
+                    # request terminated by the WSGI server), so enforce the
+                    # limit while reading instead of trusting a declared
+                    # length.
+                    chunks = []
+                    remaining = settings.DATA_UPLOAD_MAX_MEMORY_SIZE + 1
+                    while remaining > 0 and (chunk := self.read(remaining)):
+                        chunks.append(chunk)
+                        remaining -= len(chunk)
+                    self._body = b"".join(chunks)
+                    self._check_data_too_big(len(self._body))
+                else:
+                    self._body = self.read()
             except OSError as e:
                 raise UnreadablePostError(*e.args) from e
             finally:

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -48,6 +48,17 @@ All attributes should be considered read-only, unless stated otherwise.
     the ``body`` attribute *after* reading the request with either of these I/O
     stream methods will produce a ``RawPostDataException``.
 
+    Requests without a ``Content-Length`` header (e.g. with
+    ``Transfer-Encoding: chunked``) have an empty body under WSGI unless the
+    server decodes the transfer encoding and signals it with the de facto
+    ``wsgi.input_terminated`` environ key (as done by gunicorn and uWSGI).
+
+    .. versionchanged:: 6.2
+
+        Support for the ``wsgi.input_terminated`` environ key was added.
+        Previously, the body of requests without a ``Content-Length`` header
+        was always empty under WSGI.
+
 .. attribute:: HttpRequest.path
 
     A string representing the full path to the requested page, not including

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -200,7 +200,11 @@ Models
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 
-* ...
+* The request body of chunked requests is no longer discarded under WSGI when
+  the server decodes the transfer encoding and signals it with the de facto
+  ``wsgi.input_terminated`` environ key (as done by gunicorn and uWSGI). In
+  that case, :setting:`DATA_UPLOAD_MAX_MEMORY_SIZE` is enforced while reading
+  the stream, since no ``Content-Length`` header is available up front.
 
 Security
 ~~~~~~~~

--- a/tests/requests_tests/tests.py
+++ b/tests/requests_tests/tests.py
@@ -4,7 +4,7 @@ from itertools import chain
 from unittest import mock
 from urllib.parse import urlencode
 
-from django.core.exceptions import BadRequest, DisallowedHost
+from django.core.exceptions import BadRequest, DisallowedHost, RequestDataTooBig
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.core.files.uploadhandler import MemoryFileUploadHandler
 from django.core.handlers.wsgi import LimitedStream, WSGIRequest
@@ -1263,6 +1263,76 @@ class RequestsTests(SimpleTestCase):
         )
         with self.assertRaisesMessage(RuntimeError, msg):
             request.multipart_parser_class = MultiPartParser
+
+
+class InputTerminatedRequestTests(SimpleTestCase):
+    """
+    WSGI servers that decode Transfer-Encoding themselves cannot set
+    CONTENT_LENGTH but signal that the input stream ends at end of body with
+    the de facto wsgi.input_terminated key (e.g. gunicorn and uWSGI for
+    Transfer-Encoding: chunked requests). The body of such requests must not
+    be discarded (#35838).
+    """
+
+    def request(self, payload, terminated=True, **extra):
+        environ = {
+            "REQUEST_METHOD": "POST",
+            "CONTENT_TYPE": "application/x-www-form-urlencoded",
+            "wsgi.input": BytesIO(payload),
+            **extra,
+        }
+        if terminated:
+            environ["wsgi.input_terminated"] = True
+        return WSGIRequest(environ)
+
+    def test_body_without_content_length(self):
+        request = self.request(b"name=value")
+        self.assertEqual(request.body, b"name=value")
+
+    def test_post_without_content_length(self):
+        request = self.request(b"name=value")
+        self.assertEqual(request.POST, {"name": ["value"]})
+
+    def test_read_without_content_length(self):
+        request = self.request(b"name=value")
+        self.assertEqual(request.read(4), b"name")
+        self.assertEqual(request.read(), b"=value")
+
+    def test_body_without_input_terminated(self):
+        # Without wsgi.input_terminated, reading past the end of the body
+        # isn't safe and the body is treated as empty.
+        request = self.request(b"name=value", terminated=False)
+        self.assertEqual(request.body, b"")
+
+    def test_content_length_takes_precedence(self):
+        request = self.request(b"name=value", CONTENT_LENGTH="4")
+        self.assertEqual(request.body, b"name")
+
+    def test_malformed_content_length(self):
+        request = self.request(b"name=value", CONTENT_LENGTH="not-a-number")
+        self.assertEqual(request.body, b"name=value")
+
+    def test_malformed_content_length_without_input_terminated(self):
+        request = self.request(
+            b"name=value", terminated=False, CONTENT_LENGTH="not-a-number"
+        )
+        self.assertEqual(request.body, b"")
+
+    @override_settings(DATA_UPLOAD_MAX_MEMORY_SIZE=5)
+    def test_data_upload_max_memory_size_enforced(self):
+        request = self.request(b"name=value")
+        with self.assertRaises(RequestDataTooBig):
+            request.body
+
+    @override_settings(DATA_UPLOAD_MAX_MEMORY_SIZE=10)
+    def test_data_upload_max_memory_size_at_limit(self):
+        request = self.request(b"name=value")
+        self.assertEqual(request.body, b"name=value")
+
+    @override_settings(DATA_UPLOAD_MAX_MEMORY_SIZE=None)
+    def test_data_upload_max_memory_size_disabled(self):
+        request = self.request(b"x" * 1024)
+        self.assertEqual(len(request.body), 1024)
 
 
 class MemoryFileUploadHandlerTests(SimpleTestCase):


### PR DESCRIPTION
[Trac ticket #35838](https://code.djangoproject.com/ticket/35838)

## The problem

WSGI servers that decode `Transfer-Encoding: chunked` themselves cannot set `CONTENT_LENGTH` (per PEP 3333 / RFC 9112 the decoded length isn't known up front), and `WSGIRequest` reads zero bytes in that case — the request body is silently discarded. The practical impact has grown recently: CDNs/proxies (e.g. Cloudflare's current edge proxy) now stream request bodies to origins without `Content-Length`, which empties `request.POST` and makes every form submission fail CSRF validation with a 403 for Django-behind-gunicorn deployments. This is how we hit it in production across several sites.

## The approach

This is an alternative to PR #20406, using the de facto `wsgi.input_terminated` environ key instead of sniffing the `Transfer-Encoding` header:

- **`wsgi.py`**: when `CONTENT_LENGTH` is absent/malformed and the server sets `wsgi.input_terminated`, wrap `wsgi.input` in a `TerminatedStream` that reads to EOF. Otherwise, behavior is unchanged (body treated as empty).
- **`request.py`**: when the length is unknown and the stream isn't seekable, `HttpRequest.body` enforces `DATA_UPLOAD_MAX_MEMORY_SIZE` *while reading* (reads at most limit+1 bytes, then raises `RequestDataTooBig`), since the early `Content-Length`-based check can't apply. This mirrors the seekable-stream size check that `body` already performs for the ASGI `SpooledTemporaryFile` case.

Why `wsgi.input_terminated` rather than the `Transfer-Encoding` header:

- The header only says what the client sent; it doesn't say whether the WSGI server decoded it. If a server passed raw chunked framing through, header-based detection would hand the un-decoded framing to `request.body`. `wsgi.input_terminated` is set by the server itself precisely when the stream is safe to read to EOF — this addresses the framing question raised in review of #20406.
- It's an established convention: gunicorn sets it unconditionally (`gunicorn/http/wsgi.py`), uWSGI supports it, and Werkzeug/Flask consume it the same way.
- It also covers bodies streamed without *any* `Transfer-Encoding` header (e.g. HTTP/2-to-origin proxies that forward DATA frames without a length), which header-sniffing misses.

Multipart parsing with an unknown length is deliberately out of scope (it early-returns on `content_length == 0` as before) — that's ticket #35289 and involves upload-handler activation decisions that deserve their own review.

## Testing

- New `InputTerminatedRequestTests` covering: body/`POST`/`read()` with and without `wsgi.input_terminated`, explicit `CONTENT_LENGTH` precedence, malformed `CONTENT_LENGTH`, and `DATA_UPLOAD_MAX_MEMORY_SIZE` enforcement (over, at, and disabled).
- `requests_tests handlers wsgi asgi httpwrappers file_uploads csrf_tests middleware`: 593 tests pass.
- Verified end-to-end against a production reproduction (gunicorn behind a proxy sending length-less bodies): form POSTs go from CSRF 403 to working, while forged POSTs still 403.

AI assistance disclosure: this patch was developed with the help of an AI coding assistant (Claude); the analysis, code, and tests were reviewed and verified by a human before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)