### PR TITLE
Fixed #19806 -- Prevented django_bash_completion from clobbering upstream python completion.

### DIFF
--- a/extras/django_bash_completion
+++ b/extras/django_bash_completion
@@ -37,34 +37,3 @@ _django_completion()
                    DJANGO_AUTO_COMPLETE=1 $1 ) )
 }
 complete -F _django_completion -o default manage.py django-admin
-
-_python_django_completion()
-{
-    if [[ ${COMP_CWORD} -ge 2 ]]; then
-        local PYTHON_EXE=${COMP_WORDS[0]##*/}
-        if echo "$PYTHON_EXE" | grep -qE "python([3-9]\.[0-9])?"; then
-            local PYTHON_SCRIPT=${COMP_WORDS[1]##*/}
-            if echo "$PYTHON_SCRIPT" | grep -qE "manage\.py|django-admin"; then
-                COMPREPLY=( $( COMP_WORDS=( "${COMP_WORDS[*]:1}" )
-                               COMP_CWORD=$(( COMP_CWORD-1 ))
-                               DJANGO_AUTO_COMPLETE=1 ${COMP_WORDS[*]} ) )
-            fi
-        fi
-    fi
-}
-
-# Support for multiple interpreters.
-unset pythons
-if command -v whereis &>/dev/null; then
-    python_interpreters=$(whereis python | cut -d " " -f 2-)
-    for python in $python_interpreters; do
-        [[ $python != *-config ]] && pythons="${pythons} ${python##*/}"
-    done
-    unset python_interpreters
-    pythons=$(echo "$pythons" | tr " " "\n" | sort -u | tr "\n" " ")
-else
-    pythons=python
-fi
-
-complete -F _python_django_completion -o default $pythons
-unset pythons

--- a/tests/bash_completion/tests.py
+++ b/tests/bash_completion/tests.py
@@ -3,12 +3,21 @@ A series of tests to establish that the command-line bash completion works.
 """
 
 import os
+import shutil
+import subprocess
 import sys
 import unittest
+from pathlib import Path
 
 from django.apps import apps
 from django.core.management import ManagementUtility
 from django.test.utils import captured_stdout
+
+# extras/django_bash_completion, relative to the repository root. Only present
+# in a source checkout, not in an installed Django.
+DJANGO_BASH_COMPLETION = (
+    Path(__file__).resolve().parent.parent.parent / "extras" / "django_bash_completion"
+)
 
 
 class BashCompletionTests(unittest.TestCase):
@@ -104,3 +113,75 @@ class BashCompletionTests(unittest.TestCase):
             if app_config.label.startswith("a")
         )
         self.assertEqual(output, a_labels)
+
+
+@unittest.skipUnless(
+    shutil.which("bash"), "bash is required to exercise the completion script."
+)
+@unittest.skipUnless(
+    DJANGO_BASH_COMPLETION.exists(),
+    "django_bash_completion is only shipped in a source checkout.",
+)
+class BashCompletionScriptTests(unittest.TestCase):
+    """
+    Checks for the shipped extras/django_bash_completion script itself.
+
+    Regression tests for #19806: sourcing the script must not register a
+    completion hook for the ``python`` interpreter, which would clobber the
+    upstream bash completion of ``python`` (e.g. its own option flags).
+    """
+
+    def _completion_specs(self, *commands):
+        """
+        Source the completion script in a fresh, non-interactive bash shell and
+        return ``{command: registered completion spec}`` as reported by
+        ``complete -p``. A command with no completion registered maps to "".
+
+        The script path is passed as a positional argument ($1) rather than
+        interpolated into the command string, to avoid quoting issues.
+        """
+        queries = "\n".join(
+            f'printf "### %s\\n" {cmd}; complete -p {cmd} 2>/dev/null || true'
+            for cmd in commands
+        )
+        snippet = f'. "$1" || exit 2\n{queries}\n'
+        result = subprocess.run(
+            ["bash", "-c", snippet, "bash", DJANGO_BASH_COMPLETION.as_posix()],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg="Sourcing django_bash_completion failed:\n%s" % result.stderr,
+        )
+        specs = {}
+        current = None
+        for line in result.stdout.splitlines():
+            if line.startswith("### "):
+                current = line[4:]
+                specs[current] = ""
+            elif current is not None and line.strip():
+                specs[current] += line + "\n"
+        return specs
+
+    def test_python_completion_not_registered(self):
+        """
+        No Django completion hook is bound to python interpreters (#19806).
+        """
+        specs = self._completion_specs("python", "python3")
+        self.assertEqual(sorted(specs), ["python", "python3"])
+        for interpreter, spec in specs.items():
+            with self.subTest(interpreter=interpreter):
+                self.assertNotIn("_django_completion", spec)
+                self.assertNotIn("_python_django_completion", spec)
+
+    def test_manage_py_and_django_admin_still_registered(self):
+        """
+        Completion for the explicit manage.py and django-admin commands is
+        left intact.
+        """
+        specs = self._completion_specs("manage.py", "django-admin")
+        for command in ("manage.py", "django-admin"):
+            with self.subTest(command=command):
+                self.assertIn("_django_completion", specs[command])


### PR DESCRIPTION
#### Trac ticket number

ticket-19806

#### Branch description

Prevent django_bash_completion from clobbering the host system's global upstream python autocompletion, while ensuring manage.py and django-admin completions continue to function perfectly.

#### AI Assistance Disclosure (REQUIRED)

- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

I used Gemini to help isolate the clobbering behavior in the bash completion script, design the BashCompletionScriptTests regression test suite, and ensure it correctly handles execution environments via subprocess. All generated code and tests were manually reviewed, executed, and verified locally against the Django test runner.

#### Checklist
- [x] This PR follows the contribution guidelines.
- [x] This PR does not disclose a security vulnerability.
- [x] This PR targets the main branch. 
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR. 

- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.