### PR TITLE
Allowed the full Python test matrix to run on GitHub Actions.

### DIFF
--- a/.github/workflows/python_matrix.yml
+++ b/.github/workflows/python_matrix.yml
@@ -35,6 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: define-matrix
     strategy:
+      fail-fast: false
       matrix:
         python-version: ${{ fromJson(needs.define-matrix.outputs.python_versions_output) }}
     timeout-minutes: 60


### PR DESCRIPTION
#### Branch description
The Python test matrix workflow is ran after a given label is set, and it's important to run the whole matrix to catch possible regressions in older versions. Python 3.14 has been flaky since we introduced it and for security patches we truly need the ability to run all versions despite those failures.

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [X] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
<!-- If AI tools were used, provide which tools were used here. -->

#### Checklist
- [X] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [X] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [X] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
