### PR TITLE
Fixed #36027 -- Made error response rendering thread-sensitive.

### DIFF
--- a/django/contrib/staticfiles/handlers.py
+++ b/django/contrib/staticfiles/handlers.py
@@ -59,7 +59,7 @@ class StaticFilesHandlerMixin:
         try:
             return await sync_to_async(self.serve, thread_sensitive=False)(request)
         except Http404 as e:
-            return await sync_to_async(response_for_exception, thread_sensitive=False)(
+            return await sync_to_async(response_for_exception, thread_sensitive=True)(
                 request, e
             )
 

--- a/django/core/handlers/exception.py
+++ b/django/core/handlers/exception.py
@@ -43,7 +43,7 @@ def convert_exception_to_response(get_response):
                 response = await get_response(request)
             except Exception as exc:
                 response = await sync_to_async(
-                    response_for_exception, thread_sensitive=False
+                    response_for_exception, thread_sensitive=True
                 )(request, exc)
             return response
 

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -287,6 +287,12 @@ Miscellaneous
 * The minimum supported version of ``asgiref`` is increased from 3.9.1 to
   3.12.1.
 
+* In the asynchronous request path, error responses (such as those rendered by
+  ``handler404`` and ``handler500``) are now rendered on the request's
+  thread-sensitive thread, rather than on a shared thread pool, so that
+  database connections used during error handling are managed by
+  ``close_old_connections()``.
+
 .. _deprecated-features-6.2:
 
 Features deprecated in 6.2

--- a/tests/asgi/tests.py
+++ b/tests/asgi/tests.py
@@ -30,7 +30,7 @@ from django.urls import path
 from django.utils.http import http_date
 from django.views.decorators.csrf import csrf_exempt
 
-from .urls import sync_waiter, test_filename
+from .urls import permission_denied_threads, sync_waiter, test_filename
 
 TEST_STATIC_ROOT = Path(__file__).parent / "project" / "static"
 TOO_MUCH_DATA_MSG = "Request body exceeded settings.DATA_UPLOAD_MAX_MEMORY_SIZE."
@@ -495,6 +495,30 @@ class ASGITest(SimpleTestCase):
         request_started_call, request_finished_call = signal_handler.calls
         self.assertEqual(
             request_started_call["thread"], request_finished_call["thread"]
+        )
+
+    async def test_error_handler_dispatched_with_thread_sensitive(self):
+        """
+        Error responses must be rendered on the request's thread-sensitive
+        thread, where the request's database connections are usable and remain
+        subject to close_old_connections().
+        """
+        permission_denied_threads.clear()
+        application = get_asgi_application()
+        scope = self.async_request_factory._base_scope(path="/permission_denied/")
+        communicator = ApplicationCommunicator(application, scope)
+        await communicator.send_input({"type": "http.request"})
+        response_start = await communicator.receive_output()
+        self.assertEqual(response_start["type"], "http.response.start")
+        self.assertEqual(response_start["status"], 403)
+        response_body = await communicator.receive_output()
+        self.assertEqual(response_body["body"], b"Error handler content")
+        # Give response.close() time to finish.
+        await communicator.wait()
+
+        self.assertEqual(
+            permission_denied_threads["error_handler"],
+            permission_denied_threads["view"],
         )
 
     async def test_concurrent_async_uses_multiple_thread_pools(self):

--- a/tests/asgi/urls.py
+++ b/tests/asgi/urls.py
@@ -2,6 +2,7 @@ import asyncio
 import threading
 import time
 
+from django.core.exceptions import PermissionDenied
 from django.http import FileResponse, HttpResponse, StreamingHttpResponse
 from django.urls import path
 from django.views.decorators.csrf import csrf_exempt
@@ -51,6 +52,20 @@ sync_waiter.lock = threading.Lock()
 sync_waiter.barrier = threading.Barrier(2)
 
 
+def permission_denied_view(request):
+    permission_denied_threads["view"] = threading.current_thread()
+    raise PermissionDenied
+
+
+def permission_denied_error_handler(request, exception=None):
+    permission_denied_threads["error_handler"] = threading.current_thread()
+    return HttpResponse("Error handler content", status=403)
+
+
+permission_denied_threads = {}
+handler403 = permission_denied_error_handler
+
+
 async def streaming_inner(sleep_time):
     yield b"first\n"
     await asyncio.sleep(sleep_time)
@@ -73,5 +88,6 @@ urlpatterns = [
     path("post/", post_echo),
     path("wait/", sync_waiter),
     path("delayed_hello/", hello_with_delay),
+    path("permission_denied/", permission_denied_view),
     path("streaming/", streaming_view),
 ]

--- a/tests/staticfiles_tests/test_handlers.py
+++ b/tests/staticfiles_tests/test_handlers.py
@@ -1,6 +1,11 @@
+import threading
+
+from asgiref.sync import sync_to_async
+
 from django.contrib.staticfiles.handlers import ASGIStaticFilesHandler
 from django.core.handlers.asgi import ASGIHandler
-from django.test import AsyncRequestFactory
+from django.http import HttpResponse
+from django.test import AsyncRequestFactory, override_settings
 
 from .cases import StaticFilesTestCase
 
@@ -10,6 +15,21 @@ class MockApplication:
 
     async def __call__(self, scope, receive, send):
         return "Application called"
+
+
+error_handler_threads = {}
+
+
+def log_thread(key):
+    error_handler_threads[key] = threading.current_thread()
+
+
+urlpatterns = []
+
+
+def handler404(request, exception=None):
+    log_thread("error_handler")
+    return HttpResponse("Error handler content", status=404)
 
 
 class TestASGIStaticFilesHandler(StaticFilesTestCase):
@@ -23,10 +43,19 @@ class TestASGIStaticFilesHandler(StaticFilesTestCase):
         self.assertEqual(response.status_code, 200)
 
     async def test_get_async_response_not_found(self):
+        error_handler_threads.clear()
+        await sync_to_async(log_thread)("worker")
+
         request = self.async_request_factory.get("/static/test/not-found.txt")
         handler = ASGIStaticFilesHandler(ASGIHandler())
-        response = await handler.get_response_async(request)
+        with override_settings(ROOT_URLCONF="staticfiles_tests.test_handlers"):
+            response = await handler.get_response_async(request)
         self.assertEqual(response.status_code, 404)
+
+        self.assertEqual(
+            error_handler_threads["error_handler"],
+            error_handler_threads["worker"],
+        )
 
     async def test_non_http_requests_passed_to_the_wrapped_application(self):
         tests = [


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-36027

#### Branch description

Error response handling frequently makes use of the database, and so must use the request specific connection sensitive worker thread.

Previously response_for_exception was dispatched on the event loop's default executor. This potentially leads to pool exhaustion, and deadlock, when using database pooling options, or a large number of permanently held open database connections when not using pooling.

Connections held open were not subject to cleanup. If closed server side, the reported "connection is closed" would be seen until application restart.

Moving error response rendering to the request specific connection sensitive worker thread resolves both of these issues.

The `thread_sensitive=False` was set in
e17ee4468875077b90b70bb6a589ebad7493f757 to maintain the prior behaviour when asgiref switched the thread_sensitive default to `True`. There was no specific reason for the non-tread-sensitive behaviour beyond that. (With hindsight it was always incorrect for the reasons here.)

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
<!-- If AI tools were used, provide which tools were used here. -->

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
