### PR TITLE
Fixed #37242 -- Fixed reading null time fields in LayerMapping.

### DIFF
--- a/django/contrib/gis/gdal/field.py
+++ b/django/contrib/gis/gdal/field.py
@@ -217,7 +217,7 @@ class OFTTime(Field):
             seconds = int(ss.value)
             milliseconds = int(round((ss.value - seconds) * 1000))
             return time(hh.value, mn.value, seconds, milliseconds * 1000)
-        except (ValueError, GDALException):
+        except (TypeError, ValueError, GDALException):
             return None
 
 

--- a/tests/gis_tests/data/has_nulls/has_nulls.geojson
+++ b/tests/gis_tests/data/has_nulls/has_nulls.geojson
@@ -59,7 +59,6 @@
       "type": "Feature",
       "properties": {
         "uuid": "fa2ba67c-a135-4338-b924-a9622b5d869f",
-        "time": "00:00:00",
         "integer": null,
         "num": null
       },

--- a/tests/gis_tests/gdal_tests/test_ds.py
+++ b/tests/gis_tests/gdal_tests/test_ds.py
@@ -110,7 +110,7 @@ ds_list = (
                 None,
                 datetime.strptime("2018-11-29T03:02:52", datetime_format),
             ],
-            "time": [time(11, 32, 14, 123000), time(0), time(3, 2, 52)],
+            "time": [time(11, 32, 14, 123000), None, time(3, 2, 52)],
         },
         fids=range(3),
     ),


### PR DESCRIPTION

#### Trac ticket number
ticket-37242

#### Branch description
Follow-up to 75d627888bf42f8de6064a0bd665c98c0df66c55.

Bring this implementation into alignment with the `value` properties on `OFTDate` and `OFTDateTime`.

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
I got the problem diagnosis while using Codex to debug why my proposed test didn't work (that test is now in this PR).

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.