### PR TITLE
Added missing lang override in translation fetching helper for Serbian (Latin script).

### DIFF
--- a/scripts/manage_translations.py
+++ b/scripts/manage_translations.py
@@ -37,6 +37,7 @@ from django.core.management import call_command
 
 HAVE_JS = ["admin"]
 LANG_OVERRIDES = {
+    "sr@latin": "sr_Latn",
     "zh_CN": "zh_Hans",
     "zh_TW": "zh_Hant",
 }


### PR DESCRIPTION
See https://github.com/django/django/pull/21733#issuecomment-5195360237. Without this override, the `manage_translations` script fetched .po files but skipped compilation to .mo for this locale.