### PR TITLE
Fixed #30577 -- Added ModelAdmin.readonly_formfield_overrides.

### DIFF
--- a/django/contrib/admin/helpers.py
+++ b/django/contrib/admin/helpers.py
@@ -279,6 +279,12 @@ class AdminReadonlyField:
         except (AttributeError, ValueError, ObjectDoesNotExist):
             result_repr = self.empty_value_display
         else:
+            overrides = getattr(model_admin, "readonly_formfield_overrides", None)
+            if overrides and isinstance(field, str) and field in overrides:
+                widget = overrides[field]
+                if isinstance(widget, type):
+                    widget = widget()
+                return widget.render(field, value)
             if f is None:
                 if getattr(attr, "boolean", False):
                     result_repr = _boolean_icon(value)

--- a/django/contrib/admin/helpers.py
+++ b/django/contrib/admin/helpers.py
@@ -288,6 +288,9 @@ class AdminReadonlyField:
                     else:
                         result_repr = linebreaksbr(value)
             else:
+                widget = model_admin.get_readonly_widget(f)
+                if widget is not None:
+                    return widget.render(field, value)
                 if isinstance(f.remote_field, ManyToManyRel) and value is not None:
                     result_repr = ", ".join(map(str, value.all()))
                 elif (

--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -189,6 +189,7 @@ class BaseModelAdmin(metaclass=forms.MediaDefiningClass):
     prepopulated_fields = {}
     formfield_overrides = {}
     readonly_fields = ()
+    readonly_formfield_overrides = {}
     ordering = None
     sortable_by = None
     view_on_site = True

--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -189,6 +189,7 @@ class BaseModelAdmin(metaclass=forms.MediaDefiningClass):
     prepopulated_fields = {}
     formfield_overrides = {}
     readonly_fields = ()
+    readonly_formfield_overrides = {}
     ordering = None
     sortable_by = None
     view_on_site = True
@@ -206,6 +207,17 @@ class BaseModelAdmin(metaclass=forms.MediaDefiningClass):
         for k, v in self.formfield_overrides.items():
             overrides.setdefault(k, {}).update(v)
         self.formfield_overrides = overrides
+
+    def get_readonly_widget(self, db_field):
+        """
+        Hook for specifying the widget used to render db_field when it's
+        displayed as read-only. Return None to use the default rendering.
+        """
+        for klass in db_field.__class__.mro():
+            if klass in self.readonly_formfield_overrides:
+                widget = self.readonly_formfield_overrides[klass].get("widget")
+                return widget() if isinstance(widget, type) else widget
+        return None
 
     def formfield_for_dbfield(self, db_field, request, **kwargs):
         """

--- a/django/contrib/auth/admin.py
+++ b/django/contrib/auth/admin.py
@@ -1,3 +1,4 @@
+from django import forms
 from django.conf import settings
 from django.contrib import admin, messages
 from django.contrib.admin.options import IS_POPUP_VAR
@@ -9,6 +10,7 @@ from django.contrib.auth.forms import (
     UserChangeForm,
 )
 from django.contrib.auth.models import Group, User
+from django.contrib.auth.templatetags.auth import render_password_as_hash
 from django.core.exceptions import PermissionDenied
 from django.db import router, transaction
 from django.http import Http404, HttpResponseRedirect
@@ -37,10 +39,22 @@ class GroupAdmin(admin.ModelAdmin):
         return super().formfield_for_manytomany(db_field, request=request, **kwargs)
 
 
+class _PasswordHashDisplayWidget(forms.Widget):
+    """
+    Display-only rendering of a password hash summary for read-only admin
+    fields. Unlike ReadOnlyPasswordHashWidget, it renders no password
+    reset/set button, so it is safe for users without change permission.
+    """
+
+    def render(self, name, value, attrs=None, renderer=None):
+        return render_password_as_hash(value)
+
+
 @admin.register(User)
 class UserAdmin(admin.ModelAdmin):
     add_form_template = "admin/auth/user/add_form.html"
     change_user_password_template = None
+    readonly_formfield_overrides = {"password": _PasswordHashDisplayWidget}
     fieldsets = (
         (None, {"fields": ("username", "password")}),
         (_("Personal info"), {"fields": ("first_name", "last_name", "email")}),

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1208,6 +1208,40 @@ subclass::
                     ((line,) for line in instance.get_full_address()),
                 ) or mark_safe("<span class='errors'>I can't determine this address.</span>")
 
+.. attribute:: ModelAdmin.readonly_formfield_overrides
+
+    .. versionadded:: 6.2
+
+    A dictionary mapping field names to widgets used when the field is
+    displayed as read-only, either because the field is listed in
+    :attr:`ModelAdmin.readonly_fields` or because the user doesn't have
+    change permission. For example, given a model with a
+    :class:`~django.db.models.JSONField` named ``data``, this renders its
+    value in a ``<pre>`` tag instead of as a plain string::
+
+        from django.contrib import admin
+        from django.forms import Widget
+        from django.utils.html import format_html
+
+
+        class PrettyJSONWidget(Widget):
+            def render(self, name, value, attrs=None, renderer=None):
+                return format_html("<pre>{}</pre>", value)
+
+
+        class DogAdmin(admin.ModelAdmin):
+            readonly_formfield_overrides = {"data": PrettyJSONWidget}
+
+    Without an entry in this dictionary, read-only values render as text, as
+    described in :attr:`ModelAdmin.readonly_fields`.
+
+    The widget's ``render()`` method is called with the field name and the
+    field's value, with no bound form field. Values submitted for read-only
+    fields are ignored, so the widget only controls presentation. The widget
+    is rendered without access to the request or the current user, so it
+    must not embed links or buttons that trigger actions the user may not
+    have permission for.
+
 .. attribute:: ModelAdmin.save_as
 
     Set ``save_as`` to enable a "save as new" feature on admin change forms.

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1208,6 +1208,65 @@ subclass::
                     ((line,) for line in instance.get_full_address()),
                 ) or mark_safe("<span class='errors'>I can't determine this address.</span>")
 
+.. attribute:: ModelAdmin.readonly_formfield_overrides
+
+    .. versionadded:: 6.2
+
+    A dictionary mapping a field class to a dict of arguments, used when a
+    field of that class is displayed as read-only. A field is read-only when
+    it's listed in :attr:`ModelAdmin.readonly_fields`, or when the user has
+    view permission but not change permission. Only the ``widget`` argument
+    is read.
+
+    As with :attr:`ModelAdmin.formfield_overrides`, the key is the field
+    class, *not* a string. Here every read-only
+    :class:`~django.db.models.JSONField` renders inside a ``<pre>`` tag
+    instead of as a plain string::
+
+        from django.contrib import admin
+        from django.db import models
+        from django.forms import Widget
+        from django.utils.html import format_html
+
+
+        class PrettyJSONWidget(Widget):
+            def render(self, name, value, attrs=None, renderer=None):
+                return format_html("<pre>{}</pre>", value)
+
+
+        class DogAdmin(admin.ModelAdmin):
+            readonly_formfield_overrides = {
+                models.JSONField: {"widget": PrettyJSONWidget},
+            }
+
+    Django tries the field's own class first, then each of its parent classes
+    in turn, and uses the first entry it finds. An entry for
+    :class:`~django.db.models.Field` therefore covers every read-only model
+    field that no more specific entry matches. To target a single field
+    instead of a class, override
+    :meth:`ModelAdmin.get_readonly_widget`.
+
+    Without a matching entry, read-only values render as text, as described
+    in :attr:`ModelAdmin.readonly_fields`. Read-only entries that don't
+    resolve to a model field, such as a ``ModelAdmin`` method or a model
+    attribute, have no field class, so no override applies to them.
+
+    Django calls the widget's ``render()`` method with the field name and the
+    field's value, and passes no bound form field. The value is the raw
+    attribute value, not the string the admin would otherwise display, so the
+    widget does any formatting itself. Values submitted for read-only fields
+    are ignored, so the widget only controls presentation.
+
+    An entry's ``widget`` may be a class or a configured instance. Django uses
+    an instance as given, so one widget class can serve both the editable and
+    the read-only rendering, selecting between them from its own ``attrs``.
+
+    .. note::
+
+        Django doesn't add assets declared by the widget's ``Media`` class to
+        the page, so a widget that depends on its own CSS or JavaScript won't
+        have them.
+
 .. attribute:: ModelAdmin.save_as
 
     Set ``save_as`` to enable a "save as new" feature on admin change forms.
@@ -1596,6 +1655,31 @@ default templates used by the :class:`ModelAdmin` views:
     ``obj`` being edited (or ``None`` on an add form) and is expected to return
     a ``list`` or ``tuple`` of field names that will be displayed as read-only,
     as described above in the :attr:`ModelAdmin.readonly_fields` section.
+
+.. method:: ModelAdmin.get_readonly_widget(db_field)
+
+    .. versionadded:: 6.2
+
+    The ``get_readonly_widget`` method is given the model field being rendered
+    read-only, and returns the widget to render it with, or ``None`` to use
+    the default rendering. The default implementation resolves
+    :attr:`ModelAdmin.readonly_formfield_overrides`.
+
+    Override this method to target a single field, rather than every field of
+    a class. For example, to render only ``config`` as formatted JSON, while
+    leaving the model's other ``JSONField`` columns alone::
+
+        class DogAdmin(admin.ModelAdmin):
+            def get_readonly_widget(self, db_field):
+                if db_field.name == "config":
+                    return PrettyJSONWidget()
+                return super().get_readonly_widget(db_field)
+
+    Unlike :meth:`ModelAdmin.formfield_for_foreignkey`, this method doesn't
+    receive the ``HttpRequest``. The admin excludes read-only fields from the
+    form, so they're rendered outside the request-aware form machinery. A
+    widget returned here therefore can't vary by user, and it must not embed
+    links or buttons that trigger actions the user may lack permission for.
 
 .. method:: ModelAdmin.get_prepopulated_fields(request, obj=None)
 

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -37,7 +37,8 @@ Minor features
 :mod:`django.contrib.admin`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* ...
+* The new :attr:`.ModelAdmin.readonly_formfield_overrides` attribute allows
+  customizing the widget used to render read-only fields.
 
 :mod:`django.contrib.admindocs`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -37,7 +37,10 @@ Minor features
 :mod:`django.contrib.admin`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* ...
+* The new :attr:`.ModelAdmin.readonly_formfield_overrides` attribute allows
+  customizing the widget used to render read-only fields of a given field
+  class. The new :meth:`.ModelAdmin.get_readonly_widget` method allows doing
+  so for a single field.
 
 :mod:`django.contrib.admindocs`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -720,6 +720,20 @@ class FieldOverridePostAdmin(PostAdmin):
     form = FieldOverridePostForm
 
 
+class ReadonlyOverrideWidget(forms.Widget):
+    def render(self, name, value, attrs=None, renderer=None):
+        return format_html('<span class="readonly-override">{}</span>', value)
+
+
+class ReadonlyOverridePostAdmin(admin.ModelAdmin):
+    fields = ("title", "content", "posted")
+    readonly_fields = ("content", "posted")
+    readonly_formfield_overrides = {
+        "title": ReadonlyOverrideWidget,
+        "content": ReadonlyOverrideWidget,
+    }
+
+
 class CustomChangeList(ChangeList):
     def get_queryset(self, request):
         return self.root_queryset.order_by("pk").filter(pk=9999)  # Doesn't exist
@@ -1456,6 +1470,7 @@ site2.register(
 site2.register(Person, save_as_continue=False)
 site2.register(ReadOnlyRelatedField, ReadOnlyRelatedFieldAdmin)
 site2.register(Language)
+site2.register(Post, ReadonlyOverridePostAdmin)
 
 site7 = admin.AdminSite(name="admin7")
 site7.register(Article, ArticleAdmin2)

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -720,6 +720,64 @@ class FieldOverridePostAdmin(PostAdmin):
     form = FieldOverridePostForm
 
 
+class ReadonlyOverrideWidget(forms.Widget):
+    def render(self, name, value, attrs=None, renderer=None):
+        return format_html('<span class="readonly-override">{}</span>', value)
+
+
+class BaseReadonlyOverrideAdmin(admin.ModelAdmin):
+    readonly_formfield_overrides = {
+        models.CharField: {"widget": ReadonlyOverrideWidget},
+        models.TextField: {"widget": ReadonlyOverrideWidget},
+        models.BooleanField: {},
+    }
+
+
+class ReadonlyOverridePostAdmin(BaseReadonlyOverrideAdmin):
+    fields = (
+        "title",
+        "content",
+        "readonly_content",
+        "posted",
+        "public",
+        "awesomeness_level",
+    )
+    readonly_fields = (
+        "content",
+        "readonly_content",
+        "posted",
+        "public",
+        "awesomeness_level",
+    )
+
+
+class PerFieldReadonlyWidget(forms.Widget):
+    def render(self, name, value, attrs=None, renderer=None):
+        return format_html('<span class="per-field-override">{}</span>', value)
+
+
+class ReadonlyAttrsWidget(forms.Widget):
+    def render(self, name, value, attrs=None, renderer=None):
+        merged = {**self.attrs, **(attrs or {})}
+        return format_html(
+            '<span data-mode="{}">{}</span>', merged.get("data-mode", ""), value
+        )
+
+
+class ReadonlyWidgetMethodPostAdmin(BaseReadonlyOverrideAdmin):
+    fields = ("title", "content", "readonly_content", "posted")
+    readonly_fields = ("content", "readonly_content", "posted")
+    readonly_formfield_overrides = {
+        **BaseReadonlyOverrideAdmin.readonly_formfield_overrides,
+        models.DateField: {"widget": ReadonlyAttrsWidget(attrs={"data-mode": "read"})},
+    }
+
+    def get_readonly_widget(self, db_field):
+        if db_field.name == "readonly_content":
+            return PerFieldReadonlyWidget()
+        return super().get_readonly_widget(db_field)
+
+
 class CustomChangeList(ChangeList):
     def get_queryset(self, request):
         return self.root_queryset.order_by("pk").filter(pk=9999)  # Doesn't exist
@@ -1456,8 +1514,10 @@ site2.register(
 site2.register(Person, save_as_continue=False)
 site2.register(ReadOnlyRelatedField, ReadOnlyRelatedFieldAdmin)
 site2.register(Language)
+site2.register(Post, ReadonlyOverridePostAdmin)
 
 site7 = admin.AdminSite(name="admin7")
+site7.register(Post, ReadonlyWidgetMethodPostAdmin)
 site7.register(Article, ArticleAdmin2)
 site7.register(Section)
 site7.register(ParentWithUUIDPK, ParentWithUUIDPKNoAddAdmin)

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -7820,6 +7820,185 @@ class ReadonlyTest(AdminFieldExtractionMixin, TestCase):
 
 
 @override_settings(ROOT_URLCONF="admin_views.urls")
+class ReadonlyFormfieldOverridesTest(TestCase):
+    """
+    ModelAdmin.readonly_formfield_overrides customizes the rendering of
+    read-only field values.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.superuser = User.objects.create_superuser(
+            username="super", password="secret", email="super@example.com"
+        )
+        cls.viewuser = User.objects.create_user(
+            username="viewuser", password="secret", is_staff=True
+        )
+        cls.viewuser.user_permissions.add(get_perm(Post, "view_post"))
+        cls.post = Post.objects.create(
+            title="Overridden title",
+            content="Overridden content",
+            readonly_content="Readonly content",
+            public=True,
+        )
+        cls.url = reverse(
+            "namespaced_admin:admin_views_post_change", args=(cls.post.pk,)
+        )
+
+    def test_override_applies_to_view_only_user(self):
+        """
+        For a user without change permission, every field renders read-only
+        and overridden fields use the configured widget.
+        """
+        self.client.force_login(self.viewuser)
+        response = self.client.get(self.url)
+        self.assertContains(
+            response,
+            '<span class="readonly-override">Overridden title</span>',
+            html=True,
+        )
+        self.assertContains(
+            response,
+            '<span class="readonly-override">Overridden content</span>',
+            html=True,
+        )
+        self.assertNotContains(
+            response,
+            '<div class="readonly">Overridden content</div>',
+            html=True,
+        )
+
+    def test_override_by_field_class_covers_every_field_of_that_type(self):
+        """
+        One entry keyed by a field class covers every read-only field of that
+        type, on ModelAdmin subclasses that don't repeat the declaration.
+        """
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.url)
+        self.assertContains(
+            response,
+            '<span class="readonly-override">Overridden content</span>',
+            html=True,
+        )
+        self.assertContains(
+            response,
+            '<span class="readonly-override">Readonly content</span>',
+            html=True,
+        )
+
+    def test_override_entry_without_a_widget_uses_the_default_rendering(self):
+        """An entry with no "widget" key leaves the field's rendering alone."""
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.url)
+        self.assertContains(response, 'alt="True"')
+
+    def test_overrides_do_not_apply_to_callables(self):
+        """
+        A read-only entry that resolves to a ModelAdmin method or a model
+        attribute has no model field, so no override can apply to it.
+        """
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.url)
+        self.assertContains(
+            response, '<div class="readonly">Very awesome.</div>', html=True
+        )
+
+    def test_get_readonly_widget_can_target_a_single_field(self):
+        """
+        Overriding get_readonly_widget() targets one field, while another
+        field of the same class still uses readonly_formfield_overrides.
+        """
+        self.client.force_login(self.superuser)
+        response = self.client.get(
+            reverse("admin7:admin_views_post_change", args=(self.post.pk,))
+        )
+        self.assertContains(
+            response,
+            '<span class="per-field-override">Readonly content</span>',
+            html=True,
+        )
+        self.assertContains(
+            response,
+            '<span class="readonly-override">Overridden content</span>',
+            html=True,
+        )
+
+    def test_override_accepts_a_configured_widget_instance(self):
+        """
+        An entry may hold a widget instance instead of a class, and the
+        instance's own attrs are available to its render(), which receives the
+        field's raw value.
+        """
+        self.client.force_login(self.superuser)
+        response = self.client.get(
+            reverse("admin7:admin_views_post_change", args=(self.post.pk,))
+        )
+        self.assertContains(
+            response,
+            '<span data-mode="read">%s</span>' % self.post.posted.isoformat(),
+            html=True,
+        )
+
+    def test_override_applies_to_readonly_fields(self):
+        """
+        Fields listed in readonly_fields use the configured widget even for
+        users with change permission.
+        """
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.url)
+        self.assertContains(
+            response,
+            '<span class="readonly-override">Overridden content</span>',
+            html=True,
+        )
+        self.assertNotContains(
+            response,
+            '<div class="readonly">Overridden content</div>',
+            html=True,
+        )
+
+    def test_readonly_field_without_override_is_unchanged(self):
+        """A read-only field with no override keeps the default rendering."""
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.url)
+        self.assertContains(
+            response,
+            '<div class="readonly">%s</div>' % formats.localize(self.post.posted),
+            html=True,
+        )
+
+    def test_override_widget_output_is_escaped(self):
+        hostile = Post.objects.create(
+            title="Hostile",
+            content="<script>alert('boom')</script>",
+            readonly_content="rc",
+        )
+        self.client.force_login(self.superuser)
+        response = self.client.get(
+            reverse("namespaced_admin:admin_views_post_change", args=(hostile.pk,))
+        )
+        self.assertContains(
+            response,
+            "&lt;script&gt;alert(&#x27;boom&#x27;)&lt;/script&gt;",
+        )
+        self.assertNotContains(response, "<script>alert('boom')</script>")
+
+    def test_override_has_no_effect_on_editable_fields(self):
+        """
+        An override entry for a field rendered as editable doesn't affect
+        the regular form widget.
+        """
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.url)
+        self.assertContains(response, 'name="title"')
+        self.assertNotContains(
+            response,
+            '<span class="readonly-override">Overridden title</span>',
+            html=True,
+        )
+
+
+@override_settings(ROOT_URLCONF="admin_views.urls")
 class LimitChoicesToInAdminTest(TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -7954,6 +7954,113 @@ class ReadonlyTest(AdminFieldExtractionMixin, TestCase):
 
 
 @override_settings(ROOT_URLCONF="admin_views.urls")
+class ReadonlyFormfieldOverridesTest(TestCase):
+    """
+    ModelAdmin.readonly_formfield_overrides customizes the rendering of
+    read-only field values (#30577).
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.superuser = User.objects.create_superuser(
+            username="super", password="secret", email="super@example.com"
+        )
+        cls.viewuser = User.objects.create_user(
+            username="viewuser", password="secret", is_staff=True
+        )
+        cls.viewuser.user_permissions.add(get_perm(Post, "view_post"))
+        cls.post = Post.objects.create(
+            title="Overridden title",
+            content="Overridden content",
+            readonly_content="Readonly content",
+        )
+        cls.url = reverse(
+            "namespaced_admin:admin_views_post_change", args=(cls.post.pk,)
+        )
+
+    def test_override_applies_to_view_only_user(self):
+        """
+        For a user without change permission, every field renders read-only
+        and overridden fields use the configured widget.
+        """
+        self.client.force_login(self.viewuser)
+        response = self.client.get(self.url)
+        self.assertContains(
+            response,
+            '<span class="readonly-override">Overridden title</span>',
+            html=True,
+        )
+        self.assertContains(
+            response,
+            '<span class="readonly-override">Overridden content</span>',
+            html=True,
+        )
+        self.assertNotContains(
+            response,
+            '<div class="readonly">Overridden content</div>',
+            html=True,
+        )
+
+    def test_override_applies_to_readonly_fields(self):
+        """
+        Fields listed in readonly_fields use the configured widget even for
+        users with change permission.
+        """
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.url)
+        self.assertContains(
+            response,
+            '<span class="readonly-override">Overridden content</span>',
+            html=True,
+        )
+        self.assertNotContains(
+            response,
+            '<div class="readonly">Overridden content</div>',
+            html=True,
+        )
+
+    def test_readonly_field_without_override_is_unchanged(self):
+        """A read-only field with no override keeps the default rendering."""
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.url)
+        self.assertContains(
+            response,
+            '<div class="readonly">%s</div>' % formats.localize(self.post.posted),
+            html=True,
+        )
+
+    def test_override_widget_output_is_escaped(self):
+        hostile = Post.objects.create(
+            title="Hostile",
+            content="<script>alert('boom')</script>",
+            readonly_content="rc",
+        )
+        self.client.force_login(self.superuser)
+        response = self.client.get(
+            reverse("namespaced_admin:admin_views_post_change", args=(hostile.pk,))
+        )
+        self.assertContains(
+            response,
+            "&lt;script&gt;alert(&#x27;boom&#x27;)&lt;/script&gt;",
+        )
+        self.assertNotContains(response, "<script>alert('boom')</script>")
+
+    def test_override_has_no_effect_on_editable_fields(self):
+        """
+        An override entry for a field rendered as editable doesn't affect
+        the regular form widget.
+        """
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.url)
+        self.assertContains(response, 'name="title"')
+        self.assertNotContains(
+            response,
+            '<span class="readonly-override">Overridden title</span>',
+            html=True,
+        )
+
+
+@override_settings(ROOT_URLCONF="admin_views.urls")
 class LimitChoicesToInAdminTest(TestCase):
     @classmethod
     def setUpTestData(cls):


### PR DESCRIPTION
#### Trac ticket number

ticket-30577

#### Branch description

Before, the admin rendered every read-only field as a plain string, with no supported way to change that since d755a98b8438c10f3cff61303ceb1fe16d414e9b
(#35959) removed the undocumented `widget.read_only` hook. 

This adds `ModelAdmin.readonly_formfield_overrides`, mapping a model field class to `{"widget": ...}`, and `ModelAdmin.get_readonly_widget(db_field)` for a single field. The pair mirrors `formfield_overrides` and `formfield_for_foreignkey()`; both resolve through the model admin, because the admin excludes read-only fields from the form.

Thanks ldeluigi for [proposing this API](https://code.djangoproject.com/ticket/30577#comment:9).

Forum discussion: https://forum.djangoproject.com/t/proposal-resolving-the-read-only-widget-dilemma-and-establishing-a-deprecation-path-tickets-30577-35959/44887

Demo with screenshots: https://github.com/rodbv/ticket_30577

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude (Opus 5) was used to consider different solution designs and to write
part of the code and tests. I verified all the code.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
