### PR TITLE
Fixed #37237 -- Improved RelatedIn lookup preparation performance.

### DIFF
--- a/django/db/models/fields/related_lookups.py
+++ b/django/db/models/fields/related_lookups.py
@@ -66,6 +66,7 @@ class RelatedIn(In):
                         -1
                     ]
                     self.rhs = [target_field.get_prep_value(v) for v in self.rhs]
+                    self.prepare_rhs = False
             elif not getattr(self.rhs, "has_select_fields", True) and not getattr(
                 self.lhs.field.target_field, "primary_key", False
             ):

--- a/django/db/models/fields/related_lookups.py
+++ b/django/db/models/fields/related_lookups.py
@@ -52,17 +52,8 @@ class RelatedIn(In):
                 self.rhs.set_values([f.name for f in self.lhs.sources])
         else:
             if self.rhs_is_direct_value():
-                from django.db.models import Model
-
                 # If we get here, we are dealing with single-column relations.
-                self.rhs = [
-                    (
-                        get_normalized_value(val, self.lhs)[0]
-                        if isinstance(val, (Model, tuple))
-                        else val
-                    )
-                    for val in self.rhs
-                ]
+                self.rhs = [get_normalized_value(val, self.lhs)[0] for val in self.rhs]
                 # We need to run the related field's get_prep_value(). Consider
                 # case ForeignKey to IntegerField given value 'abc'. The
                 # ForeignKey itself doesn't have validation for non-integers,

--- a/django/db/models/fields/related_lookups.py
+++ b/django/db/models/fields/related_lookups.py
@@ -52,8 +52,17 @@ class RelatedIn(In):
                 self.rhs.set_values([f.name for f in self.lhs.sources])
         else:
             if self.rhs_is_direct_value():
+                from django.db.models import Model
+
                 # If we get here, we are dealing with single-column relations.
-                self.rhs = [get_normalized_value(val, self.lhs)[0] for val in self.rhs]
+                self.rhs = [
+                    (
+                        get_normalized_value(val, self.lhs)[0]
+                        if isinstance(val, (Model, tuple))
+                        else val
+                    )
+                    for val in self.rhs
+                ]
                 # We need to run the related field's get_prep_value(). Consider
                 # case ForeignKey to IntegerField given value 'abc'. The
                 # ForeignKey itself doesn't have validation for non-integers,
@@ -66,6 +75,7 @@ class RelatedIn(In):
                         -1
                     ]
                     self.rhs = [target_field.get_prep_value(v) for v in self.rhs]
+                    self.prepare_rhs = False
             elif not getattr(self.rhs, "has_select_fields", True) and not getattr(
                 self.lhs.field.target_field, "primary_key", False
             ):

--- a/tests/many_to_many/tests.py
+++ b/tests/many_to_many/tests.py
@@ -2,7 +2,6 @@ from unittest import mock
 
 from django.db import connection, transaction
 from django.db.models import FETCH_PEERS
-from django.db.models.fields.related_lookups import get_normalized_value
 from django.test import TestCase, skipIfDBFeature, skipUnlessDBFeature
 
 from .models import (
@@ -91,27 +90,6 @@ class ManyToManyTests(TestCase):
         self.assertSequenceEqual(a5.publications.all(), [self.p2])
         a5.publications.remove(self.p2.pk)
         self.assertSequenceEqual(a5.publications.all(), [])
-
-    def test_related_in_prep_lookup_literal_values(self):
-        through = Article.publications.through
-        target_field = through._meta.get_field("publication").target_field
-        values = [self.p1.pk, self.p2.pk]
-        with (
-            mock.patch.object(
-                target_field, "get_prep_value", wraps=target_field.get_prep_value
-            ) as get_prep_value,
-            mock.patch(
-                "django.db.models.fields.related_lookups.get_normalized_value",
-                wraps=get_normalized_value,
-            ) as normalize,
-        ):
-            queryset = through.objects.filter(publication__in=values)
-        self.assertEqual(get_prep_value.call_count, len(values))
-        normalize.assert_not_called()
-        self.assertCountEqual(
-            queryset.values_list("publication_id", flat=True),
-            [self.p1.pk, self.p1.pk, self.p2.pk, self.p2.pk, self.p2.pk],
-        )
 
     def test_add_remove_set_by_to_field(self):
         user_1 = User.objects.create(username="Jean")

--- a/tests/many_to_many/tests.py
+++ b/tests/many_to_many/tests.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 from django.db import connection, transaction
 from django.db.models import FETCH_PEERS
+from django.db.models.fields.related_lookups import get_normalized_value
 from django.test import TestCase, skipIfDBFeature, skipUnlessDBFeature
 
 from .models import (
@@ -90,6 +91,27 @@ class ManyToManyTests(TestCase):
         self.assertSequenceEqual(a5.publications.all(), [self.p2])
         a5.publications.remove(self.p2.pk)
         self.assertSequenceEqual(a5.publications.all(), [])
+
+    def test_related_in_prep_lookup_literal_values(self):
+        through = Article.publications.through
+        target_field = through._meta.get_field("publication").target_field
+        values = [self.p1.pk, self.p2.pk]
+        with (
+            mock.patch.object(
+                target_field, "get_prep_value", wraps=target_field.get_prep_value
+            ) as get_prep_value,
+            mock.patch(
+                "django.db.models.fields.related_lookups.get_normalized_value",
+                wraps=get_normalized_value,
+            ) as normalize,
+        ):
+            queryset = through.objects.filter(publication__in=values)
+        self.assertEqual(get_prep_value.call_count, len(values))
+        normalize.assert_not_called()
+        self.assertCountEqual(
+            queryset.values_list("publication_id", flat=True),
+            [self.p1.pk, self.p1.pk, self.p2.pk, self.p2.pk, self.p2.pk],
+        )
 
     def test_add_remove_set_by_to_field(self):
         user_1 = User.objects.create(username="Jean")


### PR DESCRIPTION
#### Trac ticket number

ticket-37237

#### Branch description

`RelatedIn` currently prepares direct values with the related target field. This patch prevents the base `In` lookup from preparing those already-prepared values a second time. Model and tuple normalization behavior remains unchanged. A separate `django-asv` benchmark was added for this performance case.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

AI tools used: Hermes Agent and Codex (gpt-5.6-sol) for code analysis, test review, and independent review. The final diff and test results were verified locally.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.

- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.

#### Tests

```
.venv/bin/python tests/runtests.py many_to_many foreign_object composite_pk.test_filter lookup --parallel 1 --verbosity 1
```

Result: 335 tests passed, 5 skipped.
