### PR TITLE
 Fixed #10403 -- Added declarative syntax for FormSet, ModelFormSet, and InlineFormSet

### DIFF
--- a/django/forms/formsets.py
+++ b/django/forms/formsets.py
@@ -582,3 +582,50 @@ def all_valid(formsets):
     """Validate every formset and return True if all are valid."""
     # List comprehension ensures is_valid() is called for all formsets.
     return all([formset.is_valid() for formset in formsets])
+
+
+# Declarative formsets ######################################################
+
+
+class FormSetMeta(type):
+    """Metaclass for creating formsets using declarative syntax."""
+
+    def __new__(cls, name, bases, attrs):
+        if "form" not in set(attrs):
+            raise TypeError("FormSet() missing 1 required positional argument: 'form'.")
+
+        if attrs.get("min_num") is None:
+            attrs["min_num"] = DEFAULT_MIN_NUM
+        if attrs.get("max_num") is None:
+            attrs["max_num"] = DEFAULT_MAX_NUM
+        formset = attrs.get("formset") or BaseFormSet
+
+        default_attrs = {
+            "form": attrs.get("form"),
+            "extra": 1,
+            "can_order": False,
+            "can_delete": False,
+            "min_num": DEFAULT_MIN_NUM,
+            "max_num": DEFAULT_MAX_NUM,
+            "absolute_max": attrs["max_num"] + DEFAULT_MAX_NUM,
+            "validate_min": False,
+            "validate_max": False,
+            "can_delete_extra": True,
+            "renderer": attrs.get("renderer"),
+        }
+
+        for key, value in default_attrs.items():
+            if key not in attrs.keys():
+                attrs.update({key: value})
+
+        if attrs["max_num"] > attrs["absolute_max"]:
+            raise ValueError("'absolute_max' must be greater or equal to 'max_num'.")
+
+        new_class = super().__new__(cls, name, (formset,), attrs)
+        return new_class
+
+
+class FormSet(BaseFormSet, metaclass=FormSetMeta):
+    """Base class for creating formsets using declarative syntax."""
+
+    form = None

--- a/django/forms/formsets.py
+++ b/django/forms/formsets.py
@@ -1,4 +1,4 @@
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.forms.fields import BooleanField, IntegerField
 from django.forms.forms import Form
 from django.forms.renderers import get_default_renderer
@@ -8,7 +8,7 @@ from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import ngettext_lazy
 
-__all__ = ("BaseFormSet", "formset_factory", "all_valid")
+__all__ = ("BaseFormSet", "FormSet", "formset_factory", "all_valid")
 
 # special field names
 TOTAL_FORM_COUNT = "TOTAL_FORMS"
@@ -23,6 +23,8 @@ DEFAULT_MIN_NUM = 0
 
 # default maximum number of forms in a formset, to prevent memory exhaustion
 DEFAULT_MAX_NUM = 1000
+
+_ABSOLUTE_MAX_ERROR = "'absolute_max' must be greater or equal to 'max_num'."
 
 
 class ManagementForm(Form):
@@ -99,6 +101,12 @@ class BaseFormSet(RenderableFormMixin):
         self.error_class = error_class
         self._errors = None
         self._non_form_errors = None
+        if getattr(self, "_declarative", False):
+            if self.min_num is None:
+                self.min_num = DEFAULT_MIN_NUM
+            self.max_num = _capped_max_num(self)
+            if self.absolute_max is None:
+                self.absolute_max = self.max_num + DEFAULT_MAX_NUM
         self.form_renderer = self.renderer
         self.renderer = self.renderer or get_default_renderer()
 
@@ -556,7 +564,7 @@ def formset_factory(
     if absolute_max is None:
         absolute_max = max_num + DEFAULT_MAX_NUM
     if max_num > absolute_max:
-        raise ValueError("'absolute_max' must be greater or equal to 'max_num'.")
+        raise ValueError(_ABSOLUTE_MAX_ERROR)
     attrs = {
         "form": form,
         "extra": extra,
@@ -575,6 +583,8 @@ def formset_factory(
         formset_name = form_name + "Set"
     else:
         formset_name = form_name + "FormSet"
+    if getattr(formset, "_declarative", False):
+        attrs["_factory_built"] = True
     return type(formset_name, (formset,), attrs)
 
 
@@ -584,48 +594,65 @@ def all_valid(formsets):
     return all([formset.is_valid() for formset in formsets])
 
 
-# Declarative formsets ######################################################
+def _capped_max_num(formset):
+    # A unique foreign key permits at most one related object.
+    fk = getattr(formset, "fk", None)
+    if fk is not None and fk.unique:
+        return 1
+    return DEFAULT_MAX_NUM if formset.max_num is None else formset.max_num
 
 
-class FormSetMeta(type):
-    """Metaclass for creating formsets using declarative syntax."""
-
-    def __new__(cls, name, bases, attrs):
-        if "form" not in set(attrs):
-            raise TypeError("FormSet() missing 1 required positional argument: 'form'.")
-
-        if attrs.get("min_num") is None:
-            attrs["min_num"] = DEFAULT_MIN_NUM
-        if attrs.get("max_num") is None:
-            attrs["max_num"] = DEFAULT_MAX_NUM
-        formset = attrs.get("formset") or BaseFormSet
-
-        default_attrs = {
-            "form": attrs.get("form"),
-            "extra": 1,
-            "can_order": False,
-            "can_delete": False,
-            "min_num": DEFAULT_MIN_NUM,
-            "max_num": DEFAULT_MAX_NUM,
-            "absolute_max": attrs["max_num"] + DEFAULT_MAX_NUM,
-            "validate_min": False,
-            "validate_max": False,
-            "can_delete_extra": True,
-            "renderer": attrs.get("renderer"),
-        }
-
-        for key, value in default_attrs.items():
-            if key not in attrs.keys():
-                attrs.update({key: value})
-
-        if attrs["max_num"] > attrs["absolute_max"]:
-            raise ValueError("'absolute_max' must be greater or equal to 'max_num'.")
-
-        new_class = super().__new__(cls, name, (formset,), attrs)
-        return new_class
+def _prepare_declarative_formset(cls):
+    if (formset := getattr(cls, "formset", None)) is not None:
+        raise ImproperlyConfigured(
+            "Formset %s must inherit from %s instead of setting 'formset'."
+            % (cls.__name__, getattr(formset, "__name__", formset))
+        )
+    if cls.absolute_max is not None and _capped_max_num(cls) > cls.absolute_max:
+        raise ValueError(_ABSOLUTE_MAX_ERROR)
 
 
-class FormSet(BaseFormSet, metaclass=FormSetMeta):
+class DeclarativeFormSetMixin:
+    """Mixin for creating formsets using declarative syntax."""
+
+    _declarative = True
+
+    def __init_subclass__(cls, abstract=False, **kwargs):
+        super().__init_subclass__(**kwargs)
+        if cls.__dict__.get("_factory_built"):
+            # The factory already configured this class, so skip
+            # _prepare_declarative().
+            del cls._factory_built
+            return
+        if abstract:
+            return
+        cls._prepare_declarative()
+
+    @classmethod
+    def _prepare_declarative(cls):
+        raise NotImplementedError
+
+
+class FormSet(BaseFormSet, DeclarativeFormSetMixin, abstract=True):
     """Base class for creating formsets using declarative syntax."""
 
     form = None
+    extra = 1
+    can_order = False
+    can_delete = False
+    can_delete_extra = True
+    min_num = None
+    max_num = None
+    absolute_max = None
+    validate_min = False
+    validate_max = False
+    renderer = None
+
+    @classmethod
+    def _prepare_declarative(cls):
+        if cls.form is None:
+            raise ImproperlyConfigured(
+                "Creating a FormSet without the 'form' attribute is "
+                "prohibited; formset %s needs updating." % cls.__name__
+            )
+        _prepare_declarative_formset(cls)

--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -15,7 +15,12 @@ from django.core.validators import ProhibitNullCharactersValidator
 from django.db.models.utils import AltersData, get_blank_choice_label
 from django.forms.fields import ChoiceField, Field
 from django.forms.forms import BaseForm, DeclarativeFieldsMetaclass
-from django.forms.formsets import BaseFormSet, FormSetMeta, formset_factory
+from django.forms.formsets import (
+    BaseFormSet,
+    DeclarativeFormSetMixin,
+    _prepare_declarative_formset,
+    formset_factory,
+)
 from django.forms.utils import ErrorList
 from django.forms.widgets import (
     HiddenInput,
@@ -38,8 +43,10 @@ __all__ = (
     "ModelMultipleChoiceField",
     "ALL_FIELDS",
     "BaseModelFormSet",
+    "ModelFormSet",
     "modelformset_factory",
     "BaseInlineFormSet",
+    "InlineFormSet",
     "inlineformset_factory",
     "modelform_factory",
 )
@@ -1105,69 +1112,82 @@ def modelformset_factory(
     return FormSet
 
 
-class ModelFormSetMeta(FormSetMeta):
-    """Metaclass for creating model formsets using declarative syntax."""
-
-    def __new__(cls, name, bases, attrs):
-        if "model" not in set(attrs):
-            raise TypeError(
-                "ModelFormSet() missing 1 required positional argument: 'model'"
-            )
-
-        kwargs = {}
-
-        form = ModelForm
-        if (passed_form := attrs.get("form")) is not None:
-            kwargs.update({"form": passed_form})
-            if hasattr(passed_form, "Meta"):
-                kwargs.update({"fields": passed_form._meta.fields})
-                kwargs.update({"exclude": passed_form._meta.exclude})
-        else:
-            kwargs.update({"form": form})
-
-        default_modelform_factory_attrs = [
-            "fields",
-            "exclude",
-            "formfield_callback",
-            "widgets",
-            "localized_fields",
-            "labels",
-            "help_texts",
-            "error_messages",
-            "field_classes",
-        ]
-        for key in default_modelform_factory_attrs:
-            if key in attrs:
-                kwargs.update({key: attrs.get(key)})
-                attrs.pop(key)
-
-        if (model := attrs.get("model")) is not None:
-            if kwargs.get("fields") is None and kwargs.get("exclude") is None:
-                raise ImproperlyConfigured(
-                    "Defining %s without defining 'fields' or 'exclude' "
-                    "explicitly is prohibited." % name
-                )
-            form = modelform_factory(model, **kwargs)
-            attrs.update({"form": form})
-
-        default_formset_attrs = {
-            "form": ModelForm,
-            "formset": BaseModelFormSet,
-            "extra": 1,
-            "can_delete_extra": True,
-        }
-        for key, value in default_formset_attrs.items():
-            if key not in attrs.keys():
-                attrs.update({key: value})
-
-        return super().__new__(cls, name, bases, attrs)
+_FORM_GENERATION_OPTIONS = (
+    "fields",
+    "exclude",
+    "formfield_callback",
+    "widgets",
+    "localized_fields",
+    "labels",
+    "help_texts",
+    "error_messages",
+    "field_classes",
+)
 
 
-class ModelFormSet(BaseModelFormSet, metaclass=ModelFormSetMeta):
+def _prepare_declarative_model_form(cls, declarative_name):
+    if cls.model is None:
+        raise ImproperlyConfigured(
+            "Creating %s without the 'model' attribute is prohibited; "
+            "formset %s needs updating." % (declarative_name, cls.__name__)
+        )
+    if "form" in cls.__dict__:
+        declared_form = cls.__dict__["form"]
+    else:
+        # Fall back to cls.form because an unprepared abstract base still
+        # holds the original form there.
+        declared_form = getattr(cls, "_declared_form", cls.form)
+    cls._declared_form = declared_form
+    options = {
+        option: value
+        for option in _FORM_GENERATION_OPTIONS
+        if (value := getattr(cls, option)) is not None
+    }
+    meta = getattr(declared_form, "Meta", None)
+    if (
+        options.get("fields") is None
+        and options.get("exclude") is None
+        and getattr(meta, "fields", None) is None
+        and getattr(meta, "exclude", None) is None
+    ):
+        raise ImproperlyConfigured(
+            "Creating %s without either the 'fields' attribute or the "
+            "'exclude' attribute is prohibited; formset %s needs updating."
+            % (declarative_name, cls.__name__)
+        )
+    cls.form = modelform_factory(cls.model, form=declared_form or ModelForm, **options)
+
+
+class ModelFormSet(BaseModelFormSet, DeclarativeFormSetMixin, abstract=True):
     """Base class for creating model formsets using declarative syntax."""
 
-    form = None
     model = None
+    form = None
+    fields = None
+    exclude = None
+    formfield_callback = None
+    widgets = None
+    localized_fields = None
+    labels = None
+    help_texts = None
+    error_messages = None
+    field_classes = None
+    extra = 1
+    can_order = False
+    can_delete = False
+    can_delete_extra = True
+    min_num = None
+    max_num = None
+    absolute_max = None
+    validate_min = False
+    validate_max = False
+    renderer = None
+    edit_only = False
+
+    @classmethod
+    def _prepare_declarative(cls):
+        _prepare_declarative_model_form(cls, "a ModelFormSet")
+        _prepare_declarative_formset(cls)
 
 
 # InlineFormSets #############################################################
@@ -1435,50 +1455,50 @@ def inlineformset_factory(
     return FormSet
 
 
-class InlineFormSetMeta(ModelFormSetMeta):
-    """Metaclass for creating inline formsets using declarative syntax."""
-
-    def __new__(cls, name, bases, attrs):
-        if "parent_model" not in set(attrs):
-            raise TypeError(
-                "InlineFormSet() missing 1 required positional argument: 'parent_model'"
-            )
-        if "model" not in set(attrs):
-            raise TypeError(
-                "InlineFormSet() missing 1 required positional argument: 'model'"
-            )
-
-        parent_model = attrs.get("parent_model", None)
-        model = attrs.get("model", None)
-        fk_name = attrs.get("fk_name", None)
-
-        default_formset_attrs = {
-            "form": ModelForm,
-            "formset": BaseInlineFormSet,
-            "extra": 3,
-            "can_delete": True,
-            "can_delete_extra": True,
-        }
-        for key, value in default_formset_attrs.items():
-            if key not in attrs.keys():
-                attrs.update({key: value})
-
-        if model is not None and parent_model is not None:
-            fk = _get_foreign_key(parent_model, model, fk_name=fk_name)
-            if fk.unique:
-                attrs.update({"max_num": 1})
-            ModelFormSet = super().__new__(cls, name, bases, attrs)
-            ModelFormSet.fk = fk
-            return ModelFormSet
-        return super().__new__(cls, name, bases, attrs)
-
-
-class InlineFormSet(BaseInlineFormSet, ModelFormSet, metaclass=InlineFormSetMeta):
+class InlineFormSet(BaseInlineFormSet, DeclarativeFormSetMixin, abstract=True):
     """Base class for creating inline formsets using declarative syntax."""
 
-    form = None
-    model = None
     parent_model = None
+    fk_name = None
+    model = None
+    form = None
+    fields = None
+    exclude = None
+    formfield_callback = None
+    widgets = None
+    localized_fields = None
+    labels = None
+    help_texts = None
+    error_messages = None
+    field_classes = None
+    extra = 3
+    can_order = False
+    can_delete = True
+    can_delete_extra = True
+    min_num = None
+    max_num = None
+    absolute_max = None
+    validate_min = False
+    validate_max = False
+    renderer = None
+    edit_only = False
+
+    @classmethod
+    def _prepare_declarative(cls):
+        if cls.parent_model is None and not hasattr(cls, "fk"):
+            raise ImproperlyConfigured(
+                "Creating an InlineFormSet without the 'parent_model' "
+                "attribute is prohibited; formset %s needs updating." % cls.__name__
+            )
+        _prepare_declarative_model_form(cls, "an InlineFormSet")
+        # Resolve the foreign key when it is not set yet or this class declares
+        # the relation.
+        if cls.parent_model is not None and (
+            not hasattr(cls, "fk")
+            or {"parent_model", "model", "fk_name"} & cls.__dict__.keys()
+        ):
+            cls.fk = _get_foreign_key(cls.parent_model, cls.model, fk_name=cls.fk_name)
+        _prepare_declarative_formset(cls)
 
 
 # Fields #####################################################################

--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -15,7 +15,7 @@ from django.core.validators import ProhibitNullCharactersValidator
 from django.db.models.utils import AltersData, get_blank_choice_label
 from django.forms.fields import ChoiceField, Field
 from django.forms.forms import BaseForm, DeclarativeFieldsMetaclass
-from django.forms.formsets import BaseFormSet, formset_factory
+from django.forms.formsets import BaseFormSet, FormSetMeta, formset_factory
 from django.forms.utils import ErrorList
 from django.forms.widgets import (
     HiddenInput,
@@ -1105,6 +1105,71 @@ def modelformset_factory(
     return FormSet
 
 
+class ModelFormSetMeta(FormSetMeta):
+    """Metaclass for creating model formsets using declarative syntax."""
+
+    def __new__(cls, name, bases, attrs):
+        if "model" not in set(attrs):
+            raise TypeError(
+                "ModelFormSet() missing 1 required positional argument: 'model'"
+            )
+
+        kwargs = {}
+
+        form = ModelForm
+        if (passed_form := attrs.get("form")) is not None:
+            kwargs.update({"form": passed_form})
+            if hasattr(passed_form, "Meta"):
+                kwargs.update({"fields": passed_form._meta.fields})
+                kwargs.update({"exclude": passed_form._meta.exclude})
+        else:
+            kwargs.update({"form": form})
+
+        default_modelform_factory_attrs = [
+            "fields",
+            "exclude",
+            "formfield_callback",
+            "widgets",
+            "localized_fields",
+            "labels",
+            "help_texts",
+            "error_messages",
+            "field_classes",
+        ]
+        for key in default_modelform_factory_attrs:
+            if key in attrs:
+                kwargs.update({key: attrs.get(key)})
+                attrs.pop(key)
+
+        if (model := attrs.get("model")) is not None:
+            if kwargs.get("fields") is None and kwargs.get("exclude") is None:
+                raise ImproperlyConfigured(
+                    "Defining %s without defining 'fields' or 'exclude' "
+                    "explicitly is prohibited." % name
+                )
+            form = modelform_factory(model, **kwargs)
+            attrs.update({"form": form})
+
+        default_formset_attrs = {
+            "form": ModelForm,
+            "formset": BaseModelFormSet,
+            "extra": 1,
+            "can_delete_extra": True,
+        }
+        for key, value in default_formset_attrs.items():
+            if key not in attrs.keys():
+                attrs.update({key: value})
+
+        return super().__new__(cls, name, bases, attrs)
+
+
+class ModelFormSet(BaseModelFormSet, metaclass=ModelFormSetMeta):
+    """Base class for creating model formsets using declarative syntax."""
+
+    form = None
+    model = None
+
+
 # InlineFormSets #############################################################
 
 
@@ -1368,6 +1433,52 @@ def inlineformset_factory(
     FormSet = modelformset_factory(model, **kwargs)
     FormSet.fk = fk
     return FormSet
+
+
+class InlineFormSetMeta(ModelFormSetMeta):
+    """Metaclass for creating inline formsets using declarative syntax."""
+
+    def __new__(cls, name, bases, attrs):
+        if "parent_model" not in set(attrs):
+            raise TypeError(
+                "InlineFormSet() missing 1 required positional argument: 'parent_model'"
+            )
+        if "model" not in set(attrs):
+            raise TypeError(
+                "InlineFormSet() missing 1 required positional argument: 'model'"
+            )
+
+        parent_model = attrs.get("parent_model", None)
+        model = attrs.get("model", None)
+        fk_name = attrs.get("fk_name", None)
+
+        default_formset_attrs = {
+            "form": ModelForm,
+            "formset": BaseInlineFormSet,
+            "extra": 3,
+            "can_delete": True,
+            "can_delete_extra": True,
+        }
+        for key, value in default_formset_attrs.items():
+            if key not in attrs.keys():
+                attrs.update({key: value})
+
+        if model is not None and parent_model is not None:
+            fk = _get_foreign_key(parent_model, model, fk_name=fk_name)
+            if fk.unique:
+                attrs.update({"max_num": 1})
+            ModelFormSet = super().__new__(cls, name, bases, attrs)
+            ModelFormSet.fk = fk
+            return ModelFormSet
+        return super().__new__(cls, name, bases, attrs)
+
+
+class InlineFormSet(BaseInlineFormSet, ModelFormSet, metaclass=InlineFormSetMeta):
+    """Base class for creating inline formsets using declarative syntax."""
+
+    form = None
+    model = None
+    parent_model = None
 
 
 # Fields #####################################################################

--- a/docs/ref/forms/formsets.txt
+++ b/docs/ref/forms/formsets.txt
@@ -66,26 +66,32 @@ Declarative ``FormSet``
     declarative syntax.
 
     You can define any argument that the ``formset_factory`` function
-    accepts as a class attribute.
+    accepts as a class attribute, except for ``formset``: to customize the
+    base formset class, inherit from it instead.
 
-    Example of a declarative formset:
+    Example of a declarative formset::
 
-    .. code-block:: pycon
+        from django.forms import FormSet
 
-        >>> from django.forms import formsets
-        >>> from myapp.forms import MyForm
+        from myapp.forms import MyForm
 
-        >>> class MyFormSet(formsets.FormSet):
-        ...     form = MyForm
-        ...     extra = 2
-        ...     can_order = True
-        ...     can_delete = True
-        ...     max_num = 10
-        ...     validate_max = True
-        ...     min_num = 3
-        ...     validate_min = True
-        ...     absolute_max = 15
-        ...     can_delete_extra = False
-        ...     renderer = None
-        ...
+
+        class MyFormSet(FormSet):
+            form = MyForm
+            extra = 2
+            can_order = True
+            can_delete = True
+            max_num = 10
+            validate_max = True
+            min_num = 3
+            validate_min = True
+            absolute_max = 15
+            can_delete_extra = False
+
+    A base class intended only for subclassing can skip the required ``form``
+    attribute by declaring itself abstract. The marker isn't inherited, so
+    concrete subclasses are still validated::
+
+        class BaseArticleFormSet(FormSet, abstract=True):
+            extra = 2
 

--- a/docs/ref/forms/formsets.txt
+++ b/docs/ref/forms/formsets.txt
@@ -8,11 +8,84 @@ Formset API reference. For introductory material about formsets, see the
 .. module:: django.forms.formsets
    :synopsis: Django's functions for building formsets.
 
+Creating formsets
+=================
+
+``BaseFormSet``
+---------------
+
+.. class:: BaseFormSet
+
+    The base class for all formsets. See the
+    :doc:`formsets topic guide </topics/forms/formsets>` for examples of
+    using its attributes and methods.
+
+Django provides two ways to create formsets:
+
 ``formset_factory``
-===================
+-------------------
 
 .. function:: formset_factory(form, formset=BaseFormSet, extra=1, can_order=False, can_delete=False, max_num=None, validate_max=False, min_num=None, validate_min=False, absolute_max=None, can_delete_extra=True, renderer=None)
 
     Returns a ``FormSet`` class for the given ``form`` class.
 
+    Arguments:
+
+    - ``form``: The form class to use in the formset.
+    - ``formset``: The formset class to use as the base formset
+      (defaults to ``BaseFormSet``).
+    - ``extra``: The number of extra empty forms to display
+      (defaults to 1).
+    - ``can_order``: Whether the forms can be ordered
+      (defaults to False).
+    - ``can_delete``: Whether the forms can be deleted
+      (defaults to False).
+    - ``max_num``: The maximum number of forms allowed
+      (defaults to 1000).
+    - ``validate_max``: Whether to validate the maximum number of forms
+      (defaults to False).
+    - ``min_num``: The minimum number of forms required (defaults to 0).
+    - ``validate_min``: Whether to validate the minimum number of forms
+      (defaults to False).
+    - ``absolute_max``: The absolute maximum number of forms allowed
+      (defaults to ``max_num`` + 1000).
+    - ``can_delete_extra``: Whether extra forms can be deleted
+      (defaults to True).
+    - ``renderer``: The formset renderer to use (defaults to None).
+
     See :doc:`formsets </topics/forms/formsets>` for example usage.
+
+Declarative ``FormSet``
+-----------------------
+
+.. class:: FormSet
+
+    .. versionadded:: 6.2
+
+    A :class:`BaseFormSet` subclass that allows defining formsets using
+    declarative syntax.
+
+    You can define any argument that the ``formset_factory`` function
+    accepts as a class attribute.
+
+    Example of a declarative formset:
+
+    .. code-block:: pycon
+
+        >>> from django.forms import formsets
+        >>> from myapp.forms import MyForm
+
+        >>> class MyFormSet(formsets.FormSet):
+        ...     form = MyForm
+        ...     extra = 2
+        ...     can_order = True
+        ...     can_delete = True
+        ...     max_num = 10
+        ...     validate_max = True
+        ...     min_num = 3
+        ...     validate_min = True
+        ...     absolute_max = 15
+        ...     can_delete_extra = False
+        ...     renderer = None
+        ...
+

--- a/docs/ref/forms/models.txt
+++ b/docs/ref/forms/models.txt
@@ -262,42 +262,67 @@ Declarative ``ModelFormSet``
     using declarative syntax.
 
     You can define any argument that the ``modelformset_factory`` function
-    accepts as a class attribute.
+    accepts as a class attribute, except for ``formset``: to customize the
+    base formset class, inherit from it instead.
 
-    For example, to create ``AuthorFormSet`` for the ``Author`` model:
+    For example, to create ``AuthorFormSet`` for the ``Author`` model::
 
-    .. code-block:: pycon
+        from django.forms import ModelFormSet
 
-        >>> from django.forms import models
-        >>> from myapp.models import Author
+        from myapp.models import Author
 
-        >>> class AuthorFormSet(models.ModelFormSet):
-        ...     model = Author
-        ...     fields = ["name", "title"]
-        ...     extra = 2
-        ...     can_order = True
-        ...     can_delete = True
-        ...     max_num = 10
-        ...     validate_max = True
-        ...     min_num = 3
-        ...     validate_min = True
-        ...     absolute_max = 15
-        ...     can_delete_extra = False
-        ...
 
-    You can also omit fields when the form class provides them:
+        class AuthorFormSet(ModelFormSet):
+            model = Author
+            fields = ["name", "title"]
+            extra = 2
+            can_order = True
+            can_delete = True
+            max_num = 10
+            validate_max = True
+            min_num = 3
+            validate_min = True
+            absolute_max = 15
+            can_delete_extra = False
 
-    .. code-block:: pycon
+    The ``form`` attribute behaves as it does for ``modelformset_factory()``.
+    It is used as the base class for a generated form bound to ``model``,
+    exactly as ``modelformset_factory(model, form=..., fields=...)`` does, so a
+    form's own fields and customizations are carried over::
 
-        >>> from django.forms import models
-        >>> from myapp.forms import PostForm
-        >>> from myapp.models import Post
+        from django.forms import ModelFormSet
 
-        >>> class PostFormSet(models.ModelFormSet):
-        ...     model = Post
-        ...     form = PostForm
-        ...     extra = 2
-        ...
+        from myapp.forms import AuthorForm
+        from myapp.models import Author
+
+
+        class AuthorFormSet(ModelFormSet):
+            model = Author
+            form = AuthorForm
+            extra = 2
+
+    Form-generation attributes accumulate down an inheritance chain, so a
+    subclass sees a base's ``fields``/``exclude``/``widgets``/etc. as if they
+    were passed to a single ``modelformset_factory()`` call. To ignore an
+    inherited attribute, set it back to ``None`` in the subclass; setting
+    ``form = None`` likewise drops an inherited form.
+
+    A base class intended only for subclassing can skip the required
+    attributes by declaring itself abstract. The marker isn't inherited, so
+    concrete subclasses are still validated::
+
+        from django.forms.models import ModelFormSet
+
+
+        class TenantFormSet(ModelFormSet, abstract=True):
+            can_delete = False
+
+    .. note::
+
+        The ``error_messages`` attribute customizes the error messages of
+        the generated form's fields, as in ``modelformset_factory()``. To
+        override the formset's own error messages, such as
+        ``too_few_forms``, declare ``default_error_messages`` instead.
 
 Creating inline formsets
 ========================
@@ -329,7 +354,19 @@ Declarative ``InlineFormSet``
     formsets using declarative syntax.
 
     You can define any argument that the ``inlineformset_factory`` function
-    accepts as a class attribute.
+    accepts as a class attribute, except for ``formset``: to customize the
+    base formset class, inherit from it instead. ``abstract=True`` may be
+    passed in the class definition to create a base class without the
+    required attributes.
+
+    As with :class:`ModelFormSet`, a ``form`` is used as the base class for a
+    generated form (as ``inlineformset_factory()`` does), so the parent foreign
+    key can be added without modifying the provided form class.
+
+    The foreign key between ``model`` and ``parent_model`` is resolved when
+    the class is defined, so both models must already be loaded. Define
+    inline formsets in ``forms.py``, or another module imported after the
+    app registry is ready, rather than in ``models.py``.
 
     For example, to create ``BookFormSet`` for the ``Book`` model with
     ``Author`` as the parent model:

--- a/docs/ref/forms/models.txt
+++ b/docs/ref/forms/models.txt
@@ -223,6 +223,11 @@ Model form factory functions
     more information. Omitting any definition of the fields to use will result
     in an :exc:`~django.core.exceptions.ImproperlyConfigured` exception.
 
+Creating model formsets
+=======================
+
+Django provides two ways to define model formsets:
+
 ``modelformset_factory``
 ------------------------
 
@@ -246,6 +251,59 @@ Model form factory functions
 
     See :ref:`model-formsets` for example usage.
 
+Declarative ``ModelFormSet``
+----------------------------
+
+.. class:: ModelFormSet
+
+    .. versionadded:: 6.2
+
+    A :class:`BaseModelFormSet` subclass that allows defining model formsets
+    using declarative syntax.
+
+    You can define any argument that the ``modelformset_factory`` function
+    accepts as a class attribute.
+
+    For example, to create ``AuthorFormSet`` for the ``Author`` model:
+
+    .. code-block:: pycon
+
+        >>> from django.forms import models
+        >>> from myapp.models import Author
+
+        >>> class AuthorFormSet(models.ModelFormSet):
+        ...     model = Author
+        ...     fields = ["name", "title"]
+        ...     extra = 2
+        ...     can_order = True
+        ...     can_delete = True
+        ...     max_num = 10
+        ...     validate_max = True
+        ...     min_num = 3
+        ...     validate_min = True
+        ...     absolute_max = 15
+        ...     can_delete_extra = False
+        ...
+
+    You can also omit fields when the form class provides them:
+
+    .. code-block:: pycon
+
+        >>> from django.forms import models
+        >>> from myapp.forms import PostForm
+        >>> from myapp.models import Post
+
+        >>> class PostFormSet(models.ModelFormSet):
+        ...     model = Post
+        ...     form = PostForm
+        ...     extra = 2
+        ...
+
+Creating inline formsets
+========================
+
+Django provides two ways to create inline formsets:
+
 ``inlineformset_factory``
 -------------------------
 
@@ -259,3 +317,31 @@ Model form factory functions
     the ``parent_model``, you must specify a ``fk_name``.
 
     See :ref:`inline-formsets` for example usage.
+
+Declarative ``InlineFormSet``
+-----------------------------
+
+.. class:: InlineFormSet
+
+    .. versionadded:: 6.2
+
+    A :class:`BaseInlineFormSet` subclass that allows defining inline
+    formsets using declarative syntax.
+
+    You can define any argument that the ``inlineformset_factory`` function
+    accepts as a class attribute.
+
+    For example, to create ``BookFormSet`` for the ``Book`` model with
+    ``Author`` as the parent model:
+
+    .. code-block:: pycon
+
+        >>> from django.forms import models
+        >>> from myapp.models import Author, Book
+
+        >>> class BookFormSet(models.InlineFormSet):
+        ...     parent_model = Author
+        ...     model = Book
+        ...     extra = 1
+        ...     fields = "__all__"
+        ...

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -155,7 +155,13 @@ File Uploads
 Forms
 ~~~~~
 
-* ...
+* The new :class:`~django.forms.formsets.FormSet`,
+  :class:`~django.forms.models.ModelFormSet`, and
+  :class:`~django.forms.models.InlineFormSet` classes allow defining formsets
+  using a declarative syntax, similar to declaring model classes, as an
+  alternative to the :func:`~django.forms.formsets.formset_factory`,
+  :func:`~django.forms.models.modelformset_factory`, and
+  :func:`~django.forms.models.inlineformset_factory` functions.
 
 Generic Views
 ~~~~~~~~~~~~~

--- a/docs/topics/forms/formsets.txt
+++ b/docs/topics/forms/formsets.txt
@@ -4,8 +4,6 @@ Formsets
 
 .. currentmodule:: django.forms.formsets
 
-.. class:: BaseFormSet
-
 A formset is a layer of abstraction to work with multiple forms on the same
 page. It can be best compared to a data grid. Let's say you have the following
 form:
@@ -19,16 +17,42 @@ form:
     ...
 
 You might want to allow the user to create several articles at once. To create
-a formset out of an ``ArticleForm`` you would do:
+a formset out of an ``ArticleForm``, you have two options:
+
+Method 1: Using ``formset_factory``
+===================================
 
 .. code-block:: pycon
 
     >>> from django.forms import formset_factory
     >>> ArticleFormSet = formset_factory(ArticleForm)
 
-You now have created a formset class named ``ArticleFormSet``.
-Instantiating the formset gives you the ability to iterate over the forms
-in the formset and display them as you would with a regular form:
+Method 2: Using ``FormSet``
+===========================
+
+.. versionadded:: 6.2
+
+.. code-block:: pycon
+
+    >>> from django.forms import formsets
+    >>> class ArticleFormSet(formsets.FormSet):
+    ...     form = ArticleForm
+    ...
+
+Using the declarative syntax, you can define the formset directly as a class,
+similar to how you declare models.
+
+.. note::
+
+    Formset behavior can be customized by overriding methods, on either
+    ``BaseFormSet`` or ``FormSet`` depending on the syntax you choose. Both
+    approaches give the same results. As with ``formset_factory``, the
+    ``form`` attribute is required when defining a ``FormSet`` subclass.
+
+Regardless of which option you choose, you have now created a formset class
+named ``ArticleFormSet``. Instantiating the formset gives you the ability to
+iterate over the forms in the formset and display them as you would with a
+regular form:
 
 .. code-block:: pycon
 
@@ -357,6 +381,9 @@ And here is a custom error message:
 Custom formset validation
 -------------------------
 
+Method 1: Using ``BaseFormSet``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 A formset has a ``clean`` method similar to the one on a ``Form`` class. This
 is where you define your own validation that works at the formset level:
 
@@ -413,6 +440,55 @@ help distinguish them from form-specific errors. For example,
     <ul class="errorlist nonform">
         <li>Articles in a set must have distinct titles.</li>
     </ul>
+
+Method 2: Using ``FormSet``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. versionadded:: 6.2
+
+Instead of using :func:`~django.forms.formsets.formset_factory`, you can
+create your formset with the ``FormSet`` class and override the ``clean``
+method directly on the class. This gives the same results as above:
+
+.. code-block:: pycon
+
+    >>> from django.core.exceptions import ValidationError
+    >>> from django.forms import formsets
+    >>> from myapp.forms import ArticleForm
+
+    >>> class ArticleFormSet(formsets.FormSet):
+    ...     form = ArticleForm
+    ...     def clean(self):
+    ...         """Checks that no two articles have the same title."""
+    ...         if any(self.errors):
+    ...             # Don't bother validating the formset unless each form is valid on its own
+    ...             return
+    ...         titles = set()
+    ...         for form in self.forms:
+    ...             if self.can_delete and self._should_delete_form(form):
+    ...                 continue
+    ...             title = form.cleaned_data.get("title")
+    ...             if title in titles:
+    ...                 raise ValidationError("Articles in a set must have distinct titles.")
+    ...             titles.add(title)
+    ...
+
+    >>> data = {
+    ...     "form-TOTAL_FORMS": "2",
+    ...     "form-INITIAL_FORMS": "0",
+    ...     "form-MAX_NUM_FORMS": "",
+    ...     "form-0-title": "Test",
+    ...     "form-0-pub_date": "1904-06-16",
+    ...     "form-1-title": "Test",
+    ...     "form-1-pub_date": "1912-06-23",
+    ... }
+    >>> formset = ArticleFormSet(data)
+    >>> formset.is_valid()
+    False
+    >>> formset.errors
+    [{}, {}]
+    >>> formset.non_form_errors()
+    ['Articles in a set must have distinct titles.']
 
 Validating the number of forms in a formset
 ===========================================
@@ -775,6 +851,9 @@ remove the option to delete extra forms.
 Adding additional fields to a formset
 =====================================
 
+Method 1: Using ``BaseFormSet``
+-------------------------------
+
 If you need to add additional fields to the formset this can be easily
 accomplished. The formset base class provides an ``add_fields`` method. You
 can override this method to add your own fields or even redefine the default
@@ -792,6 +871,33 @@ fields/attributes of the order and deletion fields:
     ...
 
     >>> ArticleFormSet = formset_factory(ArticleForm, formset=BaseArticleFormSet)
+    >>> formset = ArticleFormSet()
+    >>> for form in formset:
+    ...     print(form)
+    ...
+    <div><label for="id_form-0-title">Title:</label><input type="text" name="form-0-title" id="id_form-0-title"></div>
+    <div><label for="id_form-0-pub_date">Pub date:</label><input type="text" name="form-0-pub_date" id="id_form-0-pub_date"></div>
+    <div><label for="id_form-0-my_field">My field:</label><input type="text" name="form-0-my_field" id="id_form-0-my_field"></div>
+
+Method 2: Using ``FormSet``
+---------------------------
+
+.. versionadded:: 6.2
+
+Additional fields can also be added when using the ``FormSet`` class.
+Similar to the method above, override the ``add_fields`` method:
+
+.. code-block:: pycon
+
+    >>> from django.forms import formsets
+    >>> from myapp.forms import ArticleForm
+    >>> class ArticleFormSet(formsets.FormSet):
+    ...     form = ArticleForm
+    ...     def add_fields(self, form, index):
+    ...         super().add_fields(form, index)
+    ...         form.fields["my_field"] = forms.CharField()
+    ...
+
     >>> formset = ArticleFormSet()
     >>> for form in formset:
     ...     print(form)

--- a/docs/topics/forms/modelforms.txt
+++ b/docs/topics/forms/modelforms.txt
@@ -815,13 +815,41 @@ Model formsets
 
 Like :doc:`regular formsets </topics/forms/formsets>`, Django provides a couple
 of enhanced formset classes to make working with Django models more
-convenient. Let's reuse the ``Author`` model from above:
+convenient. To create a model formset out of the ``Author`` model from above,
+you have two options:
+
+Method 1: Using ``modelformset_factory``
+----------------------------------------
 
 .. code-block:: pycon
 
     >>> from django.forms import modelformset_factory
     >>> from myapp.models import Author
     >>> AuthorFormSet = modelformset_factory(Author, fields=["name", "title"])
+
+
+Method 2: Using ``ModelFormSet``
+--------------------------------
+
+.. versionadded:: 6.2
+
+.. code-block:: pycon
+
+    >>> from django.forms import models
+    >>> from myapp.models import Author
+    >>> class AuthorFormSet(models.ModelFormSet):
+    ...     model = Author
+    ...     fields = ("name", "title")
+    ...
+
+Using the declarative syntax, you can define the formset directly as a class,
+similar to how you declare models.
+
+.. note::
+
+    You can customize model formset behavior by overriding methods on either
+    ``BaseModelFormSet`` or ``ModelFormSet``, depending on the syntax you
+    choose.
 
 Using ``fields`` restricts the formset to use only the given fields.
 Alternatively, you can take an "opt-out" approach, specifying which fields to
@@ -849,10 +877,8 @@ with the ``Author`` model. It works just like a regular formset:
 
 .. note::
 
-    :func:`~django.forms.models.modelformset_factory` uses
-    :func:`~django.forms.formsets.formset_factory` to generate formsets. This
-    means that a model formset is an extension of a basic formset that knows
-    how to interact with a particular model.
+    A model formset is an extension of a basic formset that knows how to
+    interact with a particular model.
 
 .. note::
 
@@ -1265,7 +1291,10 @@ you have these two models::
         title = models.CharField(max_length=100)
 
 If you want to create a formset that allows you to edit books belonging to
-a particular author, you could do this:
+a particular author, you have two options:
+
+Method 1: Using ``inlineformset_factory``
+-----------------------------------------
 
 .. code-block:: pycon
 
@@ -1274,15 +1303,38 @@ a particular author, you could do this:
     >>> author = Author.objects.get(name="Mike Royko")
     >>> formset = BookFormSet(instance=author)
 
+Method 2: Using ``InlineFormSet``
+---------------------------------
+
+.. versionadded:: 6.2
+
+.. code-block:: pycon
+
+    >>> from django.forms import models
+    >>> class BookFormSet(models.InlineFormSet):
+    ...     parent_model = Author
+    ...     model = Book
+    ...     fields = ("title",)
+    ...
+    >>> author = Author.objects.get(name="Mike Royko")
+    >>> formset = BookFormSet(instance=author)
+
+Using the declarative syntax, you can define the formset directly as a class,
+similar to how you declare models.
+
+.. note::
+
+    You can customize inline formset behavior by overriding methods on either
+    ``BaseInlineFormSet`` or ``InlineFormSet``, depending on the syntax you
+    choose.
+
 ``BookFormSet``'s :ref:`prefix <formset-prefix>` is ``'book_set'``
 (``<model name>_set`` ). If ``Book``'s ``ForeignKey`` to ``Author`` has a
 :attr:`~django.db.models.ForeignKey.related_name`, that's used instead.
 
 .. note::
 
-    :func:`~django.forms.models.inlineformset_factory` uses
-    :func:`~django.forms.models.modelformset_factory` and marks
-    ``can_delete=True``.
+    Inline formsets set ``can_delete=True`` by default.
 
 .. seealso::
 

--- a/docs/topics/forms/modelforms.txt
+++ b/docs/topics/forms/modelforms.txt
@@ -1341,10 +1341,13 @@ similar to how you declare models.
     :ref:`Manually rendered can_delete and can_order
     <manually-rendered-can-delete-and-can-order>`.
 
-Overriding methods on an ``InlineFormSet``
-------------------------------------------
+Overriding methods on an inline formset
+---------------------------------------
 
-When overriding methods on ``InlineFormSet``, you should subclass
+Method 1: Using ``inlineformset_factory``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When overriding methods for use with the factory, you should subclass
 :class:`~models.BaseInlineFormSet` rather than
 :class:`~models.BaseModelFormSet`.
 
@@ -1374,6 +1377,29 @@ Then when you create your inline formset, pass in the optional argument
     ... )
     >>> author = Author.objects.get(name="Mike Royko")
     >>> formset = BookFormSet(instance=author)
+
+Method 2: Using ``InlineFormSet``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 6.2
+
+When using the declarative syntax, override methods directly on your
+``InlineFormSet`` subclass::
+
+    from django.forms import InlineFormSet
+
+
+    class BookFormSet(InlineFormSet):
+        parent_model = Author
+        model = Book
+        fields = ["title"]
+
+        def clean(self):
+            super().clean()
+            # example custom validation across forms in the formset
+            for form in self.forms:
+                # your custom formset validation
+                ...
 
 More than one foreign key to the same model
 -------------------------------------------

--- a/tests/forms_tests/tests/test_formsets.py
+++ b/tests/forms_tests/tests/test_formsets.py
@@ -19,12 +19,14 @@ from django.forms.formsets import (
     MIN_NUM_FORM_COUNT,
     TOTAL_FORM_COUNT,
     BaseFormSet,
+    FormSet,
     ManagementForm,
     all_valid,
     formset_factory,
 )
 from django.forms.renderers import (
     DjangoTemplates,
+    Jinja2,
     TemplatesSetting,
     get_default_renderer,
 )
@@ -33,6 +35,8 @@ from django.forms.widgets import HiddenInput
 from django.test import SimpleTestCase
 
 from . import jinja2_tests
+
+renderer = Jinja2()
 
 
 class Choice(Form):
@@ -64,24 +68,90 @@ class BaseFavoriteDrinksFormSet(BaseFormSet):
             seen_drinks.append(drink["name"])
 
 
-# A FormSet that takes a list of favorite drinks and raises an error if
-# there are any duplicates.
-FavoriteDrinksFormSet = formset_factory(
-    FavoriteDrinkForm, formset=BaseFavoriteDrinksFormSet, extra=3
-)
-
-
 class CustomKwargForm(Form):
     def __init__(self, *args, custom_kwarg, **kwargs):
         self.custom_kwarg = custom_kwarg
         super().__init__(*args, **kwargs)
 
 
-class FormsFormsetTestCase(SimpleTestCase):
+class DynamicBaseFormSet(BaseFormSet):
+    def get_form_kwargs(self, index):
+        return {"custom_kwarg": index}
+
+
+class CheckForm(Form):
+    field = IntegerField()
+
+
+class CheckFormMinValue(Form):
+    field = IntegerField(min_value=100)
+
+
+class DeletionAttributeFormSet(BaseFormSet):
+    deletion_widget = HiddenInput
+
+
+class DeletionMethodFormSet(BaseFormSet):
+    def get_deletion_widget(self):
+        return HiddenInput(attrs={"class": "deletion"})
+
+
+class OrderingAttributeFormSet(BaseFormSet):
+    ordering_widget = HiddenInput
+
+
+class OrderingMethodFormSet(BaseFormSet):
+    def get_ordering_widget(self):
+        return HiddenInput(attrs={"class": "ordering"})
+
+
+# Formsets can override the default iteration order
+class BaseReverseFormSet(BaseFormSet):
+    def __iter__(self):
+        return reversed(self.forms)
+
+    def __getitem__(self, idx):
+        return super().__getitem__(len(self) - idx - 1)
+
+
+class SplitDateTimeForm(Form):
+    when = SplitDateTimeField(initial=datetime.datetime.now)
+
+
+class AnotherChoice(Choice):
+    def is_valid(self):
+        self.is_valid_called = True
+        return super().is_valid()
+
+
+class BaseCustomFormSet(BaseFormSet):
+    def clean(self):
+        raise ValidationError("This is a non-form error")
+
+
+class CustomRendererTemplate(TemplatesSetting):
+    formset_template_name = "a/custom/formset/template.html"
+
+
+class CustomFormSet(BaseFormSet):
+    template_name = "a/custom/formset/template.html"
+
+
+class CustomRenderer(DjangoTemplates):
+    pass
+
+
+class ChoiceWithDefaultRenderer(Choice):
+    default_renderer = CustomRenderer()
+
+
+class FormsetTestMixin:
+    """A mixin to test declarative and factory formsets."""
+
     def make_choiceformset(
         self,
         formset_data=None,
-        formset_class=ChoiceFormSet,
+        formset_class=None,
         total_forms=None,
         initial_forms=0,
         max_num_forms=0,
@@ -89,9 +159,10 @@ class FormsFormsetTestCase(SimpleTestCase):
         **kwargs,
     ):
         """
-        Make a ChoiceFormset from the given formset_data.
+        Make a formset from the given formset_class and formset_data.
         The data should be given as a list of (choice, votes) tuples.
         """
+        formset_class = self.formset_class if not formset_class else formset_class
         kwargs.setdefault("prefix", "choices")
         kwargs.setdefault("auto_id", False)
 
@@ -160,30 +231,22 @@ class FormsFormsetTestCase(SimpleTestCase):
         Custom kwargs set on the formset instance are passed to the
         underlying forms.
         """
-        FormSet = formset_factory(CustomKwargForm, extra=2)
-        formset = FormSet(form_kwargs={"custom_kwarg": 1})
+        formset = self.custom_kwarg_extra2_formset(form_kwargs={"custom_kwarg": 1})
         for form in formset:
             self.assertTrue(hasattr(form, "custom_kwarg"))
             self.assertEqual(form.custom_kwarg, 1)
 
     def test_form_kwargs_formset_dynamic(self):
         """Form kwargs can be passed dynamically in a formset."""
-
-        class DynamicBaseFormSet(BaseFormSet):
-            def get_form_kwargs(self, index):
-                return {"custom_kwarg": index}
-
-        DynamicFormSet = formset_factory(
-            CustomKwargForm, formset=DynamicBaseFormSet, extra=2
+        formset = self.custom_kwarg_dynamic_formset(
+            form_kwargs={"custom_kwarg": "ignored"}
         )
-        formset = DynamicFormSet(form_kwargs={"custom_kwarg": "ignored"})
         for i, form in enumerate(formset):
             self.assertTrue(hasattr(form, "custom_kwarg"))
             self.assertEqual(form.custom_kwarg, i)
 
     def test_form_kwargs_empty_form(self):
-        FormSet = formset_factory(CustomKwargForm)
-        formset = FormSet(form_kwargs={"custom_kwarg": 1})
+        formset = self.custom_kwarg_formset(form_kwargs={"custom_kwarg": 1})
         self.assertTrue(hasattr(formset.empty_form, "custom_kwarg"))
         self.assertEqual(formset.empty_form.custom_kwarg, 1)
 
@@ -309,11 +372,10 @@ class FormsFormsetTestCase(SimpleTestCase):
 
     def test_displaying_more_than_one_blank_form(self):
         """
-        More than 1 empty form can be displayed using formset_factory's
-        `extra` argument.
+        More than 1 empty form can be displayed using
+        formset's (factory or declarative) `extra` argument.
         """
-        ChoiceFormSet = formset_factory(Choice, extra=3)
-        formset = ChoiceFormSet(auto_id=False, prefix="choices")
+        formset = self.choice_extra3_formset(auto_id=False, prefix="choices")
         self.assertHTMLEqual(
             "\n".join(form.as_ul() for form in formset.forms),
             """<li>Choice: <input type="text" name="choices-0-choice"></li>
@@ -338,17 +400,17 @@ class FormsFormsetTestCase(SimpleTestCase):
             "choices-2-choice": "",
             "choices-2-votes": "",
         }
-        formset = ChoiceFormSet(data, auto_id=False, prefix="choices")
+        formset = self.choice_extra3_formset(data, auto_id=False, prefix="choices")
         self.assertTrue(formset.is_valid())
         self.assertEqual([form.cleaned_data for form in formset.forms], [{}, {}, {}])
 
     def test_min_num_displaying_more_than_one_blank_form(self):
         """
-        More than 1 empty form can also be displayed using formset_factory's
-        min_num argument. It will (essentially) increment the extra argument.
+        More than 1 empty form can also be displayed using
+        formset's (factory or declarative) min_num argument.
+        It will (essentially) increment the extra argument.
         """
-        ChoiceFormSet = formset_factory(Choice, extra=1, min_num=1)
-        formset = ChoiceFormSet(auto_id=False, prefix="choices")
+        formset = self.choice_min_formset(auto_id=False, prefix="choices")
         # Min_num forms are required; extra forms can be empty.
         self.assertFalse(formset.forms[0].empty_permitted)
         self.assertTrue(formset.forms[1].empty_permitted)
@@ -362,8 +424,7 @@ class FormsFormsetTestCase(SimpleTestCase):
 
     def test_min_num_displaying_more_than_one_blank_form_with_zero_extra(self):
         """More than 1 empty form can be displayed using min_num."""
-        ChoiceFormSet = formset_factory(Choice, extra=0, min_num=3)
-        formset = ChoiceFormSet(auto_id=False, prefix="choices")
+        formset = self.choice_min3_formset(auto_id=False, prefix="choices")
         self.assertHTMLEqual(
             "\n".join(form.as_ul() for form in formset.forms),
             """<li>Choice: <input type="text" name="choices-0-choice"></li>
@@ -388,8 +449,7 @@ class FormsFormsetTestCase(SimpleTestCase):
             "choices-2-choice": "",
             "choices-2-votes": "",
         }
-        ChoiceFormSet = formset_factory(Choice, extra=3)
-        formset = ChoiceFormSet(data, auto_id=False, prefix="choices")
+        formset = self.choice_extra3_formset(data, auto_id=False, prefix="choices")
         self.assertTrue(formset.is_valid())
         self.assertEqual(
             [form.cleaned_data for form in formset.forms],
@@ -413,8 +473,9 @@ class FormsFormsetTestCase(SimpleTestCase):
             "choices-1-choice": "One",
             "choices-1-votes": "1",
         }
-        ChoiceFormSet = formset_factory(Choice, extra=1, max_num=1, validate_max=True)
-        formset = ChoiceFormSet(data, auto_id=False, prefix="choices")
+        formset = self.choice_max_validate_formset(
+            data, auto_id=False, prefix="choices"
+        )
         self.assertFalse(formset.is_valid())
         self.assertEqual(formset.non_form_errors(), ["Please submit at most 1 form."])
         self.assertEqual(
@@ -433,8 +494,7 @@ class FormsFormsetTestCase(SimpleTestCase):
             "choices-1-choice": "One",
             "choices-1-votes": "1",
         }
-        ChoiceFormSet = formset_factory(Choice, extra=1, max_num=1, validate_max=True)
-        formset = ChoiceFormSet(
+        formset = self.choice_max_validate_formset(
             data,
             auto_id=False,
             prefix="choices",
@@ -470,8 +530,9 @@ class FormsFormsetTestCase(SimpleTestCase):
             "choices-1-choice": "One",
             "choices-1-votes": "1",
         }
-        ChoiceFormSet = formset_factory(Choice, extra=1, min_num=3, validate_min=True)
-        formset = ChoiceFormSet(data, auto_id=False, prefix="choices")
+        formset = self.choice_min3_validate_formset(
+            data, auto_id=False, prefix="choices"
+        )
         self.assertFalse(formset.is_valid())
         self.assertEqual(formset.non_form_errors(), ["Please submit at least 3 forms."])
         self.assertEqual(
@@ -491,8 +552,7 @@ class FormsFormsetTestCase(SimpleTestCase):
             "choices-1-choice": "One",
             "choices-1-votes": "1",
         }
-        ChoiceFormSet = formset_factory(Choice, extra=1, min_num=3, validate_min=True)
-        formset = ChoiceFormSet(
+        formset = self.choice_min3_validate_formset(
             data,
             auto_id=False,
             prefix="choices",
@@ -530,8 +590,9 @@ class FormsFormsetTestCase(SimpleTestCase):
             "choices-1-choice": "One",
             "choices-1-votes": "1",  # changed from initial
         }
-        ChoiceFormSet = formset_factory(Choice, min_num=2, validate_min=True)
-        formset = ChoiceFormSet(data, auto_id=False, prefix="choices", initial=initial)
+        formset = self.choice_min2_validate_formset(
+            data, auto_id=False, prefix="choices", initial=initial
+        )
         self.assertFalse(formset.forms[0].has_changed())
         self.assertTrue(formset.forms[1].has_changed())
         self.assertTrue(formset.is_valid())
@@ -541,10 +602,7 @@ class FormsFormsetTestCase(SimpleTestCase):
             "choices-TOTAL_FORMS": "2",
             "choices-INITIAL_FORMS": "0",
         }
-        ChoiceFormSet = formset_factory(
-            Choice, extra=2, min_num=1, validate_min=True, can_delete=True
-        )
-        formset = ChoiceFormSet(data, prefix="choices")
+        formset = self.choice_min_validate_can_delete_formset(data, prefix="choices")
         self.assertFalse(formset.has_changed())
         self.assertFalse(formset.is_valid())
         self.assertEqual(formset.non_form_errors(), ["Please submit at least 1 form."])
@@ -563,8 +621,7 @@ class FormsFormsetTestCase(SimpleTestCase):
             "choices-2-choice": "",
             "choices-2-votes": "",
         }
-        ChoiceFormSet = formset_factory(Choice, extra=3)
-        formset = ChoiceFormSet(data, auto_id=False, prefix="choices")
+        formset = self.choice_extra3_formset(data, auto_id=False, prefix="choices")
         self.assertFalse(formset.is_valid())
         self.assertEqual(
             formset.errors, [{}, {"votes": ["This field is required."]}, {}]
@@ -576,8 +633,9 @@ class FormsFormsetTestCase(SimpleTestCase):
         data.
         """
         initial = [{"choice": "Calexico", "votes": 100}]
-        ChoiceFormSet = formset_factory(Choice, extra=3)
-        formset = ChoiceFormSet(initial=initial, auto_id=False, prefix="choices")
+        formset = self.choice_extra3_formset(
+            initial=initial, auto_id=False, prefix="choices"
+        )
         self.assertHTMLEqual(
             "\n".join(form.as_ul() for form in formset.forms),
             '<li>Choice: <input type="text" name="choices-0-choice" value="Calexico">'
@@ -600,16 +658,18 @@ class FormsFormsetTestCase(SimpleTestCase):
 
     def test_formset_with_deletion(self):
         """
-        formset_factory's can_delete argument adds a boolean "delete" field to
-        each form. When that boolean field is True, the form will be in
+        formset's (factory or declarative) can_delete argument
+        adds a boolean "delete" field to each form. When that
+        boolean field is True, the form will be in
         formset.deleted_forms.
         """
-        ChoiceFormSet = formset_factory(Choice, can_delete=True)
         initial = [
             {"choice": "Calexico", "votes": 100},
             {"choice": "Fergie", "votes": 900},
         ]
-        formset = ChoiceFormSet(initial=initial, auto_id=False, prefix="choices")
+        formset = self.choice_can_delete_formset(
+            initial=initial, auto_id=False, prefix="choices"
+        )
         self.assertHTMLEqual(
             "\n".join(form.as_ul() for form in formset.forms),
             '<li>Choice: <input type="text" name="choices-0-choice" value="Calexico">'
@@ -641,7 +701,7 @@ class FormsFormsetTestCase(SimpleTestCase):
             "choices-2-votes": "",
             "choices-2-DELETE": "",
         }
-        formset = ChoiceFormSet(data, auto_id=False, prefix="choices")
+        formset = self.choice_can_delete_formset(data, auto_id=False, prefix="choices")
         self.assertTrue(formset.is_valid())
         self.assertEqual(
             [form.cleaned_data for form in formset.forms],
@@ -662,10 +722,6 @@ class FormsFormsetTestCase(SimpleTestCase):
         form's errors shouldn't make the entire formset invalid since it's
         going to be deleted.
         """
-
-        class CheckForm(Form):
-            field = IntegerField(min_value=100)
-
         data = {
             "check-TOTAL_FORMS": "3",  # the number of forms rendered
             "check-INITIAL_FORMS": "2",  # the number of forms with initial data
@@ -678,12 +734,11 @@ class FormsFormsetTestCase(SimpleTestCase):
             "check-2-field": "",
             "check-2-DELETE": "",
         }
-        CheckFormSet = formset_factory(CheckForm, can_delete=True)
-        formset = CheckFormSet(data, prefix="check")
+        formset = self.check_min_value_formset(data, prefix="check")
         self.assertTrue(formset.is_valid())
         # If the deletion flag is removed, validation is enabled.
         data["check-1-DELETE"] = ""
-        formset = CheckFormSet(data, prefix="check")
+        formset = self.check_min_value_formset(data, prefix="check")
         self.assertFalse(formset.is_valid())
 
     def test_formset_with_deletion_invalid_deleted_form(self):
@@ -691,8 +746,7 @@ class FormsFormsetTestCase(SimpleTestCase):
         deleted_forms works on a valid formset even if a deleted form would
         have been invalid.
         """
-        FavoriteDrinkFormset = formset_factory(form=FavoriteDrinkForm, can_delete=True)
-        formset = FavoriteDrinkFormset(
+        formset = self.favorite_drink_can_delete_formset(
             {
                 "form-0-name": "",
                 "form-0-DELETE": "on",  # no name!
@@ -706,42 +760,10 @@ class FormsFormsetTestCase(SimpleTestCase):
         self.assertEqual(formset._errors, [])
         self.assertEqual(len(formset.deleted_forms), 1)
 
-    def test_formset_with_deletion_custom_widget(self):
-        class DeletionAttributeFormSet(BaseFormSet):
-            deletion_widget = HiddenInput
-
-        class DeletionMethodFormSet(BaseFormSet):
-            def get_deletion_widget(self):
-                return HiddenInput(attrs={"class": "deletion"})
-
-        tests = [
-            (DeletionAttributeFormSet, '<input type="hidden" name="form-0-DELETE">'),
-            (
-                DeletionMethodFormSet,
-                '<input class="deletion" type="hidden" name="form-0-DELETE">',
-            ),
-        ]
-        for formset_class, delete_html in tests:
-            with self.subTest(formset_class=formset_class.__name__):
-                ArticleFormSet = formset_factory(
-                    ArticleForm,
-                    formset=formset_class,
-                    can_delete=True,
-                )
-                formset = ArticleFormSet(auto_id=False)
-                self.assertHTMLEqual(
-                    "\n".join([form.as_ul() for form in formset.forms]),
-                    (
-                        f'<li>Title: <input type="text" name="form-0-title"></li>'
-                        f'<li>Pub date: <input type="text" name="form-0-pub_date">'
-                        f"{delete_html}</li>"
-                    ),
-                )
-
     def test_formsets_with_ordering(self):
         """
-        formset_factory's can_order argument adds an integer field to each
-        form. When form validation succeeds,
+        formset's (factory or declarative) can_order argument
+        adds an integer field to each form. When form validation succeeds,
             [form.cleaned_data for form in formset.forms]
         will have the data in the correct order specified by the ordering
         fields. If a number is duplicated in the set of ordering fields, for
@@ -749,12 +771,13 @@ class FormsFormsetTestCase(SimpleTestCase):
         used as a secondary ordering criteria. In order to put something at the
         front of the list, you'd need to set its order to 0.
         """
-        ChoiceFormSet = formset_factory(Choice, can_order=True)
         initial = [
             {"choice": "Calexico", "votes": 100},
             {"choice": "Fergie", "votes": 900},
         ]
-        formset = ChoiceFormSet(initial=initial, auto_id=False, prefix="choices")
+        formset = self.choice_can_order_formset(
+            initial=initial, auto_id=False, prefix="choices"
+        )
         self.assertHTMLEqual(
             "\n".join(form.as_ul() for form in formset.forms),
             '<li>Choice: <input type="text" name="choices-0-choice" value="Calexico">'
@@ -784,7 +807,7 @@ class FormsFormsetTestCase(SimpleTestCase):
             "choices-2-votes": "500",
             "choices-2-ORDER": "0",
         }
-        formset = ChoiceFormSet(data, auto_id=False, prefix="choices")
+        formset = self.choice_can_order_formset(data, auto_id=False, prefix="choices")
         self.assertTrue(formset.is_valid())
         self.assertEqual(
             [form.cleaned_data for form in formset.ordered_forms],
@@ -794,36 +817,6 @@ class FormsFormsetTestCase(SimpleTestCase):
                 {"votes": 900, "ORDER": 2, "choice": "Fergie"},
             ],
         )
-
-    def test_formsets_with_ordering_custom_widget(self):
-        class OrderingAttributeFormSet(BaseFormSet):
-            ordering_widget = HiddenInput
-
-        class OrderingMethodFormSet(BaseFormSet):
-            def get_ordering_widget(self):
-                return HiddenInput(attrs={"class": "ordering"})
-
-        tests = (
-            (OrderingAttributeFormSet, '<input type="hidden" name="form-0-ORDER">'),
-            (
-                OrderingMethodFormSet,
-                '<input class="ordering" type="hidden" name="form-0-ORDER">',
-            ),
-        )
-        for formset_class, order_html in tests:
-            with self.subTest(formset_class=formset_class.__name__):
-                ArticleFormSet = formset_factory(
-                    ArticleForm, formset=formset_class, can_order=True
-                )
-                formset = ArticleFormSet(auto_id=False)
-                self.assertHTMLEqual(
-                    "\n".join(form.as_ul() for form in formset.forms),
-                    (
-                        '<li>Title: <input type="text" name="form-0-title"></li>'
-                        '<li>Pub date: <input type="text" name="form-0-pub_date">'
-                        "%s</li>" % order_html
-                    ),
-                )
 
     def test_empty_ordered_fields(self):
         """
@@ -848,8 +841,7 @@ class FormsFormsetTestCase(SimpleTestCase):
             "choices-3-votes": "50",
             "choices-3-ORDER": "",
         }
-        ChoiceFormSet = formset_factory(Choice, can_order=True)
-        formset = ChoiceFormSet(data, auto_id=False, prefix="choices")
+        formset = self.choice_can_order_formset(data, auto_id=False, prefix="choices")
         self.assertTrue(formset.is_valid())
         self.assertEqual(
             [form.cleaned_data for form in formset.ordered_forms],
@@ -869,20 +861,20 @@ class FormsFormsetTestCase(SimpleTestCase):
             "choices-MIN_NUM_FORMS": "0",  # min number of forms
             "choices-MAX_NUM_FORMS": "0",  # max number of forms
         }
-        ChoiceFormSet = formset_factory(Choice, can_order=True)
-        formset = ChoiceFormSet(data, auto_id=False, prefix="choices")
+        formset = self.choice_can_order_formset(data, auto_id=False, prefix="choices")
         self.assertTrue(formset.is_valid())
         self.assertEqual(formset.ordered_forms, [])
 
     def test_formset_with_ordering_and_deletion(self):
         """FormSets with ordering + deletion."""
-        ChoiceFormSet = formset_factory(Choice, can_order=True, can_delete=True)
         initial = [
             {"choice": "Calexico", "votes": 100},
             {"choice": "Fergie", "votes": 900},
             {"choice": "The Decemberists", "votes": 500},
         ]
-        formset = ChoiceFormSet(initial=initial, auto_id=False, prefix="choices")
+        formset = self.choice_can_order_delete_formset(
+            initial=initial, auto_id=False, prefix="choices"
+        )
         self.assertHTMLEqual(
             "\n".join(form.as_ul() for form in formset.forms),
             '<li>Choice: <input type="text" name="choices-0-choice" value="Calexico">'
@@ -928,7 +920,9 @@ class FormsFormsetTestCase(SimpleTestCase):
             "choices-3-ORDER": "",
             "choices-3-DELETE": "",
         }
-        formset = ChoiceFormSet(data, auto_id=False, prefix="choices")
+        formset = self.choice_can_order_delete_formset(
+            data, auto_id=False, prefix="choices"
+        )
         self.assertTrue(formset.is_valid())
         self.assertEqual(
             [form.cleaned_data for form in formset.ordered_forms],
@@ -952,10 +946,7 @@ class FormsFormsetTestCase(SimpleTestCase):
         Can get ordered_forms from a valid formset even if a deleted form
         would have been invalid.
         """
-        FavoriteDrinkFormset = formset_factory(
-            form=FavoriteDrinkForm, can_delete=True, can_order=True
-        )
-        formset = FavoriteDrinkFormset(
+        formset = self.choice_can_order_delete_formset(
             {
                 "form-0-name": "",
                 "form-0-DELETE": "on",  # no name!
@@ -982,7 +973,7 @@ class FormsFormsetTestCase(SimpleTestCase):
             "drinks-0-name": "Gin and Tonic",
             "drinks-1-name": "Gin and Tonic",
         }
-        formset = FavoriteDrinksFormSet(data, prefix="drinks")
+        formset = self.favorite_drink_base_formset(data, prefix="drinks")
         self.assertFalse(formset.is_valid())
         # Any errors raised by formset.clean() are available via the
         # formset.non_form_errors() method.
@@ -990,7 +981,7 @@ class FormsFormsetTestCase(SimpleTestCase):
             self.assertEqual(str(error), "You may only specify a drink once.")
         # The valid case still works.
         data["drinks-1-name"] = "Bloody Mary"
-        formset = FavoriteDrinksFormSet(data, prefix="drinks")
+        formset = self.favorite_drink_base_formset(data, prefix="drinks")
         self.assertTrue(formset.is_valid())
         self.assertEqual(formset.non_form_errors(), [])
 
@@ -998,8 +989,7 @@ class FormsFormsetTestCase(SimpleTestCase):
         """Limiting the maximum number of forms with max_num."""
         # When not passed, max_num will take a high default value, leaving the
         # number of forms only controlled by the value of the extra parameter.
-        LimitedFavoriteDrinkFormSet = formset_factory(FavoriteDrinkForm, extra=3)
-        formset = LimitedFavoriteDrinkFormSet()
+        formset = self.favorite_drink_extra3_formset()
         self.assertHTMLEqual(
             "\n".join(str(form) for form in formset.forms),
             """<div><label for="id_form-0-name">Name:</label>
@@ -1010,17 +1000,11 @@ class FormsFormsetTestCase(SimpleTestCase):
 <input type="text" name="form-2-name" id="id_form-2-name"></div>""",
         )
         # If max_num is 0 then no form is rendered at all.
-        LimitedFavoriteDrinkFormSet = formset_factory(
-            FavoriteDrinkForm, extra=3, max_num=0
-        )
-        formset = LimitedFavoriteDrinkFormSet()
+        formset = self.favorite_drink_extra3_max0_formset()
         self.assertEqual(formset.forms, [])
 
     def test_limited_max_forms_two(self):
-        LimitedFavoriteDrinkFormSet = formset_factory(
-            FavoriteDrinkForm, extra=5, max_num=2
-        )
-        formset = LimitedFavoriteDrinkFormSet()
+        formset = self.favorite_drink_extra5_max2_formset()
         self.assertHTMLEqual(
             "\n".join(str(form) for form in formset.forms),
             """<div><label for="id_form-0-name">Name:</label>
@@ -1031,10 +1015,7 @@ class FormsFormsetTestCase(SimpleTestCase):
 
     def test_limiting_extra_lest_than_max_num(self):
         """max_num has no effect when extra is less than max_num."""
-        LimitedFavoriteDrinkFormSet = formset_factory(
-            FavoriteDrinkForm, extra=1, max_num=2
-        )
-        formset = LimitedFavoriteDrinkFormSet()
+        formset = self.favorite_drink_extra1_max2_formset()
         self.assertHTMLEqual(
             "\n".join(str(form) for form in formset.forms),
             """<div><label for="id_form-0-name">Name:</label>
@@ -1045,8 +1026,9 @@ class FormsFormsetTestCase(SimpleTestCase):
         # When not passed, max_num will take a high default value, leaving the
         # number of forms only controlled by the value of the initial and extra
         # parameters.
-        LimitedFavoriteDrinkFormSet = formset_factory(FavoriteDrinkForm, extra=1)
-        formset = LimitedFavoriteDrinkFormSet(initial=[{"name": "Fernet and Coke"}])
+        formset = self.favorite_drink_extra1_formset(
+            initial=[{"name": "Fernet and Coke"}]
+        )
         self.assertHTMLEqual(
             "\n".join(str(form) for form in formset.forms),
             """
@@ -1063,10 +1045,7 @@ class FormsFormsetTestCase(SimpleTestCase):
         If max_num is 0 then no form is rendered at all, regardless of extra,
         unless initial data is present.
         """
-        LimitedFavoriteDrinkFormSet = formset_factory(
-            FavoriteDrinkForm, extra=1, max_num=0
-        )
-        formset = LimitedFavoriteDrinkFormSet()
+        formset = self.favorite_drink_extra1_max0_formset()
         self.assertEqual(formset.forms, [])
 
     def test_max_num_zero_with_initial(self):
@@ -1075,10 +1054,7 @@ class FormsFormsetTestCase(SimpleTestCase):
             {"name": "Fernet and Coke"},
             {"name": "Bloody Mary"},
         ]
-        LimitedFavoriteDrinkFormSet = formset_factory(
-            FavoriteDrinkForm, extra=1, max_num=0
-        )
-        formset = LimitedFavoriteDrinkFormSet(initial=initial)
+        formset = self.favorite_drink_extra1_max0_formset(initial=initial)
         self.assertHTMLEqual(
             "\n".join(str(form) for form in formset.forms),
             """
@@ -1101,10 +1077,7 @@ class FormsFormsetTestCase(SimpleTestCase):
             {"name": "Bloody Mary"},
             {"name": "Jack and Coke"},
         ]
-        LimitedFavoriteDrinkFormSet = formset_factory(
-            FavoriteDrinkForm, extra=1, max_num=2
-        )
-        formset = LimitedFavoriteDrinkFormSet(initial=initial)
+        formset = self.favorite_drink_extra1_max2_formset(initial=initial)
         self.assertHTMLEqual(
             "\n".join(str(form) for form in formset.forms),
             """
@@ -1127,7 +1100,7 @@ class FormsFormsetTestCase(SimpleTestCase):
             "form-INITIAL_FORMS": "0",
             "form-MAX_NUM_FORMS": "0",
         }
-        formset = FavoriteDrinksFormSet(data=data)
+        formset = self.favorite_drink_base_formset(data=data)
         self.assertIs(formset.is_valid(), False)
         self.assertEqual(
             formset.non_form_errors(),
@@ -1141,16 +1114,12 @@ class FormsFormsetTestCase(SimpleTestCase):
             "form-INITIAL_FORMS": "0",
             "form-MAX_NUM_FORMS": "0",
         }
-        AbsoluteMaxFavoriteDrinksFormSet = formset_factory(
-            FavoriteDrinkForm,
-            absolute_max=3000,
-        )
-        formset = AbsoluteMaxFavoriteDrinksFormSet(data=data)
+        formset = self.favorite_drink_absolute_max_formset(data=data)
         self.assertIs(formset.is_valid(), True)
         self.assertEqual(len(formset.forms), 2001)
         # absolute_max provides a hard limit.
         data["form-TOTAL_FORMS"] = "3001"
-        formset = AbsoluteMaxFavoriteDrinksFormSet(data=data)
+        formset = self.favorite_drink_absolute_max_formset(data=data)
         self.assertIs(formset.is_valid(), False)
         self.assertEqual(len(formset.forms), 3000)
         self.assertEqual(
@@ -1164,12 +1133,7 @@ class FormsFormsetTestCase(SimpleTestCase):
             "form-INITIAL_FORMS": "0",
             "form-MAX_NUM_FORMS": "0",
         }
-        LimitedFavoriteDrinksFormSet = formset_factory(
-            FavoriteDrinkForm,
-            max_num=30,
-            absolute_max=1000,
-        )
-        formset = LimitedFavoriteDrinksFormSet(data=data)
+        formset = self.favorite_drink_absolute_max_num_formset(data=data)
         self.assertIs(formset.is_valid(), False)
         self.assertEqual(len(formset.forms), 1000)
         self.assertEqual(
@@ -1177,22 +1141,14 @@ class FormsFormsetTestCase(SimpleTestCase):
             ["Please submit at most 30 forms."],
         )
 
-    def test_absolute_max_invalid(self):
-        msg = "'absolute_max' must be greater or equal to 'max_num'."
-        for max_num in [None, 31]:
-            with self.subTest(max_num=max_num):
-                with self.assertRaisesMessage(ValueError, msg):
-                    formset_factory(FavoriteDrinkForm, max_num=max_num, absolute_max=30)
-
     def test_more_initial_form_result_in_one(self):
         """
         One form from initial and extra=3 with max_num=2 results in the one
         initial form and one extra.
         """
-        LimitedFavoriteDrinkFormSet = formset_factory(
-            FavoriteDrinkForm, extra=3, max_num=2
+        formset = self.favorite_drink_extra3_max2_formset(
+            initial=[{"name": "Gin Tonic"}]
         )
-        formset = LimitedFavoriteDrinkFormSet(initial=[{"name": "Gin Tonic"}])
         self.assertHTMLEqual(
             "\n".join(str(form) for form in formset.forms),
             """
@@ -1217,7 +1173,7 @@ class FormsFormsetTestCase(SimpleTestCase):
 
     def test_management_form_prefix(self):
         """The management form has the correct prefix."""
-        formset = FavoriteDrinksFormSet()
+        formset = self.favorite_drink_base_formset()
         self.assertEqual(formset.management_form.prefix, "form")
         data = {
             "form-TOTAL_FORMS": "2",
@@ -1225,9 +1181,9 @@ class FormsFormsetTestCase(SimpleTestCase):
             "form-MIN_NUM_FORMS": "0",
             "form-MAX_NUM_FORMS": "0",
         }
-        formset = FavoriteDrinksFormSet(data=data)
+        formset = self.favorite_drink_base_formset(data=data)
         self.assertEqual(formset.management_form.prefix, "form")
-        formset = FavoriteDrinksFormSet(initial={})
+        formset = self.favorite_drink_base_formset(initial={})
         self.assertEqual(formset.management_form.prefix, "form")
 
     def test_non_form_errors(self):
@@ -1239,7 +1195,7 @@ class FormsFormsetTestCase(SimpleTestCase):
             "drinks-0-name": "Gin and Tonic",
             "drinks-1-name": "Gin and Tonic",
         }
-        formset = FavoriteDrinksFormSet(data, prefix="drinks")
+        formset = self.favorite_drink_base_formset(data, prefix="drinks")
         self.assertFalse(formset.is_valid())
         self.assertEqual(
             formset.non_form_errors(), ["You may only specify a drink once."]
@@ -1252,8 +1208,7 @@ class FormsFormsetTestCase(SimpleTestCase):
 
     def test_formset_iteration(self):
         """Formset instances are iterable."""
-        ChoiceFormset = formset_factory(Choice, extra=3)
-        formset = ChoiceFormset()
+        formset = self.choice_extra3_formset()
         # An iterated formset yields formset.forms.
         forms = list(formset)
         self.assertEqual(forms, formset.forms)
@@ -1263,26 +1218,17 @@ class FormsFormsetTestCase(SimpleTestCase):
         with self.assertRaises(IndexError):
             formset[3]
 
-        # Formsets can override the default iteration order
-        class BaseReverseFormSet(BaseFormSet):
-            def __iter__(self):
-                return reversed(self.forms)
-
-            def __getitem__(self, idx):
-                return super().__getitem__(len(self) - idx - 1)
-
-        ReverseChoiceFormset = formset_factory(Choice, BaseReverseFormSet, extra=3)
-        reverse_formset = ReverseChoiceFormset()
+        reverse_formset = self.choice_reverse_formset()
         # __iter__() modifies the rendering order.
-        # Compare forms from "reverse" formset with forms from original formset
+        # Compare forms from "reverse" formset with
+        # forms from original formset
         self.assertEqual(str(reverse_formset[0]), str(forms[-1]))
         self.assertEqual(str(reverse_formset[1]), str(forms[-2]))
         self.assertEqual(len(reverse_formset), len(forms))
 
     def test_formset_nonzero(self):
         """A formsets without any forms evaluates as True."""
-        ChoiceFormset = formset_factory(Choice, extra=0)
-        formset = ChoiceFormset()
+        formset = self.choice_extra0_formset()
         self.assertEqual(len(formset.forms), 0)
         self.assertTrue(formset)
 
@@ -1290,18 +1236,13 @@ class FormsFormsetTestCase(SimpleTestCase):
         """
         Formset works with SplitDateTimeField(initial=datetime.datetime.now).
         """
-
-        class SplitDateTimeForm(Form):
-            when = SplitDateTimeField(initial=datetime.datetime.now)
-
-        SplitDateTimeFormSet = formset_factory(SplitDateTimeForm)
         data = {
             "form-TOTAL_FORMS": "1",
             "form-INITIAL_FORMS": "0",
             "form-0-when_0": "1904-06-16",
             "form-0-when_1": "15:51:33",
         }
-        formset = SplitDateTimeFormSet(data)
+        formset = self.split_datetime_formset(data)
         self.assertTrue(formset.is_valid())
 
     def test_formset_error_class(self):
@@ -1310,18 +1251,11 @@ class FormsFormsetTestCase(SimpleTestCase):
         class CustomErrorList(ErrorList):
             pass
 
-        formset = FavoriteDrinksFormSet(error_class=CustomErrorList)
+        formset = self.favorite_drink_base_formset(error_class=CustomErrorList)
         self.assertEqual(formset.forms[0].error_class, CustomErrorList)
 
     def test_formset_calls_forms_is_valid(self):
         """Formsets call is_valid() on each form."""
-
-        class AnotherChoice(Choice):
-            def is_valid(self):
-                self.is_valid_called = True
-                return super().is_valid()
-
-        AnotherChoiceFormSet = formset_factory(AnotherChoice)
         data = {
             "choices-TOTAL_FORMS": "1",  # number of forms rendered
             "choices-INITIAL_FORMS": "0",  # number of forms with initial data
@@ -1330,9 +1264,438 @@ class FormsFormsetTestCase(SimpleTestCase):
             "choices-0-choice": "Calexico",
             "choices-0-votes": "100",
         }
-        formset = AnotherChoiceFormSet(data, auto_id=False, prefix="choices")
+        formset = self.another_choice_formset(data, auto_id=False, prefix="choices")
         self.assertTrue(formset.is_valid())
         self.assertTrue(all(form.is_valid_called for form in formset.forms))
+
+    def test_non_form_errors_run_full_clean(self):
+        """
+        If non_form_errors() is called without calling is_valid() first,
+        it should ensure that full_clean() is called.
+        """
+        data = {
+            "choices-TOTAL_FORMS": "1",
+            "choices-INITIAL_FORMS": "0",
+        }
+        formset = self.choice_base_custom_formset(data, auto_id=False, prefix="choices")
+        self.assertIsInstance(formset.non_form_errors(), ErrorList)
+        self.assertEqual(list(formset.non_form_errors()), ["This is a non-form error"])
+
+    def test_validate_max_ignores_forms_marked_for_deletion(self):
+        data = {
+            "check-TOTAL_FORMS": "2",
+            "check-INITIAL_FORMS": "0",
+            "check-MAX_NUM_FORMS": "1",
+            "check-0-field": "200",
+            "check-0-DELETE": "",
+            "check-1-field": "50",
+            "check-1-DELETE": "on",
+        }
+        formset = self.check_max_validate_formset(data, prefix="check")
+        self.assertTrue(formset.is_valid())
+
+    def test_formset_total_error_count(self):
+        """A valid formset should have 0 total errors."""
+        data = [  # formset_data, expected error count
+            ([("Calexico", "100")], 0),
+            ([("Calexico", "")], 1),
+            ([("", "invalid")], 2),
+            ([("Calexico", "100"), ("Calexico", "")], 1),
+            ([("Calexico", ""), ("Calexico", "")], 2),
+        ]
+        for formset_data, expected_error_count in data:
+            formset = self.make_choiceformset(formset_data)
+            self.assertEqual(formset.total_error_count(), expected_error_count)
+
+    def test_formset_total_error_count_with_non_form_errors(self):
+        data = {
+            "choices-TOTAL_FORMS": "2",  # the number of forms rendered
+            "choices-INITIAL_FORMS": "0",  # the number of forms with initial data
+            "choices-MAX_NUM_FORMS": "2",  # max number of forms - should be ignored
+            "choices-0-choice": "Zero",
+            "choices-0-votes": "0",
+            "choices-1-choice": "One",
+            "choices-1-votes": "1",
+        }
+        formset = self.choice_max_validate_formset(
+            data, auto_id=False, prefix="choices"
+        )
+        self.assertEqual(formset.total_error_count(), 1)
+        data["choices-1-votes"] = ""
+        formset = self.choice_max_validate_formset(
+            data, auto_id=False, prefix="choices"
+        )
+        self.assertEqual(formset.total_error_count(), 2)
+
+    def test_html_safe(self):
+        formset = self.make_choiceformset()
+        self.assertTrue(hasattr(formset, "__html__"))
+        self.assertEqual(str(formset), formset.__html__())
+
+    def test_can_delete_extra_formset_forms(self):
+        formset = self.choice_extra2_can_delete_formset()
+        self.assertEqual(len(formset), 2)
+        self.assertIn("DELETE", formset.forms[0].fields)
+        self.assertIn("DELETE", formset.forms[1].fields)
+
+    def test_disable_delete_extra_formset_forms(self):
+        formset = self.choice_can_delete_no_extra_formset()
+        self.assertEqual(len(formset), 2)
+        self.assertNotIn("DELETE", formset.forms[0].fields)
+        self.assertNotIn("DELETE", formset.forms[1].fields)
+
+        formset = self.choice_can_delete_no_extra_formset(
+            initial=[{"choice": "Zero", "votes": "1"}]
+        )
+        self.assertEqual(len(formset), 3)
+        self.assertIn("DELETE", formset.forms[0].fields)
+        self.assertNotIn("DELETE", formset.forms[1].fields)
+        self.assertNotIn("DELETE", formset.forms[2].fields)
+        self.assertNotIn("DELETE", formset.empty_form.fields)
+
+        formset = self.choice_can_delete_no_extra_formset(
+            data={
+                "form-0-choice": "Zero",
+                "form-0-votes": "0",
+                "form-0-DELETE": "on",
+                "form-1-choice": "One",
+                "form-1-votes": "1",
+                "form-2-choice": "",
+                "form-2-votes": "",
+                "form-TOTAL_FORMS": "3",
+                "form-INITIAL_FORMS": "1",
+            },
+            initial=[{"choice": "Zero", "votes": "1"}],
+        )
+        self.assertEqual(
+            formset.cleaned_data,
+            [
+                {"choice": "Zero", "votes": 0, "DELETE": True},
+                {"choice": "One", "votes": 1},
+                {},
+            ],
+        )
+        self.assertIs(formset._should_delete_form(formset.forms[0]), True)
+        self.assertIs(formset._should_delete_form(formset.forms[1]), False)
+        self.assertIs(formset._should_delete_form(formset.forms[2]), False)
+
+    def test_template_name_uses_renderer_value(self):
+        self.assertEqual(
+            self.choice_renderer_formset().template_name,
+            "a/custom/formset/template.html",
+        )
+
+    def test_template_name_can_be_overridden(self):
+        self.assertEqual(
+            self.choice_custom_formset().template_name, "a/custom/formset/template.html"
+        )
+
+    def test_custom_renderer(self):
+        """
+        A custom renderer passed to a formset_factory() is passed to all forms
+        and ErrorList.
+        """
+        data = {
+            "choices-TOTAL_FORMS": "2",
+            "choices-INITIAL_FORMS": "0",
+            "choices-MIN_NUM_FORMS": "0",
+            "choices-0-choice": "Zero",
+            "choices-0-votes": "",
+            "choices-1-choice": "One",
+            "choices-1-votes": "",
+        }
+        formset = self.choice_jinja_renderer_formset(
+            data, auto_id=False, prefix="choices"
+        )
+        self.assertEqual(formset.renderer, renderer)
+        self.assertEqual(formset.forms[0].renderer, renderer)
+        self.assertEqual(formset.management_form.renderer, renderer)
+        self.assertEqual(formset.non_form_errors().renderer, renderer)
+        self.assertEqual(formset.empty_form.renderer, renderer)
+
+    def test_form_default_renderer(self):
+        """
+        In the absence of a renderer passed to the formset_factory(),
+        Form.default_renderer is respected.
+        """
+        data = {
+            "choices-TOTAL_FORMS": "1",
+            "choices-INITIAL_FORMS": "0",
+            "choices-MIN_NUM_FORMS": "0",
+        }
+
+        formset = self.choice_default_renderer_formset(data, prefix="choices")
+        self.assertEqual(
+            formset.forms[0].renderer, ChoiceWithDefaultRenderer.default_renderer
+        )
+        self.assertEqual(
+            formset.empty_form.renderer, ChoiceWithDefaultRenderer.default_renderer
+        )
+        default_renderer = get_default_renderer()
+        self.assertIsInstance(formset.renderer, type(default_renderer))
+
+    def test_form_default_renderer_class(self):
+        """
+        In the absence of a renderer passed to the formset_factory(),
+        Form.default_renderer is respected.
+        """
+        data = {
+            "choices-TOTAL_FORMS": "1",
+            "choices-INITIAL_FORMS": "0",
+            "choices-MIN_NUM_FORMS": "0",
+        }
+        formset = self.choice_default_renderer_formset(data, prefix="choices")
+        self.assertIsInstance(formset.forms[0].renderer, CustomRenderer)
+        self.assertIsInstance(formset.empty_form.renderer, CustomRenderer)
+        default_renderer = get_default_renderer()
+        self.assertIsInstance(formset.renderer, type(default_renderer))
+
+    def test_repr(self):
+        valid_formset = self.make_choiceformset([("test", 1)])
+        valid_formset.full_clean()
+        invalid_formset = self.make_choiceformset([("test", "")])
+        invalid_formset.full_clean()
+        partially_invalid_formset = self.make_choiceformset(
+            [("test", "1"), ("test", "")],
+        )
+        partially_invalid_formset.full_clean()
+        invalid_formset_non_form_errors_only = self.make_choiceformset(
+            [("test", "")],
+            formset_class=ChoiceFormsetWithNonFormError,
+        )
+        invalid_formset_non_form_errors_only.full_clean()
+
+        cases = {
+            "FactoryFormsetTestCase": [
+                (
+                    self.make_choiceformset(),
+                    "<ChoiceFormSet: bound=False valid=Unknown total_forms=1>",
+                ),
+                (
+                    self.make_choiceformset(
+                        formset_class=self.choice_extra10_formset,
+                    ),
+                    "<ChoiceFormSet: bound=False valid=Unknown total_forms=10>",
+                ),
+                (
+                    self.make_choiceformset([]),
+                    "<ChoiceFormSet: bound=True valid=Unknown total_forms=0>",
+                ),
+                (
+                    self.make_choiceformset([("test", 1)]),
+                    "<ChoiceFormSet: bound=True valid=Unknown total_forms=1>",
+                ),
+                (valid_formset, "<ChoiceFormSet: bound=True valid=True total_forms=1>"),
+                (
+                    invalid_formset,
+                    "<ChoiceFormSet: bound=True valid=False total_forms=1>",
+                ),
+                (
+                    partially_invalid_formset,
+                    "<ChoiceFormSet: bound=True valid=False total_forms=2>",
+                ),
+                (
+                    invalid_formset_non_form_errors_only,
+                    "<ChoiceFormsetWithNonFormError: "
+                    "bound=True valid=False total_forms=1>",
+                ),
+            ],
+            "DeclarativeFormsetTestCase": [
+                (
+                    self.make_choiceformset(),
+                    "<DeclarativeFormsetTestCase.DeclarativeChoiceFormSet: "
+                    "bound=False valid=Unknown total_forms=1>",
+                ),
+                (
+                    self.make_choiceformset(
+                        formset_class=self.choice_extra10_formset,
+                    ),
+                    "<DeclarativeFormsetTestCase.DeclarativeChoiceExtra10FormSet: "
+                    "bound=False valid=Unknown total_forms=10>",
+                ),
+                (
+                    self.make_choiceformset([]),
+                    "<DeclarativeFormsetTestCase.DeclarativeChoiceFormSet: "
+                    "bound=True valid=Unknown total_forms=0>",
+                ),
+                (
+                    self.make_choiceformset([("test", 1)]),
+                    "<DeclarativeFormsetTestCase.DeclarativeChoiceFormSet: "
+                    "bound=True valid=Unknown total_forms=1>",
+                ),
+                (
+                    valid_formset,
+                    "<DeclarativeFormsetTestCase.DeclarativeChoiceFormSet: "
+                    "bound=True valid=True total_forms=1>",
+                ),
+                (
+                    invalid_formset,
+                    "<DeclarativeFormsetTestCase.DeclarativeChoiceFormSet: "
+                    "bound=True valid=False total_forms=1>",
+                ),
+                (
+                    partially_invalid_formset,
+                    "<DeclarativeFormsetTestCase.DeclarativeChoiceFormSet: "
+                    "bound=True valid=False total_forms=2>",
+                ),
+                (
+                    invalid_formset_non_form_errors_only,
+                    "<ChoiceFormsetWithNonFormError: "
+                    "bound=True valid=False total_forms=1>",
+                ),
+            ],
+        }
+        for formset, expected_repr in cases[f"{self.name}"]:
+            with self.subTest(expected_repr=expected_repr):
+                self.assertEqual(repr(formset), expected_repr)
+
+    def test_repr_do_not_trigger_validation(self):
+        formset = self.make_choiceformset([("test", 1)])
+        with mock.patch.object(formset, "full_clean") as mocked_full_clean:
+            repr(formset)
+            mocked_full_clean.assert_not_called()
+            formset.is_valid()
+            mocked_full_clean.assert_called()
+
+
+class FactoryFormsetTestCase(SimpleTestCase, FormsetTestMixin):
+    """A set of tests of formset created with factories."""
+
+    name = "FactoryFormsetTestCase"
+    formset_class = formset_factory(Choice)
+    choice_extra10_formset = formset_factory(Choice, extra=10)
+    custom_kwarg_extra2_formset = formset_factory(CustomKwargForm, extra=2)
+    custom_kwarg_dynamic_formset = formset_factory(
+        CustomKwargForm, formset=DynamicBaseFormSet, extra=2
+    )
+    custom_kwarg_formset = formset_factory(CustomKwargForm)
+    choice_extra3_formset = formset_factory(Choice, extra=3)
+    choice_min_formset = formset_factory(Choice, extra=1, min_num=1)
+    choice_min3_formset = formset_factory(Choice, extra=0, min_num=3)
+    choice_max_validate_formset = formset_factory(
+        Choice, extra=1, max_num=1, validate_max=True
+    )
+    choice_min3_validate_formset = formset_factory(
+        Choice, extra=1, min_num=3, validate_min=True
+    )
+    choice_min2_validate_formset = formset_factory(Choice, min_num=2, validate_min=True)
+    choice_min_validate_can_delete_formset = formset_factory(
+        Choice, extra=2, min_num=1, validate_min=True, can_delete=True
+    )
+    choice_can_delete_formset = formset_factory(Choice, can_delete=True)
+    check_min_value_formset = formset_factory(CheckFormMinValue, can_delete=True)
+    favorite_drink_can_delete_formset = formset_factory(
+        form=FavoriteDrinkForm, can_delete=True
+    )
+    choice_can_order_formset = formset_factory(Choice, can_order=True)
+    choice_can_order_delete_formset = formset_factory(
+        Choice, can_order=True, can_delete=True
+    )
+    # A FormSet that takes a list of favorite drinks and raises an error if
+    # there are any duplicates.
+    favorite_drink_base_formset = formset_factory(
+        FavoriteDrinkForm, formset=BaseFavoriteDrinksFormSet, extra=3
+    )
+    favorite_drink_extra3_formset = formset_factory(FavoriteDrinkForm, extra=3)
+    favorite_drink_extra3_max0_formset = formset_factory(
+        FavoriteDrinkForm, extra=3, max_num=0
+    )
+    favorite_drink_extra5_max2_formset = formset_factory(
+        FavoriteDrinkForm, extra=5, max_num=2
+    )
+    favorite_drink_extra1_max2_formset = formset_factory(
+        FavoriteDrinkForm, extra=1, max_num=2
+    )
+    favorite_drink_extra1_formset = formset_factory(FavoriteDrinkForm, extra=1)
+    favorite_drink_extra1_max0_formset = formset_factory(
+        FavoriteDrinkForm, extra=1, max_num=0
+    )
+    favorite_drink_absolute_max_formset = formset_factory(
+        FavoriteDrinkForm,
+        absolute_max=3000,
+    )
+    favorite_drink_absolute_max_num_formset = formset_factory(
+        FavoriteDrinkForm,
+        max_num=30,
+        absolute_max=1000,
+    )
+    favorite_drink_extra3_max2_formset = formset_factory(
+        FavoriteDrinkForm, extra=3, max_num=2
+    )
+    choice_reverse_formset = formset_factory(Choice, BaseReverseFormSet, extra=3)
+    choice_extra0_formset = formset_factory(Choice, extra=0)
+    split_datetime_formset = formset_factory(SplitDateTimeForm)
+    another_choice_formset = formset_factory(AnotherChoice)
+    choice_base_custom_formset = formset_factory(Choice, formset=BaseCustomFormSet)
+    check_max_validate_formset = formset_factory(
+        CheckForm, max_num=1, validate_max=True, can_delete=True
+    )
+    choice_extra2_can_delete_formset = formset_factory(Choice, can_delete=True, extra=2)
+    choice_can_delete_no_extra_formset = formset_factory(
+        form=Choice,
+        can_delete=True,
+        can_delete_extra=False,
+        extra=2,
+    )
+    choice_renderer_formset = formset_factory(Choice, renderer=CustomRendererTemplate)
+    choice_custom_formset = formset_factory(Choice, formset=CustomFormSet)
+    choice_jinja_renderer_formset = formset_factory(Choice, renderer=renderer)
+    choice_default_renderer_formset = formset_factory(ChoiceWithDefaultRenderer)
+
+    def test_formset_with_deletion_custom_widget(self):
+        tests = [
+            (DeletionAttributeFormSet, '<input type="hidden" name="form-0-DELETE">'),
+            (
+                DeletionMethodFormSet,
+                '<input class="deletion" type="hidden" name="form-0-DELETE">',
+            ),
+        ]
+        for formset_class, delete_html in tests:
+            with self.subTest(formset_class=formset_class.__name__):
+                ArticleFormSet = formset_factory(
+                    ArticleForm,
+                    formset=formset_class,
+                    can_delete=True,
+                )
+                formset = ArticleFormSet(auto_id=False)
+                self.assertHTMLEqual(
+                    "\n".join([form.as_ul() for form in formset.forms]),
+                    (
+                        f'<li>Title: <input type="text" name="form-0-title"></li>'
+                        f'<li>Pub date: <input type="text" name="form-0-pub_date">'
+                        f"{delete_html}</li>"
+                    ),
+                )
+
+    def test_formsets_with_ordering_custom_widget(self):
+        tests = (
+            (OrderingAttributeFormSet, '<input type="hidden" name="form-0-ORDER">'),
+            (
+                OrderingMethodFormSet,
+                '<input class="ordering" type="hidden" name="form-0-ORDER">',
+            ),
+        )
+        for formset_class, order_html in tests:
+            with self.subTest(formset_class=formset_class.__name__):
+                ArticleFormSet = formset_factory(
+                    ArticleForm, formset=formset_class, can_order=True
+                )
+                formset = ArticleFormSet(auto_id=False)
+                self.assertHTMLEqual(
+                    "\n".join(form.as_ul() for form in formset.forms),
+                    (
+                        '<li>Title: <input type="text" name="form-0-title"></li>'
+                        '<li>Pub date: <input type="text" name="form-0-pub_date">'
+                        "%s</li>" % order_html
+                    ),
+                )
+
+    def test_absolute_max_invalid(self):
+        msg = "'absolute_max' must be greater or equal to 'max_num'."
+        for max_num in [None, 31]:
+            with self.subTest(max_num=max_num):
+                with self.assertRaisesMessage(ValueError, msg):
+                    formset_factory(FavoriteDrinkForm, max_num=max_num, absolute_max=30)
 
     def test_hard_limit_on_instantiated_forms(self):
         """A formset has a hard limit on the number of forms instantiated."""
@@ -1396,290 +1759,432 @@ class FormsFormsetTestCase(SimpleTestCase):
         finally:
             formsets.DEFAULT_MAX_NUM = _old_DEFAULT_MAX_NUM
 
-    def test_non_form_errors_run_full_clean(self):
-        """
-        If non_form_errors() is called without calling is_valid() first,
-        it should ensure that full_clean() is called.
-        """
+    def test_no_form_argument_error(self):
+        with self.assertRaises(TypeError):
+            formset_factory(extra=1)
 
-        class BaseCustomFormSet(BaseFormSet):
-            def clean(self):
-                raise ValidationError("This is a non-form error")
 
-        ChoiceFormSet = formset_factory(Choice, formset=BaseCustomFormSet)
-        data = {
-            "choices-TOTAL_FORMS": "1",
-            "choices-INITIAL_FORMS": "0",
-        }
-        formset = ChoiceFormSet(data, auto_id=False, prefix="choices")
-        self.assertIsInstance(formset.non_form_errors(), ErrorList)
-        self.assertEqual(list(formset.non_form_errors()), ["This is a non-form error"])
+class DeclarativeFormsetTestCase(SimpleTestCase, FormsetTestMixin):
+    """A set of tests of formset created with declarative syntax."""
 
-    def test_validate_max_ignores_forms_marked_for_deletion(self):
-        class CheckForm(Form):
-            field = IntegerField()
+    class DeclarativeChoiceFormSet(FormSet):
+        form = Choice
 
-        data = {
-            "check-TOTAL_FORMS": "2",
-            "check-INITIAL_FORMS": "0",
-            "check-MAX_NUM_FORMS": "1",
-            "check-0-field": "200",
-            "check-0-DELETE": "",
-            "check-1-field": "50",
-            "check-1-DELETE": "on",
-        }
-        CheckFormSet = formset_factory(
-            CheckForm, max_num=1, validate_max=True, can_delete=True
-        )
-        formset = CheckFormSet(data, prefix="check")
-        self.assertTrue(formset.is_valid())
+    class DeclarativeChoiceExtra10FormSet(FormSet):
+        """Declarative choice formset."""
 
-    def test_formset_total_error_count(self):
-        """A valid formset should have 0 total errors."""
-        data = [  # formset_data, expected error count
-            ([("Calexico", "100")], 0),
-            ([("Calexico", "")], 1),
-            ([("", "invalid")], 2),
-            ([("Calexico", "100"), ("Calexico", "")], 1),
-            ([("Calexico", ""), ("Calexico", "")], 2),
+        form = Choice
+        extra = 10
+
+    class DeclarativeCustomKwargExtra2FormSet(FormSet):
+        form = CustomKwargForm
+        extra = 2
+
+    class DeclarativeCustomKwargDynamicFormSet(FormSet):
+        form = CustomKwargForm
+        extra = 2
+
+        def get_form_kwargs(self, index):
+            return {"custom_kwarg": index}
+
+    class DeclarativeCustomKwargFormSet(FormSet):
+        form = CustomKwargForm
+
+    class DeclarativeChoiceExtra3FormSet(FormSet):
+        """Declarative choice formset."""
+
+        form = Choice
+        extra = 3
+
+    class DeclarativeChoiceMinFormSet(FormSet):
+        form = Choice
+        extra = 1
+        min_num = 1
+
+    class DeclarativeChoiceMin3FormSet(FormSet):
+        form = Choice
+        extra = 0
+        min_num = 3
+
+    class DeclarativeChoiceMaxValidateFormSet(FormSet):
+        form = Choice
+        extra = 1
+        max_num = 1
+        validate_max = True
+
+    class DeclarativeChoiceMin3ValidateFormSet(FormSet):
+        form = Choice
+        extra = 1
+        min_num = 3
+        validate_min = True
+
+    class DeclarativeChoiceMin2ValidateFormSet(FormSet):
+        form = Choice
+        min_num = 2
+        validate_min = True
+
+    class DeclarativeChoiceMinValidateCanDeleteFormSet(FormSet):
+        form = Choice
+        extra = 2
+        min_num = 1
+        validate_min = True
+        can_delete = True
+
+    class DeclarativeChoiceCanDeleteFormSet(FormSet):
+        form = Choice
+        can_delete = True
+
+    class DeclarativeCheckMinValueFormSet(FormSet):
+        form = CheckFormMinValue
+        can_delete = True
+
+    class DeclarativeDrinkCanDeleteFormSet(FormSet):
+        form = FavoriteDrinkForm
+        can_delete = True
+
+    class DeclarativeChoiceCanOrderFormSet(FormSet):
+        form = Choice
+        can_order = True
+
+    class DeclarativeChoiceCanOrderDeleteFormSet(FormSet):
+        form = Choice
+        can_order = True
+        can_delete = True
+
+    # A FormSet that takes a list of favorite drinks and raises an error if
+    # there are any duplicates.
+    class DeclarativeFavoriteDrinkBaseFormSet(FormSet):
+        form = FavoriteDrinkForm
+        extra = 3
+
+        def clean(self):
+            seen_drinks = []
+
+            for drink in self.cleaned_data:
+                if drink["name"] in seen_drinks:
+                    raise ValidationError("You may only specify a drink once.")
+
+                seen_drinks.append(drink["name"])
+
+    class DeclarativeFavoriteExtra3FormSet(FormSet):
+        """Declarative favorite drink formset."""
+
+        form = FavoriteDrinkForm
+        extra = 3
+
+    class DeclarativeFavoriteExtra3Max0FormSet(FormSet):
+        """Declarative favorite drink formset."""
+
+        form = FavoriteDrinkForm
+        extra = 3
+        max_num = 0
+
+    class DeclarativeFavoriteExtra5Max2FormSet(FormSet):
+        """Declarative favorite drink formset."""
+
+        form = FavoriteDrinkForm
+        extra = 5
+        max_num = 2
+
+    class DeclarativeFavoriteExtra1Max2FormSet(FormSet):
+        """Declarative favorite drink formset."""
+
+        form = FavoriteDrinkForm
+        extra = 1
+        max_num = 2
+
+    class DeclarativeFavoriteExtra1FormSet(FormSet):
+        """Declarative favorite drink formset."""
+
+        form = FavoriteDrinkForm
+        extra = 1
+
+    class DeclarativeFavoriteExtra1Max0FormSet(FormSet):
+        """Declarative favorite drink formset."""
+
+        form = FavoriteDrinkForm
+        extra = 1
+        max_num = 0
+
+    class DeclarativeFavoriteAbsoluteMaxFormSet(FormSet):
+        """Declarative favorite drink formset."""
+
+        form = FavoriteDrinkForm
+        absolute_max = 3000
+
+    class DeclarativeFavoriteAbsoluteMaxNumFormSet(FormSet):
+        """Declarative favorite drink formset."""
+
+        form = FavoriteDrinkForm
+        max_num = 30
+        absolute_max = 1000
+
+    class DeclarativeFavoriteExtra3Max2FormSet(FormSet):
+        """Declarative favorite drink formset."""
+
+        form = FavoriteDrinkForm
+        extra = 3
+        max_num = 2
+
+    class DeclarativeChoiceReverseFormSet(FormSet):
+        """Declarative choice formset."""
+
+        form = Choice
+        extra = 3
+
+        def __iter__(self):
+            return reversed(self.forms)
+
+        def __getitem__(self, idx):
+            return super().__getitem__(len(self) - idx - 1)
+
+    class DeclarativeChoiceExtra0FormSet(FormSet):
+        """Declarative choice formset."""
+
+        form = Choice
+        extra = 0
+
+    class DeclarativeSplitDateTimeFormSet(FormSet):
+        form = SplitDateTimeForm
+
+    class DeclarativeAnotherChoiceFormSet(FormSet):
+        form = AnotherChoice
+
+    class DeclarativeChoiceBaseCustomFormSet(FormSet):
+        form = Choice
+
+        def clean(self):
+            raise ValidationError("This is a non-form error")
+
+    class DeclarativeCheckMaxValidateFormSet(FormSet):
+        form = CheckForm
+        max_num = 1
+        validate_max = True
+        can_delete = True
+
+    class DeclarativeChoiceExtra2FormSet(FormSet):
+        """Declarative choice formset."""
+
+        form = Choice
+        can_delete = True
+        extra = 2
+
+    class DeclarativeChoiceCanDeleteNoExtraFormSet(FormSet):
+        form = Choice
+        can_delete = True
+        can_delete_extra = False
+        extra = 2
+
+    class DeclarativeChoiceRendererFormSet(FormSet):
+        form = Choice
+        renderer = CustomRendererTemplate
+
+    class DeclarativeChoiceCustomFormSet(FormSet):
+        template_name = "a/custom/formset/template.html"
+
+        form = Choice
+
+    class DeclarativeChoiceJinjaFormSet(FormSet):
+        form = Choice
+        renderer = renderer
+
+    class DeclarativeChoiceDefaultFormSet(FormSet):
+        form = ChoiceWithDefaultRenderer
+
+    name = "DeclarativeFormsetTestCase"
+    formset_class = DeclarativeChoiceFormSet
+    choice_extra10_formset = DeclarativeChoiceExtra10FormSet
+    custom_kwarg_extra2_formset = DeclarativeCustomKwargExtra2FormSet
+    custom_kwarg_dynamic_formset = DeclarativeCustomKwargDynamicFormSet
+    custom_kwarg_formset = DeclarativeCustomKwargFormSet
+    choice_extra3_formset = DeclarativeChoiceExtra3FormSet
+    choice_min_formset = DeclarativeChoiceMinFormSet
+    choice_min3_formset = DeclarativeChoiceMin3FormSet
+    choice_max_validate_formset = DeclarativeChoiceMaxValidateFormSet
+    choice_min3_validate_formset = DeclarativeChoiceMin3ValidateFormSet
+    choice_min2_validate_formset = DeclarativeChoiceMin2ValidateFormSet
+    choice_min_validate_can_delete_formset = (
+        DeclarativeChoiceMinValidateCanDeleteFormSet
+    )
+    choice_can_delete_formset = DeclarativeChoiceCanDeleteFormSet
+    check_min_value_formset = DeclarativeCheckMinValueFormSet
+    favorite_drink_can_delete_formset = DeclarativeDrinkCanDeleteFormSet
+    choice_can_order_formset = DeclarativeChoiceCanOrderFormSet
+    choice_can_order_delete_formset = DeclarativeChoiceCanOrderDeleteFormSet
+    favorite_drink_base_formset = DeclarativeFavoriteDrinkBaseFormSet
+    favorite_drink_extra3_formset = DeclarativeFavoriteExtra3FormSet
+    favorite_drink_extra3_max0_formset = DeclarativeFavoriteExtra3Max0FormSet
+    favorite_drink_extra5_max2_formset = DeclarativeFavoriteExtra5Max2FormSet
+    favorite_drink_extra1_max2_formset = DeclarativeFavoriteExtra1Max2FormSet
+    favorite_drink_extra1_formset = DeclarativeFavoriteExtra1FormSet
+    favorite_drink_extra1_max0_formset = DeclarativeFavoriteExtra1Max0FormSet
+    favorite_drink_absolute_max_formset = DeclarativeFavoriteAbsoluteMaxFormSet
+    favorite_drink_absolute_max_num_formset = DeclarativeFavoriteAbsoluteMaxNumFormSet
+    favorite_drink_extra3_max2_formset = DeclarativeFavoriteExtra3Max2FormSet
+    choice_reverse_formset = DeclarativeChoiceReverseFormSet
+    choice_extra0_formset = DeclarativeChoiceExtra0FormSet
+    split_datetime_formset = DeclarativeSplitDateTimeFormSet
+    another_choice_formset = DeclarativeAnotherChoiceFormSet
+    choice_base_custom_formset = DeclarativeChoiceBaseCustomFormSet
+    check_max_validate_formset = DeclarativeCheckMaxValidateFormSet
+    choice_extra2_can_delete_formset = DeclarativeChoiceExtra2FormSet
+    choice_can_delete_no_extra_formset = DeclarativeChoiceCanDeleteNoExtraFormSet
+    choice_renderer_formset = DeclarativeChoiceRendererFormSet
+    choice_custom_formset = DeclarativeChoiceCustomFormSet
+    choice_jinja_renderer_formset = DeclarativeChoiceJinjaFormSet
+    choice_default_renderer_formset = DeclarativeChoiceDefaultFormSet
+
+    def test_formset_with_deletion_custom_widget(self):
+        tests = [
+            (DeletionAttributeFormSet, '<input type="hidden" name="form-0-DELETE">'),
+            (
+                DeletionMethodFormSet,
+                '<input class="deletion" type="hidden" name="form-0-DELETE">',
+            ),
         ]
-        for formset_data, expected_error_count in data:
-            formset = self.make_choiceformset(formset_data)
-            self.assertEqual(formset.total_error_count(), expected_error_count)
+        for formset_class, delete_html in tests:
+            with self.subTest(formset_class=formset_class.__name__):
 
-    def test_formset_total_error_count_with_non_form_errors(self):
-        data = {
-            "choices-TOTAL_FORMS": "2",  # the number of forms rendered
-            "choices-INITIAL_FORMS": "0",  # the number of forms with initial data
-            "choices-MAX_NUM_FORMS": "2",  # max number of forms - should be ignored
-            "choices-0-choice": "Zero",
-            "choices-0-votes": "0",
-            "choices-1-choice": "One",
-            "choices-1-votes": "1",
-        }
-        ChoiceFormSet = formset_factory(Choice, extra=1, max_num=1, validate_max=True)
-        formset = ChoiceFormSet(data, auto_id=False, prefix="choices")
-        self.assertEqual(formset.total_error_count(), 1)
-        data["choices-1-votes"] = ""
-        formset = ChoiceFormSet(data, auto_id=False, prefix="choices")
-        self.assertEqual(formset.total_error_count(), 2)
+                class DeclarativeArticleFormSet(FormSet):
+                    form = ArticleForm
+                    formset = formset_class
+                    can_delete = True
 
-    def test_html_safe(self):
-        formset = self.make_choiceformset()
-        self.assertTrue(hasattr(formset, "__html__"))
-        self.assertEqual(str(formset), formset.__html__())
+                formset = DeclarativeArticleFormSet(auto_id=False)
+                self.assertHTMLEqual(
+                    "\n".join([form.as_ul() for form in formset.forms]),
+                    (
+                        f'<li>Title: <input type="text" name="form-0-title"></li>'
+                        f'<li>Pub date: <input type="text" name="form-0-pub_date">'
+                        f"{delete_html}</li>"
+                    ),
+                )
 
-    def test_can_delete_extra_formset_forms(self):
-        ChoiceFormFormset = formset_factory(form=Choice, can_delete=True, extra=2)
-        formset = ChoiceFormFormset()
-        self.assertEqual(len(formset), 2)
-        self.assertIn("DELETE", formset.forms[0].fields)
-        self.assertIn("DELETE", formset.forms[1].fields)
-
-    def test_disable_delete_extra_formset_forms(self):
-        ChoiceFormFormset = formset_factory(
-            form=Choice,
-            can_delete=True,
-            can_delete_extra=False,
-            extra=2,
-        )
-        formset = ChoiceFormFormset()
-        self.assertEqual(len(formset), 2)
-        self.assertNotIn("DELETE", formset.forms[0].fields)
-        self.assertNotIn("DELETE", formset.forms[1].fields)
-
-        formset = ChoiceFormFormset(initial=[{"choice": "Zero", "votes": "1"}])
-        self.assertEqual(len(formset), 3)
-        self.assertIn("DELETE", formset.forms[0].fields)
-        self.assertNotIn("DELETE", formset.forms[1].fields)
-        self.assertNotIn("DELETE", formset.forms[2].fields)
-        self.assertNotIn("DELETE", formset.empty_form.fields)
-
-        formset = ChoiceFormFormset(
-            data={
-                "form-0-choice": "Zero",
-                "form-0-votes": "0",
-                "form-0-DELETE": "on",
-                "form-1-choice": "One",
-                "form-1-votes": "1",
-                "form-2-choice": "",
-                "form-2-votes": "",
-                "form-TOTAL_FORMS": "3",
-                "form-INITIAL_FORMS": "1",
-            },
-            initial=[{"choice": "Zero", "votes": "1"}],
-        )
-        self.assertEqual(
-            formset.cleaned_data,
-            [
-                {"choice": "Zero", "votes": 0, "DELETE": True},
-                {"choice": "One", "votes": 1},
-                {},
-            ],
-        )
-        self.assertIs(formset._should_delete_form(formset.forms[0]), True)
-        self.assertIs(formset._should_delete_form(formset.forms[1]), False)
-        self.assertIs(formset._should_delete_form(formset.forms[2]), False)
-
-    def test_template_name_uses_renderer_value(self):
-        class CustomRenderer(TemplatesSetting):
-            formset_template_name = "a/custom/formset/template.html"
-
-        ChoiceFormSet = formset_factory(Choice, renderer=CustomRenderer)
-
-        self.assertEqual(
-            ChoiceFormSet().template_name, "a/custom/formset/template.html"
-        )
-
-    def test_template_name_can_be_overridden(self):
-        class CustomFormSet(BaseFormSet):
-            template_name = "a/custom/formset/template.html"
-
-        ChoiceFormSet = formset_factory(Choice, formset=CustomFormSet)
-
-        self.assertEqual(
-            ChoiceFormSet().template_name, "a/custom/formset/template.html"
-        )
-
-    def test_custom_renderer(self):
-        """
-        A custom renderer passed to a formset_factory() is passed to all forms
-        and ErrorList.
-        """
-        from django.forms.renderers import Jinja2
-
-        renderer = Jinja2()
-        data = {
-            "choices-TOTAL_FORMS": "2",
-            "choices-INITIAL_FORMS": "0",
-            "choices-MIN_NUM_FORMS": "0",
-            "choices-0-choice": "Zero",
-            "choices-0-votes": "",
-            "choices-1-choice": "One",
-            "choices-1-votes": "",
-        }
-        ChoiceFormSet = formset_factory(Choice, renderer=renderer)
-        formset = ChoiceFormSet(data, auto_id=False, prefix="choices")
-        self.assertEqual(formset.renderer, renderer)
-        self.assertEqual(formset.forms[0].renderer, renderer)
-        self.assertEqual(formset.management_form.renderer, renderer)
-        self.assertEqual(formset.non_form_errors().renderer, renderer)
-        self.assertEqual(formset.empty_form.renderer, renderer)
-
-    def test_form_default_renderer(self):
-        """
-        In the absence of a renderer passed to the formset_factory(),
-        Form.default_renderer is respected.
-        """
-
-        class CustomRenderer(DjangoTemplates):
-            pass
-
-        class ChoiceWithDefaultRenderer(Choice):
-            default_renderer = CustomRenderer()
-
-        data = {
-            "choices-TOTAL_FORMS": "1",
-            "choices-INITIAL_FORMS": "0",
-            "choices-MIN_NUM_FORMS": "0",
-        }
-
-        ChoiceFormSet = formset_factory(ChoiceWithDefaultRenderer)
-        formset = ChoiceFormSet(data, prefix="choices")
-        self.assertEqual(
-            formset.forms[0].renderer, ChoiceWithDefaultRenderer.default_renderer
-        )
-        self.assertEqual(
-            formset.empty_form.renderer, ChoiceWithDefaultRenderer.default_renderer
-        )
-        default_renderer = get_default_renderer()
-        self.assertIsInstance(formset.renderer, type(default_renderer))
-
-    def test_form_default_renderer_class(self):
-        """
-        In the absence of a renderer passed to the formset_factory(),
-        Form.default_renderer is respected.
-        """
-
-        class CustomRenderer(DjangoTemplates):
-            pass
-
-        class ChoiceWithDefaultRenderer(Choice):
-            default_renderer = CustomRenderer
-
-        data = {
-            "choices-TOTAL_FORMS": "1",
-            "choices-INITIAL_FORMS": "0",
-            "choices-MIN_NUM_FORMS": "0",
-        }
-
-        ChoiceFormSet = formset_factory(ChoiceWithDefaultRenderer)
-        formset = ChoiceFormSet(data, prefix="choices")
-        self.assertIsInstance(formset.forms[0].renderer, CustomRenderer)
-        self.assertIsInstance(formset.empty_form.renderer, CustomRenderer)
-        default_renderer = get_default_renderer()
-        self.assertIsInstance(formset.renderer, type(default_renderer))
-
-    def test_repr(self):
-        valid_formset = self.make_choiceformset([("test", 1)])
-        valid_formset.full_clean()
-        invalid_formset = self.make_choiceformset([("test", "")])
-        invalid_formset.full_clean()
-        partially_invalid_formset = self.make_choiceformset(
-            [("test", "1"), ("test", "")],
-        )
-        partially_invalid_formset.full_clean()
-        invalid_formset_non_form_errors_only = self.make_choiceformset(
-            [("test", "")],
-            formset_class=ChoiceFormsetWithNonFormError,
-        )
-        invalid_formset_non_form_errors_only.full_clean()
-
-        cases = [
+    def test_formsets_with_ordering_custom_widget(self):
+        tests = (
+            (OrderingAttributeFormSet, '<input type="hidden" name="form-0-ORDER">'),
             (
-                self.make_choiceformset(),
-                "<ChoiceFormSet: bound=False valid=Unknown total_forms=1>",
+                OrderingMethodFormSet,
+                '<input class="ordering" type="hidden" name="form-0-ORDER">',
             ),
-            (
-                self.make_choiceformset(
-                    formset_class=formset_factory(Choice, extra=10),
-                ),
-                "<ChoiceFormSet: bound=False valid=Unknown total_forms=10>",
-            ),
-            (
-                self.make_choiceformset([]),
-                "<ChoiceFormSet: bound=True valid=Unknown total_forms=0>",
-            ),
-            (
-                self.make_choiceformset([("test", 1)]),
-                "<ChoiceFormSet: bound=True valid=Unknown total_forms=1>",
-            ),
-            (valid_formset, "<ChoiceFormSet: bound=True valid=True total_forms=1>"),
-            (invalid_formset, "<ChoiceFormSet: bound=True valid=False total_forms=1>"),
-            (
-                partially_invalid_formset,
-                "<ChoiceFormSet: bound=True valid=False total_forms=2>",
-            ),
-            (
-                invalid_formset_non_form_errors_only,
-                "<ChoiceFormsetWithNonFormError: bound=True valid=False total_forms=1>",
-            ),
-        ]
-        for formset, expected_repr in cases:
-            with self.subTest(expected_repr=expected_repr):
-                self.assertEqual(repr(formset), expected_repr)
+        )
+        for formset_class, order_html in tests:
+            with self.subTest(formset_class=formset_class.__name__):
 
-    def test_repr_do_not_trigger_validation(self):
-        formset = self.make_choiceformset([("test", 1)])
-        with mock.patch.object(formset, "full_clean") as mocked_full_clean:
-            repr(formset)
-            mocked_full_clean.assert_not_called()
-            formset.is_valid()
-            mocked_full_clean.assert_called()
+                class DeclarativeArticleCanOrderFormSet(FormSet):
+                    form = ArticleForm
+                    formset = formset_class
+                    can_order = True
+
+                formset = DeclarativeArticleCanOrderFormSet(auto_id=False)
+                self.assertHTMLEqual(
+                    "\n".join(form.as_ul() for form in formset.forms),
+                    (
+                        '<li>Title: <input type="text" name="form-0-title"></li>'
+                        '<li>Pub date: <input type="text" name="form-0-pub_date">'
+                        "%s</li>" % order_html
+                    ),
+                )
+
+    def test_absolute_max_invalid(self):
+        msg = "'absolute_max' must be greater or equal to 'max_num'."
+        with self.subTest(max_num=None):
+            with self.assertRaisesMessage(ValueError, msg):
+
+                class DeclarativeInvalidMaxNoneFormSet(FormSet):
+                    form = FavoriteDrinkForm
+                    max_num = None
+                    absolute_max = 30
+
+        with self.subTest(max_num=31):
+            with self.assertRaisesMessage(ValueError, msg):
+
+                class DeclarativeInvalidMax31FormSet(FormSet):
+                    form = FavoriteDrinkForm
+                    max_num = 31
+                    absolute_max = 30
+
+    def test_hard_limit_on_instantiated_forms(self):
+        """A formset has a hard limit on the number of forms instantiated."""
+        # reduce the default limit of 1000 temporarily for testing
+        _old_DEFAULT_MAX_NUM = formsets.DEFAULT_MAX_NUM
+        try:
+            formsets.DEFAULT_MAX_NUM = 2
+
+            class DeclarativeChoiceMax1FormSet(FormSet):
+                form = Choice
+                max_num = 1
+
+            # someone fiddles with the mgmt form data...
+            formset = DeclarativeChoiceMax1FormSet(
+                {
+                    "choices-TOTAL_FORMS": "4",
+                    "choices-INITIAL_FORMS": "0",
+                    "choices-MIN_NUM_FORMS": "0",  # min number of forms
+                    "choices-MAX_NUM_FORMS": "4",
+                    "choices-0-choice": "Zero",
+                    "choices-0-votes": "0",
+                    "choices-1-choice": "One",
+                    "choices-1-votes": "1",
+                    "choices-2-choice": "Two",
+                    "choices-2-votes": "2",
+                    "choices-3-choice": "Three",
+                    "choices-3-votes": "3",
+                },
+                prefix="choices",
+            )
+            # But we still only instantiate 3 forms
+            self.assertEqual(len(formset.forms), 3)
+            # and the formset isn't valid
+            self.assertFalse(formset.is_valid())
+        finally:
+            formsets.DEFAULT_MAX_NUM = _old_DEFAULT_MAX_NUM
+
+    def test_increase_hard_limit(self):
+        """Can increase the built-in forms limit via a higher max_num."""
+        # reduce the default limit of 1000 temporarily for testing
+        _old_DEFAULT_MAX_NUM = formsets.DEFAULT_MAX_NUM
+        try:
+            formsets.DEFAULT_MAX_NUM = 3
+
+            # for this form, we want a limit of 4
+            class DeclarativeChoiceMax4FormSet(FormSet):
+                form = Choice
+                max_num = 4
+
+            formset = DeclarativeChoiceMax4FormSet(
+                {
+                    "choices-TOTAL_FORMS": "4",
+                    "choices-INITIAL_FORMS": "0",
+                    "choices-MIN_NUM_FORMS": "0",  # min number of forms
+                    "choices-MAX_NUM_FORMS": "4",
+                    "choices-0-choice": "Zero",
+                    "choices-0-votes": "0",
+                    "choices-1-choice": "One",
+                    "choices-1-votes": "1",
+                    "choices-2-choice": "Two",
+                    "choices-2-votes": "2",
+                    "choices-3-choice": "Three",
+                    "choices-3-votes": "3",
+                },
+                prefix="choices",
+            )
+            # Four forms are instantiated and no exception is raised
+            self.assertEqual(len(formset.forms), 4)
+        finally:
+            formsets.DEFAULT_MAX_NUM = _old_DEFAULT_MAX_NUM
+
+    def test_no_form_argument_error(self):
+        with self.assertRaisesMessage(
+            TypeError, "FormSet() missing 1 required positional argument: 'form'."
+        ):
+
+            class DeclarativeInvalid(FormSet):
+                extra = 1
 
 
 @jinja2_tests
-class Jinja2FormsFormsetTestCase(FormsFormsetTestCase):
+class Jinja2FormsFormsetTestCase(FactoryFormsetTestCase, DeclarativeFormsetTestCase):
     pass
 
 
@@ -1884,7 +2389,7 @@ class TestIsBoundBehavior(TestIsBoundBehavior):
 
 class TestEmptyFormSet(SimpleTestCase):
     def test_empty_formset_is_valid(self):
-        """An empty formset still calls clean()"""
+        """An empty formset still calls clean()."""
 
         class EmptyFsetWontValidate(BaseFormSet):
             def clean(self):

--- a/tests/forms_tests/tests/test_formsets.py
+++ b/tests/forms_tests/tests/test_formsets.py
@@ -2,7 +2,7 @@ import datetime
 from collections import Counter
 from unittest import mock
 
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.forms import (
     BaseForm,
     CharField,
@@ -2045,9 +2045,8 @@ class DeclarativeFormsetTestCase(SimpleTestCase, FormsetTestMixin):
         for formset_class, delete_html in tests:
             with self.subTest(formset_class=formset_class.__name__):
 
-                class DeclarativeArticleFormSet(FormSet):
+                class DeclarativeArticleFormSet(formset_class, FormSet):
                     form = ArticleForm
-                    formset = formset_class
                     can_delete = True
 
                 formset = DeclarativeArticleFormSet(auto_id=False)
@@ -2071,9 +2070,8 @@ class DeclarativeFormsetTestCase(SimpleTestCase, FormsetTestMixin):
         for formset_class, order_html in tests:
             with self.subTest(formset_class=formset_class.__name__):
 
-                class DeclarativeArticleCanOrderFormSet(FormSet):
+                class DeclarativeArticleCanOrderFormSet(formset_class, FormSet):
                     form = ArticleForm
-                    formset = formset_class
                     can_order = True
 
                 formset = DeclarativeArticleCanOrderFormSet(auto_id=False)
@@ -2175,16 +2173,197 @@ class DeclarativeFormsetTestCase(SimpleTestCase, FormsetTestMixin):
             formsets.DEFAULT_MAX_NUM = _old_DEFAULT_MAX_NUM
 
     def test_no_form_argument_error(self):
-        with self.assertRaisesMessage(
-            TypeError, "FormSet() missing 1 required positional argument: 'form'."
-        ):
+        msg = (
+            "Creating a FormSet without the 'form' attribute is prohibited; "
+            "formset DeclarativeInvalid needs updating."
+        )
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
 
             class DeclarativeInvalid(FormSet):
                 extra = 1
 
+    def test_form_none_error(self):
+        msg = (
+            "Creating a FormSet without the 'form' attribute is prohibited; "
+            "formset DeclarativeInvalid needs updating."
+        )
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+
+            class DeclarativeInvalid(FormSet):
+                form = None
+
+    def test_formset_attribute_error(self):
+        msg = (
+            "Formset DeclarativeInvalid must inherit from BaseFormSet "
+            "instead of setting 'formset'."
+        )
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+
+            class DeclarativeInvalid(FormSet):
+                form = Choice
+                formset = BaseFormSet
+
+
+class DeclarativeFormSetInheritanceTests(SimpleTestCase):
+    empty_data = {
+        "form-TOTAL_FORMS": "0",
+        "form-INITIAL_FORMS": "0",
+        "form-MIN_NUM_FORMS": "0",
+        "form-MAX_NUM_FORMS": "0",
+    }
+
+    def test_subclass_inherits_options(self):
+        class BaseChoiceFormSet(FormSet):
+            form = Choice
+            extra = 5
+            can_order = True
+
+        class ChoiceFormSet(BaseChoiceFormSet):
+            can_delete = True
+
+        self.assertIs(ChoiceFormSet.form, Choice)
+        self.assertEqual(ChoiceFormSet.extra, 5)
+        self.assertIs(ChoiceFormSet.can_order, True)
+        self.assertIs(ChoiceFormSet.can_delete, True)
+        self.assertEqual(len(ChoiceFormSet().forms), 5)
+
+    def test_subclass_overrides_options(self):
+        class BaseChoiceFormSet(FormSet):
+            form = Choice
+            extra = 5
+
+        class ChoiceFormSet(BaseChoiceFormSet):
+            extra = 2
+
+        self.assertEqual(ChoiceFormSet.extra, 2)
+        self.assertIs(ChoiceFormSet.form, Choice)
+        self.assertEqual(len(ChoiceFormSet().forms), 2)
+
+    def test_subclass_inherits_methods(self):
+        class BaseChoiceFormSet(FormSet):
+            form = Choice
+
+            def clean(self):
+                raise ValidationError("base clean ran")
+
+        class ChoiceFormSet(BaseChoiceFormSet):
+            extra = 1
+
+        formset = ChoiceFormSet(self.empty_data)
+        self.assertIs(formset.is_valid(), False)
+        self.assertEqual(formset.non_form_errors(), ["base clean ran"])
+
+    def test_mixin_preserved(self):
+        class CleanMixin:
+            def clean(self):
+                raise ValidationError("mixin clean ran")
+
+        class ChoiceFormSet(CleanMixin, FormSet):
+            form = Choice
+
+        self.assertIs(issubclass(ChoiceFormSet, CleanMixin), True)
+        formset = ChoiceFormSet(self.empty_data)
+        self.assertIs(formset.is_valid(), False)
+        self.assertEqual(formset.non_form_errors(), ["mixin clean ran"])
+
+    def test_issubclass_and_isinstance(self):
+        class ChoiceFormSet(FormSet):
+            form = Choice
+
+        self.assertIs(issubclass(ChoiceFormSet, FormSet), True)
+        self.assertIs(issubclass(ChoiceFormSet, BaseFormSet), True)
+        self.assertIsInstance(ChoiceFormSet(), FormSet)
+
+    def test_formset_factory_with_declarative_base(self):
+        class DeclarativeBase(FormSet):
+            form = Choice
+
+            def clean(self):
+                raise ValidationError("declarative clean ran")
+
+        ChoiceFormSet = formset_factory(Choice, formset=DeclarativeBase, extra=2)
+        self.assertIs(issubclass(ChoiceFormSet, DeclarativeBase), True)
+        self.assertEqual(ChoiceFormSet.extra, 2)
+        formset = ChoiceFormSet(self.empty_data)
+        self.assertIs(formset.is_valid(), False)
+        self.assertEqual(formset.non_form_errors(), ["declarative clean ran"])
+
+    def test_absolute_max_none(self):
+        class ChoiceFormSet(FormSet):
+            form = Choice
+            absolute_max = None
+
+        self.assertEqual(ChoiceFormSet().absolute_max, 2000)
+
+    def test_min_num_max_num_none(self):
+        class ChoiceFormSet(FormSet):
+            form = Choice
+            min_num = None
+            max_num = None
+
+        formset = ChoiceFormSet()
+        self.assertEqual(formset.min_num, 0)
+        self.assertEqual(formset.max_num, 1000)
+        self.assertEqual(formset.absolute_max, 2000)
+
+    def test_absolute_max_follows_max_num_override(self):
+        class BaseChoiceFormSet(FormSet):
+            form = Choice
+            max_num = 5
+
+        class ChoiceFormSet(BaseChoiceFormSet):
+            max_num = 1500
+
+        self.assertEqual(ChoiceFormSet().absolute_max, 2500)
+
+    def test_absolute_max_inherited_explicit(self):
+        class BaseChoiceFormSet(FormSet):
+            form = Choice
+            max_num = 5
+            absolute_max = 1500
+
+        class ChoiceFormSet(BaseChoiceFormSet):
+            max_num = 1400
+
+        self.assertEqual(ChoiceFormSet.absolute_max, 1500)
+        self.assertEqual(ChoiceFormSet().absolute_max, 1500)
+        msg = "'absolute_max' must be greater or equal to 'max_num'."
+        with self.assertRaisesMessage(ValueError, msg):
+
+            class OverCapFormSet(BaseChoiceFormSet):
+                max_num = 2000
+
+    def test_abstract_base(self):
+        class RendererFormSet(FormSet, abstract=True):
+            extra = 7
+
+        class ChoiceFormSet(RendererFormSet):
+            form = Choice
+
+        self.assertEqual(ChoiceFormSet.extra, 7)
+        self.assertIs(ChoiceFormSet.form, Choice)
+        msg = (
+            "Creating a FormSet without the 'form' attribute is prohibited; "
+            "formset BrokenFormSet needs updating."
+        )
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+
+            class BrokenFormSet(RendererFormSet):
+                extra = 2
+
+    def test_importable_from_django_forms(self):
+        import django.forms
+
+        self.assertIs(django.forms.FormSet, FormSet)
+
 
 @jinja2_tests
-class Jinja2FormsFormsetTestCase(FactoryFormsetTestCase, DeclarativeFormsetTestCase):
+class Jinja2FactoryFormsetTestCase(FactoryFormsetTestCase):
+    pass
+
+
+@jinja2_tests
+class Jinja2DeclarativeFormsetTestCase(DeclarativeFormsetTestCase):
     pass
 
 

--- a/tests/model_formsets/models.py
+++ b/tests/model_formsets/models.py
@@ -18,6 +18,11 @@ class BetterAuthor(Author):
     write_speed = models.IntegerField()
 
 
+class AuthorProxy(Author):
+    class Meta:
+        proxy = True
+
+
 class Book(models.Model):
     author = models.ForeignKey(Author, models.CASCADE)
     title = models.CharField(max_length=100)
@@ -193,6 +198,16 @@ class Player(models.Model):
 
     def __str__(self):
         return self.name
+
+
+class TeamSponsor(models.Model):
+    primary_team = models.OneToOneField(
+        Team, models.CASCADE, related_name="primary_sponsor"
+    )
+    backup_team = models.ForeignKey(
+        Team, models.CASCADE, related_name="backup_sponsors", null=True, blank=True
+    )
+    name = models.CharField(max_length=100)
 
 
 # Models for testing custom ModelForm save methods in formsets and inline

--- a/tests/model_formsets/tests.py
+++ b/tests/model_formsets/tests.py
@@ -8,8 +8,11 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.forms.formsets import formset_factory
 from django.forms.models import (
+    BaseInlineFormSet,
     BaseModelFormSet,
+    InlineFormSet,
     ModelForm,
+    ModelFormSet,
     _get_foreign_key,
     inlineformset_factory,
     modelformset_factory,
@@ -48,9 +51,90 @@ from .models import (
 )
 
 
-class DeletionTests(TestCase):
+class PoetForm(forms.ModelForm):
+    def save(self, commit=True):
+        # change the name to "Vladimir Mayakovsky" just to be a jerk.
+        author = super().save(commit=False)
+        author.name = "Vladimir Mayakovsky"
+        if commit:
+            author.save()
+        return author
+
+
+class PostForm1(forms.ModelForm):
+    class Meta:
+        model = Post
+        fields = ("title", "posted")
+
+
+class PostForm2(forms.ModelForm):
+    class Meta:
+        model = Post
+        exclude = ("subtitle",)
+
+
+class BaseAuthorFormSet(BaseModelFormSet):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.queryset = Author.objects.filter(name__startswith="Charles")
+
+
+class PoemFormSave(forms.ModelForm):
+    def save(self, commit=True):
+        # change the name to "Brooklyn Bridge" just to be a jerk.
+        poem = super().save(commit=False)
+        poem.name = "Brooklyn Bridge"
+        if commit:
+            poem.save()
+        return poem
+
+
+class PoemFormSave2(forms.ModelForm):
+    def save(self, commit=True):
+        poem = super().save(commit=False)
+        poem.name = "%s by %s" % (poem.name, poem.poet.name)
+        if commit:
+            poem.save()
+        return poem
+
+
+class PoemFormField(ModelForm):
+    class Meta:
+        model = Poem
+        fields = ("name",)
+
+
+class SimpleArrayField(forms.CharField):
+    """A proxy for django.contrib.postgres.forms.SimpleArrayField."""
+
+    def to_python(self, value):
+        value = super().to_python(value)
+        return value.split(",") if value else []
+
+
+class BookFormArrayField(forms.ModelForm):
+    title = SimpleArrayField()
+
+    class Meta:
+        model = Book
+        fields = ("title",)
+
+
+class CustomInlineFormSet(BaseInlineFormSet):
+    """A custom base inline formset."""
+
+    def clean(self):
+        super().clean()
+        for form in self.forms:
+            lowered_name = form.cleaned_data["name"].lower()
+            form.cleaned_data["name"] = lowered_name
+            form.instance.name = lowered_name
+
+
+class DeletionTestsMixin:
+    """A mixin to test deletion in declarative and factory modelformsets."""
+
     def test_deletion(self):
-        PoetFormSet = modelformset_factory(Poet, fields="__all__", can_delete=True)
         poet = Poet.objects.create(name="test")
         data = {
             "form-TOTAL_FORMS": "1",
@@ -60,7 +144,7 @@ class DeletionTests(TestCase):
             "form-0-name": "test",
             "form-0-DELETE": "on",
         }
-        formset = PoetFormSet(data, queryset=Poet.objects.all())
+        formset = self.model_formset(data, queryset=Poet.objects.all())
         formset.save(commit=False)
         self.assertEqual(Poet.objects.count(), 1)
 
@@ -73,7 +157,6 @@ class DeletionTests(TestCase):
         Make sure that an add form that is filled out, but marked for deletion
         doesn't cause validation errors.
         """
-        PoetFormSet = modelformset_factory(Poet, fields="__all__", can_delete=True)
         poet = Poet.objects.create(name="test")
         # One existing untouched and two new unvalid forms
         data = {
@@ -87,7 +170,7 @@ class DeletionTests(TestCase):
             "form-2-id": str(poet.id),  # Violate unique constraint
             "form-2-name": "test2",
         }
-        formset = PoetFormSet(data, queryset=Poet.objects.all())
+        formset = self.model_formset(data, queryset=Poet.objects.all())
         # Make sure this form doesn't pass validation.
         self.assertIs(formset.is_valid(), False)
         self.assertEqual(Poet.objects.count(), 1)
@@ -97,7 +180,7 @@ class DeletionTests(TestCase):
         data["form-0-DELETE"] = "on"
         data["form-1-DELETE"] = "on"
         data["form-2-DELETE"] = "on"
-        formset = PoetFormSet(data, queryset=Poet.objects.all())
+        formset = self.model_formset(data, queryset=Poet.objects.all())
         self.assertIs(formset.is_valid(), True)
         formset.save()
         self.assertEqual(Poet.objects.count(), 0)
@@ -107,7 +190,6 @@ class DeletionTests(TestCase):
         Make sure that a change form that is filled out, but marked for
         deletion doesn't cause validation errors.
         """
-        PoetFormSet = modelformset_factory(Poet, fields="__all__", can_delete=True)
         poet = Poet.objects.create(name="test")
         data = {
             "form-TOTAL_FORMS": "1",
@@ -116,7 +198,7 @@ class DeletionTests(TestCase):
             "form-0-id": str(poet.id),
             "form-0-name": "x" * 1000,
         }
-        formset = PoetFormSet(data, queryset=Poet.objects.all())
+        formset = self.model_formset(data, queryset=Poet.objects.all())
         # Make sure this form doesn't pass validation.
         self.assertIs(formset.is_valid(), False)
         self.assertEqual(Poet.objects.count(), 1)
@@ -124,7 +206,7 @@ class DeletionTests(TestCase):
         # Then make sure that it *does* pass validation and delete the object,
         # even though the data isn't actually valid.
         data["form-0-DELETE"] = "on"
-        formset = PoetFormSet(data, queryset=Poet.objects.all())
+        formset = self.model_formset(data, queryset=Poet.objects.all())
         self.assertIs(formset.is_valid(), True)
         formset.save()
         self.assertEqual(Poet.objects.count(), 0)
@@ -132,10 +214,6 @@ class DeletionTests(TestCase):
     def test_outdated_deletion(self):
         poet = Poet.objects.create(name="test")
         poem = Poem.objects.create(name="Brevity is the soul of wit", poet=poet)
-
-        PoemFormSet = inlineformset_factory(
-            Poet, Poem, fields="__all__", can_delete=True
-        )
 
         # Simulate deletion of an object that doesn't exist in the database
         data = {
@@ -147,7 +225,7 @@ class DeletionTests(TestCase):
             "form-1-name": "bar",
             "form-1-DELETE": "on",
         }
-        formset = PoemFormSet(data, instance=poet, prefix="form")
+        formset = self.inline_formset(data, instance=poet, prefix="form")
 
         # The formset is valid even though poem.pk + 1 doesn't exist,
         # because it's marked for deletion anyway
@@ -161,21 +239,49 @@ class DeletionTests(TestCase):
         self.assertFalse(Poem.objects.filter(pk=poem.pk + 1).exists())
 
 
-class ModelFormsetTest(TestCase):
-    def test_modelformset_factory_without_fields(self):
-        """Regression for #19733"""
-        message = (
-            "Calling modelformset_factory without defining 'fields' or 'exclude' "
-            "explicitly is prohibited."
-        )
-        with self.assertRaisesMessage(ImproperlyConfigured, message):
-            modelformset_factory(Author)
+class FactoryFormSetDeletionTests(TestCase, DeletionTestsMixin):
+    """A set of tests to test deletion of modelformsets and inlineformset.
+
+    Created with factories.
+    """
+
+    # modelformsets
+    model_formset = modelformset_factory(Poet, fields="__all__", can_delete=True)
+    # inlineformsets
+    inline_formset = inlineformset_factory(
+        Poet, Poem, fields="__all__", can_delete=True
+    )
+
+
+class DeclarativeFormSetDeletionTests(TestCase, DeletionTestsMixin):
+    """A set of tests to test deletion of modelformsets and inlineformset.
+
+    Created with declarative syntax.
+    """
+
+    class DeclarativePoetFormSet(ModelFormSet):
+        model = Poet
+        fields = "__all__"
+        can_delete = True
+
+    class DeclarativePoetInlineSet(InlineFormSet):
+        parent_model = Poet
+        model = Poem
+        fields = "__all__"
+        can_delete = True
+
+    # modelformsets
+    model_formset = DeclarativePoetFormSet
+    # inlineformsets
+    inline_formset = DeclarativePoetInlineSet
+
+
+class ModelFormsetTestMixin:
+    """A mixin to test declarative and factory model_formsets."""
 
     def test_simple_save(self):
         qs = Author.objects.all()
-        AuthorFormSet = modelformset_factory(Author, fields="__all__", extra=3)
-
-        formset = AuthorFormSet(queryset=qs)
+        formset = self.author_formset_extra_3(queryset=qs)
         self.assertEqual(len(formset.forms), 3)
         self.assertHTMLEqual(
             formset.forms[0].as_p(),
@@ -205,7 +311,7 @@ class ModelFormsetTest(TestCase):
             "form-2-name": "",
         }
 
-        formset = AuthorFormSet(data=data, queryset=qs)
+        formset = self.author_formset_extra_3(data=data, queryset=qs)
         self.assertTrue(formset.is_valid())
 
         saved = formset.save()
@@ -223,11 +329,7 @@ class ModelFormsetTest(TestCase):
         # we'll use it to display them in alphabetical order by name.
 
         qs = Author.objects.order_by("name")
-        AuthorFormSet = modelformset_factory(
-            Author, fields="__all__", extra=1, can_delete=False
-        )
-
-        formset = AuthorFormSet(queryset=qs)
+        formset = self.author_formset_delete_false(queryset=qs)
         self.assertEqual(len(formset.forms), 3)
         self.assertHTMLEqual(
             formset.forms[0].as_p(),
@@ -263,7 +365,7 @@ class ModelFormsetTest(TestCase):
             "form-2-name": "Paul Verlaine",
         }
 
-        formset = AuthorFormSet(data=data, queryset=qs)
+        formset = self.author_formset_delete_false(data=data, queryset=qs)
         self.assertTrue(formset.is_valid())
 
         # Only changed or new objects are returned from formset.save()
@@ -279,11 +381,7 @@ class ModelFormsetTest(TestCase):
         # marked for deletion, make sure we don't save that form.
 
         qs = Author.objects.order_by("name")
-        AuthorFormSet = modelformset_factory(
-            Author, fields="__all__", extra=1, can_delete=True
-        )
-
-        formset = AuthorFormSet(queryset=qs)
+        formset = self.author_formset_delete_true(queryset=qs)
         self.assertEqual(len(formset.forms), 4)
         self.assertHTMLEqual(
             formset.forms[0].as_p(),
@@ -338,7 +436,7 @@ class ModelFormsetTest(TestCase):
             "form-3-DELETE": "on",
         }
 
-        formset = AuthorFormSet(data=data, queryset=qs)
+        formset = self.author_formset_delete_true(data=data, queryset=qs)
         self.assertTrue(formset.is_valid())
 
         # No objects were changed or saved so nothing will come back.
@@ -364,7 +462,7 @@ class ModelFormsetTest(TestCase):
             "form-3-DELETE": "",
         }
 
-        formset = AuthorFormSet(data=data, queryset=qs)
+        formset = self.author_formset_delete_true(data=data, queryset=qs)
         self.assertTrue(formset.is_valid())
 
         # One record has changed.
@@ -386,10 +484,6 @@ class ModelFormsetTest(TestCase):
         # create an Author instance to add to the meeting.
 
         author4 = Author.objects.create(name="John Steinbeck")
-
-        AuthorMeetingFormSet = modelformset_factory(
-            AuthorMeeting, fields="__all__", extra=1, can_delete=True
-        )
         data = {
             "form-TOTAL_FORMS": "2",  # the number of forms rendered
             "form-INITIAL_FORMS": "1",  # the number of forms with initial data
@@ -401,7 +495,9 @@ class ModelFormsetTest(TestCase):
             "form-1-authors": "",
             "form-1-DELETE": "",
         }
-        formset = AuthorMeetingFormSet(data=data, queryset=AuthorMeeting.objects.all())
+        formset = self.author_meeting_delete_true(
+            data=data, queryset=AuthorMeeting.objects.all()
+        )
         self.assertTrue(formset.is_valid())
 
         instances = formset.save(commit=False)
@@ -425,37 +521,25 @@ class ModelFormsetTest(TestCase):
 
         qs = Author.objects.order_by("name")
 
-        AuthorFormSet = modelformset_factory(
-            Author, fields="__all__", max_num=None, extra=3
-        )
-        formset = AuthorFormSet(queryset=qs)
+        formset = self.author_formset_no_max(queryset=qs)
         self.assertEqual(len(formset.forms), 6)
         self.assertEqual(len(formset.extra_forms), 3)
 
-        AuthorFormSet = modelformset_factory(
-            Author, fields="__all__", max_num=4, extra=3
-        )
-        formset = AuthorFormSet(queryset=qs)
+        formset = self.author_formset_max_greater(queryset=qs)
         self.assertEqual(len(formset.forms), 4)
         self.assertEqual(len(formset.extra_forms), 1)
 
-        AuthorFormSet = modelformset_factory(
-            Author, fields="__all__", max_num=0, extra=3
-        )
-        formset = AuthorFormSet(queryset=qs)
+        formset = self.author_formset_max_0_extra(queryset=qs)
         self.assertEqual(len(formset.forms), 3)
         self.assertEqual(len(formset.extra_forms), 0)
 
-        AuthorFormSet = modelformset_factory(Author, fields="__all__", max_num=None)
-        formset = AuthorFormSet(queryset=qs)
+        formset = self.author_formset_max_none(queryset=qs)
         self.assertSequenceEqual(formset.get_queryset(), [a1, a2, a3])
 
-        AuthorFormSet = modelformset_factory(Author, fields="__all__", max_num=0)
-        formset = AuthorFormSet(queryset=qs)
+        formset = self.author_formset_max_0(queryset=qs)
         self.assertSequenceEqual(formset.get_queryset(), [a1, a2, a3])
 
-        AuthorFormSet = modelformset_factory(Author, fields="__all__", max_num=4)
-        formset = AuthorFormSet(queryset=qs)
+        formset = self.author_formset_max(queryset=qs)
         self.assertSequenceEqual(formset.get_queryset(), [a1, a2, a3])
 
     def test_min_num(self):
@@ -463,20 +547,13 @@ class ModelFormsetTest(TestCase):
         # added to extra.
         qs = Author.objects.none()
 
-        AuthorFormSet = modelformset_factory(Author, fields="__all__", extra=0)
-        formset = AuthorFormSet(queryset=qs)
+        formset = self.author_formset_extra_0(queryset=qs)
         self.assertEqual(len(formset.forms), 0)
 
-        AuthorFormSet = modelformset_factory(
-            Author, fields="__all__", min_num=1, extra=0
-        )
-        formset = AuthorFormSet(queryset=qs)
+        formset = self.author_formset_min_greater(queryset=qs)
         self.assertEqual(len(formset.forms), 1)
 
-        AuthorFormSet = modelformset_factory(
-            Author, fields="__all__", min_num=1, extra=1
-        )
-        formset = AuthorFormSet(queryset=qs)
+        formset = self.author_formset_same_min_extra(queryset=qs)
         self.assertEqual(len(formset.forms), 2)
 
     def test_min_num_with_existing(self):
@@ -484,24 +561,10 @@ class ModelFormsetTest(TestCase):
         Author.objects.create(name="Charles Baudelaire")
         qs = Author.objects.all()
 
-        AuthorFormSet = modelformset_factory(
-            Author, fields="__all__", extra=0, min_num=1
-        )
-        formset = AuthorFormSet(queryset=qs)
+        formset = self.author_formset_min_greater(queryset=qs)
         self.assertEqual(len(formset.forms), 1)
 
     def test_custom_save_method(self):
-        class PoetForm(forms.ModelForm):
-            def save(self, commit=True):
-                # change the name to "Vladimir Mayakovsky" just to be a jerk.
-                author = super().save(commit=False)
-                author.name = "Vladimir Mayakovsky"
-                if commit:
-                    author.save()
-                return author
-
-        PoetFormSet = modelformset_factory(Poet, fields="__all__", form=PoetForm)
-
         data = {
             "form-TOTAL_FORMS": "3",  # the number of forms rendered
             "form-INITIAL_FORMS": "0",  # the number of forms with initial data
@@ -512,7 +575,7 @@ class ModelFormsetTest(TestCase):
         }
 
         qs = Poet.objects.all()
-        formset = PoetFormSet(data=data, queryset=qs)
+        formset = self.poet_formset_model_and_form(data=data, queryset=qs)
         self.assertTrue(formset.is_valid())
 
         poets = formset.save()
@@ -526,46 +589,22 @@ class ModelFormsetTest(TestCase):
         model_formset_factory() respects fields and exclude parameters of a
         custom form.
         """
-
-        class PostForm1(forms.ModelForm):
-            class Meta:
-                model = Post
-                fields = ("title", "posted")
-
-        class PostForm2(forms.ModelForm):
-            class Meta:
-                model = Post
-                exclude = ("subtitle",)
-
-        PostFormSet = modelformset_factory(Post, form=PostForm1)
-        formset = PostFormSet()
+        formset = self.post_formset_form1()
         self.assertNotIn("subtitle", formset.forms[0].fields)
 
-        PostFormSet = modelformset_factory(Post, form=PostForm2)
-        formset = PostFormSet()
+        formset = self.post_formset_form2()
         self.assertNotIn("subtitle", formset.forms[0].fields)
 
     def test_custom_queryset_init(self):
-        """
-        A queryset can be overridden in the formset's __init__() method.
-        """
+        """A queryset can be overridden in the formset's __init__() method."""
         Author.objects.create(name="Charles Baudelaire")
         Author.objects.create(name="Paul Verlaine")
 
-        class BaseAuthorFormSet(BaseModelFormSet):
-            def __init__(self, *args, **kwargs):
-                super().__init__(*args, **kwargs)
-                self.queryset = Author.objects.filter(name__startswith="Charles")
-
-        AuthorFormSet = modelformset_factory(
-            Author, fields="__all__", formset=BaseAuthorFormSet
-        )
-        formset = AuthorFormSet()
+        formset = self.author_formset_custom_base()
         self.assertEqual(len(formset.get_queryset()), 1)
 
     def test_model_inheritance(self):
-        BetterAuthorFormSet = modelformset_factory(BetterAuthor, fields="__all__")
-        formset = BetterAuthorFormSet()
+        formset = self.better_author_formset()
         self.assertEqual(len(formset.forms), 1)
         self.assertHTMLEqual(
             formset.forms[0].as_p(),
@@ -586,7 +625,7 @@ class ModelFormsetTest(TestCase):
             "form-0-write_speed": "10",
         }
 
-        formset = BetterAuthorFormSet(data)
+        formset = self.better_author_formset(data)
         self.assertTrue(formset.is_valid())
         saved = formset.save()
         self.assertEqual(len(saved), 1)
@@ -594,7 +633,7 @@ class ModelFormsetTest(TestCase):
         self.assertEqual(author1, BetterAuthor.objects.get(name="Ernest Hemingway"))
         hemingway_id = BetterAuthor.objects.get(name="Ernest Hemingway").pk
 
-        formset = BetterAuthorFormSet()
+        formset = self.better_author_formset()
         self.assertEqual(len(formset.forms), 2)
         self.assertHTMLEqual(
             formset.forms[0].as_p(),
@@ -629,7 +668,7 @@ class ModelFormsetTest(TestCase):
             "form-1-write_speed": "",
         }
 
-        formset = BetterAuthorFormSet(data)
+        formset = self.better_author_formset(data)
         self.assertTrue(formset.is_valid())
         self.assertEqual(formset.save(), [])
 
@@ -637,12 +676,9 @@ class ModelFormsetTest(TestCase):
         # We can also create a formset that is tied to a parent model. This is
         # how the admin system's edit inline functionality works.
 
-        AuthorBooksFormSet = inlineformset_factory(
-            Author, Book, can_delete=False, extra=3, fields="__all__"
-        )
         author = Author.objects.create(name="Charles Baudelaire")
 
-        formset = AuthorBooksFormSet(instance=author)
+        formset = self.book_inlineformset_extra_3(instance=author)
         self.assertEqual(len(formset.forms), 3)
         self.assertHTMLEqual(
             formset.forms[0].as_p(),
@@ -684,7 +720,7 @@ class ModelFormsetTest(TestCase):
             "book_set-2-title": "",
         }
 
-        formset = AuthorBooksFormSet(data, instance=author)
+        formset = self.book_inlineformset_extra_3(data, instance=author)
         self.assertTrue(formset.is_valid())
 
         saved = formset.save()
@@ -697,12 +733,9 @@ class ModelFormsetTest(TestCase):
         # another one. This time though, an edit form will be available for
         # every existing book.
 
-        AuthorBooksFormSet = inlineformset_factory(
-            Author, Book, can_delete=False, extra=2, fields="__all__"
-        )
         author = Author.objects.get(name="Charles Baudelaire")
 
-        formset = AuthorBooksFormSet(instance=author)
+        formset = self.book_inlineformset_extra_2(instance=author)
         self.assertEqual(len(formset.forms), 3)
         self.assertHTMLEqual(
             formset.forms[0].as_p(),
@@ -749,7 +782,7 @@ class ModelFormsetTest(TestCase):
             "book_set-2-title": "",
         }
 
-        formset = AuthorBooksFormSet(data, instance=author)
+        formset = self.book_inlineformset_extra_2(data, instance=author)
         self.assertTrue(formset.is_valid())
 
         saved = formset.save()
@@ -763,10 +796,7 @@ class ModelFormsetTest(TestCase):
 
     def test_inline_formsets_save_as_new(self):
         # The save_as_new parameter lets you re-associate the data to a new
-        # instance. This is used in the admin for save_as functionality.
-        AuthorBooksFormSet = inlineformset_factory(
-            Author, Book, can_delete=False, extra=2, fields="__all__"
-        )
+        # instance.  This is used in the admin for save_as functionality.
         Author.objects.create(name="Charles Baudelaire")
 
         # An immutable QueryDict simulates request.POST.
@@ -785,12 +815,16 @@ class ModelFormsetTest(TestCase):
         )
         data._mutable = False
 
-        formset = AuthorBooksFormSet(data, instance=Author(), save_as_new=True)
+        formset = self.book_inlineformset_extra_2(
+            data, instance=Author(), save_as_new=True
+        )
         self.assertTrue(formset.is_valid())
         self.assertIs(data._mutable, False)
 
         new_author = Author.objects.create(name="Charles Baudelaire")
-        formset = AuthorBooksFormSet(data, instance=new_author, save_as_new=True)
+        formset = self.book_inlineformset_extra_2(
+            data, instance=new_author, save_as_new=True
+        )
         saved = formset.save()
         self.assertEqual(len(saved), 2)
         book1, book2 = saved
@@ -799,7 +833,7 @@ class ModelFormsetTest(TestCase):
 
         # Test using a custom prefix on an inline formset.
 
-        formset = AuthorBooksFormSet(prefix="test")
+        formset = self.book_inlineformset_extra_2(prefix="test")
         self.assertEqual(len(formset.forms), 2)
         self.assertHTMLEqual(
             formset.forms[0].as_p(),
@@ -824,12 +858,9 @@ class ModelFormsetTest(TestCase):
         # primary key that is not the fk to the parent object.
         self.maxDiff = 1024
 
-        AuthorBooksFormSet2 = inlineformset_factory(
-            Author, BookWithCustomPK, can_delete=False, extra=1, fields="__all__"
-        )
         author = Author.objects.create(name="Charles Baudelaire")
 
-        formset = AuthorBooksFormSet2(instance=author)
+        formset = self.book_custom_pk_inlineformset(instance=author)
         self.assertEqual(len(formset.forms), 1)
         self.assertHTMLEqual(
             formset.forms[0].as_p(),
@@ -854,7 +885,7 @@ class ModelFormsetTest(TestCase):
             "bookwithcustompk_set-0-title": "Les Fleurs du Mal",
         }
 
-        formset = AuthorBooksFormSet2(data, instance=author)
+        formset = self.book_custom_pk_inlineformset(data, instance=author)
         self.assertTrue(formset.is_valid())
 
         saved = formset.save()
@@ -869,12 +900,9 @@ class ModelFormsetTest(TestCase):
         # Test inline formsets where the inline-edited object uses multi-table
         # inheritance, thus has a non AutoField yet auto-created primary key.
 
-        AuthorBooksFormSet3 = inlineformset_factory(
-            Author, AlternateBook, can_delete=False, extra=1, fields="__all__"
-        )
         author = Author.objects.create(name="Charles Baudelaire")
 
-        formset = AuthorBooksFormSet3(instance=author)
+        formset = self.alternate_book_inlineformset(instance=author)
         self.assertEqual(len(formset.forms), 1)
         self.assertHTMLEqual(
             formset.forms[0].as_p(),
@@ -901,7 +929,7 @@ class ModelFormsetTest(TestCase):
             "alternatebook_set-0-notes": "English translation of Les Fleurs du Mal",
         }
 
-        formset = AuthorBooksFormSet3(data, instance=author)
+        formset = self.alternate_book_inlineformset(data, instance=author)
         self.assertTrue(formset.is_valid())
 
         saved = formset.save()
@@ -915,13 +943,6 @@ class ModelFormsetTest(TestCase):
         # Test inline formsets where the inline-edited object has a
         # unique_together constraint with a nullable member
 
-        AuthorBooksFormSet4 = inlineformset_factory(
-            Author,
-            BookWithOptionalAltEditor,
-            can_delete=False,
-            extra=2,
-            fields="__all__",
-        )
         author = Author.objects.create(name="Charles Baudelaire")
 
         data = {
@@ -936,7 +957,7 @@ class ModelFormsetTest(TestCase):
             "bookwithoptionalalteditor_set-1-author": str(author.pk),
             "bookwithoptionalalteditor_set-1-title": "Les Fleurs du Mal",
         }
-        formset = AuthorBooksFormSet4(data, instance=author)
+        formset = self.book_alt_editor_inlineformset(data, instance=author)
         self.assertTrue(formset.is_valid())
 
         saved = formset.save()
@@ -948,24 +969,10 @@ class ModelFormsetTest(TestCase):
         self.assertEqual(book2.title, "Les Fleurs du Mal")
 
     def test_inline_formsets_with_custom_save_method(self):
-        AuthorBooksFormSet = inlineformset_factory(
-            Author, Book, can_delete=False, extra=2, fields="__all__"
-        )
         author = Author.objects.create(name="Charles Baudelaire")
         book1 = Book.objects.create(author=author, title="Les Paradis Artificiels")
         book2 = Book.objects.create(author=author, title="Les Fleurs du Mal")
         book3 = Book.objects.create(author=author, title="Flowers of Evil")
-
-        class PoemForm(forms.ModelForm):
-            def save(self, commit=True):
-                # change the name to "Brooklyn Bridge" just to be a jerk.
-                poem = super().save(commit=False)
-                poem.name = "Brooklyn Bridge"
-                if commit:
-                    poem.save()
-                return poem
-
-        PoemFormSet = inlineformset_factory(Poet, Poem, form=PoemForm, fields="__all__")
 
         data = {
             "poem_set-TOTAL_FORMS": "3",  # the number of forms rendered
@@ -977,7 +984,7 @@ class ModelFormsetTest(TestCase):
         }
 
         poet = Poet.objects.create(name="Vladimir Mayakovsky")
-        formset = PoemFormSet(data=data, instance=poet)
+        formset = self.poem_formsave_inlineformset(data=data, instance=poet)
         self.assertTrue(formset.is_valid())
 
         saved = formset.save()
@@ -989,7 +996,7 @@ class ModelFormsetTest(TestCase):
         # We can provide a custom queryset to our InlineFormSet:
 
         custom_qs = Book.objects.order_by("-title")
-        formset = AuthorBooksFormSet(instance=author, queryset=custom_qs)
+        formset = self.book_inlineformset_extra_2(instance=author, queryset=custom_qs)
         self.assertEqual(len(formset.forms), 5)
         self.assertHTMLEqual(
             formset.forms[0].as_p(),
@@ -1055,11 +1062,13 @@ class ModelFormsetTest(TestCase):
             "book_set-3-title": "Revue des deux mondes",
             "book_set-4-title": "",
         }
-        formset = AuthorBooksFormSet(data, instance=author, queryset=custom_qs)
+        formset = self.book_inlineformset_extra_2(
+            data, instance=author, queryset=custom_qs
+        )
         self.assertTrue(formset.is_valid())
 
         custom_qs = Book.objects.filter(title__startswith="F")
-        formset = AuthorBooksFormSet(instance=author, queryset=custom_qs)
+        formset = self.book_inlineformset_extra_2(instance=author, queryset=custom_qs)
         self.assertHTMLEqual(
             formset.forms[0].as_p(),
             '<p><label for="id_book_set-0-title">Title:</label>'
@@ -1098,7 +1107,9 @@ class ModelFormsetTest(TestCase):
             "book_set-1-title": "Revue des deux mondes",
             "book_set-2-title": "",
         }
-        formset = AuthorBooksFormSet(data, instance=author, queryset=custom_qs)
+        formset = self.book_inlineformset_extra_2(
+            data, instance=author, queryset=custom_qs
+        )
         self.assertTrue(formset.is_valid())
 
     def test_inline_formsets_with_custom_save_method_related_instance(self):
@@ -1106,18 +1117,6 @@ class ModelFormsetTest(TestCase):
         The ModelForm.save() method should be able to access the related object
         if it exists in the database (#24395).
         """
-
-        class PoemForm2(forms.ModelForm):
-            def save(self, commit=True):
-                poem = super().save(commit=False)
-                poem.name = "%s by %s" % (poem.name, poem.poet.name)
-                if commit:
-                    poem.save()
-                return poem
-
-        PoemFormSet = inlineformset_factory(
-            Poet, Poem, form=PoemForm2, fields="__all__"
-        )
         data = {
             "poem_set-TOTAL_FORMS": "1",
             "poem_set-INITIAL_FORMS": "0",
@@ -1125,7 +1124,7 @@ class ModelFormsetTest(TestCase):
             "poem_set-0-name": "Le Lac",
         }
         poet = Poet()
-        formset = PoemFormSet(data=data, instance=poet)
+        formset = self.poem_formsave2_inlineformset(data=data, instance=poet)
         self.assertTrue(formset.is_valid())
 
         # The Poet instance is saved after the formset instantiation. This
@@ -1136,19 +1135,10 @@ class ModelFormsetTest(TestCase):
         poem = formset.save()[0]
         self.assertEqual(poem.name, "Le Lac by Lamartine")
 
-    def test_inline_formsets_with_wrong_fk_name(self):
-        """Regression for #23451"""
-        message = "fk_name 'title' is not a ForeignKey to 'model_formsets.Author'."
-        with self.assertRaisesMessage(ValueError, message):
-            inlineformset_factory(Author, Book, fields="__all__", fk_name="title")
-
     def test_custom_pk(self):
         # We need to ensure that it is displayed
 
-        CustomPrimaryKeyFormSet = modelformset_factory(
-            CustomPrimaryKey, fields="__all__"
-        )
-        formset = CustomPrimaryKeyFormSet()
+        formset = self.custom_pk_formset()
         self.assertEqual(len(formset.forms), 1)
         self.assertHTMLEqual(
             formset.forms[0].as_p(),
@@ -1164,10 +1154,7 @@ class ModelFormsetTest(TestCase):
 
         place = Place.objects.create(name="Giordanos", city="Chicago")
 
-        FormSet = inlineformset_factory(
-            Place, Owner, extra=2, can_delete=False, fields="__all__"
-        )
-        formset = FormSet(instance=place)
+        formset = self.owner_inlineformset_extra_2(instance=place)
         self.assertEqual(len(formset.forms), 2)
         self.assertHTMLEqual(
             formset.forms[0].as_p(),
@@ -1199,7 +1186,7 @@ class ModelFormsetTest(TestCase):
             "owner_set-1-auto_id": "",
             "owner_set-1-name": "",
         }
-        formset = FormSet(data, instance=place)
+        formset = self.owner_inlineformset_extra_2(data, instance=place)
         self.assertTrue(formset.is_valid())
         saved = formset.save()
         self.assertEqual(len(saved), 1)
@@ -1207,7 +1194,7 @@ class ModelFormsetTest(TestCase):
         self.assertEqual(owner1.name, "Joe Perry")
         self.assertEqual(owner1.place.name, "Giordanos")
 
-        formset = FormSet(instance=place)
+        formset = self.owner_inlineformset_extra_2(instance=place)
         self.assertEqual(len(formset.forms), 3)
         self.assertHTMLEqual(
             formset.forms[0].as_p(),
@@ -1251,7 +1238,7 @@ class ModelFormsetTest(TestCase):
             "owner_set-2-auto_id": "",
             "owner_set-2-name": "",
         }
-        formset = FormSet(data, instance=place)
+        formset = self.owner_inlineformset_extra_2(data, instance=place)
         self.assertTrue(formset.is_valid())
         saved = formset.save()
         self.assertEqual(len(saved), 1)
@@ -1261,8 +1248,7 @@ class ModelFormsetTest(TestCase):
 
         # A custom primary key that is a ForeignKey or OneToOneField get
         # rendered for the user to choose.
-        FormSet = modelformset_factory(OwnerProfile, fields="__all__")
-        formset = FormSet()
+        formset = self.owner_profile_formset()
         self.assertHTMLEqual(
             formset.forms[0].as_p(),
             '<p><label for="id_form-0-owner">Owner:</label>'
@@ -1277,12 +1263,9 @@ class ModelFormsetTest(TestCase):
         )
 
         owner1 = Owner.objects.get(name="Joe Perry")
-        FormSet = inlineformset_factory(
-            Owner, OwnerProfile, max_num=1, can_delete=False, fields="__all__"
-        )
-        self.assertEqual(FormSet.max_num, 1)
+        self.assertEqual(self.owner_profile_inlineformset.max_num, 1)
 
-        formset = FormSet(instance=owner1)
+        formset = self.owner_profile_inlineformset(instance=owner1)
         self.assertEqual(len(formset.forms), 1)
         self.assertHTMLEqual(
             formset.forms[0].as_p(),
@@ -1300,7 +1283,7 @@ class ModelFormsetTest(TestCase):
             "ownerprofile-0-owner": "",
             "ownerprofile-0-age": "54",
         }
-        formset = FormSet(data, instance=owner1)
+        formset = self.owner_profile_inlineformset(data, instance=owner1)
         self.assertTrue(formset.is_valid())
         saved = formset.save()
         self.assertEqual(len(saved), 1)
@@ -1308,7 +1291,7 @@ class ModelFormsetTest(TestCase):
         self.assertEqual(profile1.owner, owner1)
         self.assertEqual(profile1.age, 54)
 
-        formset = FormSet(instance=owner1)
+        formset = self.owner_profile_inlineformset(instance=owner1)
         self.assertEqual(len(formset.forms), 1)
         self.assertHTMLEqual(
             formset.forms[0].as_p(),
@@ -1326,7 +1309,7 @@ class ModelFormsetTest(TestCase):
             "ownerprofile-0-owner": str(owner1.auto_id),
             "ownerprofile-0-age": "55",
         }
-        formset = FormSet(data, instance=owner1)
+        formset = self.owner_profile_inlineformset(data, instance=owner1)
         self.assertTrue(formset.is_valid())
         saved = formset.save()
         self.assertEqual(len(saved), 1)
@@ -1339,12 +1322,9 @@ class ModelFormsetTest(TestCase):
 
         place = Place.objects.create(name="Giordanos", city="Chicago")
 
-        FormSet = inlineformset_factory(
-            Place, Location, can_delete=False, fields="__all__"
-        )
-        self.assertEqual(FormSet.max_num, 1)
+        self.assertEqual(self.location_inlineformset.max_num, 1)
 
-        formset = FormSet(instance=place)
+        formset = self.location_inlineformset(instance=place)
         self.assertEqual(len(formset.forms), 1)
         self.assertHTMLEqual(
             formset.forms[0].as_p(),
@@ -1367,14 +1347,13 @@ class ModelFormsetTest(TestCase):
         )
 
     def test_unique_validation(self):
-        FormSet = modelformset_factory(Product, fields="__all__", extra=1)
         data = {
             "form-TOTAL_FORMS": "1",
             "form-INITIAL_FORMS": "0",
             "form-MAX_NUM_FORMS": "",
             "form-0-slug": "car-red",
         }
-        formset = FormSet(data)
+        formset = self.product_formset_extra_1(data)
         self.assertTrue(formset.is_valid())
         saved = formset.save()
         self.assertEqual(len(saved), 1)
@@ -1387,7 +1366,7 @@ class ModelFormsetTest(TestCase):
             "form-MAX_NUM_FORMS": "",
             "form-0-slug": "car-red",
         }
-        formset = FormSet(data)
+        formset = self.product_formset_extra_1(data)
         self.assertFalse(formset.is_valid())
         self.assertEqual(
             formset.errors, [{"slug": ["Product with this Slug already exists."]}]
@@ -1409,17 +1388,13 @@ class ModelFormsetTest(TestCase):
             "form-1-quantity": "2",
         }
 
-        FormSet = modelformset_factory(
-            Price, fields="__all__", extra=1, max_num=1, validate_max=True
-        )
-        formset = FormSet(data)
+        formset = self.price_formset_validate_max(data)
         self.assertFalse(formset.is_valid())
         self.assertEqual(formset.non_form_errors(), ["Please submit at most 1 form."])
 
         # Now test the same thing without the validate_max flag to ensure
         # default behavior is unchanged
-        FormSet = modelformset_factory(Price, fields="__all__", extra=1, max_num=1)
-        formset = FormSet(data)
+        formset = self.price_formset_no_validate_max(data)
         self.assertTrue(formset.is_valid())
 
     def test_modelformset_min_num_equals_max_num_less_than(self):
@@ -1431,16 +1406,7 @@ class ModelFormsetTest(TestCase):
             "form-1-slug": "car-blue",
             "form-2-slug": "car-black",
         }
-        FormSet = modelformset_factory(
-            Product,
-            fields="__all__",
-            extra=1,
-            max_num=2,
-            validate_max=True,
-            min_num=2,
-            validate_min=True,
-        )
-        formset = FormSet(data)
+        formset = self.product_formset_validate(data)
         self.assertFalse(formset.is_valid())
         self.assertEqual(formset.non_form_errors(), ["Please submit at most 2 forms."])
 
@@ -1451,21 +1417,11 @@ class ModelFormsetTest(TestCase):
             "form-MAX_NUM_FORMS": "2",
             "form-0-slug": "car-red",
         }
-        FormSet = modelformset_factory(
-            Product,
-            fields="__all__",
-            extra=1,
-            max_num=2,
-            validate_max=True,
-            min_num=2,
-            validate_min=True,
-        )
-        formset = FormSet(data)
+        formset = self.product_formset_validate(data)
         self.assertFalse(formset.is_valid())
         self.assertEqual(formset.non_form_errors(), ["Please submit at least 2 forms."])
 
     def test_unique_together_validation(self):
-        FormSet = modelformset_factory(Price, fields="__all__", extra=1)
         data = {
             "form-TOTAL_FORMS": "1",
             "form-INITIAL_FORMS": "0",
@@ -1473,7 +1429,7 @@ class ModelFormsetTest(TestCase):
             "form-0-price": "12.00",
             "form-0-quantity": "1",
         }
-        formset = FormSet(data)
+        formset = self.price_formset_extra_1(data)
         self.assertTrue(formset.is_valid())
         saved = formset.save()
         self.assertEqual(len(saved), 1)
@@ -1488,7 +1444,7 @@ class ModelFormsetTest(TestCase):
             "form-0-price": "12.00",
             "form-0-quantity": "1",
         }
-        formset = FormSet(data)
+        formset = self.price_formset_extra_1(data)
         self.assertFalse(formset.is_valid())
         self.assertEqual(
             formset.errors,
@@ -1499,7 +1455,6 @@ class ModelFormsetTest(TestCase):
         # Also see bug #8882.
 
         repository = Repository.objects.create(name="Test Repo")
-        FormSet = inlineformset_factory(Repository, Revision, extra=1, fields="__all__")
         data = {
             "revision_set-TOTAL_FORMS": "1",
             "revision_set-INITIAL_FORMS": "0",
@@ -1508,7 +1463,7 @@ class ModelFormsetTest(TestCase):
             "revision_set-0-revision": "146239817507f148d448db38840db7c3cbf47c76",
             "revision_set-0-DELETE": "",
         }
-        formset = FormSet(data, instance=repository)
+        formset = self.revision_inlineformset(data, instance=repository)
         self.assertTrue(formset.is_valid())
         saved = formset.save()
         self.assertEqual(len(saved), 1)
@@ -1525,7 +1480,7 @@ class ModelFormsetTest(TestCase):
             "revision_set-0-revision": "146239817507f148d448db38840db7c3cbf47c76",
             "revision_set-0-DELETE": "",
         }
-        formset = FormSet(data, instance=repository)
+        formset = self.revision_inlineformset(data, instance=repository)
         self.assertFalse(formset.is_valid())
         self.assertEqual(
             formset.errors,
@@ -1541,9 +1496,6 @@ class ModelFormsetTest(TestCase):
         # unique_together with inlineformset_factory with overridden form
         # fields Also see #9494
 
-        FormSet = inlineformset_factory(
-            Repository, Revision, fields=("revision",), extra=1
-        )
         data = {
             "revision_set-TOTAL_FORMS": "1",
             "revision_set-INITIAL_FORMS": "0",
@@ -1552,17 +1504,14 @@ class ModelFormsetTest(TestCase):
             "revision_set-0-revision": "146239817507f148d448db38840db7c3cbf47c76",
             "revision_set-0-DELETE": "",
         }
-        formset = FormSet(data, instance=repository)
+        formset = self.revision_fields_inlineformset(data, instance=repository)
         self.assertFalse(formset.is_valid())
 
     def test_callable_defaults(self):
         # Use of callable defaults (see bug #7975).
 
         person = Person.objects.create(name="Ringo")
-        FormSet = inlineformset_factory(
-            Person, Membership, can_delete=False, extra=1, fields="__all__"
-        )
-        formset = FormSet(instance=person)
+        formset = self.membership_inlineformset(instance=person)
 
         # Django will render a hidden field for model fields that have a
         # callable default. This is required to ensure the value is tested for
@@ -1606,7 +1555,7 @@ class ModelFormsetTest(TestCase):
             "initial-membership_set-0-date_joined": now.strftime("%Y-%m-%d %H:%M:%S"),
             "membership_set-0-karma": "",
         }
-        formset = FormSet(data, instance=person)
+        formset = self.membership_inlineformset(data, instance=person)
         self.assertTrue(formset.is_valid())
 
         # now test for when the data changes
@@ -1620,54 +1569,21 @@ class ModelFormsetTest(TestCase):
             "initial-membership_set-0-date_joined": now.strftime("%Y-%m-%d %H:%M:%S"),
             "membership_set-0-karma": "",
         }
-        formset = FormSet(filled_data, instance=person)
+        formset = self.membership_inlineformset(filled_data, instance=person)
         self.assertFalse(formset.is_valid())
 
-        # now test with split datetime fields
-
-        class MembershipForm(forms.ModelForm):
-            date_joined = forms.SplitDateTimeField(initial=now)
-
-            class Meta:
-                model = Membership
-                fields = "__all__"
-
-            def __init__(self, **kwargs):
-                super().__init__(**kwargs)
-                self.fields["date_joined"].widget = forms.SplitDateTimeWidget()
-
-        FormSet = inlineformset_factory(
-            Person,
-            Membership,
-            form=MembershipForm,
-            can_delete=False,
-            extra=1,
-            fields="__all__",
-        )
-        data = {
-            "membership_set-TOTAL_FORMS": "1",
-            "membership_set-INITIAL_FORMS": "0",
-            "membership_set-MAX_NUM_FORMS": "",
-            "membership_set-0-date_joined_0": now.strftime("%Y-%m-%d"),
-            "membership_set-0-date_joined_1": now.strftime("%H:%M:%S"),
-            "initial-membership_set-0-date_joined": now.strftime("%Y-%m-%d %H:%M:%S"),
-            "membership_set-0-karma": "",
-        }
-        formset = FormSet(data, instance=person)
-        self.assertTrue(formset.is_valid())
-
-    def test_inlineformset_factory_with_null_fk(self):
-        # inlineformset_factory tests with fk having null=True. see #9462.
+    def test_inlineformset_with_null_fk(self):
+        # inlineformset factory and declarative tests
+        # with fk having null=True. see #9462.
         # create some data that will exhibit the issue
         team = Team.objects.create(name="Red Vipers")
         Player(name="Timmy").save()
         Player(name="Bobby", team=team).save()
 
-        PlayerInlineFormSet = inlineformset_factory(Team, Player, fields="__all__")
-        formset = PlayerInlineFormSet()
+        formset = self.player_inlineformset()
         self.assertQuerySetEqual(formset.get_queryset(), [])
 
-        formset = PlayerInlineFormSet(instance=team)
+        formset = self.player_inlineformset(instance=team)
         players = formset.get_queryset()
         self.assertEqual(len(players), 1)
         (player1,) = players
@@ -1675,22 +1591,6 @@ class ModelFormsetTest(TestCase):
         self.assertEqual(player1.name, "Bobby")
 
     def test_inlineformset_with_arrayfield(self):
-        class SimpleArrayField(forms.CharField):
-            """A proxy for django.contrib.postgres.forms.SimpleArrayField."""
-
-            def to_python(self, value):
-                value = super().to_python(value)
-                return value.split(",") if value else []
-
-        class BookForm(forms.ModelForm):
-            title = SimpleArrayField()
-
-            class Meta:
-                model = Book
-                fields = ["title"]
-
-        BookFormSet = inlineformset_factory(Author, Book, form=BookForm)
-        self.assertEqual(BookForm.Meta.fields, ["title"])
         data = {
             "book_set-TOTAL_FORMS": "3",
             "book_set-INITIAL_FORMS": "0",
@@ -1700,51 +1600,23 @@ class ModelFormsetTest(TestCase):
             "book_set-2-title": "test3,test4",
         }
         author = Author.objects.create(name="test")
-        formset = BookFormSet(data, instance=author)
-        self.assertEqual(BookForm.Meta.fields, ["title"])
-        self.assertEqual(
-            formset.errors,
-            [{}, {"__all__": ["Please correct the duplicate values below."]}, {}],
-        )
-
-    def test_inlineformset_with_jsonfield(self):
-        class BookForm(forms.ModelForm):
-            title = forms.JSONField()
-
-            class Meta:
-                model = Book
-                fields = ("title",)
-
-        BookFormSet = inlineformset_factory(Author, Book, form=BookForm)
-        data = {
-            "book_set-TOTAL_FORMS": "3",
-            "book_set-INITIAL_FORMS": "0",
-            "book_set-MAX_NUM_FORMS": "",
-            "book_set-0-title": {"test1": "test2"},
-            "book_set-1-title": {"test1": "test2"},
-            "book_set-2-title": {"test3": "test4"},
-        }
-        author = Author.objects.create(name="test")
-        formset = BookFormSet(data, instance=author)
+        formset = self.book_arrayfield_inlineformset(data, instance=author)
         self.assertEqual(
             formset.errors,
             [{}, {"__all__": ["Please correct the duplicate values below."]}, {}],
         )
 
     def test_model_formset_with_custom_pk(self):
-        # a formset for a Model that has a custom primary key that still needs
-        # to be added to the formset automatically
-        FormSet = modelformset_factory(
-            ClassyMexicanRestaurant, fields=["tacos_are_yummy"]
-        )
+        # a formset for a Model that has a custom primary key that still
+        # needs to be added to the formset automatically
         self.assertEqual(
-            sorted(FormSet().forms[0].fields), ["tacos_are_yummy", "the_restaurant"]
+            sorted(self.classy_mexican_formset().forms[0].fields),
+            ["tacos_are_yummy", "the_restaurant"],
         )
 
     def test_model_formset_with_initial_model_instance(self):
         # has_changed should compare model instance and primary key
         # see #18898
-        FormSet = modelformset_factory(Poem, fields="__all__")
         john_milton = Poet(name="John Milton")
         john_milton.save()
         data = {
@@ -1754,13 +1626,12 @@ class ModelFormsetTest(TestCase):
             "form-0-name": "",
             "form-0-poet": str(john_milton.id),
         }
-        formset = FormSet(initial=[{"poet": john_milton}], data=data)
+        formset = self.poem_formset(initial=[{"poet": john_milton}], data=data)
         self.assertFalse(formset.extra_forms[0].has_changed())
 
     def test_model_formset_with_initial_queryset(self):
         # has_changed should work with queryset and list of pk's
         # see #18898
-        FormSet = modelformset_factory(AuthorMeeting, fields="__all__")
         Author.objects.create(name="Charles Baudelaire")
         data = {
             "form-TOTAL_FORMS": 1,
@@ -1770,7 +1641,9 @@ class ModelFormsetTest(TestCase):
             "form-0-created": "",
             "form-0-authors": list(Author.objects.values_list("id", flat=True)),
         }
-        formset = FormSet(initial=[{"authors": Author.objects.all()}], data=data)
+        formset = self.author_meeting_formset(
+            initial=[{"authors": Author.objects.all()}], data=data
+        )
         self.assertFalse(formset.extra_forms[0].has_changed())
 
     def test_get_queryset_falls_back_to_pk_when_no_ordering_defined(self):
@@ -1814,7 +1687,6 @@ class ModelFormsetTest(TestCase):
         self.assertIs(queryset.totally_ordered, True)
 
     def test_prevent_duplicates_from_with_the_same_formset(self):
-        FormSet = modelformset_factory(Product, fields="__all__", extra=2)
         data = {
             "form-TOTAL_FORMS": 2,
             "form-INITIAL_FORMS": 0,
@@ -1822,13 +1694,12 @@ class ModelFormsetTest(TestCase):
             "form-0-slug": "red_car",
             "form-1-slug": "red_car",
         }
-        formset = FormSet(data)
+        formset = self.product_formset_extra_2(data)
         self.assertFalse(formset.is_valid())
         self.assertEqual(
             formset._non_form_errors, ["Please correct the duplicate data for slug."]
         )
 
-        FormSet = modelformset_factory(Price, fields="__all__", extra=2)
         data = {
             "form-TOTAL_FORMS": 2,
             "form-INITIAL_FORMS": 0,
@@ -1838,7 +1709,7 @@ class ModelFormsetTest(TestCase):
             "form-1-price": "25",
             "form-1-quantity": "7",
         }
-        formset = FormSet(data)
+        formset = self.price_formset_extra_2(data)
         self.assertFalse(formset.is_valid())
         self.assertEqual(
             formset._non_form_errors,
@@ -1851,7 +1722,6 @@ class ModelFormsetTest(TestCase):
         # Only the price field is specified, this should skip any unique
         # checks since the unique_together is not fulfilled. This will fail
         # with a KeyError if broken.
-        FormSet = modelformset_factory(Price, fields=("price",), extra=2)
         data = {
             "form-TOTAL_FORMS": "2",
             "form-INITIAL_FORMS": "0",
@@ -1859,10 +1729,9 @@ class ModelFormsetTest(TestCase):
             "form-0-price": "24",
             "form-1-price": "24",
         }
-        formset = FormSet(data)
+        formset = self.price_formset_fields(data)
         self.assertTrue(formset.is_valid())
 
-        FormSet = inlineformset_factory(Author, Book, extra=0, fields="__all__")
         author = Author.objects.create(name="Charles Baudelaire")
         Book.objects.create(author=author, title="Les Paradis Artificiels")
         Book.objects.create(author=author, title="Les Fleurs du Mal")
@@ -1880,7 +1749,7 @@ class ModelFormsetTest(TestCase):
             "book_set-1-author": str(author.id),
             "book_set-1-id": str(book_ids[1]),
         }
-        formset = FormSet(data=data, instance=author)
+        formset = self.book_inlineformset_extra_0(data=data, instance=author)
         self.assertFalse(formset.is_valid())
         self.assertEqual(
             formset._non_form_errors, ["Please correct the duplicate data for title."]
@@ -1890,7 +1759,6 @@ class ModelFormsetTest(TestCase):
             [{}, {"__all__": ["Please correct the duplicate values below."]}],
         )
 
-        FormSet = modelformset_factory(Post, fields="__all__", extra=2)
         data = {
             "form-TOTAL_FORMS": "2",
             "form-INITIAL_FORMS": "0",
@@ -1904,7 +1772,7 @@ class ModelFormsetTest(TestCase):
             "form-1-subtitle": "rawr",
             "form-1-posted": "2009-01-01",
         }
-        formset = FormSet(data)
+        formset = self.post_formset_extra_2(data)
         self.assertFalse(formset.is_valid())
         self.assertEqual(
             formset._non_form_errors,
@@ -1931,7 +1799,7 @@ class ModelFormsetTest(TestCase):
             "form-1-subtitle": "rawr",
             "form-1-posted": "2009-08-02",
         }
-        formset = FormSet(data)
+        formset = self.post_formset_extra_2(data)
         self.assertFalse(formset.is_valid())
         self.assertEqual(
             formset._non_form_errors,
@@ -1954,7 +1822,7 @@ class ModelFormsetTest(TestCase):
             "form-1-subtitle": "rawr",
             "form-1-posted": "2009-08-02",
         }
-        formset = FormSet(data)
+        formset = self.post_formset_extra_2(data)
         self.assertFalse(formset.is_valid())
         self.assertEqual(
             formset._non_form_errors,
@@ -1967,7 +1835,6 @@ class ModelFormsetTest(TestCase):
     def test_prevent_change_outer_model_and_create_invalid_data(self):
         author = Author.objects.create(name="Charles")
         other_author = Author.objects.create(name="Walt")
-        AuthorFormSet = modelformset_factory(Author, fields="__all__")
         data = {
             "form-TOTAL_FORMS": "2",
             "form-INITIAL_FORMS": "2",
@@ -1979,7 +1846,7 @@ class ModelFormsetTest(TestCase):
         }
         # This formset is only for Walt Whitman and shouldn't accept data for
         # other_author.
-        formset = AuthorFormSet(
+        formset = self.author_formset(
             data=data, queryset=Author.objects.filter(id__in=(author.id,))
         )
         self.assertTrue(formset.is_valid())
@@ -1989,21 +1856,19 @@ class ModelFormsetTest(TestCase):
         self.assertSequenceEqual(Author.objects.all(), [author, other_author])
 
     def test_validation_without_id(self):
-        AuthorFormSet = modelformset_factory(Author, fields="__all__")
         data = {
             "form-TOTAL_FORMS": "1",
             "form-INITIAL_FORMS": "1",
             "form-MAX_NUM_FORMS": "",
             "form-0-name": "Charles",
         }
-        formset = AuthorFormSet(data)
+        formset = self.author_formset(data)
         self.assertEqual(
             formset.errors,
             [{"id": ["This field is required."]}],
         )
 
     def test_validation_with_child_model_without_id(self):
-        BetterAuthorFormSet = modelformset_factory(BetterAuthor, fields="__all__")
         data = {
             "form-TOTAL_FORMS": "1",
             "form-INITIAL_FORMS": "1",
@@ -2011,14 +1876,13 @@ class ModelFormsetTest(TestCase):
             "form-0-name": "Charles",
             "form-0-write_speed": "10",
         }
-        formset = BetterAuthorFormSet(data)
+        formset = self.better_author_formset(data)
         self.assertEqual(
             formset.errors,
             [{"author_ptr": ["This field is required."]}],
         )
 
     def test_validation_with_invalid_id(self):
-        AuthorFormSet = modelformset_factory(Author, fields="__all__")
         data = {
             "form-TOTAL_FORMS": "1",
             "form-INITIAL_FORMS": "1",
@@ -2026,7 +1890,7 @@ class ModelFormsetTest(TestCase):
             "form-0-id": "abc",
             "form-0-name": "Charles",
         }
-        formset = AuthorFormSet(data)
+        formset = self.author_formset(data)
         self.assertEqual(
             formset.errors,
             [
@@ -2040,7 +1904,6 @@ class ModelFormsetTest(TestCase):
         )
 
     def test_validation_with_nonexistent_id(self):
-        AuthorFormSet = modelformset_factory(Author, fields="__all__")
         data = {
             "form-TOTAL_FORMS": "1",
             "form-INITIAL_FORMS": "1",
@@ -2048,7 +1911,7 @@ class ModelFormsetTest(TestCase):
             "form-0-id": "12345",
             "form-0-name": "Charles",
         }
-        formset = AuthorFormSet(data)
+        formset = self.author_formset(data)
         self.assertEqual(
             formset.errors,
             [
@@ -2062,13 +1925,11 @@ class ModelFormsetTest(TestCase):
         )
 
     def test_initial_form_count_empty_data(self):
-        AuthorFormSet = modelformset_factory(Author, fields="__all__")
-        formset = AuthorFormSet({})
+        formset = self.author_formset({})
         self.assertEqual(formset.initial_form_count(), 0)
 
     def test_edit_only(self):
         charles = Author.objects.create(name="Charles Baudelaire")
-        AuthorFormSet = modelformset_factory(Author, fields="__all__", edit_only=True)
         data = {
             "form-TOTAL_FORMS": "2",
             "form-INITIAL_FORMS": "0",
@@ -2076,7 +1937,7 @@ class ModelFormsetTest(TestCase):
             "form-0-name": "Arthur Rimbaud",
             "form-1-name": "Walt Whitman",
         }
-        formset = AuthorFormSet(data)
+        formset = self.author_formset_edit_only(data)
         self.assertIs(formset.is_valid(), True)
         formset.save()
         self.assertSequenceEqual(Author.objects.all(), [charles])
@@ -2088,7 +1949,7 @@ class ModelFormsetTest(TestCase):
             "form-0-name": "Arthur Rimbaud",
             "form-1-name": "Walt Whitman",
         }
-        formset = AuthorFormSet(data)
+        formset = self.author_formset_edit_only(data)
         self.assertIs(formset.is_valid(), True)
         formset.save()
         charles.refresh_from_db()
@@ -2098,13 +1959,6 @@ class ModelFormsetTest(TestCase):
     def test_edit_only_inlineformset_factory(self):
         charles = Author.objects.create(name="Charles Baudelaire")
         book = Book.objects.create(author=charles, title="Les Paradis Artificiels")
-        AuthorFormSet = inlineformset_factory(
-            Author,
-            Book,
-            can_delete=False,
-            fields="__all__",
-            edit_only=True,
-        )
         data = {
             "book_set-TOTAL_FORMS": "4",
             "book_set-INITIAL_FORMS": "1",
@@ -2115,7 +1969,7 @@ class ModelFormsetTest(TestCase):
             "book_set-1-title": "Flowers of Evil",
             "book_set-1-author": charles.pk,
         }
-        formset = AuthorFormSet(data, instance=charles)
+        formset = self.book_inlineformset_edit_only(data, instance=charles)
         self.assertIs(formset.is_valid(), True)
         formset.save()
         book.refresh_from_db()
@@ -2131,8 +1985,9 @@ class ModelFormsetTest(TestCase):
             "form-0-id": walt.pk,
             "form-0-name": "Parth Patil",
         }
-        AuthorFormSet = modelformset_factory(Author, fields="__all__", edit_only=True)
-        formset = AuthorFormSet(data, queryset=Author.objects.filter(pk=charles.pk))
+        formset = self.author_formset_edit_only(
+            data, queryset=Author.objects.filter(pk=charles.pk)
+        )
         self.assertIs(formset.is_valid(), True)
         formset.save()
         self.assertCountEqual(Author.objects.all(), [charles, walt])
@@ -2166,6 +2021,730 @@ class ModelFormsetTest(TestCase):
         charles.refresh_from_db()
         self.assertEqual(charles.name, "Shawn Dong")
         self.assertEqual(Author.objects.count(), 2)
+
+    def test_custom_clean_poem_formset(self):
+        """A custom clean poem formset."""
+        data = {"name": "AN UPPERCASE NAME"}
+        data = {
+            "poems-INITIAL_FORMS": "0",
+            "poems-TOTAL_FORMS": "1",
+            "poems-0-name": "AN UPPERCASE NAME",
+        }
+        formset = self.poem_custom_inlineformset(data=data, prefix="poems")
+        formset.full_clean()
+        self.assertTrue(formset.is_valid())
+        self.assertEqual(formset.forms[0].clean().get("name"), "an uppercase name")
+
+
+class FactoryModelFormsetTest(TestCase, ModelFormsetTestMixin):
+    """A set of tests of modelformsets and inlineformset.
+
+    Created with factories.
+    """
+
+    # modelformsets
+    author_formset_extra_3 = modelformset_factory(Author, fields="__all__", extra=3)
+    author_formset_delete_false = modelformset_factory(
+        Author, fields="__all__", extra=1, can_delete=False
+    )
+    author_formset_delete_true = modelformset_factory(
+        Author, fields="__all__", extra=1, can_delete=True
+    )
+    author_meeting_delete_true = modelformset_factory(
+        AuthorMeeting, fields="__all__", extra=1, can_delete=True
+    )
+    author_formset_no_max = modelformset_factory(
+        Author, fields="__all__", max_num=None, extra=3
+    )
+    author_formset_max_greater = modelformset_factory(
+        Author, fields="__all__", max_num=4, extra=3
+    )
+    author_formset_max_0_extra = modelformset_factory(
+        Author, fields="__all__", max_num=0, extra=3
+    )
+    author_formset_max_none = modelformset_factory(
+        Author, fields="__all__", max_num=None
+    )
+    author_formset_max_0 = modelformset_factory(Author, fields="__all__", max_num=0)
+    author_formset_max = modelformset_factory(Author, fields="__all__", max_num=4)
+    author_formset_extra_0 = modelformset_factory(Author, fields="__all__", extra=0)
+    author_formset_min_greater = modelformset_factory(
+        Author, fields="__all__", min_num=1, extra=0
+    )
+    author_formset_same_min_extra = modelformset_factory(
+        Author, fields="__all__", min_num=1, extra=1
+    )
+    poet_formset_model_and_form = modelformset_factory(
+        Poet, fields="__all__", form=PoetForm
+    )
+    post_formset_form1 = modelformset_factory(Post, form=PostForm1)
+    post_formset_form2 = modelformset_factory(Post, form=PostForm2)
+    author_formset_custom_base = modelformset_factory(
+        Author, fields="__all__", formset=BaseAuthorFormSet
+    )
+    better_author_formset = modelformset_factory(BetterAuthor, fields="__all__")
+    custom_pk_formset = modelformset_factory(CustomPrimaryKey, fields="__all__")
+    owner_profile_formset = modelformset_factory(OwnerProfile, fields="__all__")
+    product_formset_extra_1 = modelformset_factory(Product, fields="__all__", extra=1)
+    price_formset_validate_max = modelformset_factory(
+        Price, fields="__all__", extra=1, max_num=1, validate_max=True
+    )
+    price_formset_no_validate_max = modelformset_factory(
+        Price, fields="__all__", extra=1, max_num=1
+    )
+    product_formset_validate = modelformset_factory(
+        Product,
+        fields="__all__",
+        extra=1,
+        max_num=2,
+        validate_max=True,
+        min_num=2,
+        validate_min=True,
+    )
+    price_formset_extra_1 = modelformset_factory(Price, fields="__all__", extra=1)
+    classy_mexican_formset = modelformset_factory(
+        ClassyMexicanRestaurant, fields=["tacos_are_yummy"]
+    )
+    poem_formset = modelformset_factory(Poem, fields="__all__")
+    author_meeting_formset = modelformset_factory(AuthorMeeting, fields="__all__")
+    product_formset_extra_2 = modelformset_factory(Product, fields="__all__", extra=2)
+    price_formset_extra_2 = modelformset_factory(Price, fields="__all__", extra=2)
+    price_formset_fields = modelformset_factory(Price, fields=("price",), extra=2)
+    post_formset_extra_2 = modelformset_factory(Post, fields="__all__", extra=2)
+    author_formset = modelformset_factory(Author, fields="__all__")
+    author_formset_edit_only = modelformset_factory(
+        Author, fields="__all__", edit_only=True
+    )
+    # inlineformsets
+    book_inlineformset_extra_3 = inlineformset_factory(
+        Author, Book, can_delete=False, extra=3, fields="__all__"
+    )
+    book_inlineformset_extra_2 = inlineformset_factory(
+        Author, Book, can_delete=False, extra=2, fields="__all__"
+    )
+    book_custom_pk_inlineformset = inlineformset_factory(
+        Author, BookWithCustomPK, can_delete=False, extra=1, fields="__all__"
+    )
+    alternate_book_inlineformset = inlineformset_factory(
+        Author, AlternateBook, can_delete=False, extra=1, fields="__all__"
+    )
+    book_alt_editor_inlineformset = inlineformset_factory(
+        Author,
+        BookWithOptionalAltEditor,
+        can_delete=False,
+        extra=2,
+        fields="__all__",
+    )
+    poem_formsave_inlineformset = inlineformset_factory(
+        Poet, Poem, form=PoemFormSave, fields="__all__"
+    )
+    poem_formsave2_inlineformset = inlineformset_factory(
+        Poet, Poem, form=PoemFormSave2, fields="__all__"
+    )
+    owner_inlineformset_extra_2 = inlineformset_factory(
+        Place, Owner, extra=2, can_delete=False, fields="__all__"
+    )
+    owner_profile_inlineformset = inlineformset_factory(
+        Owner, OwnerProfile, max_num=1, can_delete=False, fields="__all__"
+    )
+    location_inlineformset = inlineformset_factory(
+        Place, Location, can_delete=False, fields="__all__"
+    )
+    revision_inlineformset = inlineformset_factory(
+        Repository, Revision, extra=1, fields="__all__"
+    )
+    revision_fields_inlineformset = inlineformset_factory(
+        Repository, Revision, fields=("revision",), extra=1
+    )
+    membership_inlineformset = inlineformset_factory(
+        Person, Membership, can_delete=False, extra=1, fields="__all__"
+    )
+    player_inlineformset = inlineformset_factory(Team, Player, fields="__all__")
+    book_arrayfield_inlineformset = inlineformset_factory(
+        Author, Book, form=BookFormArrayField
+    )
+    book_inlineformset_extra_0 = inlineformset_factory(
+        Author, Book, extra=0, fields="__all__"
+    )
+    book_inlineformset_edit_only = inlineformset_factory(
+        Author,
+        Book,
+        can_delete=False,
+        fields="__all__",
+        edit_only=True,
+    )
+    poem_custom_inlineformset = inlineformset_factory(
+        Poet, Poem, form=PoemFormField, formset=CustomInlineFormSet
+    )
+
+    def test_modelformset_without_fields(self):
+        """Regression for #19733."""
+        message = (
+            "Calling modelformset_factory without defining 'fields' or 'exclude' "
+            "explicitly is prohibited."
+        )
+        with self.assertRaisesMessage(ImproperlyConfigured, message):
+            modelformset_factory(Author)
+
+    def test_inline_formsets_with_wrong_fk_name(self):
+        """Regression for #23451."""
+        message = "fk_name 'title' is not a ForeignKey to 'model_formsets.Author'."
+        with self.assertRaisesMessage(ValueError, message):
+            inlineformset_factory(Author, Book, fields="__all__", fk_name="title")
+
+    def test_callable_defaults_split_datetime(self):
+        # Use of callable defaults with split datetime fields.
+        person = Person.objects.create(name="Ringo")
+        formset = self.membership_inlineformset(instance=person)
+        form = formset.forms[0]
+        now = form.fields["date_joined"].initial()
+
+        class MembershipForm(forms.ModelForm):
+            date_joined = forms.SplitDateTimeField(initial=now)
+
+            class Meta:
+                model = Membership
+                fields = "__all__"
+
+            def __init__(self, **kwargs):
+                super().__init__(**kwargs)
+                self.fields["date_joined"].widget = forms.SplitDateTimeWidget()
+
+        FormSet = inlineformset_factory(
+            Person,
+            Membership,
+            form=MembershipForm,
+            can_delete=False,
+            extra=1,
+            fields="__all__",
+        )
+        data = {
+            "membership_set-TOTAL_FORMS": "1",
+            "membership_set-INITIAL_FORMS": "0",
+            "membership_set-MAX_NUM_FORMS": "",
+            "membership_set-0-date_joined_0": now.strftime("%Y-%m-%d"),
+            "membership_set-0-date_joined_1": now.strftime("%H:%M:%S"),
+            "initial-membership_set-0-date_joined": now.strftime("%Y-%m-%d %H:%M:%S"),
+            "membership_set-0-karma": "",
+        }
+        formset = FormSet(data, instance=person)
+        self.assertTrue(formset.is_valid())
+
+    def test_no_model_argument_error(self):
+        """
+        Test that modelformset can not be created without a model argument.
+        """
+        msg = "modelformset_factory() missing 1 required positional argument: 'model'"
+        with self.assertRaisesMessage(TypeError, msg):
+            modelformset_factory(fields="__all__")
+
+    def test_no_model_but_form_argument_error(self):
+        """
+        Test that modelformset can not be created without a model argument,
+        even if you pass a form argument.
+        """
+        msg = "modelformset_factory() missing 1 required positional argument: 'model'"
+        with self.assertRaisesMessage(TypeError, msg):
+            modelformset_factory(form=PoetForm)
+
+    def test_model_no_fields_or_exclude_arguments_error(self):
+        """
+        Test that modelformset can not be created if you pass a model but
+        without fields or exclude arguments or a form.
+        """
+        with self.assertRaises(ImproperlyConfigured):
+            modelformset_factory(model=Post)
+
+    def test_no_parent_model_inline_argument_error(self):
+        """
+        Test that inlineformset can not be created without a parent_model.
+        """
+        msg = "inlineformset_factory() missing 1 required positional "
+        "argument: 'parent_model'"
+        with self.assertRaisesMessage(TypeError, msg):
+            inlineformset_factory(model=Poem, form=PoemFormSave)
+
+    def test_no_model_inline_argument_error(self):
+        """
+        Test that inlineformset can not be created without a model argument.
+        """
+        msg = (
+            "inlineformset_factory() missing 1 required positional " "argument: 'model'"
+        )
+        with self.assertRaisesMessage(TypeError, msg):
+            inlineformset_factory(parent_model=Poet, form=PoemFormSave)
+
+
+class DeclarativeModelFormsetTest(TestCase, ModelFormsetTestMixin):
+    """A set of tests of modelformsets created with declarative syntax."""
+
+    class DeclarativeAuthorFormSetExtra3(ModelFormSet):
+        model = Author
+        fields = "__all__"
+        extra = 3
+
+    class DeclarativeAuthorFormSetDeleteFalse(ModelFormSet):
+        model = Author
+        fields = "__all__"
+        extra = 1
+        can_delete = False
+
+    class DeclarativeAuthorFormSetDeleteTrue(ModelFormSet):
+        model = Author
+        fields = "__all__"
+        extra = 1
+        can_delete = True
+
+    class DeclarativeAuthorMeetingFormSetDelete(ModelFormSet):
+        model = AuthorMeeting
+        fields = "__all__"
+        extra = 1
+        can_delete = True
+
+    class DeclarativeAuthorFormSetNoMax(ModelFormSet):
+        model = Author
+        fields = "__all__"
+        max_num = None
+        extra = 3
+
+    class DeclarativeAuthorFormSetMaxGreater(ModelFormSet):
+        model = Author
+        fields = "__all__"
+        max_num = 4
+        extra = 3
+
+    class DeclarativeAuthorFormSetMax0Extra(ModelFormSet):
+        model = Author
+        fields = "__all__"
+        max_num = 0
+        extra = 3
+
+    class DeclarativeAuthorFormSetMaxNone(ModelFormSet):
+        model = Author
+        fields = "__all__"
+        max_num = None
+
+    class DeclarativeAuthorFormSetMax0(ModelFormSet):
+        model = Author
+        fields = "__all__"
+        max_num = 0
+
+    class DeclarativeAuthorFormSetMax(ModelFormSet):
+        model = Author
+        fields = "__all__"
+        max_num = 4
+
+    class DeclarativeAuthorFormSetExtra0(ModelFormSet):
+        model = Author
+        fields = "__all__"
+        extra = 0
+
+    class DeclarativeAuthorFormSetMinGreater(ModelFormSet):
+        model = Author
+        fields = "__all__"
+        min_num = 1
+        extra = 0
+
+    class DeclarativeAuthorFormSetSameMinExtra(ModelFormSet):
+        model = Author
+        fields = "__all__"
+        min_num = 1
+        extra = 1
+
+    class DeclarativePoetFormSetWithForm(ModelFormSet):
+        model = Poet
+        fields = "__all__"
+        form = PoetForm
+
+    class DeclarativePostFormSetPostForm1(ModelFormSet):
+        model = Post
+        form = PostForm1
+
+    class DeclarativePostFormSetPostForm2(ModelFormSet):
+        model = Post
+        form = PostForm2
+
+    class DeclarativeAuthorFormSetCustomBase(ModelFormSet):
+        model = Author
+        fields = "__all__"
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.queryset = Author.objects.filter(name__startswith="Charles")
+
+    class DeclarativeBetterAuthorFormSet(ModelFormSet):
+        model = BetterAuthor
+        fields = "__all__"
+
+    class DeclarativeCustomPrimaryKeyFormSet(ModelFormSet):
+        model = CustomPrimaryKey
+        fields = "__all__"
+
+    class DeclarativeOwnerProfileFormSet(ModelFormSet):
+        model = OwnerProfile
+        fields = "__all__"
+
+    class DeclarativeProductFormSetExtra1(ModelFormSet):
+        model = Product
+        fields = "__all__"
+        extra = 1
+
+    class DeclarativePriceFormSetValidateMax(ModelFormSet):
+        model = Price
+        fields = "__all__"
+        extra = 1
+        max_num = 1
+        validate_max = True
+
+    class DeclarativePriceFormSetNoValidateMax(ModelFormSet):
+        model = Price
+        fields = "__all__"
+        extra = 1
+        max_num = 1
+
+    class DeclarativeProductFormSetValidate(ModelFormSet):
+        model = Product
+        fields = "__all__"
+        extra = 1
+        max_num = 2
+        validate_max = True
+        min_num = 2
+        validate_min = True
+
+    class DeclarativePriceFormSetExtra1(ModelFormSet):
+        model = Price
+        fields = "__all__"
+        extra = 1
+
+    class DeclarativeClassyMexicanFormSet(ModelFormSet):
+        model = ClassyMexicanRestaurant
+        fields = ["tacos_are_yummy"]
+
+    class DeclarativePoemFormSet(ModelFormSet):
+        model = Poem
+        fields = "__all__"
+
+    class DeclarativeAuthorMeetingFormSet(ModelFormSet):
+        model = AuthorMeeting
+        fields = "__all__"
+
+    class DeclarativeProductFormSetExtra2(ModelFormSet):
+        model = Product
+        fields = "__all__"
+        extra = 2
+
+    class DeclarativePriceFormSetExtra2(ModelFormSet):
+        model = Price
+        fields = "__all__"
+        extra = 2
+
+    class DeclarativePriceFormSetFields(ModelFormSet):
+        model = Price
+        fields = ("price",)
+        extra = 2
+
+    class DeclarativePostFormSetExtra2(ModelFormSet):
+        model = Post
+        fields = "__all__"
+        extra = 2
+
+    class DeclarativeAuthorFormSet(ModelFormSet):
+        model = Author
+        fields = "__all__"
+
+    class DeclarativeAuthorFormSetEditOnly(ModelFormSet):
+        model = Author
+        fields = "__all__"
+        edit_only = True
+
+    class DeclarativeBookInlineSetExtra3(InlineFormSet):
+        parent_model = Author
+        model = Book
+        can_delete = False
+        extra = 3
+        fields = "__all__"
+
+    class DeclarativeBookInlineSetExtra2(InlineFormSet):
+        parent_model = Author
+        model = Book
+        can_delete = False
+        extra = 2
+        fields = "__all__"
+
+    class DeclarativeBookCustomInlineSet(InlineFormSet):
+        parent_model = Author
+        model = BookWithCustomPK
+        can_delete = False
+        extra = 1
+        fields = "__all__"
+
+    class DeclarativeAlternateBookInlineSet(InlineFormSet):
+        parent_model = Author
+        model = AlternateBook
+        can_delete = False
+        extra = 1
+        fields = "__all__"
+
+    class DeclarativeBookAltEditorInlineSet(InlineFormSet):
+        parent_model = Author
+        model = BookWithOptionalAltEditor
+        can_delete = False
+        extra = 2
+        fields = "__all__"
+
+    class DeclarativePoemFormSaveInlineSet(InlineFormSet):
+        parent_model = Poet
+        model = Poem
+        form = PoemFormSave
+        fields = "__all__"
+
+    class DeclarativePoemFormSave2InlineSet(InlineFormSet):
+        parent_model = Poet
+        model = Poem
+        form = PoemFormSave2
+        fields = "__all__"
+
+    class DeclarativeOwnerInlineSetExtra2(InlineFormSet):
+        parent_model = Place
+        model = Owner
+        extra = 2
+        can_delete = False
+        fields = "__all__"
+
+    class DeclarativeOwnerProfileInlineSet(InlineFormSet):
+        parent_model = Owner
+        model = OwnerProfile
+        max_num = 1
+        can_delete = False
+        fields = "__all__"
+
+    class DeclarativeLocationInlineSet(InlineFormSet):
+        parent_model = Place
+        model = Location
+        can_delete = False
+        fields = "__all__"
+
+    class DeclarativeRevisionInlineSet(InlineFormSet):
+        parent_model = Repository
+        model = Revision
+        extra = 1
+        fields = "__all__"
+
+    class DeclarativeRevisionFieldsInlineSet(InlineFormSet):
+        parent_model = Repository
+        model = Revision
+        fields = ("revision",)
+        extra = 1
+
+    class DeclarativeMembershipInlineSet(InlineFormSet):
+        parent_model = Person
+        model = Membership
+        can_delete = False
+        extra = 1
+        fields = "__all__"
+
+    class DeclarativePlayerInlineSet(InlineFormSet):
+        parent_model = Team
+        model = Player
+        fields = "__all__"
+
+    class DeclarativeBookArrayFieldInlineSet(InlineFormSet):
+        parent_model = Author
+        model = Book
+        form = BookFormArrayField
+
+    class DeclarativeBookInlineSetExtra0(InlineFormSet):
+        parent_model = Author
+        model = Book
+        extra = 0
+        fields = "__all__"
+
+    class DeclarativeBookEditOnlyInlineSet(InlineFormSet):
+        parent_model = Author
+        model = Book
+        can_delete = False
+        fields = "__all__"
+        edit_only = True
+
+    class DeclarativeCustomPoemInlineFormSet(InlineFormSet):
+        parent_model = Poet
+        model = Poem
+        form = PoemFormField
+
+        def clean(self):
+            for comment in self.cleaned_data:
+                comment["name"] = comment["name"].lower()
+            super().clean()
+
+    # modelformsets
+    author_formset_extra_3 = DeclarativeAuthorFormSetExtra3
+    author_formset_delete_false = DeclarativeAuthorFormSetDeleteFalse
+    author_formset_delete_true = DeclarativeAuthorFormSetDeleteTrue
+    author_meeting_delete_true = DeclarativeAuthorMeetingFormSetDelete
+    author_formset_no_max = DeclarativeAuthorFormSetNoMax
+    author_formset_max_greater = DeclarativeAuthorFormSetMaxGreater
+    author_formset_max_0_extra = DeclarativeAuthorFormSetMax0Extra
+    author_formset_max_none = DeclarativeAuthorFormSetMaxNone
+    author_formset_max_0 = DeclarativeAuthorFormSetMax0
+    author_formset_max = DeclarativeAuthorFormSetMax
+    author_formset_extra_0 = DeclarativeAuthorFormSetExtra0
+    author_formset_min_greater = DeclarativeAuthorFormSetMinGreater
+    author_formset_same_min_extra = DeclarativeAuthorFormSetSameMinExtra
+    poet_formset_model_and_form = DeclarativePoetFormSetWithForm
+    post_formset_form1 = DeclarativePostFormSetPostForm1
+    post_formset_form2 = DeclarativePostFormSetPostForm2
+    author_formset_custom_base = DeclarativeAuthorFormSetCustomBase
+    better_author_formset = DeclarativeBetterAuthorFormSet
+    custom_pk_formset = DeclarativeCustomPrimaryKeyFormSet
+    owner_profile_formset = DeclarativeOwnerProfileFormSet
+    product_formset_extra_1 = DeclarativeProductFormSetExtra1
+    price_formset_validate_max = DeclarativePriceFormSetValidateMax
+    price_formset_no_validate_max = DeclarativePriceFormSetNoValidateMax
+    product_formset_validate = DeclarativeProductFormSetValidate
+    price_formset_extra_1 = DeclarativePriceFormSetExtra1
+    classy_mexican_formset = DeclarativeClassyMexicanFormSet
+    poem_formset = DeclarativePoemFormSet
+    author_meeting_formset = DeclarativeAuthorMeetingFormSet
+    product_formset_extra_2 = DeclarativeProductFormSetExtra2
+    price_formset_extra_2 = DeclarativePriceFormSetExtra2
+    price_formset_fields = DeclarativePriceFormSetFields
+    post_formset_extra_2 = DeclarativePostFormSetExtra2
+    author_formset = DeclarativeAuthorFormSet
+    author_formset_edit_only = DeclarativeAuthorFormSetEditOnly
+    # inlineformsets
+    book_inlineformset_extra_3 = DeclarativeBookInlineSetExtra3
+    book_inlineformset_extra_2 = DeclarativeBookInlineSetExtra2
+    book_custom_pk_inlineformset = DeclarativeBookCustomInlineSet
+    alternate_book_inlineformset = DeclarativeAlternateBookInlineSet
+    book_alt_editor_inlineformset = DeclarativeBookAltEditorInlineSet
+    poem_formsave_inlineformset = DeclarativePoemFormSaveInlineSet
+    poem_formsave2_inlineformset = DeclarativePoemFormSave2InlineSet
+    owner_inlineformset_extra_2 = DeclarativeOwnerInlineSetExtra2
+    owner_profile_inlineformset = DeclarativeOwnerProfileInlineSet
+    location_inlineformset = DeclarativeLocationInlineSet
+    revision_inlineformset = DeclarativeRevisionInlineSet
+    revision_fields_inlineformset = DeclarativeRevisionFieldsInlineSet
+    membership_inlineformset = DeclarativeMembershipInlineSet
+    player_inlineformset = DeclarativePlayerInlineSet
+    book_arrayfield_inlineformset = DeclarativeBookArrayFieldInlineSet
+    book_inlineformset_extra_0 = DeclarativeBookInlineSetExtra0
+    book_inlineformset_edit_only = DeclarativeBookEditOnlyInlineSet
+    poem_custom_inlineformset = DeclarativeCustomPoemInlineFormSet
+
+    def test_modelformset_without_fields(self):
+        """Regression for #19733."""
+        message = (
+            "Defining DeclarativeInvalidAuthorFormSet without defining "
+            "'fields' or 'exclude' explicitly is prohibited."
+        )
+        with self.assertRaisesMessage(ImproperlyConfigured, message):
+
+            class DeclarativeInvalidAuthorFormSet(ModelFormSet):
+                model = Author
+
+    def test_inline_formsets_with_wrong_fk_name(self):
+        """Regression for #23451."""
+        message = "fk_name 'title' is not a ForeignKey to 'model_formsets.Author'."
+        with self.assertRaisesMessage(ValueError, message):
+
+            class DeclarativeInvalidBookInlineSet(InlineFormSet):
+                parent_model = Author
+                model = Book
+                fields = "__all__"
+                fk_name = "title"
+
+    def test_callable_defaults_split_datetime(self):
+        # Use of callable defaults with split datetime fields.
+        person = Person.objects.create(name="Ringo")
+        formset = self.membership_inlineformset(instance=person)
+        form = formset.forms[0]
+        now = form.fields["date_joined"].initial()
+
+        class MembershipForm(forms.ModelForm):
+            date_joined = forms.SplitDateTimeField(initial=now)
+
+            class Meta:
+                model = Membership
+                fields = "__all__"
+
+            def __init__(self, **kwargs):
+                super().__init__(**kwargs)
+                self.fields["date_joined"].widget = forms.SplitDateTimeWidget()
+
+        class DeclarativeMembershipFormInlineSet(InlineFormSet):
+            parent_model = Person
+            model = Membership
+            form = MembershipForm
+            can_delete = False
+            extra = 1
+            fields = "__all__"
+
+        data = {
+            "membership_set-TOTAL_FORMS": "1",
+            "membership_set-INITIAL_FORMS": "0",
+            "membership_set-MAX_NUM_FORMS": "",
+            "membership_set-0-date_joined_0": now.strftime("%Y-%m-%d"),
+            "membership_set-0-date_joined_1": now.strftime("%H:%M:%S"),
+            "initial-membership_set-0-date_joined": now.strftime("%Y-%m-%d %H:%M:%S"),
+            "membership_set-0-karma": "",
+        }
+        formset = DeclarativeMembershipFormInlineSet(data, instance=person)
+        self.assertTrue(formset.is_valid())
+
+    def test_no_model_argument_error(self):
+        """
+        Test that modelformset can not be created without a model argument.
+        """
+        msg = "ModelFormSet() missing 1 required positional argument: 'model'"
+        with self.assertRaisesMessage(TypeError, msg):
+
+            class DeclarativeInvalidFormSet(ModelFormSet):
+                fields = "__all__"
+
+    def test_no_model_but_form_argument_error(self):
+        """
+        Test that modelformset can not be created without a model argument,
+        even if you pass a form argument.
+        """
+        msg = "ModelFormSet() missing 1 required positional argument: 'model'"
+        with self.assertRaisesMessage(TypeError, msg):
+
+            class DeclarativeInvalidFormSet(ModelFormSet):
+                form = PoetForm
+
+    def test_model_no_fields_or_exclude_arguments_error(self):
+        """
+        Test that modelformset can not be created if you pass a model but
+        without fields or exclude arguments or a form.
+        """
+        with self.assertRaises(ImproperlyConfigured):
+
+            class DeclarativeInvalidFormSet(ModelFormSet):
+                model = Post
+
+    def test_no_parent_model_inline_argument_error(self):
+        """
+        Test that inlineformset can not be created without a parent_model.
+        """
+        msg = (
+            "InlineFormSet() missing 1 required positional argument: " "'parent_model'"
+        )
+        with self.assertRaisesMessage(TypeError, msg):
+
+            class DeclarativeInvalidInlineFormSet(InlineFormSet):
+                model = Poem
+                form = PoemFormSave
+
+    def test_no_model_inline_argument_error(self):
+        """
+        Test that inlineformset can not be created without a model argument.
+        """
+        msg = "InlineFormSet() missing 1 required positional argument: 'model'"
+        with self.assertRaisesMessage(TypeError, msg):
+
+            class DeclarativeInvalidInlineFormSet(InlineFormSet):
+                parent_model = Poet
+                form = PoemFormSave
 
 
 class TestModelFormsetOverridesTroughFormMeta(TestCase):

--- a/tests/model_formsets/tests.py
+++ b/tests/model_formsets/tests.py
@@ -6,7 +6,7 @@ from decimal import Decimal
 from django import forms
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
-from django.forms.formsets import formset_factory
+from django.forms.formsets import DEFAULT_MAX_NUM, formset_factory
 from django.forms.models import (
     BaseInlineFormSet,
     BaseModelFormSet,
@@ -25,6 +25,7 @@ from .models import (
     AlternateBook,
     Author,
     AuthorMeeting,
+    AuthorProxy,
     BetterAuthor,
     Book,
     BookWithCustomPK,
@@ -48,10 +49,15 @@ from .models import (
     Restaurant,
     Revision,
     Team,
+    TeamSponsor,
 )
 
 
 class PoetForm(forms.ModelForm):
+    class Meta:
+        model = Poet
+        fields = "__all__"
+
     def save(self, commit=True):
         # change the name to "Vladimir Mayakovsky" just to be a jerk.
         author = super().save(commit=False)
@@ -80,6 +86,10 @@ class BaseAuthorFormSet(BaseModelFormSet):
 
 
 class PoemFormSave(forms.ModelForm):
+    class Meta:
+        model = Poem
+        fields = "__all__"
+
     def save(self, commit=True):
         # change the name to "Brooklyn Bridge" just to be a jerk.
         poem = super().save(commit=False)
@@ -90,6 +100,10 @@ class PoemFormSave(forms.ModelForm):
 
 
 class PoemFormSave2(forms.ModelForm):
+    class Meta:
+        model = Poem
+        fields = "__all__"
+
     def save(self, commit=True):
         poem = super().save(commit=False)
         poem.name = "%s by %s" % (poem.name, poem.poet.name)
@@ -114,6 +128,14 @@ class SimpleArrayField(forms.CharField):
 
 class BookFormArrayField(forms.ModelForm):
     title = SimpleArrayField()
+
+    class Meta:
+        model = Book
+        fields = ["title"]
+
+
+class BookFormJSONField(forms.ModelForm):
+    title = forms.JSONField()
 
     class Meta:
         model = Book
@@ -1322,9 +1344,8 @@ class ModelFormsetTestMixin:
 
         place = Place.objects.create(name="Giordanos", city="Chicago")
 
-        self.assertEqual(self.location_inlineformset.max_num, 1)
-
         formset = self.location_inlineformset(instance=place)
+        self.assertEqual(formset.max_num, 1)
         self.assertEqual(len(formset.forms), 1)
         self.assertHTMLEqual(
             formset.forms[0].as_p(),
@@ -1591,6 +1612,7 @@ class ModelFormsetTestMixin:
         self.assertEqual(player1.name, "Bobby")
 
     def test_inlineformset_with_arrayfield(self):
+        self.assertEqual(BookFormArrayField.Meta.fields, ["title"])
         data = {
             "book_set-TOTAL_FORMS": "3",
             "book_set-INITIAL_FORMS": "0",
@@ -1601,6 +1623,23 @@ class ModelFormsetTestMixin:
         }
         author = Author.objects.create(name="test")
         formset = self.book_arrayfield_inlineformset(data, instance=author)
+        self.assertEqual(BookFormArrayField.Meta.fields, ["title"])
+        self.assertEqual(
+            formset.errors,
+            [{}, {"__all__": ["Please correct the duplicate values below."]}, {}],
+        )
+
+    def test_inlineformset_with_jsonfield(self):
+        data = {
+            "book_set-TOTAL_FORMS": "3",
+            "book_set-INITIAL_FORMS": "0",
+            "book_set-MAX_NUM_FORMS": "",
+            "book_set-0-title": {"test1": "test2"},
+            "book_set-1-title": {"test1": "test2"},
+            "book_set-2-title": {"test3": "test4"},
+        }
+        author = Author.objects.create(name="test")
+        formset = self.book_jsonfield_inlineformset(data, instance=author)
         self.assertEqual(
             formset.errors,
             [{}, {"__all__": ["Please correct the duplicate values below."]}, {}],
@@ -2034,6 +2073,7 @@ class ModelFormsetTestMixin:
         formset.full_clean()
         self.assertTrue(formset.is_valid())
         self.assertEqual(formset.forms[0].clean().get("name"), "an uppercase name")
+        self.assertEqual(formset.forms[0].instance.name, "an uppercase name")
 
 
 class FactoryModelFormsetTest(TestCase, ModelFormsetTestMixin):
@@ -2163,6 +2203,9 @@ class FactoryModelFormsetTest(TestCase, ModelFormsetTestMixin):
     book_arrayfield_inlineformset = inlineformset_factory(
         Author, Book, form=BookFormArrayField
     )
+    book_jsonfield_inlineformset = inlineformset_factory(
+        Author, Book, form=BookFormJSONField
+    )
     book_inlineformset_extra_0 = inlineformset_factory(
         Author, Book, extra=0, fields="__all__"
     )
@@ -2185,6 +2228,15 @@ class FactoryModelFormsetTest(TestCase, ModelFormsetTestMixin):
         )
         with self.assertRaisesMessage(ImproperlyConfigured, message):
             modelformset_factory(Author)
+
+    def test_modelformset_factory_form_without_meta(self):
+        class NoMetaAuthorForm(forms.ModelForm):
+            pass
+
+        AuthorFormSet = modelformset_factory(
+            Author, form=NoMetaAuthorForm, fields="__all__"
+        )
+        self.assertEqual(sorted(AuthorFormSet.form.base_fields), ["name"])
 
     def test_inline_formsets_with_wrong_fk_name(self):
         """Regression for #23451."""
@@ -2259,8 +2311,10 @@ class FactoryModelFormsetTest(TestCase, ModelFormsetTestMixin):
         """
         Test that inlineformset can not be created without a parent_model.
         """
-        msg = "inlineformset_factory() missing 1 required positional "
-        "argument: 'parent_model'"
+        msg = (
+            "inlineformset_factory() missing 1 required positional "
+            "argument: 'parent_model'"
+        )
         with self.assertRaisesMessage(TypeError, msg):
             inlineformset_factory(model=Poem, form=PoemFormSave)
 
@@ -2268,9 +2322,7 @@ class FactoryModelFormsetTest(TestCase, ModelFormsetTestMixin):
         """
         Test that inlineformset can not be created without a model argument.
         """
-        msg = (
-            "inlineformset_factory() missing 1 required positional " "argument: 'model'"
-        )
+        msg = "inlineformset_factory() missing 1 required positional argument: 'model'"
         with self.assertRaisesMessage(TypeError, msg):
             inlineformset_factory(parent_model=Poet, form=PoemFormSave)
 
@@ -2353,7 +2405,6 @@ class DeclarativeModelFormsetTest(TestCase, ModelFormsetTestMixin):
 
     class DeclarativePoetFormSetWithForm(ModelFormSet):
         model = Poet
-        fields = "__all__"
         form = PoetForm
 
     class DeclarativePostFormSetPostForm1(ModelFormSet):
@@ -2496,13 +2547,11 @@ class DeclarativeModelFormsetTest(TestCase, ModelFormsetTestMixin):
         parent_model = Poet
         model = Poem
         form = PoemFormSave
-        fields = "__all__"
 
     class DeclarativePoemFormSave2InlineSet(InlineFormSet):
         parent_model = Poet
         model = Poem
         form = PoemFormSave2
-        fields = "__all__"
 
     class DeclarativeOwnerInlineSetExtra2(InlineFormSet):
         parent_model = Place
@@ -2553,6 +2602,11 @@ class DeclarativeModelFormsetTest(TestCase, ModelFormsetTestMixin):
         model = Book
         form = BookFormArrayField
 
+    class DeclarativeBookJSONFieldInlineSet(InlineFormSet):
+        parent_model = Author
+        model = Book
+        form = BookFormJSONField
+
     class DeclarativeBookInlineSetExtra0(InlineFormSet):
         parent_model = Author
         model = Book
@@ -2566,15 +2620,10 @@ class DeclarativeModelFormsetTest(TestCase, ModelFormsetTestMixin):
         fields = "__all__"
         edit_only = True
 
-    class DeclarativeCustomPoemInlineFormSet(InlineFormSet):
+    class DeclarativeCustomPoemInlineFormSet(CustomInlineFormSet, InlineFormSet):
         parent_model = Poet
         model = Poem
         form = PoemFormField
-
-        def clean(self):
-            for comment in self.cleaned_data:
-                comment["name"] = comment["name"].lower()
-            super().clean()
 
     # modelformsets
     author_formset_extra_3 = DeclarativeAuthorFormSetExtra3
@@ -2627,6 +2676,7 @@ class DeclarativeModelFormsetTest(TestCase, ModelFormsetTestMixin):
     membership_inlineformset = DeclarativeMembershipInlineSet
     player_inlineformset = DeclarativePlayerInlineSet
     book_arrayfield_inlineformset = DeclarativeBookArrayFieldInlineSet
+    book_jsonfield_inlineformset = DeclarativeBookJSONFieldInlineSet
     book_inlineformset_extra_0 = DeclarativeBookInlineSetExtra0
     book_inlineformset_edit_only = DeclarativeBookEditOnlyInlineSet
     poem_custom_inlineformset = DeclarativeCustomPoemInlineFormSet
@@ -2634,8 +2684,9 @@ class DeclarativeModelFormsetTest(TestCase, ModelFormsetTestMixin):
     def test_modelformset_without_fields(self):
         """Regression for #19733."""
         message = (
-            "Defining DeclarativeInvalidAuthorFormSet without defining "
-            "'fields' or 'exclude' explicitly is prohibited."
+            "Creating a ModelFormSet without either the 'fields' attribute "
+            "or the 'exclude' attribute is prohibited; formset "
+            "DeclarativeInvalidAuthorFormSet needs updating."
         )
         with self.assertRaisesMessage(ImproperlyConfigured, message):
 
@@ -2677,7 +2728,6 @@ class DeclarativeModelFormsetTest(TestCase, ModelFormsetTestMixin):
             form = MembershipForm
             can_delete = False
             extra = 1
-            fields = "__all__"
 
         data = {
             "membership_set-TOTAL_FORMS": "1",
@@ -2695,8 +2745,11 @@ class DeclarativeModelFormsetTest(TestCase, ModelFormsetTestMixin):
         """
         Test that modelformset can not be created without a model argument.
         """
-        msg = "ModelFormSet() missing 1 required positional argument: 'model'"
-        with self.assertRaisesMessage(TypeError, msg):
+        msg = (
+            "Creating a ModelFormSet without the 'model' attribute is "
+            "prohibited; formset DeclarativeInvalidFormSet needs updating."
+        )
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
 
             class DeclarativeInvalidFormSet(ModelFormSet):
                 fields = "__all__"
@@ -2706,8 +2759,11 @@ class DeclarativeModelFormsetTest(TestCase, ModelFormsetTestMixin):
         Test that modelformset can not be created without a model argument,
         even if you pass a form argument.
         """
-        msg = "ModelFormSet() missing 1 required positional argument: 'model'"
-        with self.assertRaisesMessage(TypeError, msg):
+        msg = (
+            "Creating a ModelFormSet without the 'model' attribute is "
+            "prohibited; formset DeclarativeInvalidFormSet needs updating."
+        )
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
 
             class DeclarativeInvalidFormSet(ModelFormSet):
                 form = PoetForm
@@ -2717,7 +2773,12 @@ class DeclarativeModelFormsetTest(TestCase, ModelFormsetTestMixin):
         Test that modelformset can not be created if you pass a model but
         without fields or exclude arguments or a form.
         """
-        with self.assertRaises(ImproperlyConfigured):
+        msg = (
+            "Creating a ModelFormSet without either the 'fields' attribute "
+            "or the 'exclude' attribute is prohibited; formset "
+            "DeclarativeInvalidFormSet needs updating."
+        )
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
 
             class DeclarativeInvalidFormSet(ModelFormSet):
                 model = Post
@@ -2727,9 +2788,11 @@ class DeclarativeModelFormsetTest(TestCase, ModelFormsetTestMixin):
         Test that inlineformset can not be created without a parent_model.
         """
         msg = (
-            "InlineFormSet() missing 1 required positional argument: " "'parent_model'"
+            "Creating an InlineFormSet without the 'parent_model' attribute "
+            "is prohibited; formset DeclarativeInvalidInlineFormSet needs "
+            "updating."
         )
-        with self.assertRaisesMessage(TypeError, msg):
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
 
             class DeclarativeInvalidInlineFormSet(InlineFormSet):
                 model = Poem
@@ -2739,12 +2802,586 @@ class DeclarativeModelFormsetTest(TestCase, ModelFormsetTestMixin):
         """
         Test that inlineformset can not be created without a model argument.
         """
-        msg = "InlineFormSet() missing 1 required positional argument: 'model'"
-        with self.assertRaisesMessage(TypeError, msg):
+        msg = (
+            "Creating an InlineFormSet without the 'model' attribute is "
+            "prohibited; formset DeclarativeInvalidInlineFormSet needs "
+            "updating."
+        )
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
 
             class DeclarativeInvalidInlineFormSet(InlineFormSet):
                 parent_model = Poet
                 form = PoemFormSave
+
+
+class DeclarativeModelFormSetInheritanceTests(TestCase):
+    def test_subclass_inherits_options(self):
+        class BaseAuthorFormSet(ModelFormSet):
+            model = Author
+            fields = "__all__"
+            extra = 4
+
+        class AuthorFormSet(BaseAuthorFormSet):
+            extra = 2
+
+        self.assertIs(AuthorFormSet.model, Author)
+        self.assertEqual(AuthorFormSet.extra, 2)
+        self.assertIs(issubclass(AuthorFormSet, BaseAuthorFormSet), True)
+        self.assertIs(issubclass(AuthorFormSet, ModelFormSet), True)
+        formset = AuthorFormSet(queryset=Author.objects.none())
+        self.assertEqual(len(formset.forms), 2)
+        self.assertEqual(sorted(formset.forms[0].fields), ["id", "name"])
+
+    def test_subclass_overrides_fields(self):
+        class BaseBookFormSet(ModelFormSet):
+            model = Book
+            fields = "__all__"
+
+        class TitleOnlyBookFormSet(BaseBookFormSet):
+            fields = ["title"]
+
+        self.assertEqual(
+            sorted(BaseBookFormSet().forms[0].fields), ["author", "id", "title"]
+        )
+        self.assertEqual(
+            sorted(TitleOnlyBookFormSet().forms[0].fields), ["id", "title"]
+        )
+
+    def test_subclass_inherits_methods(self):
+        class BaseAuthorFormSet(ModelFormSet):
+            model = Author
+            fields = "__all__"
+
+            def get_queryset(self):
+                return super().get_queryset().filter(name__startswith="Charles")
+
+        class AuthorFormSet(BaseAuthorFormSet):
+            extra = 1
+
+        Author.objects.create(name="Charles Baudelaire")
+        Author.objects.create(name="Walt Whitman")
+        formset = AuthorFormSet()
+        self.assertEqual(len(formset.get_queryset()), 1)
+
+    def test_inline_subclass_inherits_options(self):
+        class BaseBookFormSet(InlineFormSet):
+            parent_model = Author
+            model = Book
+            fields = "__all__"
+
+        class BookFormSet(BaseBookFormSet):
+            extra = 1
+            can_delete = False
+
+        self.assertIs(issubclass(BookFormSet, BaseBookFormSet), True)
+        self.assertIs(issubclass(BookFormSet, InlineFormSet), True)
+        self.assertEqual(BookFormSet.fk, BaseBookFormSet.fk)
+        author = Author.objects.create(name="Charles Baudelaire")
+        formset = BookFormSet(instance=author)
+        self.assertEqual(len(formset.forms), 1)
+
+    def test_mixin_preserved(self):
+        class SortedQuerysetMixin:
+            def get_queryset(self):
+                return super().get_queryset().order_by("-name")
+
+        class AuthorFormSet(SortedQuerysetMixin, ModelFormSet):
+            model = Author
+            fields = "__all__"
+
+        self.assertIs(issubclass(AuthorFormSet, SortedQuerysetMixin), True)
+        Author.objects.create(name="Adam")
+        Author.objects.create(name="Zoe")
+        formset = AuthorFormSet()
+        self.assertEqual(formset.get_queryset()[0].name, "Zoe")
+
+    def test_declared_form_used_as_base(self):
+        class AuthorFormBase(forms.ModelForm):
+            class Meta:
+                model = Author
+                fields = "__all__"
+
+        class AuthorFormSet(ModelFormSet):
+            model = Author
+            form = AuthorFormBase
+
+        # A declared form is used as the base for a generated form, exactly as
+        # modelformset_factory does, rather than by identity.
+        self.assertIsNot(AuthorFormSet.form, AuthorFormBase)
+        self.assertIs(issubclass(AuthorFormSet.form, AuthorFormBase), True)
+
+        class BookFormBase(forms.ModelForm):
+            class Meta:
+                model = Book
+                fields = ["title"]
+
+        class BookFormSet(InlineFormSet):
+            parent_model = Author
+            model = Book
+            form = BookFormBase
+
+        # An inline formset likewise wraps the form (like
+        # inlineformset_factory) so the parent foreign key can be added.
+        self.assertIsNot(BookFormSet.form, BookFormBase)
+        self.assertIs(issubclass(BookFormSet.form, BookFormBase), True)
+
+    def test_form_with_options_generates_from_form(self):
+        class AuthorFormBase(forms.ModelForm):
+            class Meta:
+                model = Author
+                fields = "__all__"
+
+        class AuthorFormSet(ModelFormSet):
+            model = Author
+            form = AuthorFormBase
+            fields = ["name"]
+
+        FactoryFormSet = modelformset_factory(
+            Author, form=AuthorFormBase, fields=["name"]
+        )
+        self.assertIs(issubclass(AuthorFormSet.form, AuthorFormBase), True)
+        self.assertEqual(
+            list(AuthorFormSet.form.base_fields),
+            list(FactoryFormSet.form.base_fields),
+        )
+
+    def test_inherited_options_wrap_declared_form(self):
+        class AuthorFormOverride(forms.ModelForm):
+            class Meta:
+                model = Author
+                fields = "__all__"
+
+        class BaseAuthorFormSet(ModelFormSet):
+            model = Author
+            fields = ["name"]
+
+        class AuthorFormSet(BaseAuthorFormSet):
+            form = AuthorFormOverride
+
+        self.assertIs(issubclass(AuthorFormSet.form, AuthorFormOverride), True)
+        self.assertEqual(list(AuthorFormSet.form.base_fields), ["name"])
+
+    def test_form_without_model_or_fields_error(self):
+        # A form without its own model is allowed (it is rebuilt against the
+        # formset's model), but a field source is still required.
+        class ModellessForm(forms.ModelForm):
+            pass
+
+        msg = (
+            "Creating a ModelFormSet without either the 'fields' attribute or "
+            "the 'exclude' attribute is prohibited; formset AuthorFormSet "
+            "needs updating."
+        )
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+
+            class AuthorFormSet(ModelFormSet):
+                model = Author
+                form = ModellessForm
+
+    def test_modelformset_factory_with_declarative_base(self):
+        class BaseAuthorFormSet(ModelFormSet):
+            model = Author
+            fields = "__all__"
+
+            def get_queryset(self):
+                return super().get_queryset().filter(name__startswith="Charles")
+
+        AuthorFormSet = modelformset_factory(
+            Author, fields="__all__", formset=BaseAuthorFormSet
+        )
+        self.assertIs(issubclass(AuthorFormSet, BaseAuthorFormSet), True)
+        Author.objects.create(name="Charles Baudelaire")
+        Author.objects.create(name="Walt Whitman")
+        self.assertEqual(len(AuthorFormSet().get_queryset()), 1)
+
+    def test_importable_from_django_forms(self):
+        self.assertIs(forms.ModelFormSet, ModelFormSet)
+        self.assertIs(forms.InlineFormSet, InlineFormSet)
+
+    def test_abstract_base(self):
+        class TenantFormSet(ModelFormSet, abstract=True):
+            can_delete = False
+
+        class AuthorFormSet(TenantFormSet):
+            model = Author
+            fields = "__all__"
+
+        self.assertIs(AuthorFormSet.can_delete, False)
+        msg = (
+            "Creating a ModelFormSet without the 'model' attribute is "
+            "prohibited; formset BrokenFormSet needs updating."
+        )
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+
+            class BrokenFormSet(TenantFormSet):
+                fields = "__all__"
+
+    def test_abstract_inline_base(self):
+        class AuditInline(InlineFormSet, abstract=True):
+            extra = 1
+
+        class BookInline(AuditInline):
+            parent_model = Author
+            model = Book
+            fields = "__all__"
+
+        self.assertEqual(BookInline.extra, 1)
+        self.assertEqual(BookInline.fk.name, "author")
+
+    def test_modelformset_factory_with_modelformset_base(self):
+        AuthorFormSet = modelformset_factory(
+            Author, fields="__all__", formset=ModelFormSet
+        )
+        self.assertIs(issubclass(AuthorFormSet, ModelFormSet), True)
+        self.assertIs(AuthorFormSet.model, Author)
+        formset = AuthorFormSet(queryset=Author.objects.none())
+        self.assertEqual(len(formset.forms), 1)
+
+    def test_inlineformset_factory_with_inlineformset_base(self):
+        BookFormSet = inlineformset_factory(
+            Author, Book, fields="__all__", formset=InlineFormSet
+        )
+        self.assertIs(issubclass(BookFormSet, InlineFormSet), True)
+        self.assertEqual(BookFormSet.fk.name, "author")
+
+    def test_factory_fk_name_overrides_declarative_base(self):
+        class SponsorInline(InlineFormSet):
+            parent_model = Team
+            model = TeamSponsor
+            fk_name = "primary_team"
+            fields = "__all__"
+
+        # The declarative base's fk is unique, capping max_num.
+        self.assertEqual(SponsorInline.fk.name, "primary_team")
+        self.assertEqual(SponsorInline().max_num, 1)
+
+        BackupSponsorFormSet = inlineformset_factory(
+            Team,
+            TeamSponsor,
+            formset=SponsorInline,
+            fk_name="backup_team",
+            fields="__all__",
+        )
+        self.assertEqual(BackupSponsorFormSet.fk.name, "backup_team")
+        self.assertEqual(BackupSponsorFormSet.max_num, 1000)
+
+        class SubFormSet(BackupSponsorFormSet):
+            pass
+
+        self.assertEqual(SubFormSet.fk.name, "backup_team")
+        self.assertEqual(SubFormSet.max_num, 1000)
+
+    def test_unique_fk_subclass_keeps_absolute_max(self):
+        class OwnerProfileInline(InlineFormSet):
+            parent_model = Owner
+            model = OwnerProfile
+            fields = "__all__"
+            absolute_max = 3
+
+        class SubInline(OwnerProfileInline):
+            pass
+
+        self.assertEqual(OwnerProfileInline.absolute_max, 3)
+        self.assertEqual(SubInline.absolute_max, 3)
+
+    def test_unique_fk_max_num_not_bypassable(self):
+        class OwnerProfileInline(InlineFormSet):
+            parent_model = Owner
+            model = OwnerProfile
+            fields = "__all__"
+
+        self.assertEqual(OwnerProfileInline().max_num, 1)
+
+        # A subclass can't lift the unique-fk cap by declaring max_num.
+        class SubInline(OwnerProfileInline):
+            max_num = 5
+
+        self.assertEqual(SubInline().max_num, 1)
+
+    def test_relation_restate_keeps_inherited_max_num(self):
+        class BaseBookInline(InlineFormSet):
+            parent_model = Author
+            model = Book
+            fields = ["title"]
+            max_num = 5
+
+        # Restating the same relation must not discard the inherited max_num.
+        class BookInline(BaseBookInline):
+            model = Book
+            fields = ["title"]
+
+        self.assertEqual(BookInline().max_num, 5)
+
+    def test_relation_repoint_recomputes_caps(self):
+        class PrimaryInline(InlineFormSet):
+            parent_model = Team
+            model = TeamSponsor
+            fk_name = "primary_team"  # unique
+            fields = "__all__"
+
+        primary = PrimaryInline()
+        self.assertEqual(primary.max_num, 1)
+        self.assertEqual(primary.absolute_max, 1 + DEFAULT_MAX_NUM)
+
+        # Re-pointing to a non-unique fk drops the unique cap and recomputes
+        # absolute_max from the effective max_num.
+        class BackupInline(PrimaryInline):
+            fk_name = "backup_team"
+
+        backup = BackupInline()
+        self.assertEqual(backup.max_num, DEFAULT_MAX_NUM)
+        self.assertEqual(backup.absolute_max, 2 * DEFAULT_MAX_NUM)
+
+    def test_form_reset_with_fields_none(self):
+        class TitleOnlyBookForm(forms.ModelForm):
+            class Meta:
+                model = Book
+                fields = ["title"]
+
+        class BaseBookFormSet(ModelFormSet):
+            model = Book
+            fields = ["author", "title"]
+
+        # Resetting the inherited fields rebuilds from the declared form rather
+        # than the base's generated one, so only the declared form's fields
+        # remain.
+        class BookFormSet(BaseBookFormSet):
+            form = TitleOnlyBookForm
+            fields = None
+
+        self.assertIs(issubclass(BookFormSet.form, TitleOnlyBookForm), True)
+        self.assertEqual(list(BookFormSet.form.base_fields), ["title"])
+
+    def test_generated_form_mro_stays_flat(self):
+        class BaseAuthorFormSet(ModelFormSet):
+            model = Author
+            fields = "__all__"
+
+        class MidAuthorFormSet(BaseAuthorFormSet):
+            widgets = {"name": forms.Textarea()}
+
+        class LeafAuthorFormSet(MidAuthorFormSet):
+            labels = {"name": "Full name"}
+
+        # Each generation rebuilds from ModelForm, so the form MRO doesn't
+        # accumulate a layer per subclass.
+        base = BaseAuthorFormSet.form.__mro__
+        leaf = LeafAuthorFormSet.form.__mro__
+        self.assertEqual(len(leaf), len(base))
+
+    def test_relation_repoint_forms_independent(self):
+        class BackupInline(InlineFormSet):
+            parent_model = Team
+            model = TeamSponsor
+            fk_name = "backup_team"
+            fields = ["name"]
+
+        class PrimaryInline(BackupInline):
+            fk_name = "primary_team"
+
+        BackupInline()
+        PrimaryInline()
+        # Re-pointing the relation gives each formset its own form, so the fk
+        # added to one does not leak into the other's fields.
+        self.assertIsNot(BackupInline.form, PrimaryInline.form)
+        self.assertNotIn("primary_team", BackupInline.form._meta.fields)
+        self.assertNotIn("backup_team", PrimaryInline.form._meta.fields)
+
+    def test_inline_direct_form_not_mutated(self):
+        class SponsorForm(forms.ModelForm):
+            class Meta:
+                model = TeamSponsor
+                fields = ["name"]
+
+        class SponsorInline(InlineFormSet):
+            parent_model = Team
+            model = TeamSponsor
+            fk_name = "primary_team"
+            form = SponsorForm
+
+        SponsorInline()  # instantiate to trigger any fk-field mutation
+        # The user's form class is left untouched. The fk was added to a
+        # formset-owned wrapper instead.
+        self.assertEqual(SponsorForm._meta.fields, ["name"])
+        self.assertIsNot(SponsorInline.form, SponsorForm)
+
+    def test_abstract_base_with_generated_form(self):
+        class AuditAuthorFormSet(ModelFormSet, abstract=True):
+            model = Author
+            fields = ["name"]
+
+        # A concrete subclass that changes nothing form-affecting still builds
+        # a form from the abstract base's declared model/fields.
+        class AuthorFormSet(AuditAuthorFormSet):
+            extra = 2
+
+        self.assertEqual(sorted(AuthorFormSet.form.base_fields), ["name"])
+
+    def test_option_without_fields_error(self):
+        msg = (
+            "Creating a ModelFormSet without either the 'fields' attribute "
+            "or the 'exclude' attribute is prohibited; formset AuthorFormSet "
+            "needs updating."
+        )
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+
+            class AuthorFormSet(ModelFormSet):
+                model = Author
+                widgets = {"name": forms.Textarea()}
+
+    def test_form_for_parent_model_rebound_to_child(self):
+        # A form for a parent model may be given on a child-model formset
+        # (multi-table inheritance). It is rebuilt from the parent form and
+        # bound to the child model, exactly as modelformset_factory does.
+        class AuthorForm(forms.ModelForm):
+            class Meta:
+                model = Author
+                fields = "__all__"
+
+        class BetterAuthorFormSet(ModelFormSet):
+            model = BetterAuthor
+            form = AuthorForm
+
+        factory_form = modelformset_factory(BetterAuthor, form=AuthorForm).form
+        self.assertIsNot(BetterAuthorFormSet.form, AuthorForm)
+        self.assertIs(issubclass(BetterAuthorFormSet.form, AuthorForm), True)
+        self.assertIs(BetterAuthorFormSet.form._meta.model, BetterAuthor)
+        self.assertEqual(
+            list(BetterAuthorFormSet.form.base_fields),
+            list(factory_form.base_fields),
+        )
+
+    def test_error_messages_apply_to_generated_form(self):
+        class AuthorFormSet(ModelFormSet):
+            model = Author
+            fields = ["name"]
+            error_messages = {"name": {"required": "Name required!"}}
+
+        self.assertEqual(
+            AuthorFormSet.form.base_fields["name"].error_messages["required"],
+            "Name required!",
+        )
+
+    def test_default_error_messages_override_formset_messages(self):
+        class AuthorFormSet(ModelFormSet):
+            model = Author
+            fields = ["name"]
+            default_error_messages = {"too_few_forms": "Need more authors."}
+
+        self.assertEqual(
+            AuthorFormSet().error_messages["too_few_forms"], "Need more authors."
+        )
+
+    def test_form_for_unrelated_model_rebuilt(self):
+        # A form for an unrelated model is not validated. It is rebuilt against
+        # the formset's model, exactly as modelformset_factory does.
+        class AuthorForm(forms.ModelForm):
+            class Meta:
+                model = Author
+                fields = "__all__"
+
+        class BookFormSet(ModelFormSet):
+            model = Book
+            form = AuthorForm
+            fields = ["title"]
+
+        factory_form = modelformset_factory(
+            Book, form=AuthorForm, fields=["title"]
+        ).form
+        self.assertIs(BookFormSet.form._meta.model, Book)
+        self.assertEqual(
+            list(BookFormSet.form.base_fields), list(factory_form.base_fields)
+        )
+
+    def test_form_without_model_used_as_mixin(self):
+        # A ModelForm without its own model contributes its declared fields and
+        # behavior while the formset's model is supplied on rebuild.
+        class NoteMixin(forms.ModelForm):
+            note = forms.CharField(required=False)
+
+        class AuthorFormSet(ModelFormSet):
+            model = Author
+            form = NoteMixin
+            fields = ["name"]
+
+        self.assertIs(AuthorFormSet.form._meta.model, Author)
+        self.assertEqual(list(AuthorFormSet.form.base_fields), ["name", "note"])
+
+    def test_proxy_model_form_rebound_to_proxy(self):
+        # A form for a concrete model given on a proxy-model formset is rebuilt
+        # and bound to the proxy, matching modelformset_factory.
+        class AuthorForm(forms.ModelForm):
+            class Meta:
+                model = Author
+                fields = "__all__"
+
+        class AuthorProxyFormSet(ModelFormSet):
+            model = AuthorProxy
+            form = AuthorForm
+
+        self.assertIsNot(AuthorProxyFormSet.form, AuthorForm)
+        self.assertIs(AuthorProxyFormSet.form._meta.model, AuthorProxy)
+
+    def test_form_declared_on_abstract_base_inherited(self):
+        # A form declared on an abstract base is inherited by concrete
+        # subclasses, like the generation options.
+        class CustomAuthorForm(forms.ModelForm):
+            class Meta:
+                model = Author
+                fields = ["name"]
+
+        class BaseAuthorFormSet(ModelFormSet, abstract=True):
+            model = Author
+            form = CustomAuthorForm
+
+        class AuthorFormSet(BaseAuthorFormSet):
+            extra = 3
+
+        self.assertIs(issubclass(AuthorFormSet.form, CustomAuthorForm), True)
+
+    def test_form_none_resets_to_generated_form(self):
+        # An explicit form = None drops an inherited form, reverting to a
+        # generated ModelForm, like fields = None resets the options.
+        class CustomBookForm(forms.ModelForm):
+            class Meta:
+                model = Book
+                fields = ["title"]
+
+        class BaseBookFormSet(ModelFormSet):
+            model = Book
+            form = CustomBookForm
+
+        class PlainBookFormSet(BaseBookFormSet):
+            form = None
+            fields = ["title"]
+
+        self.assertIs(issubclass(BaseBookFormSet.form, CustomBookForm), True)
+        self.assertIs(issubclass(PlainBookFormSet.form, CustomBookForm), False)
+        self.assertEqual(list(PlainBookFormSet.form.base_fields), ["title"])
+
+    def test_formfield_callback_errors_propagate(self):
+        def broken_callback(model_field, **kwargs):
+            raise ImproperlyConfigured("broken callback")
+
+        with self.assertRaisesMessage(ImproperlyConfigured, "broken callback"):
+
+            class AuthorFormSet(ModelFormSet):
+                model = Author
+                fields = "__all__"
+                formfield_callback = broken_callback
+
+    def test_mixin_options_apply(self):
+        class TitleOnlyMixin:
+            fields = ["title"]
+
+        class BaseBookFormSet(ModelFormSet):
+            model = Book
+            fields = "__all__"
+
+        class BookFormSet(TitleOnlyMixin, BaseBookFormSet):
+            pass
+
+        self.assertEqual(list(BookFormSet.form.base_fields), ["title"])
 
 
 class TestModelFormsetOverridesTroughFormMeta(TestCase):


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-10403

#### Branch description
Continuing https://github.com/django/django/pull/19960

I've done nothing other than address the review comments there. I consider this ready for review but I will also review it a bit more myself and make any changes. If there are none, you can assume I didn't find anything obvious.

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

I asked Claude Code to sync my fork and pull the changes into a new PR because I'm very lazy. I didn't ask it to make the commit but it did it anyway /shrug

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
