### PR TITLE
Fixed #36337 -- Reinitialized admin autocomplete after inline reindex.

### DIFF
--- a/django/contrib/admin/static/admin/js/autocomplete.js
+++ b/django/contrib/admin/static/admin/js/autocomplete.js
@@ -30,4 +30,11 @@
     document.addEventListener("formset:added", (event) => {
         $(event.target).find(".admin-autocomplete").djangoAdminSelect2();
     });
+
+    document.addEventListener("formset:after-reindex", (event) => {
+        $(event.target)
+            .find(".admin-autocomplete")
+            .not("[name*=__prefix__]")
+            .djangoAdminSelect2();
+    });
 }

--- a/django/contrib/admin/static/admin/js/inlines.js
+++ b/django/contrib/admin/static/admin/js/inlines.js
@@ -177,6 +177,8 @@
             const deleteButton = $(e1.target);
             const row = deleteButton.closest("." + options.formCssClass);
             const inlineGroup = row.closest(".inline-group");
+            const deletedIndex = $("." + options.formCssClass).index(row);
+            const formsToReindex = row.nextAll("." + options.formCssClass);
             // Remove the parent form containing this button,
             // and also remove the relevant row with non-field errors:
             const prevRow = row.prev();
@@ -211,10 +213,24 @@
             const updateElementCallback = function () {
                 updateElementIndex(this, options.prefix, i);
             };
-            for (i = 0, formCount = forms.length; i < formCount; i++) {
+            for (
+                i = Math.max(deletedIndex, 0), formCount = forms.length;
+                i < formCount;
+                i++
+            ) {
                 updateElementIndex($(forms).get(i), options.prefix, i);
                 $(forms.get(i)).find("*").each(updateElementCallback);
             }
+            formsToReindex.each(function () {
+                this.dispatchEvent(
+                    new CustomEvent("formset:after-reindex", {
+                        bubbles: true,
+                        detail: {
+                            formsetName: options.prefix,
+                        },
+                    }),
+                );
+            });
         };
 
         const toggleDeleteButtonVisibility = function (inlineGroup) {

--- a/js_tests/admin/autocomplete.test.js
+++ b/js_tests/admin/autocomplete.test.js
@@ -1,0 +1,58 @@
+/* global QUnit */
+"use strict";
+
+QUnit.module("admin.autocomplete", {
+    beforeEach: function () {
+        const $ = django.jQuery;
+
+        $("#qunit-fixture").append(
+            $("#tabular-formset-with-autocomplete").text(),
+        );
+        this.table = $("table.inline");
+        this.inlineRows = this.table.find("tr.form-row");
+        this.inlineRows.tabularFormset("table.inline tr.form-row", {
+            prefix: "autocomplete",
+            addText: "Add another",
+            deleteText: "Remove",
+        });
+        this.table
+            .find(".admin-autocomplete")
+            .not("[name*=__prefix__]")
+            .djangoAdminSelect2();
+    },
+    afterEach: function () {
+        django
+            .jQuery(".admin-autocomplete.select2-hidden-accessible")
+            .select2("destroy");
+    },
+});
+
+QUnit.test(
+    "autocomplete is reinitialized after deleting an inline row",
+    function (assert) {
+        const $ = django.jQuery;
+        assert.expect(7);
+        const addButton = this.table.find("tr.add-row a");
+        addButton.trigger($.Event("click", { target: addButton }));
+
+        const addedSelect = this.table.find("#id_autocomplete-2-products");
+        const initialContainer = addedSelect.next(".select2").get(0);
+        assert.ok(addedSelect.hasClass("select2-hidden-accessible"));
+        assert.equal(this.table.find(".select2").length, 3);
+
+        const deleteLink = this.table.find(
+            "#autocomplete-1 .inline-deletelink",
+        );
+        deleteLink.trigger($.Event("click", { target: deleteLink }));
+
+        const reindexedSelect = this.table.find("#id_autocomplete-1-products");
+        assert.equal(reindexedSelect.attr("name"), "autocomplete-1-products");
+        assert.ok(reindexedSelect.hasClass("select2-hidden-accessible"));
+        assert.equal(this.table.find(".select2").length, 2);
+        assert.notEqual(
+            reindexedSelect.next(".select2").get(0),
+            initialContainer,
+        );
+        assert.equal(this.table.find("#autocomplete-empty .select2").length, 0);
+    },
+);

--- a/js_tests/admin/inlines.test.js
+++ b/js_tests/admin/inlines.test.js
@@ -132,6 +132,33 @@ QUnit.test(
     },
 );
 
+QUnit.test("reindex events target only subsequent rows", function (assert) {
+    const $ = django.jQuery;
+    assert.expect(4);
+    const addButton = this.table.find("tr.add-row > td > a");
+    addButton.trigger($.Event("click", { target: addButton }));
+    const afterReindexTargets = [];
+    const afterReindexHandler = function (event) {
+        afterReindexTargets.push(event.target.id);
+        assert.equal(event.detail.formsetName, "second");
+    };
+    document.addEventListener("formset:after-reindex", afterReindexHandler);
+
+    try {
+        const deleteLink = this.table.find("#second-1 .inline-deletelink");
+        deleteLink.trigger($.Event("click", { target: deleteLink }));
+
+        assert.deepEqual(afterReindexTargets, ["second-1"]);
+        assert.equal(this.table.find("#second-0").length, 1);
+        assert.equal(this.table.find("#second-1").length, 1);
+    } finally {
+        document.removeEventListener(
+            "formset:after-reindex",
+            afterReindexHandler,
+        );
+    }
+});
+
 QUnit.module("admin.inlines: tabular formsets with max_num", {
     beforeEach: function () {
         const $ = django.jQuery;

--- a/js_tests/tests.html
+++ b/js_tests/tests.html
@@ -83,6 +83,74 @@
             </div>
         </div>
     </script>
+    <script type="text/html" id="tabular-formset-with-autocomplete">
+        <div class="inline-group">
+            <div class="tabular inline-related">
+                <input id="id_autocomplete-TOTAL_FORMS" value="2">
+                <input id="id_autocomplete-MAX_NUM_FORMS" value="">
+                <input id="id_autocomplete-MIN_NUM_FORMS" value="">
+                <table class="inline">
+                    <tr id="autocomplete-0" class="form-row">
+                        <td class="field-products">
+                            <select name="autocomplete-0-products"
+                                    id="id_autocomplete-0-products"
+                                    class="admin-autocomplete"
+                                    data-ajax--cache="true"
+                                    data-ajax--delay="250"
+                                    data-ajax--type="GET"
+                                    data-ajax--url="/admin/autocomplete/"
+                                    data-app-label="admin"
+                                    data-model-name="order"
+                                    data-field-name="products"
+                                    data-theme="admin-autocomplete"
+                                    data-allow-clear="false"
+                                    data-placeholder=""
+                                    multiple></select>
+                        </td>
+                        <td class="delete"></td>
+                    </tr>
+                    <tr id="autocomplete-1" class="form-row">
+                        <td class="field-products">
+                            <select name="autocomplete-1-products"
+                                    id="id_autocomplete-1-products"
+                                    class="admin-autocomplete"
+                                    data-ajax--cache="true"
+                                    data-ajax--delay="250"
+                                    data-ajax--type="GET"
+                                    data-ajax--url="/admin/autocomplete/"
+                                    data-app-label="admin"
+                                    data-model-name="order"
+                                    data-field-name="products"
+                                    data-theme="admin-autocomplete"
+                                    data-allow-clear="false"
+                                    data-placeholder=""
+                                    multiple></select>
+                        </td>
+                        <td class="delete"></td>
+                    </tr>
+                    <tr id="autocomplete-empty" class="form-row empty-form">
+                        <td class="field-products">
+                            <select name="autocomplete-__prefix__-products"
+                                    id="id_autocomplete-__prefix__-products"
+                                    class="admin-autocomplete"
+                                    data-ajax--cache="true"
+                                    data-ajax--delay="250"
+                                    data-ajax--type="GET"
+                                    data-ajax--url="/admin/autocomplete/"
+                                    data-app-label="admin"
+                                    data-model-name="order"
+                                    data-field-name="products"
+                                    data-theme="admin-autocomplete"
+                                    data-allow-clear="false"
+                                    data-placeholder=""
+                                    multiple></select>
+                        </td>
+                        <td class="delete"></td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+    </script>
     <script type="text/html" id="nav-sidebar-filter">
       <nav class="sticky" id="nav-sidebar">
         <input type="search" id="nav-filter"
@@ -114,6 +182,7 @@
 
     <script src='../django/contrib/admin/static/admin/js/vendor/xregexp/xregexp.min.js'></script>
     <script src='../django/contrib/admin/static/admin/js/vendor/jquery/jquery.min.js'></script>
+    <script src='../django/contrib/admin/static/admin/js/vendor/select2/select2.full.js'></script>
     <script src='../django/contrib/admin/static/admin/js/jquery.init.js'></script>
     <script src='./admin/jsi18n-mocks.test.js'></script>
 
@@ -141,6 +210,8 @@
 
     <script src='../django/contrib/admin/static/admin/js/inlines.js' data-cover></script>
     <script src='./admin/inlines.test.js'></script>
+    <script src='../django/contrib/admin/static/admin/js/autocomplete.js' data-cover></script>
+    <script src='./admin/autocomplete.test.js'></script>
 
     <script src='../django/contrib/admin/static/admin/js/actions.js' data-cover></script>
     <script src='../django/contrib/admin/static/admin/js/prepopulate.js' data-cover></script>


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-36337

#### Branch description
<!-- Provide a concise overview of the issue or rationale behind the proposed changes. Minimum five words. -->

When autocompletes are used in inlines in admin, deleting and adding form rows can cause Select2 initialization to target wrong row, resulting in broken autocomplete widget in that specific row. This is caused by direct modification of DOM in `inlines.js`, and is fixed by reinitializing the autocomplete in any form row that was reindexed, which is every row after the deleted one.

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
<!-- If AI tools were used, provide which tools were used here. -->

Codex was used for determining the source of the problem and partly for code writing.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
