### PR TITLE
Fixed #29602 -- Allowed third-party template engines to force-escape SafeString.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -671,6 +671,7 @@ answer newbie questions, and generally made Django that much better:
     Maciej Wiśniowski <pigletto@gmail.com>
     Mads Jensen <https://github.com/atombrella>
     Makoto Tsuyuki <mtsuyuki@gmail.com>
+    Malachi Moody <https://github.com/moodyastra>
     Malcolm Tredinnick
     Manas Madeshiya <manas112madeshiya@gmail.com>
     Manav Agarwal <dpsman13016@gmail.com>

--- a/django/utils/html.py
+++ b/django/utils/html.py
@@ -126,7 +126,9 @@ def conditional_escape(text):
     """
     if isinstance(text, Promise):
         text = str(text)
-    if hasattr(text, "__html__"):
+    if isinstance(text, SafeString) and type(text).__html__ is SafeString.__html__:
+        return text
+    elif hasattr(text, "__html__"):
         return text.__html__()
     else:
         return escape(text)

--- a/django/utils/safestring.py
+++ b/django/utils/safestring.py
@@ -30,6 +30,13 @@ class SafeString(str, SafeData):
 
     __slots__ = ()
 
+    def __html__(self):
+        """
+        Return a plain string so third-party force-escaping can remove the
+        safety marker.
+        """
+        return str.__str__(self)
+
     def __add__(self, rhs):
         """
         Concatenating a safe string with another safe bytestring or

--- a/tests/template_backends/test_jinja2.py
+++ b/tests/template_backends/test_jinja2.py
@@ -4,6 +4,7 @@ from unittest import mock, skipIf
 from django.contrib.auth.models import User
 from django.template import TemplateSyntaxError
 from django.test import RequestFactory, TestCase
+from django.utils.safestring import mark_safe
 
 from .test_dummy import TemplateStringsTests
 
@@ -47,6 +48,21 @@ class Jinja2Tests(TemplateStringsTests):
         template = self.engine.from_string("hello {{ foo }}!")
         content = template.render(context={"self": "self", "foo": "world"})
         self.assertEqual(content, "hello world!")
+
+    def test_forceescape_django_safe_string(self):
+        template = self.engine.from_string(
+            '<iframe srcdoc="{{ value|forceescape }}"></iframe>'
+        )
+
+        content = template.render(
+            context={"value": mark_safe('<p data-note="a&b">safe</p>')}
+        )
+
+        self.assertEqual(
+            content,
+            '<iframe srcdoc="&lt;p data-note=&#34;a&amp;b&#34;&gt;safe&lt;/p&gt;">'
+            "</iframe>",
+        )
 
     def test_exception_debug_info_min_context(self):
         with self.assertRaises(TemplateSyntaxError) as e:

--- a/tests/utils_tests/test_html.py
+++ b/tests/utils_tests/test_html.py
@@ -23,7 +23,7 @@ from django.utils.html import (
     strip_tags,
     urlize,
 )
-from django.utils.safestring import mark_safe
+from django.utils.safestring import SafeData, SafeString, mark_safe
 
 
 @override_settings(URLIZE_ASSUME_HTTPS=True)
@@ -372,8 +372,30 @@ class TestUtilsHtml(SimpleTestCase):
     def test_conditional_escape(self):
         s = "<h1>interop</h1>"
         self.assertEqual(conditional_escape(s), "&lt;h1&gt;interop&lt;/h1&gt;")
-        self.assertEqual(conditional_escape(mark_safe(s)), s)
+        safe_s = mark_safe(s)
+        self.assertIs(conditional_escape(safe_s), safe_s)
         self.assertEqual(conditional_escape(lazystr(mark_safe(s))), s)
+
+    def test_conditional_escape_safe_data_subclass(self):
+        class CustomSafeData(SafeData):
+            def __html__(self):
+                return "<h1>safe</h1>"
+
+            def __str__(self):
+                return "<script>unsafe</script>"
+
+        value = CustomSafeData()
+        self.assertEqual(conditional_escape(value), "<h1>safe</h1>")
+        self.assertEqual(format_html("{}", value), "<h1>safe</h1>")
+
+    def test_conditional_escape_safe_string_subclass(self):
+        class CustomSafeString(SafeString):
+            def __html__(self):
+                return "<h1>safe</h1>"
+
+        value = CustomSafeString("<script>unsafe</script>")
+        self.assertEqual(conditional_escape(value), "<h1>safe</h1>")
+        self.assertEqual(format_html("{}", value), "<h1>safe</h1>")
 
     def test_html_safe(self):
         @html_safe


### PR DESCRIPTION
--