### PR TITLE
Fixed #37215 - Allowed Geography fields to accept non-4326 SRIDs on PostGIS.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -312,6 +312,7 @@ answer newbie questions, and generally made Django that much better:
     Dimitris Glezos <dimitris@glezos.com>
     Dirk Datzert <dummy@habmalnefrage.de>
     Dirk Eschler <dirk.eschler@gmx.net>
+    Djonathan Goulart <contact@djonathan.dev>
     Dmitri Fedortchenko <zeraien@gmail.com>
     Dmitry Jemerov <intelliyole@gmail.com>
     dne@mayonnaise.net

--- a/django/contrib/gis/db/backends/postgis/operations.py
+++ b/django/contrib/gis/db/backends/postgis/operations.py
@@ -9,7 +9,7 @@ from django.contrib.gis.geos.geometry import GEOSGeometryBase
 from django.contrib.gis.geos.prototypes.io import wkb_r
 from django.contrib.gis.measure import Distance
 from django.core.exceptions import ImproperlyConfigured
-from django.db import NotSupportedError, ProgrammingError
+from django.db import ProgrammingError
 from django.db.backends.postgresql.operations import DatabaseOperations
 from django.db.backends.postgresql.psycopg_any import is_psycopg3
 from django.db.models import Func, Value
@@ -258,11 +258,6 @@ class PostGISOperations(BaseSpatialOperations, DatabaseOperations):
         else:
             geom_type = f.geom_type
         if f.geography:
-            if f.srid != 4326:
-                raise NotSupportedError(
-                    "PostGIS only supports geography columns with an SRID of 4326."
-                )
-
             return "geography(%s,%d)" % (geom_type, f.srid)
         else:
             return "geometry(%s,%d)" % (geom_type, f.srid)

--- a/django/contrib/gis/db/models/functions.py
+++ b/django/contrib/gis/db/models/functions.py
@@ -306,7 +306,7 @@ class DistanceResultMixin:
         return DistanceField(self.geo_field)
 
     def source_is_geography(self):
-        return self.geo_field.geography and self.geo_field.srid == 4326
+        return self.geo_field.geography
 
 
 class Distance(DistanceResultMixin, OracleToleranceMixin, GeoFunc):

--- a/docs/ref/contrib/gis/model-api.txt
+++ b/docs/ref/contrib/gis/model-api.txt
@@ -221,7 +221,13 @@ details.
 
 .. note::
 
-    Geography support is limited to PostGIS and will force the SRID to be 4326.
+    Geography support is limited to PostGIS.
+
+.. versionchanged:: 6.2
+
+    In older versions, Django strictly enforced an SRID of 4326 for geography
+    fields to match a restriction on PostGIS < 2.2. It now supports any valid
+    geography SRID.
 
 .. _geography-type:
 

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -58,7 +58,8 @@ Minor features
 :mod:`django.contrib.gis`
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* ...
+* The restriction that prevented using SRIDs other than 4326 with geography
+  field, that matched the behavior of PostGIS < 2.2, is removed.
 
 :mod:`django.contrib.messages`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/gis_tests/gis_migrations/test_operations.py
+++ b/tests/gis_tests/gis_migrations/test_operations.py
@@ -416,6 +416,17 @@ class OperationTests(OperationTestCase):
             )
             self.assertIn("geom_within_constraint", constraints)
 
+    @skipUnlessDBFeature("supports_geography")
+    def test_add_geography_field_with_geographic_srid(self):
+        self.alter_gis_model(
+            migrations.AddField,
+            "Neighborhood",
+            "path",
+            fields.LineStringField,
+            {"geography": True, "srid": 4674},
+        )
+        self.assertColumnExists("gis_neighborhood", "path")
+
 
 @skipIfDBFeature("supports_raster")
 class NoRasterSupportTests(OperationTestCase):


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37215

#### Branch description
Previously, GeoDjango strictly enforced an SRID of 4326 for all geography columns when using the PostGIS backend, reflecting a historical limitation of older PostGIS versions. PostGIS 2.2 introduced support for arbitrary geography SRIDs.

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

<!-- If AI tools were used, provide which tools were used here. -->
Gemini was used to write messages (docs, release note, commit).

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
