### PR TITLE
Fixed #15130 -- Made Model.validate_unique() respect multi-database routing

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -23,7 +23,6 @@ from django.core.exceptions import (
 from django.db import (
     DJANGO_VERSION_PICKLE_KEY,
     DatabaseError,
-    connection,
     connections,
     router,
     transaction,
@@ -1455,15 +1454,17 @@ class Model(AltersData, metaclass=ModelBase):
         """
         pass
 
-    def validate_unique(self, exclude=None):
+    def validate_unique(self, exclude=None, using=None):
         """
         Check unique constraints on the model and raise ValidationError if any
         failed.
         """
+        if using is None:
+            using = router.db_for_write(self.__class__, instance=self)
         unique_checks, date_checks = self._get_unique_checks(exclude=exclude)
 
-        errors = self._perform_unique_checks(unique_checks)
-        date_errors = self._perform_date_checks(date_checks)
+        errors = self._perform_unique_checks(unique_checks, using=using)
+        date_errors = self._perform_date_checks(date_checks, using=using)
 
         for k, v in date_errors.items():
             errors.setdefault(k, []).extend(v)
@@ -1539,7 +1540,9 @@ class Model(AltersData, metaclass=ModelBase):
                     date_checks.append((model_class, "month", name, f.unique_for_month))
         return unique_checks, date_checks
 
-    def _perform_unique_checks(self, unique_checks):
+    def _perform_unique_checks(self, unique_checks, using=None):
+        if using is None:
+            using = router.db_for_write(self.__class__, instance=self)
         errors = {}
 
         for model_class, unique_check in unique_checks:
@@ -1550,10 +1553,9 @@ class Model(AltersData, metaclass=ModelBase):
             for field_name in unique_check:
                 f = self._meta.get_field(field_name)
                 lookup_value = getattr(self, f.attname)
-                # TODO: Handle multiple backends with different feature flags.
                 if lookup_value is None or (
                     lookup_value == ""
-                    and connection.features.interprets_empty_strings_as_nulls
+                    and connections[using].features.interprets_empty_strings_as_nulls
                 ):
                     # no value, skip the lookup
                     continue
@@ -1566,7 +1568,7 @@ class Model(AltersData, metaclass=ModelBase):
             if len(unique_check) != len(lookup_kwargs):
                 continue
 
-            qs = model_class._default_manager.filter(**lookup_kwargs)
+            qs = model_class._default_manager.using(using).filter(**lookup_kwargs)
 
             # Exclude the current object from the query if we are editing an
             # instance (as opposed to creating a new one)
@@ -1588,7 +1590,9 @@ class Model(AltersData, metaclass=ModelBase):
 
         return errors
 
-    def _perform_date_checks(self, date_checks):
+    def _perform_date_checks(self, date_checks, using=None):
+        if using is None:
+            using = router.db_for_write(self.__class__, instance=self)
         errors = {}
         for model_class, lookup_type, field, unique_for in date_checks:
             lookup_kwargs = {}
@@ -1607,7 +1611,7 @@ class Model(AltersData, metaclass=ModelBase):
                 )
             lookup_kwargs[field] = getattr(self, field)
 
-            qs = model_class._default_manager.filter(**lookup_kwargs)
+            qs = model_class._default_manager.using(using).filter(**lookup_kwargs)
             # Exclude the current object from the query if we are editing an
             # instance (as opposed to creating a new one)
             if not self._state.adding and self._is_pk_set():
@@ -1695,7 +1699,9 @@ class Model(AltersData, metaclass=ModelBase):
         if errors:
             raise ValidationError(errors)
 
-    def full_clean(self, exclude=None, validate_unique=True, validate_constraints=True):
+    def full_clean(
+        self, exclude=None, validate_unique=True, validate_constraints=True, using=None
+    ):
         """
         Call clean_fields(), clean(), validate_unique(), and
         validate_constraints() on the model. Raise a ValidationError for any
@@ -1725,7 +1731,7 @@ class Model(AltersData, metaclass=ModelBase):
                 if name != NON_FIELD_ERRORS and name not in exclude:
                     exclude.add(name)
             try:
-                self.validate_unique(exclude=exclude)
+                self.validate_unique(exclude=exclude, using=using)
             except ValidationError as e:
                 errors = e.update_error_dict(errors)
 

--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -519,7 +519,9 @@ class BaseModelForm(BaseForm, AltersData):
         """
         exclude = self._get_validation_exclusions()
         try:
-            self.instance.validate_unique(exclude=exclude)
+            self.instance.validate_unique(
+                exclude=exclude, using=self.instance._state.db
+            )
         except ValidationError as e:
             self._update_errors(e)
 

--- a/docs/ref/models/instances.txt
+++ b/docs/ref/models/instances.txt
@@ -255,7 +255,7 @@ need to call a model's :meth:`~Model.full_clean` method if you plan to handle
 validation errors yourself, or if you have excluded fields from the
 :class:`~django.forms.ModelForm` that require validation.
 
-.. method:: Model.full_clean(exclude=None, validate_unique=True, validate_constraints=True)
+.. method:: Model.full_clean(exclude=None, validate_unique=True, validate_constraints=True, using=None)
 
 This method calls :meth:`Model.clean_fields`, :meth:`Model.clean`,
 :meth:`Model.validate_unique` (if ``validate_unique`` is ``True``),  and
@@ -268,6 +268,10 @@ names that can be excluded from validation and cleaning.
 :class:`~django.forms.ModelForm` uses this argument to exclude fields that
 aren't present on your form from being validated since any errors raised could
 not be corrected by the user.
+
+The optional ``using`` argument specifies the database alias used to check
+uniqueness during :meth:`Model.validate_unique`. If not provided, it defaults
+to the database that :meth:`Model.save` would use.
 
 Note that ``full_clean()`` will *not* be called automatically when you call
 your model's :meth:`~Model.save` method. You'll need to call it manually
@@ -394,7 +398,7 @@ Then, ``full_clean()`` will check unique constraints on your model.
                             }
                         )
 
-.. method:: Model.validate_unique(exclude=None)
+.. method:: Model.validate_unique(exclude=None, using=None)
 
 This method is similar to :meth:`~Model.clean_fields`, but validates
 uniqueness constraints defined via :attr:`.Field.unique`,
@@ -404,6 +408,12 @@ uniqueness constraints defined via :attr:`.Field.unique`,
 field values. The optional ``exclude`` argument allows you to provide a ``set``
 of field names to exclude from validation. It will raise a
 :exc:`~django.core.exceptions.ValidationError` if any fields fail validation.
+
+The optional ``using`` argument specifies the database alias to query when
+checking for existing records with conflicting values. If not provided, it
+defaults to the database that would be chosen by the :ref:`database router
+<topics-db-multi-db-routing>` for a write of this instance (the same database
+:meth:`Model.save` would use).
 
 :class:`~django.db.models.UniqueConstraint`\s defined in the
 :attr:`Meta.constraints <django.db.models.Options.constraints>` are validated

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -195,7 +195,10 @@ Migrations
 Models
 ~~~~~~
 
-* ...
+* :meth:`.Model.validate_unique` and :meth:`.Model.full_clean` now accept a
+  ``using`` argument, and default to the database that would be used by
+  :meth:`.Model.save`, rather than always checking uniqueness against the
+  default database (:ticket:`15130`).
 
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/multiple_database/tests.py
+++ b/tests/multiple_database/tests.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.core import management
+from django.core.exceptions import ValidationError
 from django.db import DEFAULT_DB_ALIAS, router, transaction
 from django.db.models import signals
 from django.db.utils import ConnectionRouter
@@ -798,6 +799,22 @@ class QueryTestCase(TestCase):
         mickey = Person.objects.create(name="Mickey")
         owner_field = Pet._meta.get_field("owner")
         self.assertEqual(owner_field.clean(mickey.pk, None), mickey.pk)
+
+    def test_validate_unique_uses_correct_database(self):
+        "Model.validate_unique() checks uniqueness against the right database"
+        Person.objects.using("default").create(name="Anne")
+
+        # A person with the same name doesn't conflict when validated against
+        # "other", where no such person exists (the bug: this used to always
+        # raise, because the check always hit "default").
+        Person(name="Anne").full_clean(using="other")
+
+        # The same, unsaved instance still correctly raises when explicitly
+        # validated against the database that does have the duplicate.
+        with self.assertRaises(ValidationError):
+            Person(name="Anne").full_clean(using="default")
+        with self.assertRaises(ValidationError):
+            Person(name="Anne").validate_unique(using="default")
 
     def test_o2o_separation(self):
         "OneToOne fields are constrained to a single database"


### PR DESCRIPTION
Trac ticket: https://code.djangoproject.com/ticket/15130

## Problem

`Model.validate_unique()` and its helpers (`_perform_unique_checks()`, `_perform_date_checks()`) always queried the default database via `_default_manager.filter(...)`, regardless of which database the instance actually belongs to or is being saved to. On multi-database setups this produces incorrect uniqueness validation results, e.g. `ModelAdmin` passing `using=` for a non-default alias, or application code validating against a non-default database.

A prior attempt at this ticket (#15975) was closed because it used `self._state.db` directly, which bypasses read-replica routing, as noted in review by a core developer.

## Fix

`validate_unique()`, `full_clean()`, `_perform_unique_checks()`, and `_perform_date_checks()` now accept a `using` argument. When not given explicitly, it defaults to `router.db_for_write(self.__class__, instance=self)`, mirroring what `save()` already does rather than hard-coding an instance attribute. The empty-string/null feature check in `_perform_unique_checks()` now also reads from the target database's connection (`connections[using]`) instead of the global default connection.

`BaseModelForm._post_clean()` passes the form instance's own database (`instance._state.db`) through to `validate_unique()`, so `ModelForm` validation checks uniqueness against the database the instance is actually bound to.

## Tests

Added `QueryTestCase.test_validate_unique_uses_correct_database` in `tests/multiple_database/tests.py`, confirming validation against a different alias no longer raises a false-positive `ValidationError`, while a real duplicate on the correct alias still correctly raises.

Ran:
- `tests/runtests.py multiple_database` — OK
- `tests/runtests.py model_forms validation forms_tests model_formsets multiple_database` — OK, no regressions

Also updated the release notes and the `full_clean`/`validate_unique` signature docs for the new parameter.