### PR TITLE
Fixed #37233 -- Prevented sort controls for unordered __str__ admin columns.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -41,6 +41,7 @@ answer newbie questions, and generally made Django that much better:
     Akash Kumar Sen <akashkumarsen4@gmail.com>
     Akis Kesoglou <akiskesoglou@gmail.com>
     Aksel Ethem <aksel.ethem@gmail.com>
+    Akshat Sparsh <https://github.com/AKSHATSPAR>
     Akshesh Doshi <aksheshdoshi+django@gmail.com>
     alang@bright-green.com
     Alasdair Nicol <https://al.sdair.co.uk/>

--- a/django/contrib/admin/templatetags/admin_list.py
+++ b/django/contrib/admin/templatetags/admin_list.py
@@ -18,7 +18,6 @@ from django.contrib.admin.views.main import (
 )
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
-from django.db.models.constants import LOOKUP_SEP
 from django.template import Library
 from django.template.loader import get_template
 from django.templatetags.static import static
@@ -96,6 +95,7 @@ def result_headers(cl):
         )
         is_field_sortable = cl.sortable_by is None or field_name in cl.sortable_by
         if attr:
+            field_name_for_ordering = field_name
             field_name = _coerce_field_name(field_name, i)
             # Potentially not sortable
 
@@ -112,11 +112,7 @@ def result_headers(cl):
                 }
                 continue
 
-            admin_order_field = getattr(attr, "admin_order_field", None)
-            # Set ordering for attr that is a property, if defined.
-            if isinstance(attr, property) and hasattr(attr, "fget"):
-                admin_order_field = getattr(attr.fget, "admin_order_field", None)
-            if not admin_order_field and LOOKUP_SEP not in field_name:
+            if not cl.get_ordering_field(field_name_for_ordering):
                 is_field_sortable = False
 
         if not is_field_sortable:

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -4,7 +4,7 @@ from unittest import mock
 from django.contrib import admin
 from django.contrib.admin.models import LogEntry
 from django.contrib.admin.options import IncorrectLookupParameters
-from django.contrib.admin.templatetags.admin_list import pagination
+from django.contrib.admin.templatetags.admin_list import pagination, result_headers
 from django.contrib.admin.tests import AdminSeleniumTestCase
 from django.contrib.admin.views.main import (
     ALL_VAR,
@@ -114,6 +114,23 @@ class ChangeListTests(TestCase):
         request.user = self.superuser
         cl = m.get_changelist_instance(request)
         self.assertEqual(repr(cl), "<ChangeList: model=Child model_admin=ChildAdmin>")
+
+    def test_default_str_column_is_not_sortable(self):
+        GrandChild.objects.create(name="Grandchild")
+        m = admin.ModelAdmin(GrandChild, custom_site)
+        request = self._mocked_authenticated_request("/grandchild/", self.superuser)
+        response = m.changelist_view(request)
+        response.render()
+        cl = response.context_data["cl"]
+
+        headers = list(result_headers(cl))
+
+        self.assertEqual(cl.list_display, ["action_checkbox", "__str__"])
+        self.assertIs(headers[1]["sortable"], False)
+        self.assertContains(response, '<th scope="col" class="column-__str__">')
+        self.assertNotContains(
+            response, '<th scope="col" class="sortable column-__str__">'
+        )
 
     def test_specified_ordering_by_f_expression(self):
         class OrderedByFBandAdmin(admin.ModelAdmin):


### PR DESCRIPTION
#### Trac ticket number

ticket-37233

#### Branch description

`result_headers()` treated any name containing `__` as sortable. This made the default `__str__` column show a sort control even when it had no ordering field, while `ChangeList.get_ordering()` ignored the same selection.

This change uses `ChangeList.get_ordering_field()` for both decisions and adds a rendered changelist regression test.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

OpenAI Codex (GPT-5) helped with ticket analysis, the code, regression tests, and local verification. I reviewed the final diff and verified the behavior in a standalone Django project and with the test suite.

#### Testing

Tested with the admin changelist and admin view suites, the full locally available SQLite suite, Chrome Selenium tests, keyboard navigation, and Axe.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.

- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
