### PR TITLE
Fixed #37238 -- Fixed unintentional fallback to python default for a db_default.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1094,7 +1094,9 @@ class Model(AltersData, metaclass=ModelBase):
                 if f.name in update_fields or f.attname in update_fields
             ]
 
-        if not self._is_pk_set(meta):
+        if not self._is_pk_set(meta) and not isinstance(
+            getattr(self, meta.pk.attname), DatabaseDefault
+        ):
             pk_val = meta.pk.get_pk_value_on_save(self)
             setattr(self, meta.pk.attname, pk_val)
         pk_set = self._is_pk_set(meta)

--- a/docs/ref/models/instances.txt
+++ b/docs/ref/models/instances.txt
@@ -996,6 +996,12 @@ Other attributes
 
 .. method:: Model._is_pk_set()
 
-The ``_is_pk_set()`` method returns whether the model instance's ``pk`` is set.
-It abstracts the model's primary key definition, ensuring consistent behavior
-regardless of the specific ``pk`` configuration.
+    The ``_is_pk_set()`` method returns whether the model instance's ``pk`` is
+    set. It abstracts the model's primary key definition, ensuring consistent
+    behavior regardless of the specific ``pk`` configuration. A
+    ``DatabaseDefault`` on an unsaved instance is considered unset.
+
+    .. versionchanged:: 6.1
+
+        In earlier versions, ``True`` was returned for ``DatabaseDefault``
+        values.

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -508,6 +508,9 @@ Models
   using :class:`.RawSQL`, might have to be adjusted to also make use of
   quoting.
 
+* :meth:`~django.db.models.Model._is_pk_set` now returns ``False`` for
+  ``DatabaseDefault`` values on unsaved instances.
+
 System checks
 -------------
 

--- a/tests/field_defaults/models.py
+++ b/tests/field_defaults/models.py
@@ -68,3 +68,13 @@ class DBDefaultsFK(models.Model):
     language_code = models.ForeignKey(
         DBDefaultsPK, db_default="fr", on_delete=models.CASCADE
     )
+
+
+class DBDefaultsOneToOnePK(models.Model):
+    language_code = models.OneToOneField(
+        DBDefaultsPK,
+        primary_key=True,
+        default="tr",
+        db_default="kr",
+        on_delete=models.CASCADE,
+    )

--- a/tests/field_defaults/tests.py
+++ b/tests/field_defaults/tests.py
@@ -23,6 +23,7 @@ from .models import (
     DBDefaults,
     DBDefaultsFK,
     DBDefaultsFunction,
+    DBDefaultsOneToOnePK,
     DBDefaultsPK,
 )
 
@@ -136,6 +137,23 @@ class DefaultTests(TestCase):
             parent2 = DBDefaultsPK.objects.get(pk="en")
         child2 = DBDefaultsFK.objects.create(language_code=parent2)
         self.assertEqual(child2.language_code, parent2)
+
+    def test_primary_key_assigned_db_default_expression(self):
+        # Create the target of the foreign key.
+        DBDefaultsPK.objects.create(language_code="kr")
+        # Create an object that happens to match the python default for
+        # DBDefaultsOneToOnePK.language_code.
+        DBDefaultsPK.objects.create(language_code="tr")
+
+        related = DBDefaultsPK()
+        obj = DBDefaultsOneToOnePK(language_code_id=related.pk)
+        related.save()
+        obj.save()
+
+        # The python default is not used.
+        # This should either be "en" or "kr" depending on which model's
+        # DatabaseDefault is used, but this behavior varies across databases.
+        self.assertNotEqual(obj.language_code_id, "tr")
 
     @skipUnlessDBFeature("supports_expression_defaults")
     def test_case_when_db_default_returning(self):


### PR DESCRIPTION
#### Trac ticket number
ticket-37238

#### Branch description
On 6.1, we started considering `DatabaseDefault` to "not count" as having a pk set in `_is_pk_set()`. That took a different branch in `save()` for foreign keys that are also primary keys, e.g. for MTI, where the python default was unexpectedly picked instead of one of the database defaults (which is apparently backend-dependent).

Eventually, I suppose we want to have the commented out assertion passing, but that's another kettle of fish that goes back farther, and that needs to go through triage, see ticket-37239 / #21694.

Regression in a2348c85fc6c20087935c74cd99340dd4ef2dcdc.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.