### PR TITLE
Fixed #36813 -- Made CharField.max_length and DecimalField's

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1249,6 +1249,12 @@ class CharField(Field):
         super().__init__(*args, **kwargs)
         self.db_collation = db_collation
         if self.max_length is not None:
+            if (
+                not isinstance(self.max_length, int)
+                or isinstance(self.max_length, bool)
+                or self.max_length <= 0
+            ):
+                raise ValueError("'max_length' must be a positive integer.")
             self.validators.append(validators.MaxLengthValidator(self.max_length))
 
     @property
@@ -1281,20 +1287,7 @@ class CharField(Field):
                     id="fields.E120",
                 )
             ]
-        elif (
-            not isinstance(self.max_length, int)
-            or isinstance(self.max_length, bool)
-            or self.max_length <= 0
-        ):
-            return [
-                checks.Error(
-                    "'max_length' must be a positive integer.",
-                    obj=self,
-                    id="fields.E121",
-                )
-            ]
-        else:
-            return []
+        return []
 
     def _check_db_collation(self, databases):
         errors = []
@@ -1753,6 +1746,20 @@ class DecimalField(Field):
         decimal_places=None,
         **kwargs,
     ):
+        if max_digits is not None:
+            try:
+                max_digits = int(max_digits)
+                if max_digits <= 0:
+                    raise ValueError()
+            except (TypeError, ValueError):
+                raise ValueError("'max_digits' must be a positive integer.")
+        if decimal_places is not None:
+            try:
+                decimal_places = int(decimal_places)
+                if decimal_places < 0:
+                    raise ValueError()
+            except (TypeError, ValueError):
+                raise ValueError("'decimal_places' must be a non-negative integer.")
         self.max_digits, self.decimal_places = max_digits, decimal_places
         super().__init__(verbose_name, name, **kwargs)
 
@@ -1798,19 +1805,6 @@ class DecimalField(Field):
                             id="fields.E135",
                         ),
                     ]
-        else:
-            try:
-                decimal_places = int(self.decimal_places)
-                if decimal_places < 0:
-                    raise ValueError()
-            except ValueError:
-                return [
-                    checks.Error(
-                        "'decimal_places' must be a non-negative integer.",
-                        obj=self,
-                        id="fields.E131",
-                    )
-                ]
         return []
 
     def _check_max_digits(self, databases):
@@ -1841,19 +1835,6 @@ class DecimalField(Field):
                             id="fields.E135",
                         ),
                     ]
-        else:
-            try:
-                max_digits = int(self.max_digits)
-                if max_digits <= 0:
-                    raise ValueError()
-            except ValueError:
-                return [
-                    checks.Error(
-                        "'max_digits' must be a positive integer.",
-                        obj=self,
-                        id="fields.E133",
-                    )
-                ]
         return []
 
     def _check_decimal_places_and_max_digits(self, **kwargs):

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -200,13 +200,16 @@ Model fields
   appeared before support for null values was added in Django 2.1.*
 * **fields.E120**: ``CharField``\s must define a ``max_length`` attribute.
 * **fields.E121**: ``max_length`` must be a positive integer.
+  *This check appeared before being converted to a runtime check in Django 6.2.*
 * **fields.W122**: ``max_length`` is ignored when used with
   ``<integer field type>``.
 * **fields.E130**: ``DecimalField``\s must define a ``decimal_places``
   attribute.
 * **fields.E131**: ``decimal_places`` must be a non-negative integer.
+  *This check appeared before being converted to a runtime check in Django 6.2.*
 * **fields.E132**: ``DecimalField``\s must define a ``max_digits`` attribute.
 * **fields.E133**: ``max_digits`` must be a positive integer.
+  *This check appeared before being converted to a runtime check in Django 6.2.*
 * **fields.E134**: ``max_digits`` must be greater or equal to
   ``decimal_places``.
 * **fields.E135**: ``DecimalField``’s ``max_digits`` and ``decimal_places``

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -200,16 +200,19 @@ Model fields
   appeared before support for null values was added in Django 2.1.*
 * **fields.E120**: ``CharField``\s must define a ``max_length`` attribute.
 * **fields.E121**: ``max_length`` must be a positive integer.
-  *This check appeared before being converted to a runtime check in Django 6.2.*
+  *This check appeared before being converted to a runtime check
+  in Django 6.2.*
 * **fields.W122**: ``max_length`` is ignored when used with
   ``<integer field type>``.
 * **fields.E130**: ``DecimalField``\s must define a ``decimal_places``
   attribute.
 * **fields.E131**: ``decimal_places`` must be a non-negative integer.
-  *This check appeared before being converted to a runtime check in Django 6.2.*
+  *This check appeared before being converted to a runtime check
+  in Django 6.2.*
 * **fields.E132**: ``DecimalField``\s must define a ``max_digits`` attribute.
 * **fields.E133**: ``max_digits`` must be a positive integer.
-  *This check appeared before being converted to a runtime check in Django 6.2.*
+  *This check appeared before being converted to a runtime check
+  in Django 6.2.*
 * **fields.E134**: ``max_digits`` must be greater or equal to
   ``decimal_places``.
 * **fields.E135**: ``DecimalField``’s ``max_digits`` and ``decimal_places``

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -195,6 +195,13 @@ Migrations
 Models
 ~~~~~~
 
+* Invalid ``CharField.max_length`` and ``DecimalField.max_digits``/
+  ``decimal_places`` values now raise ``ValueError`` immediately when the
+  field is instantiated, rather than only being caught by system checks.
+  This catches mistakes earlier, including in cases where fields are used
+  standalone (e.g. as an ``output_field`` for :class:`~django.db.models.functions.Cast`)
+  and never reach a system check.
+
 * ...
 
 Requests and Responses
@@ -275,6 +282,15 @@ backends.
 * The admin history view now checks permissions before object existence,
   consistently returning an HTTP 403 response for staff users without the view
   or change permission regardless of whether the object exists.
+
+Models
+------
+
+* ``CharField.max_length`` and ``DecimalField.max_digits``/
+  ``decimal_places`` are now validated when the field is instantiated,
+  raising ``ValueError`` for invalid values (e.g. non-integers, negative
+  numbers) instead of being reported later by
+  :ref:`system checks <system-checks>`.
 
 Miscellaneous
 -------------

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -196,13 +196,12 @@ Models
 ~~~~~~
 
 * Invalid ``CharField.max_length`` and ``DecimalField.max_digits``/
-  ``decimal_places`` values now raise ``ValueError`` immediately when the
-  field is instantiated, rather than only being caught by system checks.
-  This catches mistakes earlier, including in cases where fields are used
-  standalone (e.g. as an ``output_field`` for :class:`~django.db.models.functions.Cast`)
-  and never reach a system check.
-
-* ...
+  ``decimal_places`` values now raise ``ValueError`` immediately when
+  the field is instantiated, rather than only being caught by system
+  checks. This catches mistakes earlier, including in cases where fields
+  are used standalone (e.g. as an ``output_field`` for
+  :class:`~django.db.models.functions.Cast`) and never reach a system
+  check.
 
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -289,8 +288,7 @@ Models
 * ``CharField.max_length`` and ``DecimalField.max_digits``/
   ``decimal_places`` are now validated when the field is instantiated,
   raising ``ValueError`` for invalid values (e.g. non-integers, negative
-  numbers) instead of being reported later by
-  :ref:`system checks <system-checks>`.
+  numbers) instead of being reported later by ``system checks``.
 
 Miscellaneous
 -------------

--- a/tests/invalid_models_tests/test_ordinary_fields.py
+++ b/tests/invalid_models_tests/test_ordinary_fields.py
@@ -127,68 +127,32 @@ class CharFieldTests(TestCase):
         self.assertEqual(field.check(), expected)
 
     def test_negative_max_length(self):
-        class Model(models.Model):
-            field = models.CharField(max_length=-1)
+        msg = "'max_length' must be a positive integer."
+        with self.assertRaisesMessage(ValueError, msg):
 
-        field = Model._meta.get_field("field")
-        self.assertEqual(
-            field.check(),
-            [
-                Error(
-                    "'max_length' must be a positive integer.",
-                    obj=field,
-                    id="fields.E121",
-                ),
-            ],
-        )
+            class Model(models.Model):
+                field = models.CharField(max_length=-1)
 
     def test_bad_max_length_value(self):
-        class Model(models.Model):
-            field = models.CharField(max_length="bad")
+        msg = "'max_length' must be a positive integer."
+        with self.assertRaisesMessage(ValueError, msg):
 
-        field = Model._meta.get_field("field")
-        self.assertEqual(
-            field.check(),
-            [
-                Error(
-                    "'max_length' must be a positive integer.",
-                    obj=field,
-                    id="fields.E121",
-                ),
-            ],
-        )
+            class Model(models.Model):
+                field = models.CharField(max_length="bad")
 
     def test_str_max_length_value(self):
-        class Model(models.Model):
-            field = models.CharField(max_length="20")
+        msg = "'max_length' must be a positive integer."
+        with self.assertRaisesMessage(ValueError, msg):
 
-        field = Model._meta.get_field("field")
-        self.assertEqual(
-            field.check(),
-            [
-                Error(
-                    "'max_length' must be a positive integer.",
-                    obj=field,
-                    id="fields.E121",
-                ),
-            ],
-        )
+            class Model(models.Model):
+                field = models.CharField(max_length="20")
 
     def test_str_max_length_type(self):
-        class Model(models.Model):
-            field = models.CharField(max_length=True)
+        msg = "'max_length' must be a positive integer."
+        with self.assertRaisesMessage(ValueError, msg):
 
-        field = Model._meta.get_field("field")
-        self.assertEqual(
-            field.check(),
-            [
-                Error(
-                    "'max_length' must be a positive integer.",
-                    obj=field,
-                    id="fields.E121",
-                ),
-            ],
-        )
+            class Model(models.Model):
+                field = models.CharField(max_length=True)
 
     def test_non_iterable_choices(self):
         class Model(models.Model):
@@ -669,46 +633,18 @@ class DecimalFieldTests(TestCase):
         )
 
     def test_negative_max_digits_and_decimal_places(self):
-        class Model(models.Model):
-            field = models.DecimalField(max_digits=-1, decimal_places=-1)
+        msg = "'max_digits' must be a positive integer."
+        with self.assertRaisesMessage(ValueError, msg):
 
-        field = Model._meta.get_field("field")
-        self.assertEqual(
-            field.check(databases=self.databases),
-            [
-                Error(
-                    "'decimal_places' must be a non-negative integer.",
-                    obj=field,
-                    id="fields.E131",
-                ),
-                Error(
-                    "'max_digits' must be a positive integer.",
-                    obj=field,
-                    id="fields.E133",
-                ),
-            ],
-        )
+            class Model(models.Model):
+                field = models.DecimalField(max_digits=-1, decimal_places=-1)
 
     def test_bad_values_of_max_digits_and_decimal_places(self):
-        class Model(models.Model):
-            field = models.DecimalField(max_digits="bad", decimal_places="bad")
+        msg = "'max_digits' must be a positive integer."
+        with self.assertRaisesMessage(ValueError, msg):
 
-        field = Model._meta.get_field("field")
-        self.assertEqual(
-            field.check(databases=self.databases),
-            [
-                Error(
-                    "'decimal_places' must be a non-negative integer.",
-                    obj=field,
-                    id="fields.E131",
-                ),
-                Error(
-                    "'max_digits' must be a positive integer.",
-                    obj=field,
-                    id="fields.E133",
-                ),
-            ],
-        )
+            class Model(models.Model):
+                field = models.DecimalField(max_digits="bad", decimal_places="bad")
 
     def test_decimal_places_greater_than_max_digits(self):
         class Model(models.Model):
@@ -1441,15 +1377,15 @@ class GeneratedFieldTests(TestCase):
             value = models.DecimalField(max_digits=5, decimal_places=2)
             field = models.GeneratedField(
                 expression=models.F("value") * 2,
-                output_field=models.DecimalField(max_digits=-1, decimal_places=-1),
+                output_field=models.DecimalField(max_digits=2, decimal_places=3),
                 db_persist=True,
             )
 
         expected_errors = [
             Error(
                 "GeneratedField.output_field has errors:"
-                "\n    'decimal_places' must be a non-negative integer. (fields.E131)"
-                "\n    'max_digits' must be a positive integer. (fields.E133)",
+                "\n    'max_digits' must be greater or equal to "
+                "'decimal_places'. (fields.E134)",
                 obj=Model._meta.get_field("field"),
                 id="fields.E223",
             ),

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -831,15 +831,11 @@ class TestOtherTypesExactQuerying(PostgreSQLTestCase):
 @isolate_apps("postgres_tests")
 class TestChecks(PostgreSQLSimpleTestCase):
     def test_field_checks(self):
-        class MyModel(PostgreSQLModel):
-            field = ArrayField(models.CharField(max_length=-1))
+        msg = "'max_length' must be a positive integer."
+        with self.assertRaisesMessage(ValueError, msg):
 
-        model = MyModel()
-        errors = model.check()
-        self.assertEqual(len(errors), 1)
-        # The inner CharField has a non-positive max_length.
-        self.assertEqual(errors[0].id, "postgres.E001")
-        self.assertIn("max_length", errors[0].msg)
+            class MyModel(PostgreSQLModel):
+                field = ArrayField(models.CharField(max_length=-1))
 
     def test_base_field_check_kwargs(self):
         passed_kwargs = None
@@ -910,16 +906,11 @@ class TestChecks(PostgreSQLSimpleTestCase):
         """
         Nested ArrayFields are permitted.
         """
+        msg = "'max_length' must be a positive integer."
+        with self.assertRaisesMessage(ValueError, msg):
 
-        class MyModel(PostgreSQLModel):
-            field = ArrayField(ArrayField(models.CharField(max_length=-1)))
-
-        model = MyModel()
-        errors = model.check()
-        self.assertEqual(len(errors), 1)
-        # The inner CharField has a non-positive max_length.
-        self.assertEqual(errors[0].id, "postgres.E001")
-        self.assertIn("max_length", errors[0].msg)
+            class MyModel(PostgreSQLModel):
+                field = ArrayField(ArrayField(models.CharField(max_length=-1)))
 
     def test_choices_tuple_list(self):
         class MyModel(PostgreSQLModel):


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-36813

#### Branch description
<!-- Provide a concise overview of the issue or rationale behind the proposed changes. Minimum five words. -->
Moves CharField.max_length and DecimalField.max_digits/decimal_places
validation from system checks into __init__(), raising ValueError
immediately for invalid values instead of only via manage.py check.

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
<!-- If AI tools were used, provide which tools were used here. -->
Claude for verification of work after I wrote the code myself and ran all tests to make sure if I did not make any wrong changes.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
