### PR TITLE
Fixed #37239 -- Cleared stale db_default when pk comes from related object expression.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -28,7 +28,14 @@ from django.db import (
     router,
     transaction,
 )
-from django.db.models import NOT_PROVIDED, ExpressionWrapper, IntegerField, Max, Value
+from django.db.models import (
+    NOT_PROVIDED,
+    Expression,
+    ExpressionWrapper,
+    IntegerField,
+    Max,
+    Value,
+)
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.deletion import CASCADE, DO_NOTHING, Collector, DatabaseOnDelete
 from django.db.models.expressions import DatabaseDefault
@@ -1295,7 +1302,9 @@ class Model(AltersData, metaclass=ModelBase):
                         "%s() prohibited to prevent data loss due to unsaved "
                         "related object '%s'." % (operation_name, field.name)
                     )
-                elif getattr(self, field.attname) in field.empty_values:
+                if (
+                    field_val := getattr(self, field.attname)
+                ) in field.empty_values or isinstance(field_val, Expression):
                     # Set related object if it has been saved after an
                     # assignment.
                     setattr(self, field.name, obj)

--- a/tests/field_defaults/models.py
+++ b/tests/field_defaults/models.py
@@ -13,7 +13,7 @@ from datetime import datetime
 from decimal import Decimal
 
 from django.db import models
-from django.db.models.functions import Coalesce, ExtractYear, Now, Pi
+from django.db.models.functions import UUID4, Coalesce, ExtractYear, Now, Pi
 from django.db.models.lookups import GreaterThan
 
 
@@ -78,3 +78,23 @@ class DBDefaultsOneToOnePK(models.Model):
         db_default="kr",
         on_delete=models.CASCADE,
     )
+
+
+class DBDefaultsFunctionPK(models.Model):
+    uuid = models.UUIDField(primary_key=True, db_default=UUID4())
+
+    class Meta:
+        required_db_features = {
+            "supports_uuid4_function_in_default",
+            "supports_expression_defaults",
+        }
+
+
+class DBDefaultsFunctionFK(models.Model):
+    parent = models.ForeignKey(DBDefaultsFunctionPK, models.CASCADE)
+
+    class Meta:
+        required_db_features = {
+            "supports_uuid4_function_in_default",
+            "supports_expression_defaults",
+        }

--- a/tests/field_defaults/tests.py
+++ b/tests/field_defaults/tests.py
@@ -13,7 +13,7 @@ from django.db.models.expressions import (
     OrderByList,
     RawSQL,
 )
-from django.db.models.functions import Collate
+from django.db.models.functions import UUID4, Collate
 from django.db.models.lookups import GreaterThan
 from django.test import SimpleTestCase, TestCase, skipUnlessDBFeature
 
@@ -23,6 +23,8 @@ from .models import (
     DBDefaults,
     DBDefaultsFK,
     DBDefaultsFunction,
+    DBDefaultsFunctionFK,
+    DBDefaultsFunctionPK,
     DBDefaultsOneToOnePK,
     DBDefaultsPK,
 )
@@ -154,6 +156,18 @@ class DefaultTests(TestCase):
         # This should either be "en" or "kr" depending on which model's
         # DatabaseDefault is used, but this behavior varies across databases.
         self.assertNotEqual(obj.language_code_id, "tr")
+
+    @skipUnlessDBFeature(
+        "can_return_columns_from_insert",
+        "supports_expression_defaults",
+        "supports_uuid4_function_in_default",
+    )
+    def test_foreign_key_to_parent_with_expression_pk(self):
+        parent = DBDefaultsFunctionPK(pk=UUID4())
+        obj = DBDefaultsFunctionFK(parent=parent)
+        parent.save()
+        obj.save()
+        self.assertEqual(obj.parent_id, parent.pk)
 
     @skipUnlessDBFeature("supports_expression_defaults")
     def test_case_when_db_default_returning(self):


### PR DESCRIPTION
#### Trac ticket number
ticket-37239

#### Branch description
Before, a stale `DatabaseDefault` object might have lingered on the related object assigned to a second object, ultimately causing the db_default expression to be evaluated again when the second object is saved, instead of the related object's pk being used.
#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.