### PR TITLE
Fixed #37234 -- Fixed bulk_create() for late-saved related primary keys.

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -747,6 +747,7 @@ class QuerySet(AltersData):
     def _prepare_for_bulk_create(self, objs):
         objs_with_pk, objs_without_pk = [], []
         for obj in objs:
+            obj._prepare_related_fields_for_save(operation_name="bulk_create")
             if isinstance(obj.pk, DatabaseDefault):
                 objs_without_pk.append(obj)
             elif obj._is_pk_set():
@@ -757,7 +758,6 @@ class QuerySet(AltersData):
                     objs_with_pk.append(obj)
                 else:
                     objs_without_pk.append(obj)
-            obj._prepare_related_fields_for_save(operation_name="bulk_create")
         return objs_with_pk, objs_without_pk
 
     def _check_bulk_create_options(

--- a/docs/releases/6.0.8.txt
+++ b/docs/releases/6.0.8.txt
@@ -11,4 +11,7 @@ bugs in 6.0.7.
 Bugfixes
 ========
 
-* ...
+* Fixed a regression in Django 6.0 that caused
+  :meth:`~django.db.models.query.QuerySet.bulk_create` to crash on databases
+  that support returning rows from bulk inserts when a related object providing
+  the primary key was saved after assignment (:ticket:`37234`).

--- a/tests/bulk_create/tests.py
+++ b/tests/bulk_create/tests.py
@@ -439,6 +439,13 @@ class BulkCreateTests(TestCase):
         child = NullableFields.objects.get(integer_field=88)
         self.assertEqual(child.auto_field, parent)
 
+    def test_pk_from_related_instance_saved_after_init(self):
+        country = Country(name="Syldavia", iso_two_letter="SW")
+        related = RelatedModel(country=country)
+        country.save()
+        RelatedModel.objects.bulk_create([related])
+        self.assertEqual(related.country_id, country.pk)
+
     def test_unsaved_parent(self):
         parent = NoFields()
         msg = (


### PR DESCRIPTION
#### Trac ticket number

ticket-37234

#### Branch description

`bulk_create()` classified objects before preparing their related fields. If a related object supplied the primary key and was saved after assignment, the insert succeeded but Django could raise an assertion error afterward on databases that return rows from bulk inserts.

This prepares the related fields before the final classification while preserving the existing primary key default behavior. It also adds a regression test and a Django 6.0.8 release note.

Tested with the full SQLite suite and the `bulk_create` and `field_defaults` tests on PostgreSQL 18 and MariaDB 11.8. The HTML and spelling documentation builds also pass.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

OpenAI Codex, using GPT-5, helped analyze the regression, draft the code, test, and release note, and run local checks. I manually reviewed and verified every change before submitting.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.

- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
