### PR TITLE
Fixed #34654 -- Fixed UsernameField whitespace stripping bypass after Unicode normalization.

### DIFF
--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -58,15 +58,14 @@ class ReadOnlyPasswordHashField(forms.Field):
 
 class UsernameField(forms.CharField):
     def to_python(self, value):
-        value = super().to_python(value)
-        if self.max_length is not None and len(value) > self.max_length:
-            # Normalization can increase the string length (e.g.
-            # "ﬀ" -> "ff", "½" -> "1⁄2") but cannot reduce it, so there is no
-            # point in normalizing invalid data. Moreover, Unicode
-            # normalization is very slow on Windows and can be a DoS attack
-            # vector.
-            return value
-        return unicodedata.normalize("NFKC", value)
+        if value not in self.empty_values:
+            if self.max_length is None or len(value) <= self.max_length:
+                # Normalization can increase string length (e.g. "ﬀ" -> "ff",
+                # "½" -> "1⁄2") but cannot reduce it, so there is no point in
+                # normalizing invalid data. Moreover, Unicode normalization is
+                # very slow on Windows and can be a DoS attack vector.
+                value = unicodedata.normalize("NFKC", value)
+        return super().to_python(value)
 
     def widget_attrs(self, widget):
         return {

--- a/tests/auth_tests/test_forms.py
+++ b/tests/auth_tests/test_forms.py
@@ -1773,3 +1773,28 @@ class SensitiveVariablesTest(TestDataMixin, TestCase):
                 self.assertContains(
                     response, password2_fragment, html=True, status_code=500
                 )
+
+
+class UsernameFieldTest(SimpleTestCase):
+    def test_strip_whitespace_post_normalization(self):
+        """
+        UsernameField normalizes Unicode before stripping, ensuring characters
+        that normalize to whitespace (e.g. \u1680, \u3000) are stripped.
+        """
+        field = UsernameField(max_length=150)
+        tests = [
+            ("  testuser  ", "testuser"),
+            ("\u1680testuser\u1680", "testuser"),
+            ("\u3000testuser\u3000", "testuser"),
+            ("\u2000testuser\u200a", "testuser"),
+            ("   \u3000testuser\u1680   ", "testuser"),
+        ]
+        for value, expected in tests:
+            with self.subTest(value=value):
+                self.assertEqual(field.clean(value), expected)
+
+    def test_exceeding_max_length_skips_normalization(self):
+        field = UsernameField(max_length=5)
+        long_value = "a" * 10
+        with self.assertRaises(ValidationError):
+            field.clean(long_value)


### PR DESCRIPTION
#### Trac ticket number

ticket-34654

#### Branch description

Reordered UsernameField.to_python() to apply NFKC Unicode normalization before CharField.to_python() (which performs whitespace stripping). Previously, stripping ran first and normalization second, so Unicode characters that normalize to whitespace (e.g. \u1680, \u3000, \u2000) survived stripping and ended up as leading/trailing spaces in the stored username. This could lead to username spoofing. The fix calls super().to_python() after unicodedata.normalize(), ensuring all Unicode whitespace variants are properly stripped.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

AI tools used: Claude was used to assist with drafting code. All output was reviewed, tested, and verified manually.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
