### PR TITLE
Added setting to disable management commands

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -222,6 +222,9 @@ EMAIL_TIMEOUT = None
 # List of strings representing installed apps.
 INSTALLED_APPS = []
 
+# List of management commands disabled from command-line execution.
+DISABLED_MANAGEMENT_COMMANDS = []
+
 TEMPLATES = []
 
 # Default form rendering class.

--- a/django/core/management/__init__.py
+++ b/django/core/management/__init__.py
@@ -275,6 +275,17 @@ class ManagementUtility:
             sys.exit(1)
         return klass
 
+    def check_command_disabled(self, subcommand):
+        if not settings.configured:
+            return
+        disabled_commands = set(settings.DISABLED_MANAGEMENT_COMMANDS)
+        if subcommand in disabled_commands:
+            sys.stderr.write(
+                "CommandError: Management command %r is disabled by "
+                "settings.DISABLED_MANAGEMENT_COMMANDS.\n" % subcommand
+            )
+            sys.exit(1)
+
     def autocomplete(self):
         """
         Output completion suggestions for BASH.
@@ -431,6 +442,7 @@ class ManagementUtility:
         elif self.argv[1:] in (["--help"], ["-h"]):
             sys.stdout.write(self.main_help_text() + "\n")
         else:
+            self.check_command_disabled(subcommand)
             self.fetch_command(subcommand).run_from_argv(self.argv)
 
 

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -2177,6 +2177,9 @@ Note that command options that take no arguments are passed as keywords
 with ``True`` or ``False``, as you can see with the ``interactive`` option
 above.
 
+The :setting:`DISABLED_MANAGEMENT_COMMANDS` setting prevents commands from
+being executed from the command line. It doesn't affect ``call_command()``.
+
 Named arguments can be passed by using either one of the following syntaxes::
 
       # Similar to the command line

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -1379,6 +1379,25 @@ Default: ``''`` (Empty string)
 Default tablespace to use for models that don't specify one, if the
 backend supports it (see :doc:`/topics/db/tablespaces`).
 
+.. setting:: DISABLED_MANAGEMENT_COMMANDS
+
+``DISABLED_MANAGEMENT_COMMANDS``
+--------------------------------
+
+Default: ``[]`` (Empty list)
+
+A list of management command names that can't be executed from the command line
+with ``django-admin`` or ``manage.py``.
+
+For example::
+
+    DISABLED_MANAGEMENT_COMMANDS = ["flush", "migrate"]
+
+Attempts to run a disabled command exit with an error before the command is
+loaded.
+
+This setting doesn't affect :func:`~django.core.management.call_command()`.
+
 .. setting:: DISALLOWED_USER_AGENTS
 
 ``DISALLOWED_USER_AGENTS``

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -74,6 +74,13 @@ queries:
 
 See :doc:`fetch modes </topics/db/fetch-modes>` for more details.
 
+Management Commands
+-------------------
+
+The new :setting:`DISABLED_MANAGEMENT_COMMANDS` setting allows disabling
+selected management commands from command-line execution with ``django-admin``
+or ``manage.py``.
+
 Database-level delete options for ``ForeignKey.on_delete``
 ----------------------------------------------------------
 

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -2579,6 +2579,43 @@ class ArgumentOrder(AdminScriptTestCase):
         )
 
 
+class DisabledManagementCommands(AdminScriptTestCase):
+    def setUp(self):
+        super().setUp()
+        self.write_settings(
+            "settings.py",
+            sdict={"DISABLED_MANAGEMENT_COMMANDS": "['base_command']"},
+        )
+        self.write_settings("alternate_settings.py")
+        self.write_settings(
+            "disabled_settings.py",
+            sdict={"DISABLED_MANAGEMENT_COMMANDS": "['base_command']"},
+        )
+
+    def test_disabled_command(self):
+        out, err = self.run_manage(["base_command"])
+        self.assertNoOutput(out)
+        self.assertOutput(
+            err,
+            "CommandError: Management command 'base_command' is disabled by "
+            "settings.DISABLED_MANAGEMENT_COMMANDS.",
+        )
+
+    def test_enabled_command(self):
+        out, err = self.run_manage(["base_command", "--settings=alternate_settings"])
+        self.assertNoOutput(err)
+        self.assertOutput(out, "EXECUTE:BaseCommand labels=(), options=")
+
+    def test_disabled_command_with_settings_option(self):
+        out, err = self.run_manage(["base_command", "--settings=disabled_settings"])
+        self.assertNoOutput(out)
+        self.assertOutput(
+            err,
+            "CommandError: Management command 'base_command' is disabled by "
+            "settings.DISABLED_MANAGEMENT_COMMANDS.",
+        )
+
+
 @mock.patch.dict(os.environ, {"PYTHON_COLORS": "0"})
 class ExecuteFromCommandLine(SimpleTestCase):
     def test_program_name_from_argv(self):


### PR DESCRIPTION
Added `DISABLED_MANAGEMENT_COMMANDS` to prevent selected management commands from being executed with `django-admin` or `manage.py`.

#### Branch description
Added a setting to disable selected command-line management commands for projects that need to prevent manual execution of risky commands such as `flush` or `migrate`.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

AI tools used: OpenAI Codex. I reviewed the generated code, documentation, and tests, and verified the focused test coverage locally.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [ ] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.

<!-- Leave the following items unchecked if not applicable. -->
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.