### PR TITLE
Fixed #37233 -- Prevented sort controls for unordered __str__ admin columns.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -41,6 +41,7 @@ answer newbie questions, and generally made Django that much better:
     Akash Kumar Sen <akashkumarsen4@gmail.com>
     Akis Kesoglou <akiskesoglou@gmail.com>
     Aksel Ethem <aksel.ethem@gmail.com>
+    Akshat Sparsh <https://github.com/AKSHATSPAR>
     Akshesh Doshi <aksheshdoshi+django@gmail.com>
     alang@bright-green.com
     Alasdair Nicol <https://al.sdair.co.uk/>

--- a/django/contrib/admin/templatetags/admin_list.py
+++ b/django/contrib/admin/templatetags/admin_list.py
@@ -116,7 +116,9 @@ def result_headers(cl):
             # Set ordering for attr that is a property, if defined.
             if isinstance(attr, property) and hasattr(attr, "fget"):
                 admin_order_field = getattr(attr.fget, "admin_order_field", None)
-            if not admin_order_field and LOOKUP_SEP not in field_name:
+            if not admin_order_field and not (
+                LOOKUP_SEP in field_name and isinstance(attr, models.Field)
+            ):
                 is_field_sortable = False
 
         if not is_field_sortable:

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -4,7 +4,7 @@ from unittest import mock
 from django.contrib import admin
 from django.contrib.admin.models import LogEntry
 from django.contrib.admin.options import IncorrectLookupParameters
-from django.contrib.admin.templatetags.admin_list import pagination
+from django.contrib.admin.templatetags.admin_list import pagination, result_headers
 from django.contrib.admin.tests import AdminSeleniumTestCase
 from django.contrib.admin.views.main import (
     ALL_VAR,
@@ -114,6 +114,20 @@ class ChangeListTests(TestCase):
         request.user = self.superuser
         cl = m.get_changelist_instance(request)
         self.assertEqual(repr(cl), "<ChangeList: model=Child model_admin=ChildAdmin>")
+
+    def test_default_str_column_is_not_sortable(self):
+        GrandChild.objects.create(name="Grandchild")
+        m = admin.ModelAdmin(GrandChild, custom_site)
+        request = self._mocked_authenticated_request("/grandchild/", self.superuser)
+        cl = m.get_changelist_instance(request)
+        headers = list(result_headers(cl))
+        self.assertEqual(cl.list_display[1], "__str__")
+        self.assertIs(headers[1]["sortable"], False)
+        response = m.changelist_view(request)
+        self.assertContains(response, '<th scope="col" class="column-__str__">')
+        self.assertNotContains(
+            response, '<th scope="col" class="sortable column-__str__">'
+        )
 
     def test_specified_ordering_by_f_expression(self):
         class OrderedByFBandAdmin(admin.ModelAdmin):
@@ -1726,6 +1740,13 @@ class ChangeListTests(TestCase):
         response = m.changelist_view(request)
         self.assertContains(response, parent.name)
         self.assertContains(response, child.name)
+        self.assertContains(
+            response, '<th scope="col" class="sortable column-parent__name">'
+        )
+        self.assertContains(
+            response,
+            '<th scope="col" class="sortable column-parent__parent__name">',
+        )
 
     def test_list_display_related_field_null(self):
         GrandChild.objects.create(name="I am parentless", parent=None)

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -4323,6 +4323,11 @@ class TestGenericRelations(TestCase):
         FunkyTag.objects.create(content_object=self.pl3, name="hott")
         response = self.client.get(reverse("admin:admin_views_funkytag_changelist"))
         self.assertContains(response, "%s</td>" % self.pl3)
+        self.assertContains(response, '<th scope="col" class="column-content_object">')
+        self.assertNotContains(
+            response,
+            '<th scope="col" class="sortable column-content_object">',
+        )
 
 
 @override_settings(ROOT_URLCONF="admin_views.urls")


### PR DESCRIPTION
#### Trac ticket number

ticket-37233

#### Branch description

`result_headers()` treated any name containing `__` as sortable. This made the default `__str__` column show a sort control even though it had no ordering field.

This change limits implicit sorting for `__` names to values resolved as model fields. It keeps valid related-field paths sortable without exposing sort controls for `__str__` or `GenericForeignKey` columns. Regression tests cover all three cases.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

OpenAI Codex (GPT-5) helped with ticket analysis, the code, regression tests, and local verification. I reviewed the final diff and verified the behavior in a standalone Django project and with the test suite.

#### Testing

Passed the admin changelist and admin view suites, the full locally available SQLite suite, the focused regression tests, and the relevant Chrome Selenium ordering test. I also verified the behavior in a standalone Django project, including keyboard navigation and Axe.

#### Screenshots

Captured directly from the standalone Django project in Chrome. These are not generated images.

Light mode, before and after:

<img width="1200" height="684" alt="37233-before-light" src="https://github.com/user-attachments/assets/0fefd78e-7001-4be1-baff-6734bba88d3b" />
<img width="1200" height="684" alt="37233-fixed-light" src="https://github.com/user-attachments/assets/2b324417-91a7-40d3-9d1f-d60c8943f346" />

Dark mode, before and after:

<img width="1200" height="684" alt="37233-before-dark" src="https://github.com/user-attachments/assets/448aebd6-6f8f-4036-8722-103d800f354f" />
<img width="1200" height="684" alt="37233-fixed-dark" src="https://github.com/user-attachments/assets/565b186a-0878-465e-afe0-24ba06095638" />

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.

- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
