### PR TITLE
Refs #28586 -- Renamed RAISE fetch mode to FETCH_RAISE.

### DIFF
--- a/django/db/models/__init__.py
+++ b/django/db/models/__init__.py
@@ -40,7 +40,7 @@ from django.db.models.expressions import (
     WindowFrame,
     WindowFrameExclusion,
 )
-from django.db.models.fetch_modes import FETCH_ONE, FETCH_PEERS, RAISE
+from django.db.models.fetch_modes import FETCH_ONE, FETCH_PEERS, FETCH_RAISE
 from django.db.models.fields import *  # NOQA
 from django.db.models.fields import __all__ as fields_all
 from django.db.models.fields.composite import CompositePrimaryKey
@@ -115,7 +115,7 @@ __all__ += [
     "OrderWrt",
     "FETCH_ONE",
     "FETCH_PEERS",
-    "RAISE",
+    "FETCH_RAISE",
     "Lookup",
     "Transform",
     "Manager",

--- a/django/db/models/fetch_modes.py
+++ b/django/db/models/fetch_modes.py
@@ -46,7 +46,7 @@ class FetchPeers(FetchMode):
 FETCH_PEERS = FetchPeers()
 
 
-class Raise(FetchMode):
+class FetchRaise(FetchMode):
     __slots__ = ()
 
     def fetch(self, fetcher, instance):
@@ -55,7 +55,7 @@ class Raise(FetchMode):
         raise FieldFetchBlocked(f"Fetching of {klass}.{field_name} blocked.") from None
 
     def __reduce__(self):
-        return "RAISE"
+        return "FETCH_RAISE"
 
 
-RAISE = Raise()
+FETCH_RAISE = FetchRaise()

--- a/docs/ref/exceptions.txt
+++ b/docs/ref/exceptions.txt
@@ -171,7 +171,7 @@ Django core exception classes are defined in ``django.core.exceptions``.
 .. exception:: FieldFetchBlocked
 
     Raised when a field would be fetched on-demand and the
-    :attr:`~django.db.models.RAISE` fetch mode is active.
+    :attr:`~django.db.models.FETCH_RAISE` fetch mode is active.
 
 ``ValidationError``
 -------------------

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -48,7 +48,7 @@ Django provides three fetch modes:
    cases of the "N+1 queries problem" to two queries without any work to
    maintain a list of fields to prefetch.
 
-3. ``RAISE`` raises a :exc:`~django.core.exceptions.FieldFetchBlocked`
+3. ``FETCH_RAISE`` raises a :exc:`~django.core.exceptions.FieldFetchBlocked`
    exception.
 
    This mode can prevent unintentional queries in performance-critical

--- a/docs/topics/db/fetch-modes.txt
+++ b/docs/topics/db/fetch-modes.txt
@@ -104,12 +104,12 @@ much effort.
 The "peer" instances are tracked in a list of weak references, to avoid
 memory leaks where some peer instances are discarded.
 
-.. attribute:: RAISE
+.. attribute:: FETCH_RAISE
 
 Raises a :exc:`~django.core.exceptions.FieldFetchBlocked` exception.
 
-Using ``RAISE`` for the above example would raise an exception at the access of
-``book.author``, like:
+Using ``FETCH_RAISE`` for the above example would raise an exception at the
+access of ``book.author``, like:
 
 .. code-block:: python
 

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -1104,19 +1104,19 @@ class ModelRefreshTests(TestCase):
         a = Article.objects.create(pub_date=datetime.now())
         fa = FeaturedArticle.objects.fetch_mode(models.FETCH_PEERS).create(article=a)
 
-        from_queryset = FeaturedArticle.objects.fetch_mode(models.RAISE).select_related(
-            "article"
-        )
+        from_queryset = FeaturedArticle.objects.fetch_mode(
+            models.FETCH_RAISE
+        ).select_related("article")
         fa.refresh_from_db(from_queryset=from_queryset)
         self.assertEqual(fa._state.fetch_mode, models.FETCH_PEERS)
-        self.assertEqual(fa.article._state.fetch_mode, models.RAISE)
+        self.assertEqual(fa.article._state.fetch_mode, models.FETCH_RAISE)
 
     def test_refresh_ignores_fetch_mode_if_no_instance_plucked(self):
         a = Article.objects.create(pub_date=datetime.now())
         fa = FeaturedArticle.objects.fetch_mode(models.FETCH_PEERS).create(article=a)
 
         # This queryset's fetch mode is not used because no fields are plucked.
-        from_queryset = FeaturedArticle.objects.fetch_mode(models.RAISE)
+        from_queryset = FeaturedArticle.objects.fetch_mode(models.FETCH_RAISE)
         fa.refresh_from_db(from_queryset=from_queryset)
         self.assertEqual(fa._state.fetch_mode, models.FETCH_PEERS)
         self.assertEqual(fa.article._state.fetch_mode, models.FETCH_PEERS)

--- a/tests/defer/tests.py
+++ b/tests/defer/tests.py
@@ -1,5 +1,5 @@
 from django.core.exceptions import FieldDoesNotExist, FieldError, FieldFetchBlocked
-from django.db.models import FETCH_PEERS, RAISE
+from django.db.models import FETCH_PEERS, FETCH_RAISE
 from django.test import SimpleTestCase, TestCase
 from django.test.utils import ignore_warnings
 from django.utils.deprecation import RemovedInDjango70Warning
@@ -241,7 +241,7 @@ class DeferTests(AssertionMixin, TestCase):
             self.assertEqual(p2.related, self.s1)
 
     def test_only_fetch_mode_raise(self):
-        p1 = Primary.objects.fetch_mode(RAISE).only("name").get(name="p1")
+        p1 = Primary.objects.fetch_mode(FETCH_RAISE).only("name").get(name="p1")
         msg = "Fetching of Primary.value blocked."
         with self.assertRaisesMessage(FieldFetchBlocked, msg) as cm:
             p1.value
@@ -249,7 +249,7 @@ class DeferTests(AssertionMixin, TestCase):
         self.assertTrue(cm.exception.__suppress_context__)
 
     def test_defer_fetch_mode_raise(self):
-        p1 = Primary.objects.fetch_mode(RAISE).defer("value").get(name="p1")
+        p1 = Primary.objects.fetch_mode(FETCH_RAISE).defer("value").get(name="p1")
         msg = "Fetching of Primary.value blocked."
         with self.assertRaisesMessage(FieldFetchBlocked, msg) as cm:
             p1.value

--- a/tests/generic_relations/tests.py
+++ b/tests/generic_relations/tests.py
@@ -2,7 +2,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes.prefetch import GenericPrefetch
 from django.core.exceptions import FieldError, FieldFetchBlocked
 from django.db.models import Q, prefetch_related_objects
-from django.db.models.fetch_modes import FETCH_PEERS, RAISE
+from django.db.models.fetch_modes import FETCH_PEERS, FETCH_RAISE
 from django.test import SimpleTestCase, TestCase, skipUnlessDBFeature
 
 from .models import (
@@ -813,7 +813,7 @@ class GenericRelationsTests(TestCase):
             self.assertEqual(quartz_tag.content_object, self.quartz)
 
     def test_fetch_mode_raise(self):
-        tag = TaggedItem.objects.fetch_mode(RAISE).get(tag="yellow")
+        tag = TaggedItem.objects.fetch_mode(FETCH_RAISE).get(tag="yellow")
         msg = "Fetching of TaggedItem.content_object blocked."
         with self.assertRaisesMessage(FieldFetchBlocked, msg) as cm:
             tag.content_object

--- a/tests/many_to_one/tests.py
+++ b/tests/many_to_one/tests.py
@@ -7,7 +7,7 @@ from django.core.exceptions import (
     MultipleObjectsReturned,
 )
 from django.db import IntegrityError, models, transaction
-from django.db.models import FETCH_PEERS, RAISE
+from django.db.models import FETCH_PEERS, FETCH_RAISE
 from django.test import TestCase
 from django.utils.translation import gettext_lazy
 
@@ -947,7 +947,7 @@ class ManyToOneTests(TestCase):
             a2.reporter
 
     def test_fetch_mode_raise_forward(self):
-        a = Article.objects.fetch_mode(RAISE).get(pk=self.a.pk)
+        a = Article.objects.fetch_mode(FETCH_RAISE).get(pk=self.a.pk)
         msg = "Fetching of Article.reporter blocked."
         with self.assertRaisesMessage(FieldFetchBlocked, msg) as cm:
             a.reporter

--- a/tests/one_to_one/tests.py
+++ b/tests/one_to_one/tests.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import FieldFetchBlocked
 from django.db import IntegrityError, connection, transaction
-from django.db.models import FETCH_PEERS, RAISE
+from django.db.models import FETCH_PEERS, FETCH_RAISE
 from django.test import TestCase
 
 from .models import (
@@ -643,7 +643,7 @@ class OneToOneTests(TestCase):
             p2.restaurant
 
     def test_fetch_mode_raise_forward(self):
-        r = Restaurant.objects.fetch_mode(RAISE).get(pk=self.r1.pk)
+        r = Restaurant.objects.fetch_mode(FETCH_RAISE).get(pk=self.r1.pk)
         msg = "Fetching of Restaurant.place blocked."
         with self.assertRaisesMessage(FieldFetchBlocked, msg) as cm:
             r.place
@@ -651,7 +651,7 @@ class OneToOneTests(TestCase):
         self.assertTrue(cm.exception.__suppress_context__)
 
     def test_fetch_mode_raise_reverse(self):
-        p = Place.objects.fetch_mode(RAISE).get(pk=self.p1.pk)
+        p = Place.objects.fetch_mode(FETCH_RAISE).get(pk=self.p1.pk)
         msg = "Fetching of Place.restaurant blocked."
         with self.assertRaisesMessage(FieldFetchBlocked, msg) as cm:
             p.restaurant

--- a/tests/prefetch_related/tests.py
+++ b/tests/prefetch_related/tests.py
@@ -10,7 +10,7 @@ from django.db.models import (
     QuerySet,
     prefetch_related_objects,
 )
-from django.db.models.fetch_modes import RAISE
+from django.db.models.fetch_modes import FETCH_RAISE
 from django.db.models.query import get_prefetcher
 from django.db.models.sql import Query
 from django.test import (
@@ -137,7 +137,9 @@ class PrefetchRelatedTests(TestDataMixin, TestCase):
         )
 
     def test_fetch_mode_raise(self):
-        authors = list(Author.objects.fetch_mode(RAISE).prefetch_related("first_book"))
+        authors = list(
+            Author.objects.fetch_mode(FETCH_RAISE).prefetch_related("first_book")
+        )
         authors[0].first_book  # No exception, already loaded
 
     def test_foreignkey_reverse(self):

--- a/tests/queryset_pickle/tests.py
+++ b/tests/queryset_pickle/tests.py
@@ -372,11 +372,11 @@ class PickleabilityTestCase(TestCase):
         self.assertEqual(restored[0]._state.peers, ())
 
     def test_fetch_mode_raise(self):
-        objs = list(Happening.objects.fetch_mode(models.RAISE))
-        self.assertEqual(objs[0]._state.fetch_mode, models.RAISE)
+        objs = list(Happening.objects.fetch_mode(models.FETCH_RAISE))
+        self.assertEqual(objs[0]._state.fetch_mode, models.FETCH_RAISE)
 
         restored = pickle.loads(pickle.dumps(objs))
-        self.assertIs(restored[0]._state.fetch_mode, models.RAISE)
+        self.assertIs(restored[0]._state.fetch_mode, models.FETCH_RAISE)
 
 
 class InLookupTests(TestCase):

--- a/tests/raw_query/tests.py
+++ b/tests/raw_query/tests.py
@@ -2,7 +2,7 @@ from datetime import date
 from decimal import Decimal
 
 from django.core.exceptions import FieldDoesNotExist, FieldFetchBlocked
-from django.db.models import FETCH_PEERS, RAISE
+from django.db.models import FETCH_PEERS, FETCH_RAISE
 from django.db.models.query import RawQuerySet
 from django.test import TestCase, skipUnlessDBFeature
 
@@ -168,7 +168,7 @@ class RawQueryTests(TestCase):
 
     def test_fk_fetch_mode_raise(self):
         query = "SELECT * FROM raw_query_book"
-        books = list(Book.objects.fetch_mode(RAISE).raw(query))
+        books = list(Book.objects.fetch_mode(FETCH_RAISE).raw(query))
         msg = "Fetching of Book.author blocked."
         with self.assertRaisesMessage(FieldFetchBlocked, msg) as cm:
             books[0].author
@@ -320,7 +320,7 @@ class RawQueryTests(TestCase):
 
     def test_missing_fields_fetch_mode_raise(self):
         query = "SELECT id, first_name, dob FROM raw_query_author"
-        authors = list(Author.objects.fetch_mode(RAISE).raw(query))
+        authors = list(Author.objects.fetch_mode(FETCH_RAISE).raw(query))
         msg = "Fetching of Author.last_name blocked."
         with self.assertRaisesMessage(FieldFetchBlocked, msg) as cm:
             authors[0].last_name


### PR DESCRIPTION
@charettes had the idea to prevent confusion particularly in the `django.db.models` namespace by grouping all three fetch modes under `FETCH_*`:

From https://github.com/django/django/pull/21660#discussion_r3670763484:
> On a related note this made me realize that we should potentially rename `RAISE` to `FETCH_RAISE` given it's exposed on the global `django.db.models` namespace given it could have many different interpretation (e.g. attempted to be used for `on_delete`).

Thoughts?