### PR TITLE
Refs #26223 -- Kept one-off defaults out of state when optimizing.

### DIFF
--- a/django/db/migrations/operations/fields.py
+++ b/django/db/migrations/operations/fields.py
@@ -7,10 +7,26 @@ from .base import Operation, OperationCategory
 
 
 class FieldOperation(Operation):
+    # Operations that accept a one-off default set this to False.
+    preserve_default = True
+
     def __init__(self, model_name, name, field=None):
         self.model_name = model_name
         self.name = name
         self.field = field
+
+    @property
+    def state_field(self):
+        """
+        The field as it appears in the model state. A default that isn't
+        preserved only exists for the duration of the migration, so it is not
+        part of the state.
+        """
+        if self.preserve_default:
+            return self.field
+        field = self.field.clone()
+        field.default = NOT_PROVIDED
+        return field
 
     @cached_property
     def model_name_lower(self):
@@ -146,6 +162,7 @@ class AddField(FieldOperation):
                         self,
                         name=operation.name,
                         field=operation.field,
+                        preserve_default=operation.preserve_default,
                     ),
                 ]
             elif isinstance(operation, RemoveField):

--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -231,7 +231,7 @@ class CreateModel(ModelOperation):
                 return [
                     replace(
                         self,
-                        fields=[*self.fields, (operation.name, operation.field)],
+                        fields=[*self.fields, (operation.name, operation.state_field)],
                     ),
                 ]
             elif isinstance(operation, AlterField):
@@ -239,7 +239,7 @@ class CreateModel(ModelOperation):
                     replace(
                         self,
                         fields=[
-                            (n, operation.field if n == operation.name else v)
+                            (n, operation.state_field if n == operation.name else v)
                             for n, v in self.fields
                         ],
                     ),

--- a/tests/migrations/test_optimizer.py
+++ b/tests/migrations/test_optimizer.py
@@ -686,6 +686,61 @@ class OptimizerTests(OptimizerTestBase):
             ],
         )
 
+    def test_create_model_add_field_not_preserve_default(self):
+        """
+        A default that isn't preserved is only used by the migration that adds
+        the field, so it must not end up in CreateModel.
+        """
+        self.assertOptimizesTo(
+            [
+                migrations.CreateModel(
+                    name="Foo",
+                    fields=[("name", models.CharField(max_length=255))],
+                ),
+                migrations.AddField(
+                    "Foo",
+                    "age",
+                    models.IntegerField(default=42),
+                    preserve_default=False,
+                ),
+            ],
+            [
+                migrations.CreateModel(
+                    name="Foo",
+                    fields=[
+                        ("name", models.CharField(max_length=255)),
+                        ("age", models.IntegerField()),
+                    ],
+                ),
+            ],
+        )
+
+    def test_create_model_alter_field_not_preserve_default(self):
+        """
+        A default that isn't preserved is only used by the migration that
+        alters the field, so it must not end up in CreateModel.
+        """
+        self.assertOptimizesTo(
+            [
+                migrations.CreateModel(
+                    name="Foo",
+                    fields=[("age", models.IntegerField(null=True))],
+                ),
+                migrations.AlterField(
+                    "Foo",
+                    "age",
+                    models.IntegerField(default=42),
+                    preserve_default=False,
+                ),
+            ],
+            [
+                migrations.CreateModel(
+                    name="Foo",
+                    fields=[("age", models.IntegerField())],
+                ),
+            ],
+        )
+
     def test_create_model_rename_field(self):
         """
         RenameField should optimize into CreateModel.
@@ -807,6 +862,31 @@ class OptimizerTests(OptimizerTestBase):
             [
                 migrations.AddField(
                     "Foo", name="age", field=models.FloatField(default=2.4)
+                ),
+            ],
+        )
+
+    def test_add_field_alter_field_not_preserve_default(self):
+        """
+        AlterField should optimize into AddField, keeping whether the altered
+        field's default is preserved.
+        """
+        self.assertOptimizesTo(
+            [
+                migrations.AddField("Foo", "age", models.IntegerField(null=True)),
+                migrations.AlterField(
+                    "Foo",
+                    "age",
+                    models.IntegerField(default=42),
+                    preserve_default=False,
+                ),
+            ],
+            [
+                migrations.AddField(
+                    "Foo",
+                    name="age",
+                    field=models.IntegerField(default=42),
+                    preserve_default=False,
                 ),
             ],
         )


### PR DESCRIPTION
#### Trac ticket number

ticket-26223

#### Branch description

Squashing migrations turns a one-off default into a permanent one. Given a `CreateModel` followed by `AddField(..., preserve_default=False)`, the optimizer folds the field into `CreateModel` using `operation.field`, which still carries the default. `ProjectState.add_field()` and `alter_field()` deliberately strip that default, because it only exists for the migration that sets it, so the optimized operations describe a different model state than the operations they replace.

Reproducing the report on `main`, with the two migrations from the ticket:

```
$ django-admin squashmigrations foo 0001 0002
    operations = [
        migrations.CreateModel(
            name='FooBar',
            fields=[
                ('id', models.AutoField(...)),
                ('foo', models.TextField(default='bar')),   # <-- one-off default kept
            ],
        ),
    ]
$ django-admin makemigrations foo
  foo/migrations/0003_alter_foobar_foo.py
    ~ Alter field foo on foobar                            # <-- immediately removes it again
```

With this change the squashed operation is `('foo', models.TextField())` and `makemigrations` reports no changes.

`AddField.reduce()` has the same problem in the other direction: when it absorbs a following `AlterField` it keeps its own `preserve_default` instead of the one belonging to the operation it absorbed, so `AddField(field, preserve_default=True)` + `AlterField(field, preserve_default=False)` optimizes into a single `AddField` whose default *is* part of the state.

The fix adds a `state_field` property to `FieldOperation`, mirroring what `ProjectState` does, and uses it when folding fields into `CreateModel`.

Still open on the ticket, and not addressed here: when `AddField(preserve_default=False)` or `AlterField(preserve_default=False)` is followed by an `AlterField` whose field has no default, the resulting operation loses the one-off default altogether (cases in comments 3 and 7 of the ticket). The resulting state is correct in those cases, but the database-level default that populated existing rows disappears. Carrying an old one-off default onto a differently shaped field seemed like a separate decision, so I left it out rather than guess.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [X] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude Code (Claude Opus 5) was used to analyse the ticket, reproduce it, and draft the fix and the tests. I reviewed and verified the change myself, checked it against `ProjectState.add_field()`/`alter_field()`, reproduced the reported behaviour end to end with `squashmigrations` before and after, and ran the full test suite (19708 tests, no failures, same skips and expected failures as `main`).

#### Checklist

- [X] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [X] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [X] This PR targets the `main` branch.
- [X] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [X] I have not requested, and will not request, an automated AI review for this PR.

- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
