### PR TITLE
Fixed #33689 -- Standardized CSS custom property naming conventions in admin.

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -12,24 +12,31 @@ html[data-theme="light"],
 
     --body-fg: #333;
     --body-bg: #fff;
-    --body-quiet-color: #666;
-    --body-medium-color: #444;
-    --body-loud-color: #000;
+    --body-quiet-fg: #666;
+    --body-quiet-color: var(--body-quiet-fg);
+    --body-medium-fg: #444;
+    --body-medium-color: var(--body-medium-fg);
+    --body-loud-fg: #000;
+    --body-loud-color: var(--body-loud-fg);
 
-    --header-color: #ffc;
+    --header-fg: #ffc;
+    --header-color: var(--header-fg);
     --header-branding-color: var(--accent);
     --header-bg: var(--secondary);
-    --header-link-color: var(--primary-fg);
+    --header-link-fg: var(--primary-fg);
+    --header-link-color: var(--header-link-fg);
 
     --breadcrumbs-fg: #c4dce8;
     --breadcrumbs-link-fg: var(--body-bg);
     --breadcrumbs-bg: #264b5d;
 
     --link-fg: #417893;
-    --link-hover-color: #036;
+    --link-hover-fg: #036;
+    --link-hover-color: var(--link-hover-fg);
     --link-selected-fg: var(--secondary);
 
-    --hairline-color: #e8e8e8;
+    --hairline-border: #e8e8e8;
+    --hairline-color: var(--hairline-border);
     --border-color: #ccc;
 
     --error-fg: #ba2121;
@@ -47,7 +54,8 @@ html[data-theme="light"],
 
     --darkened-bg: #f8f8f8; /* A bit darker than --body-bg */
     --selected-bg: #e4e4e4; /* E.g. selected table cells */
-    --selected-row: #ffc;
+    --selected-row-bg: #ffc;
+    --selected-row: var(--selected-row-bg);
 
     --button-fg: #fff;
     --button-bg: var(--secondary);
@@ -139,7 +147,7 @@ a img {
 
 a.section:link,
 a.section:visited {
-    color: var(--header-link-color);
+    color: var(--header-link-fg);
     text-decoration: none;
 }
 
@@ -189,7 +197,7 @@ h2.subhead {
 h3 {
     font-size: 0.875rem;
     margin: 0.8em 0 0.3em 0;
-    color: var(--body-medium-color);
+    color: var(--body-medium-fg);
     font-weight: bold;
 }
 
@@ -197,13 +205,13 @@ h4 {
     font-size: 0.75rem;
     margin: 1em 0 0.8em 0;
     padding-bottom: 3px;
-    color: var(--body-medium-color);
+    color: var(--body-medium-fg);
 }
 
 h5 {
     font-size: 0.625rem;
     margin: 1.5em 0 0.5em 0;
-    color: var(--body-quiet-color);
+    color: var(--body-quiet-fg);
     text-transform: uppercase;
     letter-spacing: 1px;
 }
@@ -252,7 +260,7 @@ details summary {
 
 blockquote {
     font-size: 0.6875rem;
-    color: var(--body-quiet-color);
+    color: var(--body-quiet-fg);
     margin-left: 2px;
     padding-left: 10px;
     border-left: 5px solid currentColor;
@@ -261,7 +269,7 @@ blockquote {
 code,
 pre {
     font-family: var(--font-family-monospace);
-    color: var(--body-quiet-color);
+    color: var(--body-quiet-fg);
     font-size: 0.75rem;
     overflow-x: auto;
 }
@@ -304,7 +312,7 @@ div.help,
 form div.help,
 div.help li {
     font-size: 0.6875rem;
-    color: var(--body-quiet-color);
+    color: var(--body-quiet-fg);
 }
 
 div.help ul {
@@ -327,7 +335,7 @@ td img {
 .quiet,
 a.quiet:link,
 a.quiet:visited {
-    color: var(--body-quiet-color);
+    color: var(--body-quiet-fg);
     font-weight: normal;
 }
 
@@ -366,7 +374,7 @@ th {
 
 thead th,
 tfoot td {
-    color: var(--body-quiet-color);
+    color: var(--body-quiet-fg);
     padding: 5px 10px;
     font-size: 0.6875rem;
     background: var(--body-bg);
@@ -411,7 +419,7 @@ thead th {
 
 thead th a:link,
 thead th a:visited {
-    color: var(--body-quiet-color);
+    color: var(--body-quiet-fg);
 }
 
 thead th.sorted {
@@ -482,7 +490,7 @@ table thead th.sorted .sortoptions a.sortremove:after {
     left: 3px;
     font-weight: 200;
     font-size: 1.125rem;
-    color: var(--body-quiet-color);
+    color: var(--body-quiet-fg);
 }
 
 table thead th.sorted .sortoptions a.sortremove:focus:after,
@@ -569,7 +577,7 @@ input[type="tel"]:focus,
 textarea:focus,
 select:focus,
 .vTextField:focus {
-    border-color: var(--body-quiet-color);
+    border-color: var(--body-quiet-fg);
 }
 
 select {
@@ -683,7 +691,7 @@ input[type="button"][disabled].default {
     font-size: 0.8125rem;
     text-align: left;
     background: var(--header-bg);
-    color: var(--header-link-color);
+    color: var(--header-link-fg);
 }
 
 .module caption,
@@ -962,7 +970,7 @@ a.deletelink:hover {
 }
 
 #change-history .paginator {
-    color: var(--body-quiet-color);
+    color: var(--body-quiet-fg);
     border-bottom: 1px solid var(--hairline-color);
     background: var(--body-bg);
     overflow: hidden;
@@ -1064,13 +1072,13 @@ a.deletelink:hover {
     align-items: center;
     padding: 10px 40px;
     background: var(--header-bg);
-    color: var(--header-color);
+    color: var(--header-fg);
 }
 
 #header a:link,
 #header a:visited,
 #logout-form button {
-    color: var(--header-link-color);
+    color: var(--header-link-fg);
 }
 
 #header a:focus,
@@ -1107,7 +1115,7 @@ a.deletelink:hover {
     font-size: 0.875rem;
     margin: -8px 0 8px 0;
     font-weight: normal;
-    color: var(--header-color);
+    color: var(--header-fg);
 }
 
 #branding a:hover {
@@ -1169,7 +1177,7 @@ a.deletelink:hover {
 }
 
 #content-related h3 {
-    color: var(--body-quiet-color);
+    color: var(--body-quiet-fg);
     padding: 0 16px;
     margin: 0 0 16px;
 }
@@ -1285,7 +1293,7 @@ a.deletelink:hover {
 }
 
 .paginator a[aria-current="page"] {
-    color: var(--body-quiet-color);
+    color: var(--body-quiet-fg);
     background: transparent;
     font-weight: bold;
     cursor: default;
@@ -1326,7 +1334,7 @@ a.deletelink:hover {
     border-top: none;
     border-bottom: none;
     line-height: 1.5rem;
-    color: var(--body-quiet-color);
+    color: var(--body-quiet-fg);
     width: 100%;
     box-sizing: border-box;
 }
@@ -1356,7 +1364,7 @@ a.deletelink:hover {
 }
 
 .actions select:focus {
-    border-color: var(--body-quiet-color);
+    border-color: var(--body-quiet-fg);
 }
 
 .actions label {
@@ -1381,5 +1389,5 @@ a.deletelink:hover {
 
 .actions .button:focus,
 .actions .button:hover {
-    border-color: var(--body-quiet-color);
+    border-color: var(--body-quiet-fg);
 }

--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -5,77 +5,79 @@
 /* VARIABLE DEFINITIONS */
 html[data-theme="light"],
 :root {
-    --primary: #79aec8;
-    --secondary: #417690;
-    --accent: #f5dd5d;
-    --primary-fg: #fff;
+    /* ----------------------------------------------------- */
+    /* 1. PRIMARY PREFIXED VARIABLES                         */
+    /* ----------------------------------------------------- */
+    --django-primary: #79aec8;
+    --django-secondary: #417690;
+    --django-accent: #f5dd5d;
+    --django-primary-fg: #fff;
 
-    --body-fg: #333;
-    --body-bg: #fff;
-    --body-quiet-fg: #666;
-    --body-quiet-color: var(--body-quiet-fg);
-    --body-medium-fg: #444;
-    --body-medium-color: var(--body-medium-fg);
-    --body-loud-fg: #000;
-    --body-loud-color: var(--body-loud-fg);
+    --django-body-fg: #333;
+    --django-body-bg: #fff;
+    --django-body-quiet-fg: #666;
+    --django-body-quiet-color: var(--django-body-quiet-fg);
+    --django-body-medium-fg: #444;
+    --django-body-medium-color: var(--django-body-medium-fg);
+    --django-body-loud-fg: #000;
+    --django-body-loud-color: var(--django-body-loud-fg);
 
-    --header-fg: #ffc;
-    --header-color: var(--header-fg);
-    --header-branding-color: var(--accent);
-    --header-bg: var(--secondary);
-    --header-link-fg: var(--primary-fg);
-    --header-link-color: var(--header-link-fg);
+    --django-header-fg: #ffc;
+    --django-header-color: var(--django-header-fg);
+    --django-header-branding-color: var(--django-accent);
+    --django-header-bg: var(--django-secondary);
+    --django-header-link-fg: var(--django-primary-fg);
+    --django-header-link-color: var(--django-header-link-fg);
 
-    --breadcrumbs-fg: #c4dce8;
-    --breadcrumbs-link-fg: var(--body-bg);
-    --breadcrumbs-bg: #264b5d;
+    --django-breadcrumbs-fg: #c4dce8;
+    --django-breadcrumbs-link-fg: var(--django-body-bg);
+    --django-breadcrumbs-bg: #264b5d;
 
-    --link-fg: #417893;
-    --link-hover-fg: #036;
-    --link-hover-color: var(--link-hover-fg);
-    --link-selected-fg: var(--secondary);
+    --django-link-fg: #417893;
+    --django-link-hover-fg: #036;
+    --django-link-hover-color: var(--django-link-hover-fg);
+    --django-link-selected-fg: var(--django-secondary);
 
-    --hairline-border: #e8e8e8;
-    --hairline-color: var(--hairline-border);
-    --border-color: #ccc;
+    --django-hairline-border: #e8e8e8;
 
-    --error-fg: #ba2121;
+    --django-border-color: #ccc;
+    --django-error-fg: #ba2121;
 
-    --message-debug-bg: #efefef;
-    --message-debug-icon: url(../img/icon-debug.svg);
-    --message-info-bg: #ccefff;
-    --message-info-icon: url(../img/icon-info.svg);
-    --message-success-bg: #dfd;
-    --message-success-icon: url(../img/icon-yes.svg);
-    --message-warning-bg: #ffc;
-    --message-warning-icon: url(../img/icon-alert.svg);
-    --message-error-bg: #ffefef;
-    --message-error-icon: url(../img/icon-no.svg);
+    --django-message-debug-bg: #efefef;
+    --django-message-debug-icon: url(../img/icon-debug.svg);
+    --django-message-info-bg: #ccefff;
+    --django-message-info-icon: url(../img/icon-info.svg);
+    --django-message-success-bg: #dfd;
+    --django-message-success-icon: url(../img/icon-yes.svg);
+    --django-message-warning-bg: #ffc;
+    --django-message-warning-icon: url(../img/icon-alert.svg);
+    --django-message-error-bg: #ffefef;
+    --django-message-error-icon: url(../img/icon-no.svg);
 
-    --darkened-bg: #f8f8f8; /* A bit darker than --body-bg */
-    --selected-bg: #e4e4e4; /* E.g. selected table cells */
-    --selected-row-bg: #ffc;
-    --selected-row: var(--selected-row-bg);
+    --django-darkened-bg: #f8f8f8;
+    --django-selected-bg: #e4e4e4;
+    --django-selected-row-bg: #ffc;
+    --django-selected-row: var(--django-selected-row-bg);
 
-    --button-fg: #fff;
-    --button-bg: var(--secondary);
-    --button-hover-bg: #205067;
-    --default-button-bg: #205067;
-    --default-button-hover-bg: var(--secondary);
-    --close-button-bg: #747474;
-    --close-button-hover-bg: #333;
-    --delete-button-bg: #ba2121;
-    --delete-button-hover-bg: #a41515;
+    --django-button-fg: #fff;
+    --django-button-bg: var(--django-secondary);
+    --django-button-hover-bg: #205067;
+    --django-default-button-bg: #205067;
+    --django-default-button-hover-bg: var(--django-secondary);
+    --django-close-button-bg: #747474;
+    --django-close-button-hover-bg: #333;
+    --django-delete-button-bg: #ba2121;
+    --django-delete-button-hover-bg: #a41515;
 
-    --object-tools-fg: var(--button-fg);
-    --object-tools-bg: var(--close-button-bg);
-    --object-tools-hover-bg: var(--close-button-hover-bg);
+    --django-object-tools-fg: var(--django-button-fg);
+    --django-object-tools-bg: var(--django-close-button-bg);
+    --django-object-tools-hover-bg: var(--django-close-button-hover-bg);
 
-    --font-family-primary:
+    --django-font-family-primary:
         "Segoe UI", system-ui, Roboto, "Helvetica Neue", Arial, sans-serif,
         "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
         "Noto Color Emoji";
-    --font-family-monospace:
+    --django-font-family-monospace:
         ui-monospace,
         Menlo,
         Monaco,
@@ -93,6 +95,78 @@ html[data-theme="light"],
         "Segoe UI Emoji",
         "Segoe UI Symbol",
         "Noto Color Emoji";
+
+    /* ----------------------------------------------------- */
+    /* 2. LEGACY BACKWARD-COMPATIBILITY ALIASES              */
+    /* ----------------------------------------------------- */
+    --primary: var(--django-primary);
+    --secondary: var(--django-secondary);
+    --accent: var(--django-accent);
+    --primary-fg: var(--django-primary-fg);
+
+    --body-fg: var(--django-body-fg);
+    --body-bg: var(--django-body-bg);
+    --body-quiet-fg: var(--django-body-quiet-fg);
+    --body-quiet-color: var(--django-body-quiet-color);
+    --body-medium-fg: var(--django-body-medium-fg);
+    --body-medium-color: var(--django-body-medium-color);
+    --body-loud-fg: var(--django-body-loud-fg);
+    --body-loud-color: var(--django-body-loud-color);
+
+    --header-fg: var(--django-header-fg);
+    --header-color: var(--django-header-color);
+    --header-branding-color: var(--django-header-branding-color);
+    --header-bg: var(--django-header-bg);
+    --header-link-fg: var(--django-header-link-fg);
+    --header-link-color: var(--django-header-link-color);
+
+    --breadcrumbs-fg: var(--django-breadcrumbs-fg);
+    --breadcrumbs-link-fg: var(--django-breadcrumbs-link-fg);
+    --breadcrumbs-bg: var(--django-breadcrumbs-bg);
+
+    --link-fg: var(--django-link-fg);
+    --link-hover-fg: var(--django-link-hover-fg);
+    --link-hover-color: var(--django-link-hover-color);
+    --link-selected-fg: var(--django-link-selected-fg);
+
+    --hairline-border: var(--django-hairline-border);
+    --hairline-color: var(--django-hairline-border);
+
+    --border-color: var(--django-border-color);
+    --error-fg: var(--django-error-fg);
+
+    --message-debug-bg: var(--django-message-debug-bg);
+    --message-debug-icon: var(--django-message-debug-icon);
+    --message-info-bg: var(--django-message-info-bg);
+    --message-info-icon: var(--django-message-info-icon);
+    --message-success-bg: var(--django-message-success-bg);
+    --message-success-icon: var(--django-message-success-icon);
+    --message-warning-bg: var(--django-message-warning-bg);
+    --message-warning-icon: var(--django-message-warning-icon);
+    --message-error-bg: var(--django-message-error-bg);
+    --message-error-icon: var(--django-message-error-icon);
+
+    --darkened-bg: var(--django-darkened-bg);
+    --selected-bg: var(--django-selected-bg);
+    --selected-row-bg: var(--django-selected-row-bg);
+    --selected-row: var(--django-selected-row);
+
+    --button-fg: var(--django-button-fg);
+    --button-bg: var(--django-button-bg);
+    --button-hover-bg: var(--django-button-hover-bg);
+    --default-button-bg: var(--django-default-button-bg);
+    --default-button-hover-bg: var(--django-default-button-hover-bg);
+    --close-button-bg: var(--django-close-button-bg);
+    --close-button-hover-bg: var(--django-close-button-hover-bg);
+    --delete-button-bg: var(--django-delete-button-bg);
+    --delete-button-hover-bg: var(--django-delete-button-hover-bg);
+
+    --object-tools-fg: var(--django-object-tools-fg);
+    --object-tools-bg: var(--django-object-tools-bg);
+    --object-tools-hover-bg: var(--django-object-tools-hover-bg);
+
+    --font-family-primary: var(--django-font-family-primary);
+    --font-family-monospace: var(--django-font-family-monospace);
 
     color-scheme: light;
 }

--- a/django/contrib/admin/static/admin/css/dark_mode.css
+++ b/django/contrib/admin/static/admin/css/dark_mode.css
@@ -49,18 +49,23 @@ html[data-theme="dark"] {
 
     --body-fg: #eeeeee;
     --body-bg: #121212;
-    --body-quiet-color: #d0d0d0;
-    --body-medium-color: #e0e0e0;
-    --body-loud-color: #ffffff;
+    --body-quiet-fg: #d0d0d0;
+    --body-quiet-color: var(--body-quiet-fg);
+    --body-medium-fg: #e0e0e0;
+    --body-medium-color: var(--body-medium-fg);
+    --body-loud-fg: #ffffff;
+    --body-loud-color: var(--body-loud-fg);
 
     --breadcrumbs-link-fg: #e0e0e0;
     --breadcrumbs-bg: var(--primary);
 
     --link-fg: #81d4fa;
-    --link-hover-color: #4ac1f7;
+    --link-hover-fg: #4ac1f7;
+    --link-hover-color: var(--link-hover-fg);
     --link-selected-fg: #6f94c6;
 
-    --hairline-color: #272727;
+    --hairline-border: #272727;
+    --hairline-color: var(--hairline-border);
     --border-color: #353535;
 
     --error-fg: #e35f5f;
@@ -78,7 +83,8 @@ html[data-theme="dark"] {
 
     --darkened-bg: #212121;
     --selected-bg: #1b1b1b;
-    --selected-row: #00363a;
+    --selected-row-bg: #00363a;
+    --selected-row: var(--selected-row-bg);
 
     --close-button-bg: #333333;
     --close-button-hover-bg: #666666;
@@ -128,7 +134,7 @@ html[data-theme="light"] .theme-toggle .theme-label-when-light {
 .theme-toggle svg.theme-icon-when-auto,
 .theme-toggle svg.theme-icon-when-dark,
 .theme-toggle svg.theme-icon-when-light {
-    fill: var(--header-link-color);
+    fill: var(--header-link-fg);
     color: var(--header-bg);
 }
 

--- a/django/contrib/admin/templates/admin/app_list.html
+++ b/django/contrib/admin/templates/admin/app_list.html
@@ -3,20 +3,20 @@
 {% if app_list %}
   {% for app in app_list %}
     <div class="app-{{ app.app_label }} module{% if app.app_url in request.path|urlencode %} current-app{% endif %}">
-      <table>
-        <caption>
+      <ul>
+        <h2>
           <a href="{{ app.app_url }}" class="section">{{ app.name }}</a>
-        </caption>
+        </h2>
         <thead class="visually-hidden">
-          <tr>
+          <li>
             <th scope="col">{% translate 'Model name' %}</th>
             <th scope="col">{% translate 'Add link' %}</th>
             <th scope="col">{% translate 'Change or view list link' %}</th>
-          </tr>
+          </li>
         </thead>
         {% for model in app.models %}
           {% with model_name=model.object_name|lower %}
-            <tr class="model-{{ model_name }}{% if model.admin_url in request.path|urlencode %} current-model{% endif %}">
+            <li class="model-{{ model_name }}{% if model.admin_url in request.path|urlencode %} current-model{% endif %}">
               <th scope="row" id="{{ app.app_label }}-{{ model_name }}">
                 {% if model.admin_url %}
                   <a href="{{ model.admin_url }}"{% if model.admin_url in request.path|urlencode %} aria-current="page"{% endif %}>{{ model.name }}</a>
@@ -40,10 +40,10 @@
               {% elif show_changelinks %}
                 <td></td>
               {% endif %}
-            </tr>
+            </li>
           {% endwith %}
         {% endfor %}
-      </table>
+      </ul>
     </div>
   {% endfor %}
 {% else %}

--- a/django/contrib/admin/templates/admin/app_list.html
+++ b/django/contrib/admin/templates/admin/app_list.html
@@ -3,10 +3,12 @@
 {% if app_list %}
   {% for app in app_list %}
     <div class="app-{{ app.app_label }} module{% if app.app_url in request.path|urlencode %} current-app{% endif %}">
-      <ul>
-        <h2>
-          <a href="{{ app.app_url }}" class="section">{{ app.name }}</a>
-        </h2>
+      <table>
+        <caption>
+          <h2>
+           <a href="{{ app.app_url }}" class="section">{{ app.name }}</a>
+          </h2>
+        </caption>
         <thead class="visually-hidden">
           <tr>
             <th scope="col">{% translate 'Model name' %}</th>
@@ -43,7 +45,7 @@
             </tr>
           {% endwith %}
         {% endfor %}
-      </ul>
+          </table>
     </div>
   {% endfor %}
 {% else %}

--- a/django/contrib/admin/templates/admin/app_list.html
+++ b/django/contrib/admin/templates/admin/app_list.html
@@ -8,15 +8,15 @@
           <a href="{{ app.app_url }}" class="section">{{ app.name }}</a>
         </h2>
         <thead class="visually-hidden">
-          <li>
+          <tr>
             <th scope="col">{% translate 'Model name' %}</th>
             <th scope="col">{% translate 'Add link' %}</th>
             <th scope="col">{% translate 'Change or view list link' %}</th>
-          </li>
+          </tr>
         </thead>
         {% for model in app.models %}
           {% with model_name=model.object_name|lower %}
-            <li class="model-{{ model_name }}{% if model.admin_url in request.path|urlencode %} current-model{% endif %}">
+            <tr class="model-{{ model_name }}{% if model.admin_url in request.path|urlencode %} current-model{% endif %}">
               <th scope="row" id="{{ app.app_label }}-{{ model_name }}">
                 {% if model.admin_url %}
                   <a href="{{ model.admin_url }}"{% if model.admin_url in request.path|urlencode %} aria-current="page"{% endif %}>{{ model.name }}</a>
@@ -40,7 +40,7 @@
               {% elif show_changelinks %}
                 <td></td>
               {% endif %}
-            </li>
+            </tr>
           {% endwith %}
         {% endfor %}
       </ul>


### PR DESCRIPTION
#### Trac ticket number
ticket-33689

#### Branch description
Standardize CSS custom properties in Django admin (`base.css` and `dark_mode.css`) to use consistent foreground (`-fg`) and background (`-bg`) naming conventions while maintaining backward compatibility fallbacks.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Tools used: Claude / ChatGPT / Gemini for explaining CSS variable fallbacks and reviewing git workflows. All code and changes were manually inspected, edited, and verified.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.