### PR TITLE
Refs #37055 -- Raised NotImplementedError for unsupported GDAL raster float16 pixel type.

### DIFF
--- a/django/contrib/gis/gdal/raster/band.py
+++ b/django/contrib/gis/gdal/raster/band.py
@@ -204,7 +204,12 @@ class GDALBand(GDALRasterBase):
             raise ValueError("Size is larger than raster.")
 
         # Create ctypes type array generator
-        ctypes_array = GDAL_TO_CTYPES[self.datatype()] * (shape[0] * shape[1])
+        datatype = self.datatype()
+        if datatype == 15:
+            raise NotImplementedError(
+                "16 bit floating point (GDT_Float16) is not yet supported."
+            )
+        ctypes_array = GDAL_TO_CTYPES[datatype] * (shape[0] * shape[1])
 
         if data is None:
             # Set read mode

--- a/django/contrib/gis/gdal/raster/const.py
+++ b/django/contrib/gis/gdal/raster/const.py
@@ -32,6 +32,8 @@ GDAL_PIXEL_TYPES = {
     12: "GDT_UInt64",  # 64 bit unsigned integer (GDAL 3.5+).
     13: "GDT_Int64",  # 64 bit signed integer (GDAL 3.5+).
     14: "GDT_Int8",  # 8 bit signed integer (GDAL 3.7+).
+    15: "GDT_Float16",  # 16 bit floating point (GDAL 3.11+).
+    16: "GDT_CFloat16",  # Complex Float16 (GDAL 3.11+).
 }
 
 # A list of gdal datatypes that are integers.
@@ -57,6 +59,8 @@ GDAL_TO_CTYPES = [
     c_uint64,
     c_int64,
     c_int8,
+    None,  # _Float16 ticket https://github.com/python/cpython/issues/153740
+    None,
 ]
 
 # List of resampling algorithms that can be used to warp a GDALRaster.

--- a/tests/gis_tests/gdal_tests/test_raster.py
+++ b/tests/gis_tests/gdal_tests/test_raster.py
@@ -1006,3 +1006,26 @@ class GDALBandTests(SimpleTestCase):
                 )
             else:
                 self.assertEqual(band.data(), list(combo[2]))
+
+    def test_16bit_float(self):
+        rstfile = NamedTemporaryFile(suffix=".tif")
+        self.addCleanup(rstfile.close)
+        rst = GDALRaster(
+            {
+                "driver": "GTiff",
+                "name": rstfile.name,
+                "srid": 4326,
+                "width": 255,
+                "height": 255,
+                "nr_of_bands": 1,
+                "papsz_options": dict(NBITS=16),
+            }
+        )
+        if GDAL_VERSION < (3, 11):
+            self.assertEqual(rst.bands[0].datatype(as_string=True), "GDT_Float32")
+        else:
+            with self.assertRaisesMessage(
+                NotImplementedError,
+                "16 bit floating point (GDT_Float16) is not yet supported.",
+            ):
+                rst.bands[0].data()


### PR DESCRIPTION

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37055

#### Branch description
<!-- Provide a concise overview of the issue or rationale behind the proposed changes. 5 word minimum. -->
Python does not currently have a ctype for float16. This is being tracked in https://github.com/python/cpython/issues/153740. Updated GDAL_PIXEL_TYPES to allow a more specific error message to be raised until an appropriate datatype is available in the ctypes module.



#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [X] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
<!-- If AI tools were used, provide which tools were used here. -->

#### Checklist
- [X] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [X] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [X] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.


