### PR TITLE
Fixed #37201 -- Supported writable properties in Prefetch.to_attr.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -475,6 +475,14 @@ class ModelStateFetchModeDescriptor:
         return res
 
 
+class ModelStatePrefetchedToAttrsDescriptor:
+    def __get__(self, instance, cls=None):
+        if instance is None:
+            return self
+        res = instance.prefetched_to_attrs = set()
+        return res
+
+
 class ModelState:
     """Store model instance state."""
 
@@ -486,6 +494,7 @@ class ModelState:
     adding = True
     fields_cache = ModelStateFieldsCacheDescriptor()
     fetch_mode = ModelStateFetchModeDescriptor()
+    prefetched_to_attrs = ModelStatePrefetchedToAttrsDescriptor()
     peers = ()
 
     def __getstate__(self):
@@ -661,6 +670,11 @@ class Model(AltersData, metaclass=ModelBase):
         state = self.__dict__.copy()
         state["_state"] = copy.copy(state["_state"])
         state["_state"].fields_cache = state["_state"].fields_cache.copy()
+        # Copy prefetched_to_attrs only if it was initialized lazily.
+        if "prefetched_to_attrs" in state["_state"].__dict__:
+            state["_state"].prefetched_to_attrs = state[
+                "_state"
+            ].prefetched_to_attrs.copy()
         # memoryview cannot be pickled, so cast it to bytes and store
         # separately.
         _memoryview_attrs = []

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -7,6 +7,7 @@ import operator
 import warnings
 from contextlib import nullcontext
 from functools import reduce
+from inspect import getattr_static
 from itertools import chain, islice
 from weakref import ref as weak_ref
 
@@ -2690,7 +2691,31 @@ def prefetch_related_objects(model_instances, *related_lookups):
             # premise of prefetch_related), so what applies to first object
             # applies to all.
             first_obj = next(iter(obj_list))
-            to_attr = lookup.get_current_to_attr(level)[0]
+            to_attr, as_attr = lookup.get_current_to_attr(level)
+            # Inspect a custom destination statically so that determining
+            # whether it can be assigned doesn't execute a property getter.
+            skip_prefetch = False
+            if as_attr:
+                # Preserve the historical behavior of silently skipping
+                # Django's internal instance attributes. They must never be
+                # overwritten by a custom prefetch result.
+                if to_attr in {"_state", "_prefetched_objects_cache"}:
+                    skip_prefetch = True
+                to_attr_descriptor = getattr_static(first_obj.__class__, to_attr, None)
+                if isinstance(to_attr_descriptor, property) and not callable(
+                    to_attr_descriptor.fset
+                ):
+                    # RemovedInDjango71Warning: replace this warning with a
+                    # ValueError when the deprecation ends.
+                    warn_about_external_use(
+                        "Prefetch() with to_attr=%r targeting a property "
+                        "without a setter is deprecated. Add a setter, use "
+                        "cached_property, or use a different to_attr. This "
+                        "will raise ValueError in Django 7.1." % to_attr,
+                        category=RemovedInDjango71Warning,
+                        skip_name_prefixes=("django.db.models",),
+                    )
+                    skip_prefetch = True
             prefetcher, descriptor, attr_found, is_fetched = get_prefetcher(
                 first_obj, through_attr, to_attr
             )
@@ -2717,7 +2742,7 @@ def prefetch_related_objects(model_instances, *related_lookups):
                 )
 
             obj_to_fetch = None
-            if prefetcher is not None:
+            if prefetcher is not None and not skip_prefetch:
                 obj_to_fetch = [obj for obj in obj_list if not is_fetched(obj)]
 
             if obj_to_fetch:
@@ -2794,19 +2819,21 @@ def get_prefetcher(instance, through_attr, to_attr):
     """
 
     def is_to_attr_fetched(model, to_attr):
-        # Special case cached_property instances because hasattr() triggers
-        # attribute computation and assignment.
-        if isinstance(getattr(model, to_attr, None), cached_property):
+        descriptor = getattr_static(model, to_attr, None)
+        if isinstance(descriptor, cached_property):
 
             def has_cached_property(instance):
-                return to_attr in instance.__dict__
+                return (
+                    to_attr in instance._state.prefetched_to_attrs
+                    or to_attr in instance.__dict__
+                )
 
             return has_cached_property
 
-        def has_to_attr_attribute(instance):
-            return hasattr(instance, to_attr)
+        def has_prefetched_to_attr(instance):
+            return to_attr in instance._state.prefetched_to_attrs
 
-        return has_to_attr_attribute
+        return has_prefetched_to_attr
 
     prefetcher = None
     is_fetched = is_to_attr_fetched(instance.__class__, to_attr)
@@ -2930,6 +2957,7 @@ def prefetch_one_level(instances, prefetcher, lookup, level):
             if as_attr:
                 # A to_attr has been given for the prefetch.
                 setattr(obj, to_attr, val)
+                obj._state.prefetched_to_attrs.add(to_attr)
             elif is_descriptor:
                 # cache_name points to a field name in obj.
                 # This field is a descriptor for a related object.
@@ -2942,6 +2970,7 @@ def prefetch_one_level(instances, prefetcher, lookup, level):
         else:
             if as_attr:
                 setattr(obj, to_attr, vals)
+                obj._state.prefetched_to_attrs.add(to_attr)
             else:
                 manager = getattr(obj, to_attr)
                 if leaf and lookup.queryset is not None:

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -23,6 +23,9 @@ details on these changes.
 * Calling ``QuerySet.aiterator()`` after ``prefetch_related()`` without
   providing a ``chunk_size`` will raise :exc:`ValueError`.
 
+* Using :class:`~django.db.models.Prefetch` with ``to_attr`` targeting a
+  :class:`property` without a setter will raise :exc:`ValueError`.
+
 .. _deprecation-removed-in-7.0:
 
 7.0

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -302,3 +302,8 @@ Miscellaneous
   providing a ``chunk_size`` is deprecated. It currently falls back to a
   ``chunk_size`` of 2000, but a ``ValueError`` will be raised in
   Django 7.1.
+
+* Using :class:`~django.db.models.Prefetch` with ``to_attr`` targeting a
+  :class:`property` without a setter is deprecated. Add a setter, use
+  :class:`~django.utils.functional.cached_property`, or use a different
+  ``to_attr``. This will raise :exc:`ValueError` in Django 7.1.

--- a/tests/model_regress/tests.py
+++ b/tests/model_regress/tests.py
@@ -281,3 +281,16 @@ class ModelFieldsCacheTest(TestCase):
         worker2.department = department2
         self.assertEqual(worker2.department, department2)
         self.assertEqual(worker1.department, department1)
+
+    def test_prefetched_to_attrs_reset_on_copy(self):
+        department = Department.objects.create(id=1, name="department")
+        department._state.prefetched_to_attrs.add("workers")
+
+        copied_department = copy.copy(department)
+        copied_department._state.prefetched_to_attrs.add("managers")
+
+        self.assertEqual(department._state.prefetched_to_attrs, {"workers"})
+        self.assertEqual(
+            copied_department._state.prefetched_to_attrs,
+            {"workers", "managers"},
+        )

--- a/tests/prefetch_related/models.py
+++ b/tests/prefetch_related/models.py
@@ -269,6 +269,17 @@ class Person(models.Model):
     def all_houses(self):
         return list(self.houses.all())
 
+    @property
+    def writable_all_houses(self):
+        try:
+            return self._writable_all_houses
+        except AttributeError:
+            return self.all_houses
+
+    @writable_all_houses.setter
+    def writable_all_houses(self, houses):
+        self._writable_all_houses = houses
+
     @cached_property
     def cached_all_houses(self):
         return self.all_houses

--- a/tests/prefetch_related/test_prefetch_related_objects.py
+++ b/tests/prefetch_related/test_prefetch_related_objects.py
@@ -1,9 +1,10 @@
 from collections import deque
+from unittest import mock
 
 from django.db.models import Prefetch, prefetch_related_objects
 from django.test import TestCase
 
-from .models import Author, Book, House, Reader, Room
+from .models import Author, Book, House, Person, Reader, Room
 
 
 class PrefetchRelatedObjectsTests(TestCase):
@@ -207,6 +208,64 @@ class PrefetchRelatedObjectsTests(TestCase):
             )
         with self.assertNumQueries(0):
             self.assertCountEqual(book2.the_authors, [self.author1])
+
+    def test_prefetch_object_to_internal_state_attr(self):
+        book = Book.objects.get(id=self.book1.id)
+        state = book._state
+        with self.assertNumQueries(0):
+            prefetch_related_objects(
+                [book],
+                Prefetch("authors", to_attr="_state"),
+            )
+        self.assertIs(book._state, state)
+
+    def test_prefetch_object_to_writable_property_twice(self):
+        person1 = Person.objects.create(name="Joe")
+        person2 = Person.objects.create(name="Mary")
+        person1.houses.add(self.house1)
+        person2.houses.add(self.house2)
+        lookup = Prefetch("houses", to_attr="writable_all_houses")
+
+        with self.assertNumQueries(1):
+            prefetch_related_objects([person1], lookup)
+        # person1 was already populated by the call above, so only person2's
+        # relation should be fetched.
+        with self.assertNumQueries(1):
+            prefetch_related_objects([person1, person2], lookup)
+
+        with self.assertNumQueries(0):
+            self.assertEqual(person1.writable_all_houses, [self.house1])
+            self.assertEqual(person2.writable_all_houses, [self.house2])
+
+    def test_failed_to_attr_assignment_is_not_marked_as_fetched(self):
+        person = Person.objects.create(name="Joe")
+        person.houses.add(self.house1)
+        descriptor = Person.__dict__["writable_all_houses"]
+        lookup = Prefetch("houses", to_attr="writable_all_houses")
+
+        # If the setter raises, the assignment must not be recorded as fetched,
+        # otherwise a later prefetch would be silently skipped.
+        with mock.patch.object(
+            Person,
+            "writable_all_houses",
+            property(
+                descriptor.fget,
+                mock.Mock(side_effect=ValueError("setter failed")),
+            ),
+        ):
+            with (
+                self.assertNumQueries(1),
+                self.assertRaisesMessage(ValueError, "setter failed"),
+            ):
+                prefetch_related_objects([person], lookup)
+
+        self.assertNotIn("writable_all_houses", person._state.prefetched_to_attrs)
+        # The failed assignment leaves the instance unmarked, so the
+        # prefetch is retried when the setter works again.
+        with self.assertNumQueries(1):
+            prefetch_related_objects([person], lookup)
+        with self.assertNumQueries(0):
+            self.assertEqual(person.writable_all_houses, [self.house1])
 
     def test_prefetch_queryset(self):
         book1 = Book.objects.get(id=self.book1.id)

--- a/tests/prefetch_related/tests.py
+++ b/tests/prefetch_related/tests.py
@@ -20,6 +20,7 @@ from django.test import (
     skipUnlessDBFeature,
 )
 from django.test.utils import CaptureQueriesContext
+from django.utils.deprecation import RemovedInDjango71Warning
 
 from .models import (
     Article,
@@ -350,6 +351,13 @@ class PrefetchRelatedTests(TestDataMixin, TestCase):
         # Without the ValueError, an author was deleted due to the implicit
         # save of the relation assignment.
         self.assertEqual(self.book1.authors.count(), 3)
+
+    def test_to_attr_field_conflict(self):
+        # A field named by to_attr must not be treated as already fetched when
+        # it differs from the relationship being prefetched.
+        msg = "to_attr=title conflicts with a field on the Book model."
+        with self.assertRaisesMessage(ValueError, msg):
+            list(Book.objects.prefetch_related(Prefetch("authors", to_attr="title")))
 
     def test_reverse_m2m_to_attr_conflict(self):
         msg = "to_attr=books conflicts with a field on the Author model."
@@ -1126,6 +1134,56 @@ class CustomPrefetchTests(TestCase):
             all_houses = list(House.objects.filter(occupants=person))
             with self.assertNumQueries(0):
                 self.assertEqual(person.cached_all_houses, all_houses)
+
+    def test_to_attr_does_not_overwrite_cached_property(self):
+        person = Person.objects.get(pk=self.person1.pk)
+        # Trigger computation of the cached_property before prefetching so the
+        # existing value must be preserved.
+        cached_houses = person.cached_all_houses
+        with self.assertNumQueries(0):
+            prefetch_related_objects(
+                [person],
+                Prefetch("houses", to_attr="cached_all_houses"),
+            )
+        self.assertIs(person.cached_all_houses, cached_houses)
+
+    def test_to_attr_overwrites_instance_attribute(self):
+        person = Person.objects.get(pk=self.person1.pk)
+        person.custom_houses = object()
+        with self.assertNumQueries(1):
+            prefetch_related_objects(
+                [person],
+                Prefetch("houses", to_attr="custom_houses"),
+            )
+        self.assertEqual(person.custom_houses, [self.house1, self.house2])
+
+    def test_to_attr_writable_property(self):
+        persons = Person.objects.prefetch_related(
+            Prefetch("houses", House.objects.all(), to_attr="writable_all_houses"),
+        )
+        for person in persons:
+            # To bypass caching at the related descriptor level, don't use
+            # person.houses.all() here.
+            all_houses = list(House.objects.filter(occupants=person))
+            with self.assertNumQueries(0):
+                self.assertEqual(person.writable_all_houses, all_houses)
+
+    def test_to_attr_read_only_property_deprecation_warning(self):
+        msg = (
+            "Prefetch() with to_attr='all_houses' targeting a property without a "
+            "setter is deprecated. Add a setter, use cached_property, or use a "
+            "different to_attr. This will raise ValueError in Django 7.1."
+        )
+        with self.assertWarnsMessage(RemovedInDjango71Warning, msg):
+            with self.assertNumQueries(1):
+                persons = list(
+                    Person.objects.prefetch_related(
+                        Prefetch("houses", to_attr="all_houses"),
+                    )
+                )
+        for person in persons:
+            with self.assertNumQueries(1):
+                person.all_houses
 
     def test_filter_deferred(self):
         """


### PR DESCRIPTION
#### Trac ticket number

  ticket-37201

  #### Branch description
  
  Fixed `Prefetch.to_attr` handling for model properties.

  `Prefetch` previously used attribute presence to determine whether a custom
  `to_attr` had already been fetched. This could invoke property getters and
  silently skip the prefetch when a matching property or model field existed.

  This change:

  - Adds internal per-instance bookkeeping for successfully populated custom
    `to_attr` destinations.
  - Supports properties that define a setter without making assumptions about
    where the setter stores its value.
  - Deprecates using a property without a setter as `to_attr`. This usage now
    emits `RemovedInDjango71Warning` and will raise `ValueError` in Django 7.1.
  - Preserves the existing behavior for an already evaluated `cached_property`.
  - Ensures a failed property assignment isn't marked as successfully prefetched.
  - Preserves model state when copying model instances.
  - Adds regression tests and updates the Django 6.2 release notes and
    deprecation timeline.

  #### AI Assistance Disclosure (REQUIRED)

  - [ ] **No AI tools were used** in preparing this PR.
  - [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

  Claude Code by Anthropic was used to assist with codebase investigation,
  implementation drafting, test generation, and documentation updates. I
  reviewed the generated changes and verified them using the Django test suite
  and pre-commit checks.

  #### Checklist

  - [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
  - [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
  - [x] This PR targets the `main` branch.
  - [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see
  [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
  - [x] I have not requested, and will not request, an automated AI review for this PR.

  <!-- Leave the following items unchecked if not applicable. -->
  - [x] I have checked the "Has patch" ticket flag in the Trac system.
  - [x] I have added or updated relevant tests.
  - [x] I have added or updated relevant docs, including release notes if applicable.
  - [ ] I have attached screenshots in both light and dark modes for any UI changes.