### PR TITLE
Refs #36735 -- Added DatabaseFeatures.supports_uuid4_function_in_default feature flag.

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -450,6 +450,7 @@ class BaseDatabaseFeatures:
     ]
 
     supports_uuid4_function = False
+    supports_uuid4_function_in_default = False
     supports_uuid7_function = False
     supports_uuid7_function_shift = False
 

--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -237,6 +237,10 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             return self.connection.mysql_version >= (11, 7)
         return False
 
+    supports_uuid4_function_in_default = property(
+        operator.attrgetter("supports_uuid4_function")
+    )
+
     @cached_property
     def supports_uuid7_function(self):
         if self.connection.mysql_is_mariadb:

--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -236,6 +236,10 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         return self.connection.oracle_version >= (23, 9)
 
     @cached_property
+    def supports_uuid4_function_in_default(self):
+        return self.connection.oracle_version >= (23, 26, 2)
+
+    @cached_property
     def supports_stored_generated_columns(self):
         return self.connection.oracle_version >= (23, 7)
 

--- a/django/db/backends/postgresql/features.py
+++ b/django/db/backends/postgresql/features.py
@@ -190,3 +190,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_virtual_generated_columns = property(
         operator.attrgetter("is_postgresql_18")
     )
+    supports_uuid4_function_in_default = property(
+        operator.attrgetter("supports_uuid4_function")
+    )

--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -172,3 +172,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
 
     can_introspect_json_field = property(operator.attrgetter("supports_json_field"))
     has_json_object_function = property(operator.attrgetter("supports_json_field"))
+    supports_uuid4_function_in_default = property(
+        operator.attrgetter("supports_uuid4_function")
+    )

--- a/tests/inline_formsets/models.py
+++ b/tests/inline_formsets/models.py
@@ -27,7 +27,7 @@ class ParentUUIDPk(models.Model):
 
     class Meta:
         required_db_features = {
-            "supports_uuid4_function",
+            "supports_uuid4_function_in_default",
             "supports_expression_defaults",
         }
 
@@ -38,7 +38,7 @@ class ChildUUIDPk(models.Model):
 
     class Meta:
         required_db_features = {
-            "supports_uuid4_function",
+            "supports_uuid4_function_in_default",
             "supports_expression_defaults",
         }
 

--- a/tests/inline_formsets/tests.py
+++ b/tests/inline_formsets/tests.py
@@ -113,7 +113,9 @@ class DeletionTests(TestCase):
             obj.save()
         self.assertEqual(school.child_set.count(), 1)
 
-    @skipUnlessDBFeature("supports_uuid4_function", "supports_expression_defaults")
+    @skipUnlessDBFeature(
+        "supports_uuid4_function_in_default", "supports_expression_defaults"
+    )
     def test_add_form_uuid_pk(self):
         ChildFormSet = inlineformset_factory(ParentUUIDPk, ChildUUIDPk, fields=["name"])
         data = {


### PR DESCRIPTION
ticket-36735

The `ParentUUIDPk` test from a2348c8 was failing test runs on 23.9.

Oracle 23.9 supported UUID() in SELECT contexts, but any use in column defaults fails until 23.26.2.0 with:

```py
django.db.utils.DatabaseError: ORA-04044: procedure, function, package, or type is not allowed here
```

Earlier, we [manually tested](https://github.com/django/django/pull/20101#issuecomment-3592566179) SELECT contexts.

