### PR TITLE
Fixed #32734 -- Fixed startapp crash with trailing slash in directory name.

### DIFF
--- a/django/core/management/templates.py
+++ b/django/core/management/templates.py
@@ -74,7 +74,7 @@ class TemplateCommand(BaseCommand):
                 raise CommandError(e)
         else:
             if app_or_project == 'app':
-                self.validate_name(os.path.basename(target), 'directory')
+                self.validate_name(os.path.basename(target.rstrip(os.sep)), 'directory')
             top_dir = os.path.abspath(os.path.expanduser(target))
             if not os.path.exists(top_dir):
                 raise CommandError("Destination directory '%s' does not "


### PR DESCRIPTION
When using bash tab-completion, a trailing slash is appended to directory names. Running `django-admin startapp name directory/` resulted in:

```
CommandError: '' is not a valid app directory. Please make sure the directory is a valid identifier.
```

The error occurred because `os.path.basename()` returns an empty string when the path ends with a trailing slash (e.g., `os.path.basename('myapp/')` → `''`).

This only affected `startapp`, not `startproject`, because the `validate_name` call on the directory is inside an `if app_or_project == 'app'` block. (The fix for `startproject` was applied in a previous PR, 11270 — this completes the same fix for the `startapp` path.)

The fix strips trailing separators with `rstrip(os.sep)` before passing to `basename()`, so `os.path.basename('myapp/'.rstrip(os.sep))` correctly returns `'myapp'`.

Co-authored-by: whatevertogo <149563971+whatevertogo@users.noreply.github.com>