### PR TITLE
Fixed #23326 -- Made DatabaseCache.incr() atomic.

### DIFF
--- a/django/core/cache/backends/db.py
+++ b/django/core/cache/backends/db.py
@@ -116,6 +116,68 @@ class DatabaseCache(BaseDatabaseCache):
         key = self.make_and_validate_key(key, version=version)
         return self._base_set("touch", key, None, timeout)
 
+    def incr(self, key, delta=1, version=None):
+        cache_key = self.make_and_validate_key(key, version=version)
+        db = router.db_for_write(self.cache_model_class)
+        connection = connections[db]
+        quote_name = connection.ops.quote_name
+        table = quote_name(self._table)
+        value_column = quote_name("value")
+        expires_column = quote_name("expires")
+        cache_key_column = quote_name("cache_key")
+        key_found = False
+
+        with transaction.atomic(using=db), connection.cursor() as cursor:
+            select = "SELECT %s, %s FROM %s WHERE %s = %%s" % (
+                value_column,
+                expires_column,
+                table,
+                cache_key_column,
+            )
+            if connection.features.has_select_for_update:
+                select = "%s %s" % (select, connection.ops.for_update_sql())
+            else:
+                # Acquire a write lock before reading on databases without
+                # SELECT ... FOR UPDATE support, such as SQLite.
+                cursor.execute(
+                    "UPDATE %s SET %s = %s WHERE %s = %%s"
+                    % (table, value_column, value_column, cache_key_column),
+                    [cache_key],
+                )
+            cursor.execute(select, [cache_key])
+            result = cursor.fetchone()
+            if result:
+                value, expires = result
+                expression = models.Expression(output_field=models.DateTimeField())
+                for converter in connection.ops.get_db_converters(
+                    expression
+                ) + expression.get_db_converters(connection):
+                    expires = converter(expires, expression, connection)
+                if expires < tz_now():
+                    cursor.execute(
+                        "DELETE FROM %s WHERE %s = %%s" % (table, cache_key_column),
+                        [cache_key],
+                    )
+                else:
+                    value = connection.ops.process_clob(value)
+                    value = pickle.loads(
+                        base64.b64decode(value.encode(), validate=True)
+                    )
+                    value = value + delta
+                    encoded = base64.b64encode(
+                        pickle.dumps(value, self.pickle_protocol)
+                    ).decode("latin1")
+                    cursor.execute(
+                        "UPDATE %s SET %s = %%s WHERE %s = %%s"
+                        % (table, value_column, cache_key_column),
+                        [encoded, cache_key],
+                    )
+                    key_found = True
+
+        if not key_found:
+            raise ValueError("Key '%s' not found" % key)
+        return value
+
     def _base_set(self, mode, key, value, timeout=DEFAULT_TIMEOUT):
         timeout = self.get_backend_timeout(timeout)
         db = router.db_for_write(self.cache_model_class)

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -26,6 +26,7 @@ from django.core.cache import (
     caches,
 )
 from django.core.cache.backends.base import BaseCache, InvalidCacheBackendError
+from django.core.cache.backends.db import DatabaseCache
 from django.core.cache.backends.redis import RedisCacheClient
 from django.core.cache.utils import make_template_fragment_key
 from django.db import close_old_connections, connection, connections
@@ -51,6 +52,7 @@ from django.test import (
     TestCase,
     TransactionTestCase,
     override_settings,
+    skipUnlessDBFeature,
 )
 from django.test.signals import setting_changed
 from django.test.utils import CaptureQueriesContext
@@ -1287,6 +1289,117 @@ class DBCacheTests(BaseCacheTests, TransactionTestCase):
         time.sleep(0.02)
         with self.assertNumQueries(2):
             self.assertEqual(cache.get_many(["a", "b", "expired"]), {"a": 1, "b": 2})
+
+    @skipUnlessDBFeature("test_db_allows_multiple_connections")
+    def test_incr_is_atomic(self):
+        cache.set("counter", 0)
+        barrier = threading.Barrier(2, timeout=10)
+        errors = []
+        results = []
+        original_get = DatabaseCache.get
+
+        def synchronized_get(cache_instance, *args, **kwargs):
+            value = original_get(cache_instance, *args, **kwargs)
+            barrier.wait()
+            return value
+
+        def increment():
+            try:
+                results.append(caches["default"].incr("counter"))
+            except Exception as error:
+                errors.append(error)
+            finally:
+                connections.close_all()
+
+        threads = [threading.Thread(target=increment) for _ in range(2)]
+        with mock.patch.object(DatabaseCache, "get", synchronized_get):
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+
+        self.assertEqual(errors, [])
+        self.assertCountEqual(results, [1, 2])
+        self.assertEqual(cache.get("counter"), 2)
+
+    def test_incr_locks_row(self):
+        cache.set("counter", 1)
+        with CaptureQueriesContext(connection) as captured_queries:
+            cache.incr("counter")
+        queries = "\n".join(query["sql"] for query in captured_queries)
+
+        if connection.features.has_select_for_update:
+            self.assertIn(connection.ops.for_update_sql(), queries)
+        else:
+            quote_name = connection.ops.quote_name
+            table, value_column, expires_column, cache_key_column = map(
+                quote_name, ("test cache table", "value", "expires", "cache_key")
+            )
+            write_lock_sql = "UPDATE %s SET %s = %s WHERE %s =" % (
+                table,
+                value_column,
+                value_column,
+                cache_key_column,
+            )
+            select_sql = "SELECT %s, %s FROM %s WHERE %s =" % (
+                value_column,
+                expires_column,
+                table,
+                cache_key_column,
+            )
+            self.assertIn(write_lock_sql, queries)
+            self.assertIn(select_sql, queries)
+            self.assertLess(queries.index(write_lock_sql), queries.index(select_sql))
+
+    def test_incr_preserves_expiry(self):
+        cache.set("counter", 1, timeout=60)
+        cache_key = cache.make_key("counter")
+        table = connection.ops.quote_name("test cache table")
+        cache_key_column = connection.ops.quote_name("cache_key")
+        expires_column = connection.ops.quote_name("expires")
+
+        def get_expiry():
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    "SELECT %s FROM %s WHERE %s = %%s"
+                    % (expires_column, table, cache_key_column),
+                    [cache_key],
+                )
+                return cursor.fetchone()[0]
+
+        expiry = get_expiry()
+        self.assertEqual(cache.incr("counter"), 2)
+        self.assertEqual(get_expiry(), expiry)
+
+    def test_incr_expired_key(self):
+        cache.set("counter", 1, timeout=0)
+        with self.assertRaisesMessage(ValueError, "Key 'counter' not found"):
+            cache.incr("counter")
+        cache_key = cache.make_key("counter")
+        table = connection.ops.quote_name("test cache table")
+        cache_key_column = connection.ops.quote_name("cache_key")
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT 1 FROM %s WHERE %s = %%s" % (table, cache_key_column),
+                [cache_key],
+            )
+            self.assertIsNone(cursor.fetchone())
+
+    def test_incr_uses_write_database(self):
+        cache.set("counter", 1)
+        with (
+            mock.patch(
+                "django.core.cache.backends.db.router.db_for_write",
+                return_value="default",
+            ) as db_for_write,
+            mock.patch(
+                "django.core.cache.backends.db.router.db_for_read",
+                return_value="default",
+            ) as db_for_read,
+        ):
+            self.assertEqual(cache.incr("counter"), 2)
+        db_for_write.assert_called_once_with(cache.cache_model_class)
+        db_for_read.assert_not_called()
 
     def test_delete_many_num_queries(self):
         cache.set_many({"a": 1, "b": 2, "c": 3})


### PR DESCRIPTION
#### Trac ticket number

ticket-23326

#### Branch description

`DatabaseCache` currently inherits `BaseCache.incr()`, which reads and writes in separate operations. Concurrent increments can overwrite each other, and the write also resets the key's expiry.

This adds a database-specific implementation that uses the write database and keeps the read, increment, and update in one transaction. It locks the cache row with `SELECT ... FOR UPDATE` where supported, with a write-lock fallback for SQLite. The update changes only the cached value, so the existing expiry is preserved.

Regression tests cover concurrent increments, row locking, expiry handling, expired keys, and database routing. Atomicity requires a transactional database engine, so non-transactional engines such as MyISAM remain outside this guarantee.

Related work: [ticket #26619](https://code.djangoproject.com/ticket/26619) and PR #19875 address timeout preservation for `DatabaseCache` and `FileBasedCache`. This PR is limited to ticket #23326 and does not resolve ticket #26619.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

OpenAI Codex (GPT-5) was used to analyze the ticket and related code, help prepare the implementation and regression tests, and run multi-database checks. I reviewed and verified the final changes.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.

- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
