### PR TITLE
Fixed #36770 -- Fixed incomplete mocking in SQLiteInMemoryTestDbs.

### DIFF
--- a/tests/servers/tests.py
+++ b/tests/servers/tests.py
@@ -106,7 +106,6 @@ class LiveServerTestCloseConnectionTest(LiveServerBase):
         self.assertIsNone(conn.connection)
 
 
-@unittest.skip("Flaky test as described in https://code.djangoproject.com/ticket/36770")
 @unittest.skipUnless(connection.vendor == "sqlite", "SQLite specific test.")
 class LiveServerInMemoryDatabaseLockTest(LiveServerBase):
     def test_in_memory_database_lock(self):

--- a/tests/test_runner/tests.py
+++ b/tests/test_runner/tests.py
@@ -799,7 +799,12 @@ class SQLiteInMemoryTestDbs(TransactionTestCase):
                     },
                 }
             )
-            with mock.patch("django.test.utils.connections", new=tested_connections):
+            with (
+                mock.patch("django.test.utils.connections", new=tested_connections),
+                mock.patch.dict(
+                    settings.DATABASES, tested_connections.settings, clear=True
+                ),
+            ):
                 other = tested_connections["other"]
                 try:
                     new_test_connections = DiscoverRunner(verbosity=0).setup_databases()


### PR DESCRIPTION
#### Trac ticket number
ticket-36770

#### Branch description
This fixes the flakes we've been living with since adding 3.14 to CI last year.

`SQLiteInMemoryTestDbs` mocks a connections object in `django.test.utils`. Without also mocking the global settings, there was pollution of the test database name, since `create_test_db()` writes to it like so:

https://github.com/django/django/blob/ea303dee45f4b703b31f73ceb235f11742d3c518/django/db/backends/base/creation.py#L78

This caused other tests that explicitly reopen database connections to fail under parallel test execution (in forkserver mode) because at the moment of reopening, the db name was `memorydb_default` rather than the suffixed version `memorydb_default_2`:
```
  backends.sqlite.tests.ThreadSharing.test_database_sharing_in_threads
  servers.tests.LiveServerInMemoryDatabaseLockTest.test_in_memory_database_lock
```

We didn't see this before 3.14 on CI, because we only have suffixed test db names since d55979334dcefdb11626220000bec97ade09df07 added `forkserver` support, and POSIX systems defaulted to it on 3.14.

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
Codex helped me more quickly stub out instrumentation. Here is the final piece that confirmed it:

```py
AssertionError: Subsuite 1405 (<unittest.suite.TestSuite tests=[<test_runner.tests.SQLiteInMemoryTestDbs testMethod=test_transaction_support>]>) changed database names from {'default': 'file:memorydb_default_2?mode=memory&cache=shared', 'other': 'file:memorydb_other_2?mode=memory&cache=shared'} to {'default': 'file:memorydb_default?mode=memory&cache=shared', 'other': 'file:memorydb_other?mode=memory&cache=shared'}.
```

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
