### PR TITLE
Fixed #31714 -- Deferred lookup resolution for OuterRef annotations.

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -69,6 +69,29 @@ FORBIDDEN_ALIAS_PATTERN = _lazy_re_compile(
 EXPLAIN_OPTIONS_PATTERN = _lazy_re_compile(r"[\w-]+")
 
 
+class DeferredOuterRefLookup(Lookup):
+    """A lookup whose lhs cannot be resolved until its subquery is used."""
+
+    def __init__(self, lookups, lhs, rhs):
+        # Skip Lookup.__init__ prep work until the lhs type is known.
+        self.lookups = lookups
+        self.lhs = lhs
+        self.rhs = rhs
+        self.bilateral_transforms = []
+
+    @property
+    def identity(self):
+        # Include lookup/transform names; Lookup.identity only has lhs/rhs.
+        return self.__class__, tuple(self.lookups), self.lhs, self.rhs
+
+    def as_sql(self, compiler, connection):
+        lhs = self.lhs
+        while isinstance(lhs, (OuterRef, ResolvedOuterRef)):
+            lhs = lhs.resolve_expression(compiler.query)
+        lookup = compiler.query.build_lookup(self.lookups, lhs, self.rhs)
+        return compiler.compile(lookup)
+
+
 def get_field_names_from_opts(opts):
     if opts is None:
         return set()
@@ -1421,6 +1444,8 @@ class Query(BaseExpression):
         The lookups is a list of names to extract using get_lookup()
         and get_transform().
         """
+        if isinstance(lhs, (OuterRef, ResolvedOuterRef)):
+            return DeferredOuterRefLookup(lookups, lhs, rhs)
         # __exact is the default lookup if one isn't given.
         *transforms, lookup_name = lookups or ["exact"]
         for name in transforms:

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -1010,6 +1010,84 @@ class BasicExpressionsTests(TestCase):
         ).get(pk=self.gmbh.pk)
         self.assertEqual(gmbh_salary.max_ceo_salary_raise, 2332)
 
+    def test_lookup_filter_on_annotation_with_outerref(self):
+        annotated_queryset = Company.objects.annotate(
+            salary_raise=OuterRef("num_employees"),
+            company_name=OuterRef("name"),
+        )
+        with register_lookup(CharField, Lower):
+            gmbh_salary = Company.objects.annotate(
+                true_filter=Exists(
+                    Subquery(annotated_queryset.filter(salary_raise__gt=1))
+                ),
+                false_filter=Exists(
+                    Subquery(annotated_queryset.filter(salary_raise__lt=1))
+                ),
+                transformed_filter=Exists(
+                    Subquery(
+                        annotated_queryset.filter(
+                            company_name__lower__startswith="test"
+                        )
+                    )
+                ),
+                null_filter=Exists(
+                    Subquery(annotated_queryset.filter(salary_raise__exact=None))
+                ),
+                not_null_filter=Exists(
+                    Subquery(annotated_queryset.filter(salary_raise__isnull=False))
+                ),
+            ).get(pk=self.gmbh.pk)
+        self.assertTrue(gmbh_salary.true_filter)
+        self.assertFalse(gmbh_salary.false_filter)
+        self.assertTrue(gmbh_salary.transformed_filter)
+        self.assertFalse(gmbh_salary.null_filter)
+        self.assertTrue(gmbh_salary.not_null_filter)
+
+    def test_lookup_filter_on_annotation_with_nested_outerref(self):
+        inner = Company.objects.annotate(
+            outer_name=OuterRef(OuterRef("name")),
+        ).filter(outer_name__startswith=F("name"))
+        middle = Company.objects.filter(Exists(inner))
+        self.assertTrue(
+            Company.objects.filter(name="Test GmbH").filter(Exists(middle)).exists()
+        )
+
+    def test_deferred_outerref_lookup_identity_includes_lookups(self):
+        from django.db.models.sql.query import DeferredOuterRefLookup
+
+        gt_lookup = DeferredOuterRefLookup(["gt"], OuterRef("num_employees"), 1)
+        lt_lookup = DeferredOuterRefLookup(["lt"], OuterRef("num_employees"), 1)
+        self.assertNotEqual(gt_lookup, lt_lookup)
+        resolved = gt_lookup.resolve_expression()
+        self.assertIsInstance(resolved, DeferredOuterRefLookup)
+        self.assertEqual(resolved.lookups, ["gt"])
+
+    def test_lookup_filter_on_annotation_with_outerref_after_clone(self):
+        annotated_queryset = Company.objects.annotate(
+            salary_raise=OuterRef("num_employees"),
+            company_name=OuterRef("name"),
+        )
+        filtered = annotated_queryset.filter(salary_raise__gt=1)
+        # Clone and rewrite the queryset before SQL compilation.
+        cloned = filtered.all().alias(tmp=F("name"))
+        with register_lookup(CharField, Lower):
+            gmbh_salary = Company.objects.annotate(
+                true_filter=Exists(Subquery(cloned)),
+                transformed_filter=Exists(
+                    Subquery(
+                        annotated_queryset.filter(
+                            company_name__lower__startswith="test"
+                        ).alias(y=F("name"))
+                    )
+                ),
+                reused_filter=Exists(
+                    Subquery(filtered.filter(salary_raise__isnull=False))
+                ),
+            ).get(pk=self.gmbh.pk)
+        self.assertTrue(gmbh_salary.true_filter)
+        self.assertTrue(gmbh_salary.transformed_filter)
+        self.assertTrue(gmbh_salary.reused_filter)
+
     def test_annotation_with_outerref_and_output_field(self):
         gmbh_salary = Company.objects.annotate(
             max_ceo_salary_raise=Subquery(


### PR DESCRIPTION
#### Trac ticket number

ticket-31714

#### Branch description

Defer lookup and transform resolution for annotations based on `OuterRef` until the referenced outer column is available. This fixes filters such as `annotation__gt`, `annotation__isnull`, and transform-based lookups without requiring an `ExpressionWrapper` workaround.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

AI assistance used: Hermes Agent for repository investigation, implementation assistance, test execution, and an independent code review. The final changes and all reported results were manually reviewed and verified.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://www.djangoproject.com/foundation/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.

#### Verification

- `.venv/bin/python tests/runtests.py expressions.tests.BasicExpressionsTests.test_lookup_filter_on_annotation_with_outerref`
- `.venv/bin/python tests/runtests.py expressions.tests.BasicExpressionsTests.test_lookup_filter_on_annotation_with_nested_outerref`
- `.venv/bin/python tests/runtests.py expressions.tests.BasicExpressionsTests` — 80 tests passed.
- `.venv/bin/python tests/runtests.py expressions` — 215 tests passed, 2 skipped, 1 expected failure.
- `ruff check django/db/models/sql/query.py tests/expressions/tests.py` — passed.
- `git diff --check` — passed.
