### PR TITLE
Fixed #37240 -- Fixed simplify_regex() with multiple unnamed groups.

### DIFF
--- a/django/urls/utils.py
+++ b/django/urls/utils.py
@@ -136,12 +136,11 @@ def replace_unnamed_groups(pattern):
     2. ^(?P<a>\w+)/b/((x|y)\w+)$ ==> ^(?P<a>\w+)/b/<var>$
     3. ^(?P<a>\w+)/b/(\w+) ==> ^(?P<a>\w+)/b/<var>
     4. ^(?P<a>\w+)/b/((x|y)\w+) ==> ^(?P<a>\w+)/b/<var>
+    5. ^(\w+)/b/(\w+)$ ==> ^<var>/b/<var>$
     """
     final_pattern, prev_end = "", None
     for start, end, _ignored in _find_groups(pattern, _UNNAMED_GROUP_MATCHER):
-        if prev_end:
-            final_pattern += pattern[prev_end:start]
-        final_pattern += pattern[:start] + "<var>"
+        final_pattern += pattern[prev_end:start] + "<var>"
         prev_end = end
     return final_pattern + pattern[prev_end:]
 

--- a/tests/urlpatterns/tests.py
+++ b/tests/urlpatterns/tests.py
@@ -454,6 +454,13 @@ class SimplifyRegexTests(SimpleTestCase):
             (r"^(?P<a>(x|y))/b/(?P<c>\w+)", "/<a>/b/<c>"),
             (r"^(?P<a>(x|y))/b/(?P<c>\w+)ab", "/<a>/b/<c>ab"),
             (r"^(?P<a>(x|y)(\(|\)))/b/(?P<c>\w+)ab", "/<a>/b/<c>ab"),
+            # Multiple unnamed groups.
+            (r"^(\w+)/b/(\w+)$", "/<var>/b/<var>"),
+            (r"^(\w+)/b/(\w+)", "/<var>/b/<var>"),
+            (r"^a/(\w+)/b/(\d+)/c/(\w+)$", "/a/<var>/b/<var>/c/<var>"),
+            (r"^(?P<a>\w+)/b/(\w+)/(\d+)$", "/<a>/b/<var>/<var>"),
+            (r"^b/((x|y)\w+)/((z|w)\d+)$", "/b/<var>/<var>"),
+            (r"^(\w+)/\((\d+)\)$", r"/<var>/(<var>)"),
             # Non-capturing groups.
             (r"^a(?:\w+)b", "/ab"),
             (r"^a(?:(x|y))", "/a"),


### PR DESCRIPTION
#### Trac ticket number

ticket-37240

#### Branch description

`simplify_regex()` re-emits the whole pattern prefix once per capture group, so any `re_path()` containing two or more unnamed capture groups was rendered with a duplicated, malformed path.

```python
>>> simplify_regex(r'^articles/(\w+)/comments/(\d+)/$')
'/articles/<var>/comments/articles/(\w)/comments/<var>/'   # expected '/articles/<var>/comments/<var>/'
```

The corruption compounds with each additional group — three unnamed groups produce `/a/<var>/b/a/(\w)/b/<var>/c/a/(\w)/b/(\d)/c/<var>`.

Both callers are affected: the admindocs "Views" page (`ViewIndexView.get_context_data()` passes `simplify_regex(regex)` straight into the `url` context value) and the `listurls` management command added in 6.2.

**Cause.** In `replace_unnamed_groups()`, the first iteration correctly emits `pattern[:start]` because `prev_end` is `None`. Every later iteration appends the text between the previous group and this one (correct) and *then* appends `pattern[:start]` again, duplicating the entire prefix from index 0:

```python
if prev_end:
    final_pattern += pattern[prev_end:start]
final_pattern += pattern[:start] + "<var>"     # re-emits the prefix
```

The sibling `remove_non_capturing_groups()` in the same module already has the correct shape, relying on `pattern[None:start] == pattern[:start]` for the first iteration. This change collapses the three lines into the same idiom:

```python
final_pattern += pattern[prev_end:start] + "<var>"
```

**Why it went unnoticed.** `SimplifyRegexTests.test_simplify_regex` has over 100 cases, but every one of them contains at most one unnamed group, so the second-iteration path was never executed. This patch adds six cases covering two and three unnamed groups, unnamed groups mixed with named ones, nested alternations, and escaped parentheses. All six fail before the fix.

**Long-standing, not a regression.** Verified by running the reproduction against released wheels:

| Version | Output for `^articles/(\w+)/comments/(\d+)/$` |
| --- | --- |
| 2.2.28 | `^articles/<var>/comments/^articles/(\w+)/comments/<var>/$` |
| 4.2.16 | `/articles/<var>/comments/articles/(\w)/comments/<var>/` |
| 5.2.9 | `/articles/<var>/comments/articles/(\w)/comments/<var>/` |
| 6.0.7 | `/articles/<var>/comments/articles/(\w)/comments/<var>/` |
| main | `/articles/<var>/comments/articles/(\w)/comments/<var>/` |

The 2.2 result confirms the defect predates both the move of these helpers to `django/urls/utils.py` in 6.2 and the changes made for #30731.

Per the [backport policy](https://docs.djangoproject.com/en/dev/internals/release-process/#supported-versions) this is main-only — a long-standing bug, not a regression, crashing bug, or data-loss issue — so no release note is included. Thanks to @sarahboyce for pointing that out on the ticket.

This supersedes #21698, which was auto-closed before review and could not be reopened after the commit was amended.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude Code (Claude Opus 5) was used to locate the bug, write the fix and the regression tests, and run the verification against released versions. I have reviewed and verified all of it myself.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.

- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
