### PR TITLE
Fixed #33155 -- Made InlineModelAdmin.verbose_name_plural default based on verbose_name

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -2040,7 +2040,7 @@ class InlineModelAdmin(BaseModelAdmin):
         if self.verbose_name is None:
             self.verbose_name = self.model._meta.verbose_name
         if self.verbose_name_plural is None:
-            self.verbose_name_plural = self.model._meta.verbose_name_plural
+            self.verbose_name_plural = format_lazy('{}s', self.verbose_name)
 
     @property
     def media(self):

--- a/tests/admin_inlines/tests.py
+++ b/tests/admin_inlines/tests.py
@@ -1071,6 +1071,25 @@ class TestVerboseNameInlineForms(TestDataMixin, TestCase):
         self.assertNotContains(response, '<h2>Model with both - plural name</h2>')
         self.assertNotContains(response, 'Add another Model with both - name')
 
+    def test_verbose_name_only_inline(self):
+        class VerboseNameOnlyInline(TabularInline):
+            model = VerboseNameProfile
+            verbose_name = 'Guest'
+
+        modeladmin = ModelAdmin(ProfileCollection, admin_site)
+        modeladmin.inlines = [VerboseNameOnlyInline]
+        obj = ProfileCollection.objects.create()
+        url = reverse('admin:admin_inlines_profilecollection_change', args=(obj.pk,))
+        request = self.factory.get(url)
+        request.user = self.superuser
+        response = modeladmin.changeform_view(request)
+        # verbose_name_plural should be derived from verbose_name.
+        self.assertContains(response, '<h2>Guests</h2>')
+        self.assertContains(response, 'Add another Guest')
+        # The model's own verbose_name_plural should not appear.
+        self.assertNotContains(response, '<h2>Model with verbose name onlys</h2>')
+        self.assertNotContains(response, '<h2>Profiles</h2>')
+
 
 @override_settings(ROOT_URLCONF='admin_inlines.urls')
 class SeleniumTests(AdminSeleniumTestCase):


### PR DESCRIPTION
## Description

Django allows specifying `verbose_name` and `verbose_name_plural` for Inline classes in admin views. However, `verbose_name_plural` for an Inline was not based on a specified `verbose_name`. Instead, it fell back to the model's `_meta.verbose_name_plural`, ignoring whether `verbose_name` had been explicitly set on the inline.

This was confusing (users had to specify both name forms if they wanted to override the default name) and inconsistent with how `Model.Meta` works — the model's Meta class *does* automatically derive the plural form from a specified `verbose_name`.

## Changes

1. **`django/contrib/admin/options.py`**: Changed `InlineModelAdmin.__init__` so that when `verbose_name_plural` is not explicitly set, it defaults to `format_lazy('{}s', self.verbose_name)` — pluralizing whatever `verbose_name` resolved to — rather than unconditionally falling back to the model's `_meta.verbose_name_plural`.

2. **`tests/admin_inlines/tests.py`**: Added `test_verbose_name_only_inline` to verify that an inline with only `verbose_name='Guest'` set renders "Guests" in the heading and "Add another Guest" in the link, without using the model's default plural.

This matches the existing logic in `django/db/models/options.py` (lines 192, 201) where the model's Meta class already does the same.