### PR TITLE
Fixed #37226 -- Raised ValidationError for invalid geometries during model validation.

### DIFF
--- a/django/contrib/gis/db/models/fields.py
+++ b/django/contrib/gis/db/models/fields.py
@@ -78,6 +78,9 @@ class BaseSpatialField(Field):
 
     description = _("The base GIS field.")
     empty_strings_allowed = False
+    default_error_messages = {
+        "invalid": _("“%(value)s” value has an invalid format."),
+    }
 
     def __init__(self, verbose_name=None, srid=4326, spatial_index=True, **kwargs):
         """

--- a/django/contrib/gis/db/models/proxy.py
+++ b/django/contrib/gis/db/models/proxy.py
@@ -6,6 +6,9 @@ objects corresponding to geographic model fields.
 Thanks to Robert Coup for providing this functionality (see #4322).
 """
 
+from django.contrib.gis.gdal.error import GDALException
+from django.contrib.gis.geos import GEOSException
+from django.core.exceptions import ValidationError
 from django.db.models.query_utils import DeferredAttribute
 
 
@@ -43,7 +46,16 @@ class SpatialProxy(DeferredAttribute):
         else:
             # Otherwise, a geometry or raster object is built using the field's
             # contents, and the model's corresponding attribute is set.
-            geo_obj = self._load_func(geo_value)
+            try:
+                geo_obj = self._load_func(geo_value)
+            except (GEOSException, GDALException, TypeError, ValueError) as err:
+                # Re-raise as a ValidationError so that invalid values are
+                # reported consistently during model validation (full_clean()).
+                raise ValidationError(
+                    self.field.error_messages["invalid"],
+                    code="invalid",
+                    params={"value": geo_value},
+                ) from err
             setattr(instance, self.field.attname, geo_obj)
         return geo_obj
 

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1754,15 +1754,17 @@ class Model(AltersData, metaclass=ModelBase):
         for f in self._meta.fields:
             if f.name in exclude or f.generated:
                 continue
-            # Skip validation for empty fields with blank=True. The developer
-            # is responsible for making sure they have a valid value.
-            raw_value = getattr(self, f.attname)
-            if f.blank and raw_value in f.empty_values:
-                continue
-            # Skip validation for empty fields when db_default is used.
-            if isinstance(raw_value, DatabaseDefault):
-                continue
             try:
+                # Skip validation for empty fields with blank=True. The
+                # developer is responsible for making sure they have a valid
+                # value. Reading the attribute may itself raise a
+                # ValidationError (e.g. for GIS fields with an invalid value).
+                raw_value = getattr(self, f.attname)
+                if f.blank and raw_value in f.empty_values:
+                    continue
+                # Skip validation for empty fields when db_default is used.
+                if isinstance(raw_value, DatabaseDefault):
+                    continue
                 setattr(self, f.attname, f.clean(raw_value, self))
             except ValidationError as e:
                 errors[f.name] = e.error_list

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -58,7 +58,10 @@ Minor features
 :mod:`django.contrib.gis`
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* ...
+* Spatial fields now raise a
+  :exc:`~django.core.exceptions.ValidationError` instead of a :exc:`ValueError`
+  when validating a model instance (e.g. via ``full_clean()``) that has an
+  invalid geometry or raster value.
 
 :mod:`django.contrib.messages`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/gis_tests/geoapp/tests.py
+++ b/tests/gis_tests/geoapp/tests.py
@@ -15,6 +15,7 @@ from django.contrib.gis.geos import (
     Polygon,
     fromstr,
 )
+from django.core.exceptions import ValidationError
 from django.core.files.temp import NamedTemporaryFile
 from django.core.management import call_command
 from django.db import DatabaseError, NotSupportedError, connection
@@ -38,6 +39,35 @@ from .models import (
     ThreeDimensionalFeature,
     Track,
 )
+
+
+class GeoModelValidationTest(TestCase):
+    def test_full_clean_invalid_geometry(self):
+        city = City(name="Foo", point="invalid")
+        msg = "“invalid” value has an invalid format."
+        with self.assertRaisesMessage(ValidationError, msg) as cm:
+            city.full_clean()
+        self.assertEqual(cm.exception.message_dict, {"point": [msg]})
+
+    def test_full_clean_valid_geometry(self):
+        city = City(name="Foo", point="POINT(5 23)")
+        city.full_clean()
+
+    def test_clean_fields_collects_all_errors(self):
+        # An invalid geometry does not prevent other fields from being
+        # validated.
+        city = City(name="", point="invalid")
+        with self.assertRaises(ValidationError) as cm:
+            city.full_clean()
+        self.assertEqual(set(cm.exception.message_dict), {"name", "point"})
+
+    def test_empty_geometry_does_not_raise(self):
+        # Empty values are not converted to a geometry and therefore never
+        # raise when the attribute is read during validation.
+        city = City(name="Foo", point="")
+        self.assertIsNone(city.point)
+        city.point = None
+        self.assertIsNone(city.point)
 
 
 class GeoModelTest(TestCase):


### PR DESCRIPTION
#### Trac ticket number
ticket-37226

#### Branch description
Invalid spatial values raised a raw `ValueError` from `GEOSGeometry` during `Model.full_clean()` instead of the documented `ValidationError`. This re-raises conversion failures (`GEOSException`, `GDALException`, `TypeError`, `ValueError`) in `SpatialProxy.__get__` as `ValidationError(code="invalid")`, adds an `invalid` default message to `BaseSpatialField`, and moves the attribute read in `clean_fields` inside the existing `try` so the error is field-keyed and remaining fields still validate.
Tested against SpatiaLite: the full GIS suite (652 passed) and the complete test suite (19705 passed) are green.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
Claude Code was used to help write the implementation and tests and to run the test suites. I reviewed and verified all output, and ran the full and GIS test suites myself against a real SpatiaLite backend.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
