### PR TITLE
Fixed #37223 -- Switched signing's JSONSerializer from latin-1 to UTF-8.

### DIFF
--- a/django/core/signing.py
+++ b/django/core/signing.py
@@ -163,10 +163,10 @@ class JSONSerializer:
     """
 
     def dumps(self, obj):
-        return json.dumps(obj, separators=(",", ":")).encode("latin-1")
+        return json.dumps(obj, separators=(",", ":")).encode("utf-8")
 
     def loads(self, data):
-        return json.loads(data.decode("latin-1"))
+        return json.loads(data.decode("utf-8"))
 
 
 def dumps(

--- a/tests/signing/tests.py
+++ b/tests/signing/tests.py
@@ -249,3 +249,24 @@ class TestBase62(SimpleTestCase):
         tests = [-(10**10), 10**10, 1620378259, *range(-100, 100)]
         for i in tests:
             self.assertEqual(i, signing.b62_decode(signing.b62_encode(i)))
+
+
+class TestJSONSerializerEncoding(SimpleTestCase):
+    def test_non_ascii_round_trip(self):
+        """non-ASCII payloads survive a dumps/loads cycle unchanged."""
+        payload = {
+            "precomposed": "héllo",
+            "combining": "he\u0301llo",
+            "emoji": "🐍",
+            "zh": "你好",
+        }
+        serializer = signing.JSONSerializer()
+        decoded = serializer.loads(serializer.dumps(payload))
+        self.assertEqual(decoded, payload)
+
+    def test_loads_reads_utf_8_bytes(self):
+        """loads() decodes raw UTF-8 bytes to the original value."""
+        expected = {"text": "héllo"}
+        external_bytes = b'{"text":"h\xc3\xa9llo"}'
+        decoded = signing.JSONSerializer().loads(external_bytes)
+        self.assertEqual(decoded, expected)


### PR DESCRIPTION
#### Trac ticket number

ticket-37223

#### Branch description

Switched `django.core.signing.JSONSerializer` to encode/decode JSON as UTF-8 instead of latin-1.

`signing.dumps(serializer=...)` and `SESSION_SERIALIZER` are documented extension points, so a project can plug in a serializer that emits raw UTF-8 (orjson, msgspec, `json.dumps(..., ensure_ascii=False)`). The scenario that bites is the rollback: a project runs `OrjsonSerializer` for `SESSION_SERIALIZER`, then switches back to the default — every session signed while orjson was active comes back mojibaked, with no `BadSignature` and no `UnicodeDecodeError` (the HMAC is over the bytes, which are intact, so the corrupted value is returned as if it were valid).

With the default `ensure_ascii=True` serializer the output is pure ASCII, so latin-1 and UTF-8 are indistinguishable and the bug is invisible. Fully backward-compatible: existing signed tokens contain only ASCII bytes, which decode identically under latin-1 and UTF-8.

The fix changes the encode/decode step to UTF-8 in both `dumps` and `loads`, leaving `separators=(",", ":")` untouched so determinism is preserved. Regression tests cover a UTF-8-bytes `loads` input (bytes a UTF-8-emitting serializer would produce, not bytes `JSONSerializer.dumps` could ever produce) and a non-ASCII round-trip (precomposed, combining, emoji, CJK).

The same latin-1 pattern exists independently in `contrib/messages/storage/cookie.py` and will be addressed in a separate follow-up ticket/PR — same bug, separate code path (it bypasses `signing.JSONSerializer`), no shared code, so the two fixes can land in either order; kept out of this PR to keep the diff minimal and the review focused on the signing contract.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

AI tools were used generically only for analysis and for drafting the English text of this pull request description. The code changes (the fix in `django/core/signing.py` and the tests in `tests/signing/tests.py`) were written and personally reviewed by hand by the contributor. No automated AI review will be requested on this PR.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable. *(N/A: bug fix targeting `main`, no release note required for non-backported fixes.)*
- [ ] I have attached screenshots in both light and dark modes for any UI changes. *(N/A: no UI changes.)*