### PR TITLE
Fixed #37230 -- Handled relation field verbose_name in admin label_for_field.

### DIFF
--- a/django/contrib/admin/utils.py
+++ b/django/contrib/admin/utils.py
@@ -396,7 +396,9 @@ def label_for_field(name, model, model_admin=None, return_attr=False, form=None)
                         message += f" or {form.__class__.__name__}"
                     raise AttributeError(message)
 
-            if hasattr(attr, "short_description"):
+            if hasattr(attr, "verbose_name"):
+                label = attr.verbose_name
+            elif hasattr(attr, "short_description"):
                 label = attr.short_description
             elif (
                 isinstance(attr, property)


### PR DESCRIPTION
## Description
This PR resolves Ticket #37230 by checking `hasattr(attr, 'verbose_name')` in `label_for_field()` in `django/contrib/admin/utils.py`.

## Details
- Fixes `AttributeError` and fallback labeling when a `list_display` lookup path ends in a relation field with a `verbose_name`.