### PR TITLE
Refs #36694 -- Skipped GIS test needing spatial index on Oracle.

### DIFF
--- a/tests/gis_tests/geoapp/test_indexes.py
+++ b/tests/gis_tests/geoapp/test_indexes.py
@@ -96,6 +96,8 @@ class SchemaIndexesTests(TransactionTestCase):
 
     @skipUnlessDBFeature("supports_tablespaces")
     def test_tablespace(self):
+        if not self.has_spatial_indexes(City._meta.db_table):
+            self.skipTest("Spatial indexes in Meta.indexes are not supported.")
         index_name = "city_point_partial_tblspce_idx"
         index = Index(
             name=index_name,


### PR DESCRIPTION
See Oracle [failure](https://djangoci.com/job/pull-requests-oracle/database=oragis19,label=oracle,python=python3.14/1074/testReport/junit/gis_tests.geoapp.test_indexes/SchemaIndexesTests/test_tablespace/):
```py
Traceback (most recent call last):
  File "/home/jenkins/workspace/pull-requests-oracle/database/oragis19/label/oracle/python/python3.14/tests/gis_tests/geoapp/test_indexes.py", line 106, in test_tablespace
    editor.add_index(City, index)
```

Surrounding tests gate on `self.has_spatial_indexes`.