### PR TITLE
Fixed #37236 -- Allowed altering spatial indexes on RasterField.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -688,6 +688,7 @@ answer newbie questions, and generally made Django that much better:
     Marc-Aurèle Brothier <ma.brothier@gmail.com>
     Margaret Fero <maggiefero@gmail.com>
     Marian Andre <django@andre.sk>
+    Mariano Baragiola <mbaragiola@linux.com>
     Marijke Luttekes <mail@marijkeluttekes.dev>
     Marijn Vriens <marijn@metronomo.cl>
     Mario Gonzalez <gonzalemario@gmail.com>

--- a/django/contrib/gis/db/backends/postgis/schema.py
+++ b/django/contrib/gis/db/backends/postgis/schema.py
@@ -1,4 +1,4 @@
-from django.contrib.gis.db.models import GeometryField
+from django.contrib.gis.db.models.fields import BaseSpatialField
 from django.db.backends.postgresql.schema import DatabaseSchemaEditor
 from django.db.models.expressions import Col, Func
 
@@ -82,10 +82,10 @@ class PostGISSchemaEditor(DatabaseSchemaEditor):
         )
 
         old_field_spatial_index = (
-            isinstance(old_field, GeometryField) and old_field.spatial_index
+            isinstance(old_field, BaseSpatialField) and old_field.spatial_index
         )
         new_field_spatial_index = (
-            isinstance(new_field, GeometryField) and new_field.spatial_index
+            isinstance(new_field, BaseSpatialField) and new_field.spatial_index
         )
         if not old_field_spatial_index and new_field_spatial_index:
             self.execute(self._create_spatial_index_sql(model, new_field))

--- a/tests/gis_tests/gis_migrations/test_operations.py
+++ b/tests/gis_tests/gis_migrations/test_operations.py
@@ -292,6 +292,45 @@ class OperationTests(OperationTestCase):
         )
         self.assertSpatialIndexNotExists("gis_neighborhood", "geom")
 
+    @skipUnlessDBFeature("can_alter_geometry_field", "supports_raster")
+    def test_alter_raster_field_add_spatial_index(self):
+        if not self.has_spatial_indexes:
+            self.skipTest("No support for Spatial indexes")
+
+        self.alter_gis_model(
+            migrations.AddField,
+            "Neighborhood",
+            "heatmap",
+            fields.RasterField,
+            field_class_kwargs={"spatial_index": False},
+        )
+        self.assertSpatialIndexNotExists("gis_neighborhood", "heatmap", raster=True)
+
+        self.alter_gis_model(
+            migrations.AlterField,
+            "Neighborhood",
+            "heatmap",
+            fields.RasterField,
+            field_class_kwargs={"spatial_index": True},
+        )
+        self.assertSpatialIndexExists("gis_neighborhood", "heatmap", raster=True)
+
+    @skipUnlessDBFeature("can_alter_geometry_field", "supports_raster")
+    def test_alter_raster_field_remove_spatial_index(self):
+        if not self.has_spatial_indexes:
+            self.skipTest("No support for Spatial indexes")
+
+        self.assertSpatialIndexExists("gis_neighborhood", "rast", raster=True)
+
+        self.alter_gis_model(
+            migrations.AlterField,
+            "Neighborhood",
+            "rast",
+            fields.RasterField,
+            field_class_kwargs={"spatial_index": False},
+        )
+        self.assertSpatialIndexNotExists("gis_neighborhood", "rast", raster=True)
+
     @skipUnlessDBFeature("can_alter_geometry_field")
     @skipUnless(connection.vendor == "mysql", "MySQL specific test")
     def test_alter_field_nullable_with_spatial_index(self):


### PR DESCRIPTION
#### Trac ticket number

ticket-37236

#### Branch description

PostGIS `_alter_field` only treated `GeometryField` when toggling `spatial_index`, so `RasterField` indexes were never added or removed on alter. Use `BaseSpatialField` so both geometry and raster fields are handled. Raster index SQL already uses `ST_ConvexHull`.

#### AI Assistance Disclosure (REQUIRED)

- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

AI tools: Codex `gpt-5.6-sol` assisted implementation and an independent read-only review. All code and tests were reviewed and verified manually before submission.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.

- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.

#### Tests

Local PostGIS (Docker `postgis/postgis:16-3.4` on `127.0.0.1:55437`, host GDAL 3.12.4 / GEOS 3.14.1):

```text
python -Wall runtests.py --settings=test_postgis_local -v2 \
  gis_tests.gis_migrations.test_operations.OperationTests.test_alter_raster_field_add_spatial_index \
  gis_tests.gis_migrations.test_operations.OperationTests.test_alter_raster_field_remove_spatial_index \
  gis_tests.gis_migrations.test_operations.OperationTests.test_alter_field_add_spatial_index \
  gis_tests.gis_migrations.test_operations.OperationTests.test_alter_field_remove_spatial_index \
  gis_tests.gis_migrations.test_operations.OperationTests.test_create_model_spatial_index \
  gis_tests.gis_migrations.test_operations.OperationTests.test_add_raster_field \
  gis_tests.gis_migrations.test_operations.OperationTests.test_remove_raster_field
# Ran 7 tests — OK

python -Wall runtests.py --settings=test_postgis_local -v1 gis_tests.gis_migrations
# Ran 21 tests — OK (skipped=4)
```

Also: black check on touched files; independent read-only review ACCEPT before open.
