### PR TITLE
Fixed #37235 -- Added compatibility for sqlparse 0.5.5.

### DIFF
--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -5,6 +5,7 @@ from importlib import import_module
 from itertools import chain
 
 import sqlparse
+from sqlparse.exceptions import SQLParseError
 
 from django.conf import settings
 from django.db import NotSupportedError, models, transaction
@@ -873,7 +874,11 @@ class BaseDatabaseOperations:
 
     def format_debug_sql(self, sql):
         # Hook for backends (e.g. NoSQL) to customize formatting.
-        return sqlparse.format(sql, reindent=True, keyword_case="upper")
+        try:
+            return sqlparse.format(sql, reindent=True, keyword_case="upper")
+        except SQLParseError:
+            # Fallback to unformatted sql.
+            return sql
 
     def format_json_path_numeric_index(self, num):
         """

--- a/docs/releases/6.0.8.txt
+++ b/docs/releases/6.0.8.txt
@@ -15,3 +15,5 @@ Bugfixes
   :meth:`~django.db.models.query.QuerySet.bulk_create` to crash on databases
   that support returning rows from bulk inserts when a related object providing
   the primary key was saved after assignment (:ticket:`37234`).
+
+* Added compatibility for ``sqlparse`` 0.5.5 (:ticket:`37235`).


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37235

#### Branch description
<!-- Provide a concise overview of the issue or rationale behind the proposed changes. Minimum five words. -->

I have tested using the existing test described in the ticket. I do not think this requires a specific test but I am happy to be overturned here

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
<!-- If AI tools were used, provide which tools were used here. -->

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
