### PR TITLE
Bumped minimum setuptools version to 83.

### DIFF
--- a/docs/intro/reusable-apps.txt
+++ b/docs/intro/reusable-apps.txt
@@ -211,7 +211,7 @@ this. For a small app like polls, this process isn't too difficult.
        :caption: ``django-polls/pyproject.toml``
 
        [build-system]
-       requires = ["setuptools>=77.0.3"]
+       requires = ["setuptools>83"]
        build-backend = "setuptools.build_meta"
 
        [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=77.0.3"]
+requires = ["setuptools>=83"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Refs CVE-2026-59890

Django was not affected (no exclude rules with non-ascii characters), but worth upgrading anyway to avoid any doubt.

Verified `python -m build` works on main and stable/5.2.x (Minimum version of python for setuptools 83 is 3.10.)