### PR TITLE
Fix IndexError in numberformat.format() when number is an empty string

### DIFF
--- a/django/utils/numberformat.py
+++ b/django/utils/numberformat.py
@@ -68,7 +68,7 @@ def format(
             str_number = "{:f}".format(number)
     else:
         str_number = str(number)
-    if str_number[0] == "-":
+    if str_number and str_number[0] == "-":
         sign = "-"
         str_number = str_number[1:]
     # decimal part

--- a/tests/utils_tests/test_numberformat.py
+++ b/tests/utils_tests/test_numberformat.py
@@ -42,6 +42,9 @@ class TestNumberFormat(SimpleTestCase):
             "10comma000",
         )
 
+    def test_empty_string(self):
+        self.assertEqual(nformat("", "."), "")
+
     def test_large_number(self):
         most_max = (
             "{}179769313486231570814527423731704356798070567525844996"


### PR DESCRIPTION
When `numberformat.format()` receives an empty string (e.g. from a null database field rendered in admin `list_display`), `str('')` produces `''`, and accessing `str_number[0]` raises `IndexError: string index out of range`.

This adds a guard to skip the sign check when `str_number` is empty, so the function returns `''` instead of crashing.

A test for this edge case is included.