### PR TITLE
Fixed #37222 -- Fixed QuerySet.distinct() crash on duplicated selections.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -281,6 +281,7 @@ answer newbie questions, and generally made Django that much better:
     Dan Stephenson <http://dan.io/>
     Dan Watson <http://danwatson.net/>
     dave@thebarproject.com
+    Dave Gaeddert <dave.gaeddert@gmail.com>
     David Ascher <https://ascher.ca/>
     David Avsajanishvili <avsd05@gmail.com>
     David Blewett <david@dawninglight.net>

--- a/AUTHORS
+++ b/AUTHORS
@@ -284,6 +284,7 @@ answer newbie questions, and generally made Django that much better:
     Dan Stephenson <http://dan.io/>
     Dan Watson <http://danwatson.net/>
     dave@thebarproject.com
+    Dave Gaeddert <dave.gaeddert@gmail.com>
     David Ascher <https://ascher.ca/>
     David Avsajanishvili <avsd05@gmail.com>
     David Blewett <david@dawninglight.net>

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -357,11 +357,30 @@ class SQLCompiler:
         # Avoid computing `selected_exprs` if there is no `ordering` as it's
         # relatively expensive.
         if ordering and (select := self.select):
+            distinct_fields = self.query.distinct_fields
+            annotation_select = self.query.annotation_select
+            # An expression can be selected at more than one position, e.g.
+            # when two lookup paths resolve to the same column. get_distinct()
+            # refers to such selections by expression and PostgreSQL binds an
+            # expression reference to the first position it is selected at, so
+            # ordering must refer to that position as well for the prefixes of
+            # both clauses to match. Raw selections are excluded as equal SQL
+            # is not necessarily interchangeable, e.g. a volatile function
+            # selected twice.
+            first_positions = {}
             for ordinal, (expr, _, alias) in enumerate(select, start=1):
                 pos_expr = PositionRef(ordinal, alias, expr)
+                if distinct_fields and not isinstance(expr, RawSQL):
+                    first_pos_expr = first_positions.setdefault(expr, pos_expr)
+                else:
+                    first_pos_expr = pos_expr
                 if alias:
-                    selected_exprs[alias] = pos_expr
-                selected_exprs[expr] = pos_expr
+                    # get_distinct() refers to annotations by alias, which
+                    # binds to their own position.
+                    selected_exprs[alias] = (
+                        pos_expr if alias in annotation_select else first_pos_expr
+                    )
+                selected_exprs[expr] = first_pos_expr
 
         for field in ordering:
             if hasattr(field, "resolve_expression"):

--- a/docs/releases/6.1.1.txt
+++ b/docs/releases/6.1.1.txt
@@ -4,10 +4,14 @@ Django 6.1.1 release notes
 
 *Expected September 2, 2026*
 
-Django 6.1.1 fixes several bugs in 6.1.
+Django 6.1.1 fixes one crash in Django 5.2 and several bugs in 6.1.
 
 Bugfixes
 ========
+
+* Fixed a crash in Django 5.2 when combining :meth:`distinct(*fields)
+  <.QuerySet.distinct>` with ``order_by()`` and ``values()`` and using two
+  lookup paths resolving to the same column (:ticket:`37222`).
 
 * Fixed a regression in Django 6.1 where the deprecation of double-dot variable
   lookups incorrectly applied to string and translated template literals

--- a/tests/distinct_on_fields/tests.py
+++ b/tests/distinct_on_fields/tests.py
@@ -1,5 +1,6 @@
 from django.db import connection
-from django.db.models import CharField, F, Max
+from django.db.models import CharField, F, FloatField, Max
+from django.db.models.expressions import RawSQL
 from django.db.models.functions import Lower
 from django.test import TestCase, skipUnlessDBFeature
 from django.test.utils import register_lookup
@@ -178,6 +179,133 @@ class DistinctOnTests(TestCase):
             .order_by("nAmEAlIaS")
         )
         self.assertSequenceEqual(qs, [self.p1_o1, self.p2_o1, self.p3_o1])
+
+    def test_distinct_on_duplicated_selected_columns(self):
+        # "stafftag__tag__name" and "tags__name" resolve to the same column, so
+        # it's selected twice, but DISTINCT ON refers to its first selection.
+        fields = ["stafftag__tag__name", "tags__name", "name"]
+        qs = (
+            Staff.objects.order_by(*[F(field).asc(nulls_last=True) for field in fields])
+            .distinct(*fields)
+            .values_list(*fields)
+        )
+        self.assertSequenceEqual(
+            qs,
+            [
+                ("t1", "t1", "p1"),
+                (None, None, "p1"),
+                (None, None, "p2"),
+                (None, None, "p3"),
+            ],
+        )
+
+    def test_distinct_on_duplicated_selected_columns_descending(self):
+        fields = ["stafftag__tag__name", "tags__name", "name"]
+        qs = (
+            Staff.objects.order_by(
+                *[F(field).desc(nulls_first=True) for field in fields]
+            )
+            .distinct(*fields)
+            .values_list(*fields)
+        )
+        self.assertSequenceEqual(
+            qs,
+            [
+                (None, None, "p3"),
+                (None, None, "p2"),
+                (None, None, "p1"),
+                ("t1", "t1", "p1"),
+            ],
+        )
+
+    def test_distinct_on_duplicated_selected_foreign_key_columns(self):
+        # The local "tag_id" and remote "tag__id" references of a foreign key
+        # resolve to the same column without requiring different join aliases.
+        fields = ["tag_id", "tag__id", "tag__name"]
+        qs = StaffTag.objects.order_by(*fields).distinct(*fields).values_list(*fields)
+        self.assertSequenceEqual(qs, [(self.t1.pk, self.t1.pk, "t1")])
+
+    def test_distinct_on_duplicated_selected_transforms(self):
+        # Transforms of the same column are equal expressions as well, and are
+        # also referred to by expression by DISTINCT ON.
+        fields = ["stafftag__tag__name__lower", "tags__name__lower", "name"]
+        with register_lookup(CharField, Lower):
+            qs = (
+                Staff.objects.order_by(
+                    *[F(field).asc(nulls_last=True) for field in fields]
+                )
+                .distinct(*fields)
+                .values_list(*fields)
+            )
+            self.assertSequenceEqual(
+                qs,
+                [
+                    ("t1", "t1", "p1"),
+                    (None, None, "p1"),
+                    (None, None, "p2"),
+                    (None, None, "p3"),
+                ],
+            )
+
+    def test_distinct_on_column_selected_by_annotation_first(self):
+        # The annotation selects the column before the lookup path does, and
+        # DISTINCT ON binds to the first selection of the column regardless of
+        # it being selected by an annotation.
+        qs = (
+            Staff.objects.annotate(name_alias=F("name"))
+            .order_by("name")
+            .distinct("name")
+            .values_list("name_alias", "name")
+        )
+        self.assertSequenceEqual(qs, [("p1", "p1"), ("p2", "p2"), ("p3", "p3")])
+
+    def test_distinct_on_annotation_duplicating_selected_column(self):
+        # The annotation duplicates a column selected at an earlier position.
+        # get_distinct() refers to annotations by alias, which binds to the
+        # annotation's own position, so ordering by the alias must not refer
+        # to the earlier position.
+        qs = (
+            Staff.objects.annotate(name_alias=F("name"))
+            .order_by("name_alias")
+            .distinct("name_alias")
+            .values_list("name", "name_alias")
+        )
+        self.assertSequenceEqual(qs, [("p1", "p1"), ("p2", "p2"), ("p3", "p3")])
+
+    def test_distinct_on_duplicated_selected_columns_with_annotation(self):
+        # The annotation is selected between the two selections of the column
+        # it aliases. DISTINCT ON refers to annotations by alias, so it must
+        # not shadow the first selection of the column itself.
+        fields = ["stafftag__tag__name", "tags__name", "name"]
+        qs = (
+            Staff.objects.annotate(tag_name=F("tags__name"))
+            .order_by(*[F(field).asc(nulls_last=True) for field in fields])
+            .distinct(*fields)
+            .values_list("stafftag__tag__name", "tag_name", "tags__name", "name")
+        )
+        self.assertSequenceEqual(
+            qs,
+            [
+                ("t1", "t1", "t1", "p1"),
+                (None, None, None, "p1"),
+                (None, None, None, "p2"),
+                (None, None, None, "p3"),
+            ],
+        )
+
+    def test_distinct_on_duplicated_raw_sql_annotations(self):
+        # Identical raw SQL selections compare equal but are evaluated
+        # independently, so each keeps ordering by its own position.
+        qs = (
+            Staff.objects.annotate(
+                a=RawSQL("random()", [], output_field=FloatField()),
+                b=RawSQL("random()", [], output_field=FloatField()),
+            )
+            .values("a", "b", "id")
+            .distinct("name")
+            .order_by("name", "b")
+        )
+        self.assertEqual(len(qs), 3)
 
     def test_disallowed_update_distinct_on(self):
         qs = Staff.objects.distinct("organisation").order_by("organisation")


### PR DESCRIPTION
#### Trac ticket number

ticket-37222

#### Branch description

Regression in 65ad4ade74dc9208b9d686a451cd6045df0c9c3a. When two lookup paths resolve to the same column, `values()` selects that column at two positions and ordering referred to each selection by its own position. PostgreSQL binds a DISTINCT ON expression to the first position it is selected at, so the later position fell outside the DISTINCT ON set and the query was rejected with "SELECT DISTINCT ON expressions must match initial ORDER BY expressions".

Ordering now refers to the first position an expression is selected at when distinct fields are used. Annotations take part in that (PostgreSQL binds to their position as well when they select an expression first), but an annotation's alias keeps referring to its own position since `get_distinct()` refers to annotations by alias. Raw `extra()` selections keep ordering by their own position, as equal SQL is not necessarily interchangeable (e.g. volatile selections).

Tests cover the original many-to-many/through reproducer from the ticket as well as the local `tracer_id` / remote `tracer__id` foreign key variant from the triage comment. Verified against PostgreSQL 16.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude Code was used to reduce the reproducer, bisect, and draft the patch; I reviewed the changes and verified the reproducer, the patch, and the test results against PostgreSQL 16.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.

