### PR TITLE
Fixed PR number lookup in coverage comment workflow.

### DIFF
--- a/.github/workflows/coverage_comment.yml
+++ b/.github/workflows/coverage_comment.yml
@@ -49,16 +49,16 @@ jobs:
               '**Note:** Missing lines are warnings only. Some database-specific lines may not be measured. [More information](https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/unit-tests/#code-coverage-on-pull-requests)'
             );
 
-            const headSha = context.payload.workflow_run.head_sha;
-            const { data: prs } =
-              await github.rest.repos.listPullRequestsAssociatedWithCommit({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                commit_sha: headSha,
-              });
-            const pr = prs.find((p) => p.head.sha === headSha);
+            const run = context.payload.workflow_run;
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              head: `${run.head_repository.owner.login}:${run.head_branch}`,
+            });
+            const pr = prs[0];
             if (!pr) {
-              core.setFailed(`No PR found for commit ${headSha}.`);
+              core.setFailed(`No PR found for commit ${run.head_sha}.`);
               return;
             }
             


### PR DESCRIPTION
We merged an improvement to the coverage comment workflow to reduce the number of artifacts it used, but it didn't handle cross-fork PRs correctly.

There is a bit of shotgun debugging here short of merging all of these changes to forks during testing, but we didn't want to do that with public forks while it was being first iterated on.

Here is a working example run targeting a fork with this change applied:
https://github.com/jacobtylerwalls/django/pull/26

Follow-up to a959c2596f8a1d1ef9f321b8b227a399e86409e2.

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Used Claude to fix Claude's mistakes.