### PR TITLE
Fixed #28554 -- Added support for multiple file form fields.

### DIFF
--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -27,6 +27,7 @@ from django.forms.widgets import (
     EmailInput,
     FileInput,
     HiddenInput,
+    MultipleFileInput,
     MultipleHiddenInput,
     NullBooleanSelect,
     NumberInput,
@@ -60,6 +61,7 @@ __all__ = (
     "RegexField",
     "EmailField",
     "FileField",
+    "MultipleFileField",
     "ImageField",
     "URLField",
     "BooleanField",
@@ -667,14 +669,22 @@ class FileField(Field):
             raise ValidationError(self.error_messages["invalid"], code="invalid")
 
         if self.max_length is not None and len(file_name) > self.max_length:
-            params = {"max": self.max_length, "length": len(file_name)}
+            params = {
+                "file_name": file_name,
+                "max": self.max_length,
+                "length": len(file_name),
+            }
             raise ValidationError(
                 self.error_messages["max_length"], code="max_length", params=params
             )
         if not file_name:
             raise ValidationError(self.error_messages["invalid"], code="invalid")
         if not self.allow_empty_file and not file_size:
-            raise ValidationError(self.error_messages["empty"], code="empty")
+            raise ValidationError(
+                self.error_messages["empty"],
+                code="empty",
+                params={"file_name": file_name},
+            )
 
         return data
 
@@ -708,6 +718,36 @@ class FileField(Field):
     def _clean_bound_field(self, bf):
         value = bf.initial if self.disabled else bf.data
         return self.clean(value, bf.initial)
+
+
+class MultipleFileField(FileField):
+    widget = MultipleFileInput
+    default_error_messages = {
+        "empty": _("The submitted file %(file_name)s is empty."),
+        "max_length": ngettext_lazy(
+            "Ensure the filename %(file_name)s has at most %(max)d character "
+            "(it has %(length)d).",
+            "Ensure the filename %(file_name)s has at most %(max)d characters "
+            "(it has %(length)d).",
+            "max",
+        ),
+    }
+
+    def clean(self, data, initial=None):
+        single_file_clean = super().clean
+        if data in self.empty_values:
+            value = single_file_clean(data, initial)
+            if value in self.empty_values:
+                return []
+            if isinstance(value, (list, tuple)):
+                return list(value)
+            return [value]
+        if not isinstance(data, (list, tuple)):
+            data = [data]
+        return [single_file_clean(file, None) for file in data]
+
+    def has_changed(self, initial, data):
+        return not self.disabled and bool(data)
 
 
 class ImageField(FileField):

--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -39,6 +39,7 @@ __all__ = (
     "HiddenInput",
     "MultipleHiddenInput",
     "FileInput",
+    "MultipleFileInput",
     "ClearableFileInput",
     "Textarea",
     "DateInput",
@@ -564,6 +565,10 @@ class FileInput(Input):
 
     def use_required_attribute(self, initial):
         return super().use_required_attribute(initial) and not initial
+
+
+class MultipleFileInput(FileInput):
+    allow_multiple_selected = True
 
 
 FILE_INPUT_CONTRADICTION = object()

--- a/docs/ref/forms/fields.txt
+++ b/docs/ref/forms/fields.txt
@@ -675,7 +675,9 @@ For each field, we describe the default widget used if you don't specify
     When you use a ``FileField`` in a form, you must also remember to
     :ref:`bind the file data to the form <binding-uploaded-files>`.
 
-    The ``max_length`` error refers to the length of the filename. In the error
+    The ``empty`` and ``max_length`` error messages may contain
+    ``%(file_name)s``, which will be replaced with the submitted filename. The
+    ``max_length`` error refers to the length of the filename. In the error
     message for that key, ``%(max)d`` will be replaced with the maximum
     filename length and ``%(length)d`` will be replaced with the current
     filename length.
@@ -986,6 +988,27 @@ For each field, we describe the default widget used if you don't specify
 
     Takes one extra required argument, ``choices``, as for
     :class:`ChoiceField`.
+
+``MultipleFileField``
+---------------------
+
+.. class:: MultipleFileField(**kwargs)
+
+    .. versionadded:: 6.2
+
+    * Default widget: :class:`MultipleFileInput`
+    * Empty value: ``[]`` (an empty list)
+    * Normalizes to: A list of
+      :class:`~django.core.files.uploadedfile.UploadedFile` objects.
+    * Validates each uploaded file using the same validation as
+      :class:`FileField`.
+    * Error message keys: ``required``, ``invalid``, ``missing``, ``empty``,
+      ``max_length``
+
+    Accepts the same arguments as :class:`FileField`.
+
+    This field supports multiple files at the form level. It cannot store
+    multiple files in a single model :class:`~django.db.models.FileField`.
 
 ``NullBooleanField``
 --------------------

--- a/docs/ref/forms/widgets.txt
+++ b/docs/ref/forms/widgets.txt
@@ -902,6 +902,18 @@ File upload widgets
     * ``template_name``: ``'django/forms/widgets/file.html'``
     * Renders as: ``<input type="file" ...>``
 
+``MultipleFileInput``
+~~~~~~~~~~~~~~~~~~~~~
+
+.. class:: MultipleFileInput
+
+    .. versionadded:: 6.2
+
+    * ``template_name``: ``'django/forms/widgets/file.html'``
+    * Renders as: ``<input type="file" multiple ...>``
+
+    Allows selecting multiple files and returns them as a list.
+
 ``ClearableFileInput``
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -156,7 +156,9 @@ File Uploads
 Forms
 ~~~~~
 
-* ...
+* The new :class:`~django.forms.MultipleFileField` and
+  :class:`~django.forms.MultipleFileInput` classes support uploading and
+  validating multiple files with a single form field.
 
 Generic Views
 ~~~~~~~~~~~~~

--- a/docs/topics/http/file-uploads.txt
+++ b/docs/topics/http/file-uploads.txt
@@ -150,22 +150,9 @@ a :class:`~django.core.files.File` like object to the
 Uploading multiple files
 ------------------------
 
-..
-    Tests in tests.forms_tests.field_tests.test_filefield.MultipleFileFieldTest
-    should be updated after any changes in the following snippets.
-
-If you want to upload multiple files using one form field, create a subclass
-of the field's widget and set its ``allow_multiple_selected`` class attribute
-to ``True``.
-
-In order for such files to be all validated by your form (and have the value of
-the field include them all), you will also have to subclass ``FileField``. See
-below for an example.
-
-.. admonition:: Multiple file field
-
-    Django is likely to have a proper multiple file field support at some point
-    in the future.
+If you want to upload multiple files using one form field, use
+:class:`~django.forms.MultipleFileField`. Each submitted file is validated and
+the field's cleaned value is a list of uploaded files.
 
 .. code-block:: python
     :caption: ``forms.py``
@@ -173,26 +160,8 @@ below for an example.
     from django import forms
 
 
-    class MultipleFileInput(forms.ClearableFileInput):
-        allow_multiple_selected = True
-
-
-    class MultipleFileField(forms.FileField):
-        def __init__(self, *args, **kwargs):
-            kwargs.setdefault("widget", MultipleFileInput())
-            super().__init__(*args, **kwargs)
-
-        def clean(self, data, initial=None):
-            single_file_clean = super().clean
-            if isinstance(data, (list, tuple)):
-                result = [single_file_clean(d, initial) for d in data]
-            else:
-                result = [single_file_clean(data, initial)]
-            return result
-
-
     class FileFieldForm(forms.Form):
-        file_field = MultipleFileField()
+        file_field = forms.MultipleFileField()
 
 Then override the ``form_valid()`` method of your
 :class:`~django.views.generic.edit.FormView` subclass to handle multiple file

--- a/tests/forms_tests/field_tests/test_filefield.py
+++ b/tests/forms_tests/field_tests/test_filefield.py
@@ -4,8 +4,9 @@ import unittest
 from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.validators import validate_image_file_extension
-from django.forms import FileField, FileInput
+from django.forms import FileField, Form, MultipleFileField, MultipleFileInput
 from django.test import SimpleTestCase
+from django.utils.datastructures import MultiValueDict
 
 try:
     from PIL import Image  # NOQA
@@ -120,23 +121,25 @@ class FileFieldTest(SimpleTestCase):
     def test_file_picklable(self):
         self.assertIsInstance(pickle.loads(pickle.dumps(FileField())), FileField)
 
-
-class MultipleFileInput(FileInput):
-    allow_multiple_selected = True
-
-
-class MultipleFileField(FileField):
-    def __init__(self, *args, **kwargs):
-        kwargs.setdefault("widget", MultipleFileInput())
-        super().__init__(*args, **kwargs)
-
-    def clean(self, data, initial=None):
-        single_file_clean = super().clean
-        if isinstance(data, (list, tuple)):
-            result = [single_file_clean(d, initial) for d in data]
-        else:
-            result = single_file_clean(data, initial)
-        return result
+    def test_file_name_error_param(self):
+        tests = [
+            (
+                FileField(),
+                SimpleUploadedFile("empty.txt", b""),
+                "empty",
+            ),
+            (
+                FileField(max_length=5),
+                SimpleUploadedFile("too-long.txt", b"content"),
+                "max_length",
+            ),
+        ]
+        for field, file, code in tests:
+            with self.subTest(code=code):
+                with self.assertRaises(ValidationError) as cm:
+                    field.clean(file)
+                self.assertEqual(cm.exception.code, code)
+                self.assertEqual(cm.exception.params["file_name"], file.name)
 
 
 class MultipleFileFieldTest(SimpleTestCase):
@@ -148,13 +151,49 @@ class MultipleFileFieldTest(SimpleTestCase):
         ]
         self.assertEqual(f.clean(files), files)
 
+    def test_file_single(self):
+        f = MultipleFileField()
+        file = SimpleUploadedFile("name", b"Content")
+        self.assertEqual(f.clean(file), [file])
+
+    def test_file_empty(self):
+        required = MultipleFileField()
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            required.clean([])
+        optional = MultipleFileField(required=False)
+        self.assertEqual(optional.clean([]), [])
+        self.assertEqual(optional.clean(None), [])
+
+    def test_file_initial(self):
+        f = MultipleFileField()
+        initial = [
+            SimpleUploadedFile("name1", b"Content 1"),
+            SimpleUploadedFile("name2", b"Content 2"),
+        ]
+        self.assertEqual(f.clean([], initial), initial)
+
     def test_file_multiple_empty(self):
         f = MultipleFileField()
         files = [
-            SimpleUploadedFile("empty", b""),
-            SimpleUploadedFile("nonempty", b"Some Content"),
+            SimpleUploadedFile("empty.txt", b""),
+            SimpleUploadedFile("nonempty.txt", b"Some Content"),
         ]
-        msg = "'The submitted file is empty.'"
+        msg = "'The submitted file empty.txt is empty.'"
+        with self.assertRaisesMessage(ValidationError, msg):
+            f.clean(files)
+        with self.assertRaisesMessage(ValidationError, msg):
+            f.clean(files[::-1])
+
+    def test_file_multiple_max_length(self):
+        f = MultipleFileField(max_length=8)
+        files = [
+            SimpleUploadedFile("too_long.txt", b"Some Content"),
+            SimpleUploadedFile("short", b"Some Content"),
+        ]
+        msg = (
+            "'Ensure the filename too_long.txt has at most 8 characters "
+            "(it has 12).'"
+        )
         with self.assertRaisesMessage(ValidationError, msg):
             f.clean(files)
         with self.assertRaisesMessage(ValidationError, msg):
@@ -185,3 +224,69 @@ class MultipleFileFieldTest(SimpleTestCase):
         for rotated_evil_files in evil_rotations:
             with self.assertRaisesMessage(ValidationError, msg):
                 f.clean(rotated_evil_files)
+
+    def test_has_changed(self):
+        f = MultipleFileField()
+        self.assertIs(f.has_changed(None, None), False)
+        self.assertIs(f.has_changed(None, []), False)
+        self.assertIs(
+            f.has_changed(None, [SimpleUploadedFile("name", b"Content")]), True
+        )
+
+    def test_disabled_has_changed(self):
+        f = MultipleFileField(disabled=True)
+        self.assertIs(
+            f.has_changed(None, [SimpleUploadedFile("name", b"Content")]), False
+        )
+
+    def test_widget(self):
+        f = MultipleFileField()
+        self.assertIsInstance(f.widget, MultipleFileInput)
+        self.assertIs(f.widget.allow_multiple_selected, True)
+
+    def test_form(self):
+        class MultipleFileForm(Form):
+            files = MultipleFileField()
+
+        files = [
+            SimpleUploadedFile("name1", b"Content 1"),
+            SimpleUploadedFile("name2", b"Content 2"),
+        ]
+        form = MultipleFileForm({}, MultiValueDict({"files": files}))
+        self.assertIs(form.is_valid(), True)
+        self.assertEqual(form.cleaned_data["files"], files)
+        self.assertHTMLEqual(
+            str(MultipleFileForm()),
+            '<div><label for="id_files">Files:</label>'
+            '<input type="file" name="files" multiple required id="id_files"></div>',
+        )
+
+    def test_form_required(self):
+        class MultipleFileForm(Form):
+            files = MultipleFileField()
+
+        form = MultipleFileForm({}, MultiValueDict())
+        self.assertIs(form.is_valid(), False)
+        self.assertEqual(form.errors["files"], ["This field is required."])
+
+    def test_form_optional(self):
+        class MultipleFileForm(Form):
+            files = MultipleFileField(required=False)
+
+        form = MultipleFileForm({}, MultiValueDict())
+        self.assertIs(form.is_valid(), True)
+        self.assertEqual(form.cleaned_data["files"], [])
+        self.assertEqual(form.changed_data, [])
+
+    def test_form_initial(self):
+        class MultipleFileForm(Form):
+            files = MultipleFileField()
+
+        initial = [
+            SimpleUploadedFile("name1", b"Content 1"),
+            SimpleUploadedFile("name2", b"Content 2"),
+        ]
+        form = MultipleFileForm({}, MultiValueDict(), initial={"files": initial})
+        self.assertIs(form.is_valid(), True)
+        self.assertEqual(form.cleaned_data["files"], initial)
+        self.assertEqual(form.changed_data, [])

--- a/tests/forms_tests/widget_tests/test_fileinput.py
+++ b/tests/forms_tests/widget_tests/test_fileinput.py
@@ -1,5 +1,5 @@
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.forms import FileField, FileInput, Form
+from django.forms import FileField, FileInput, Form, MultipleFileInput
 from django.utils.datastructures import MultiValueDict
 
 from .base import WidgetTest
@@ -57,9 +57,6 @@ class FileInputTest(WidgetTest):
             FileInput(attrs={"multiple": True})
 
     def test_value_from_datadict_multiple(self):
-        class MultipleFileInput(FileInput):
-            allow_multiple_selected = True
-
         file_1 = SimpleUploadedFile("something1.txt", b"content 1")
         file_2 = SimpleUploadedFile("something2.txt", b"content 2")
         # Uploading multiple files is allowed.
@@ -80,9 +77,6 @@ class FileInputTest(WidgetTest):
         self.assertEqual(value, file_2)
 
     def test_multiple_default(self):
-        class MultipleFileInput(FileInput):
-            allow_multiple_selected = True
-
         tests = [
             (None, True),
             ({"class": "myclass"}, True),


### PR DESCRIPTION
#### Trac ticket number

ticket-28554

#### Branch description

This adds public `MultipleFileInput` and `MultipleFileField` classes for handling multiple uploads through one form field. It replaces the custom classes currently shown in Django's file upload documentation and keeps the feature at the form layer, without changing model `FileField` storage.

`MultipleFileField` validates each submitted file and consistently returns a list. It also handles required and optional empty submissions, initial values, disabled fields, and change detection. The separate classes follow the direction discussed in #9011.

#### Validation

- `python -Wa tests/runtests.py --parallel 1`
- `python -Wa tests/runtests.py forms_tests --parallel auto`
- Strict Sphinx documentation build
- Black, blacken-docs, sphinx-lint, and `git diff --check`

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

OpenAI Codex (GPT-5) helped analyze the ticket and earlier PR, draft the implementation, tests, and documentation, and run the verification commands. I manually reviewed and verified the final diff and test results before submission.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.

- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
