### PR TITLE
Refs #28586 -- Added coverage for from_queryset's fetch mode in refresh_from_db().

### DIFF
--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -1099,3 +1099,24 @@ class ModelRefreshTests(TestCase):
         with self.assertNumQueries(1):
             a.refresh_from_db(fields=["headline"], from_queryset=from_queryset)
             self.assertEqual(a.headline, headline)
+
+    def test_refresh_copies_fetch_mode_from_plucked_instance(self):
+        a = Article.objects.create(pub_date=datetime.now())
+        fa = FeaturedArticle.objects.fetch_mode(models.FETCH_PEERS).create(article=a)
+
+        from_queryset = FeaturedArticle.objects.fetch_mode(models.RAISE).select_related(
+            "article"
+        )
+        fa.refresh_from_db(from_queryset=from_queryset)
+        self.assertEqual(fa._state.fetch_mode, models.FETCH_PEERS)
+        self.assertEqual(fa.article._state.fetch_mode, models.RAISE)
+
+    def test_refresh_ignores_fetch_mode_if_no_instance_plucked(self):
+        a = Article.objects.create(pub_date=datetime.now())
+        fa = FeaturedArticle.objects.fetch_mode(models.FETCH_PEERS).create(article=a)
+
+        # This queryset's fetch mode is not used because no fields are plucked.
+        from_queryset = FeaturedArticle.objects.fetch_mode(models.RAISE)
+        fa.refresh_from_db(from_queryset=from_queryset)
+        self.assertEqual(fa._state.fetch_mode, models.FETCH_PEERS)
+        self.assertEqual(fa.article._state.fetch_mode, models.FETCH_PEERS)


### PR DESCRIPTION
#### Trac ticket number
ticket-28586

#### Branch description
In review, we wondered what effect the fetch mode of the `from_queryset` parameter to `refresh_from_db()` should have.

@charettes [answered](https://github.com/django/django/pull/17554#issuecomment-3285450280):

> 1. The model instance `refresh_from_db` is called on preserves it's existing `fetch_mode` affinity. That is if a model was fetched with `FETCH_PEERS` and `from_queryset` fetch mode is different the instance remains `FETCH_PEERS`.
> 2. The model instances (instance**s** as there can be select related of prefetched objects) created from using `from_queryset` to pluck `fields` attribute from use `from_queryset` fetch mode.
> 
> In summary I think the way work by default is sensible and allow `from_queryset.fetch_mode` to be used efficiently to catch potential overfetching?

~I assumed both points were implemented together, but only point 1 is implemented. Point 2 is not implemented, as shown in this test.~

~We should have some test demonstrating what we want here. Just checking that this is what we want?~

EDIT: whoops, that first draft didn't demonstrate what I meant to demonstrate because it used a reverse relation instead of a foreign key, and reverse relations are ignored by `refresh_from_db()`.

/cc @adamchainz

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.