### PR TITLE
Refs #36905 -- Fixed outdated docs for JSONResponse safe parameter.

### DIFF
--- a/django/http/response.py
+++ b/django/http/response.py
@@ -749,7 +749,7 @@ class JsonResponse(HttpResponse):
     :param encoder: Should be a json encoder class. Defaults to
       ``django.core.serializers.json.DjangoJSONEncoder``.
     :param safe: Controls if only ``dict`` objects may be serialized. Defaults
-      to ``True``.
+      to ``False``.
     :param json_dumps_params: A dictionary of kwargs passed to json.dumps().
     """
 
@@ -757,7 +757,8 @@ class JsonResponse(HttpResponse):
         self,
         data,
         encoder=DjangoJSONEncoder,
-        # RemovedInDjango71Warning: Remove the safe parameter.
+        # RemovedInDjango71Warning: Remove the safe parameter from here and
+        # the docstring.
         safe=None,
         json_dumps_params=None,
         **kwargs,

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -1222,7 +1222,7 @@ can create it with the help of :class:`http.HTTPStatus`. For example::
 ``JsonResponse`` objects
 ========================
 
-.. class:: JsonResponse(data, encoder=DjangoJSONEncoder, safe=True, json_dumps_params=None, **kwargs)
+.. class:: JsonResponse(data, encoder=DjangoJSONEncoder, safe=False, json_dumps_params=None, **kwargs)
 
     An :class:`HttpResponse` subclass that helps to create a JSON-encoded
     response. It inherits most behavior from its superclass with a couple
@@ -1239,13 +1239,21 @@ can create it with the help of :class:`http.HTTPStatus`. For example::
     serialize the data. See :ref:`JSON serialization
     <serialization-formats-json>` for more details about this serializer.
 
-    The ``safe`` boolean parameter defaults to ``True``. If it's set to
+    The ``safe`` boolean parameter defaults to ``False``. If it's set to
     ``False``, any object can be passed for serialization (otherwise only
     ``dict`` instances are allowed). If ``safe`` is ``True`` and a non-``dict``
     object is passed as the first argument, a :exc:`TypeError` will be raised.
 
     The ``json_dumps_params`` parameter is a dictionary of keyword arguments
     to pass to the ``json.dumps()`` call used to generate the response.
+
+.. versionchanged:: 6.2
+
+    In earlier versions, the ``safe`` parameter defaulted to ``True``.
+
+.. deprecated:: 6.2
+
+    The ``safe`` parameter is deprecated.
 
 Usage
 -----
@@ -1277,10 +1285,6 @@ using non-dict objects in JSON-encoded responses.
     In earlier versions, it was necessary to pass ``safe=False`` to serialize
     other objects besides dictionaries, as the (now deprecated) ``safe``
     parameter defaulted to ``True``, raising :exc:`TypeError`.
-
-.. deprecated:: 6.2
-
-    The ``safe`` parameter is deprecated.
 
 Changing the default JSON encoder
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
### Trac ticket number

ticket-36905

#### Branch description

Follow-up to the deprecation of the `safe` parameter in 6e15ac8066: the
`JsonResponse` docstring and reference docs still described `safe` as
defaulting to `True` and `data` as restricted to `dict` by default, which
contradicts the current behavior (and the `versionchanged:: 6.2` note on
the same page).

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

AI tools used: Claude Code (identified the inconsistency and drafted the patch); I reviewed and verified the changes against the current implementation.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.

- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.