### PR TITLE
Fixed #37233 -- Prevented sort controls for unordered __str__ admin columns.

### DIFF
--- a/django/contrib/admin/views/main.py
+++ b/django/contrib/admin/views/main.py
@@ -357,6 +357,9 @@ class ChangeList:
         except FieldDoesNotExist:
             # See whether field_name is a name of a non-field
             # that allows sorting.
+            if field_name == "__str__":
+                attr = getattr(self.model, "__str__")
+                return getattr(attr, "admin_order_field", None)
             if callable(field_name):
                 attr = field_name
             elif hasattr(self.model_admin, field_name):


### PR DESCRIPTION
## Description
This PR resolves Ticket #37233 by handling `field_name == '__str__'` in `ChangeList.get_ordering_field()` in `django/contrib/admin/views/main.py`.

## Details
- Prevents rendering sort controls for `__str__` admin list display columns when `admin_order_field` is not set on the model's `__str__` method.