### PR TITLE
Fixed #37224 -- Skipped questioner for changes on unmanaged model fields.

### DIFF
--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -1155,6 +1155,9 @@ class MigrationAutodetector:
         # which don't allow empty strings as default.
         time_fields = (models.DateField, models.DateTimeField, models.TimeField)
         auto_fields = (models.AutoField, models.SmallAutoField, models.BigAutoField)
+        is_managed = self.to_state.models[app_label, model_name].options.get(
+            "managed", True
+        )
         preserve_default = (
             field.null
             or field.has_default()
@@ -1163,6 +1166,7 @@ class MigrationAutodetector:
             or (field.blank and field.empty_strings_allowed)
             or (isinstance(field, time_fields) and field.auto_now)
             or (isinstance(field, auto_fields))
+            or not is_managed
         )
         if not preserve_default:
             field = field.clone()
@@ -1174,7 +1178,12 @@ class MigrationAutodetector:
                 field.default = self.questioner.ask_not_null_addition(
                     field_name, model_name
                 )
-        if field.unique and field.has_default() and callable(field.default):
+        if (
+            field.unique
+            and field.has_default()
+            and callable(field.default)
+            and is_managed
+        ):
             self.questioner.ask_unique_callable_default_addition(field_name, model_name)
         self.add_operation(
             app_label,
@@ -1322,6 +1331,9 @@ class MigrationAutodetector:
                 target_changed = (
                     both_m2m and new_field_dec[2]["to"] != old_field_dec[2]["to"]
                 )
+                is_managed = self.to_state.models[app_label, model_name].options.get(
+                    "managed", True
+                )
                 if (both_m2m or neither_m2m) and not target_changed:
                     # Either both fields are m2m or neither is
                     preserve_default = True
@@ -1331,6 +1343,7 @@ class MigrationAutodetector:
                         and not new_field.has_default()
                         and not new_field.has_db_default()
                         and not new_field.many_to_many
+                        and is_managed
                     ):
                         field = new_field.clone()
                         new_default = self.questioner.ask_not_null_alteration(

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -1,6 +1,7 @@
 import copy
 import functools
 import re
+import uuid
 from unittest import mock
 
 from django.apps import apps
@@ -757,12 +758,42 @@ class AutodetectorTests(BaseAutodetectorTests):
         {"managed": False},
         ("testapp.author",),
     )
+    author_unmanaged_uid_unique_default = ModelState(
+        "testapp",
+        "Author",
+        [
+            ("id", models.AutoField(primary_key=True)),
+            ("uid", models.UUIDField(default=uuid.uuid4, unique=True)),
+        ],
+        {"managed": False},
+        ("testapp.author",),
+    )
     author_unmanaged_name_longer = ModelState(
         "testapp",
         "Author",
         [
             ("id", models.AutoField(primary_key=True)),
             ("name", models.CharField(max_length=400)),
+        ],
+        {"managed": False},
+        ("testapp.author",),
+    )
+    author_unmanaged_name_no_default = ModelState(
+        "testapp",
+        "Author",
+        [
+            ("id", models.AutoField(primary_key=True)),
+            ("name", models.CharField(max_length=200)),
+        ],
+        {"managed": False},
+        ("testapp.author",),
+    )
+    author_unmanaged_name_nullable = ModelState(
+        "testapp",
+        "Author",
+        [
+            ("id", models.AutoField(primary_key=True)),
+            ("name", models.CharField(max_length=200, null=True)),
         ],
         {"managed": False},
         ("testapp.author",),
@@ -4132,12 +4163,31 @@ class AutodetectorTests(BaseAutodetectorTests):
         self.assertOperationTypes(changes, "testapp", 0, ["AddField"])
         self.assertOperationAttributes(changes, "testapp", 0, 0, name="name")
 
+    def test_unmanaged_add_field_unique_default(self):
+        changes = self.get_changes(
+            [self.author_unmanaged_empty], [self.author_unmanaged_uid_unique_default]
+        )
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["AddField"])
+        self.assertOperationAttributes(changes, "testapp", 0, 0, name="uid")
+
     def test_unmanaged_alter_field(self):
         """Tests autodetection of altered fields on an unmanaged model."""
         changes = self.get_changes(
             [self.author_unmanaged_name_default], [self.author_unmanaged_name_longer]
         )
         # Right number/type of migrations?
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["AlterField"])
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 0, name="name", preserve_default=True
+        )
+
+    def test_unmanaged_alter_field_no_default(self):
+        changes = self.get_changes(
+            [self.author_unmanaged_name_nullable],
+            [self.author_unmanaged_name_no_default],
+        )
         self.assertNumberMigrations(changes, "testapp", 1)
         self.assertOperationTypes(changes, "testapp", 0, ["AlterField"])
         self.assertOperationAttributes(


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37224

#### Branch description
Short-circuits the migration questioner for unmanaged models when adding NOT NULL fields or altering null to NOT NULL, since unmanaged models don't own their database schema and no DDL is executed for them.

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
<!-- If AI tools were used, provide which tools were used here. -->

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
