### PR TITLE
Fixed #37252 -- Made If-Unmodified-Since ignored for responses without Last-Modified.

### DIFF
--- a/django/utils/cache.py
+++ b/django/utils/cache.py
@@ -241,7 +241,7 @@ def _if_unmodified_since_passes(last_modified, if_unmodified_since):
     Test the If-Unmodified-Since comparison as defined in RFC 9110 Section
     13.1.4.
     """
-    return last_modified and last_modified <= if_unmodified_since
+    return not last_modified or last_modified <= if_unmodified_since
 
 
 def _if_none_match_passes(target_etag, etags):

--- a/tests/conditional_processing/tests.py
+++ b/tests/conditional_processing/tests.py
@@ -67,6 +67,21 @@ class ConditionalGet(SimpleTestCase):
         response = self.client.get("/condition/")
         self.assertEqual(response.status_code, 412)
 
+    def test_if_unmodified_since_without_last_modified(self):
+        # If the resource has no modification date, an If-Unmodified-Since
+        # header must be ignored (RFC 9110 Section 13.1.4).
+        for header in (
+            LAST_MODIFIED_STR,
+            EXPIRED_LAST_MODIFIED_STR,
+            LAST_MODIFIED_INVALID_STR,
+        ):
+            with self.subTest(header=header):
+                self.client.defaults["HTTP_IF_UNMODIFIED_SINCE"] = header
+                response = self.client.get("/condition/etag/")
+                self.assertFullResponse(response, check_last_modified=False)
+                response = self.client.put("/condition/etag/")
+                self.assertFullResponse(response, check_last_modified=False)
+
     def test_if_none_match(self):
         self.client.defaults["HTTP_IF_NONE_MATCH"] = ETAG
         response = self.client.get("/condition/")
@@ -227,8 +242,10 @@ class ConditionalGet(SimpleTestCase):
         self.client.defaults["HTTP_IF_UNMODIFIED_SINCE"] = EXPIRED_LAST_MODIFIED_STR
         response = self.client.get("/condition/last_modified/")
         self.assertEqual(response.status_code, 412)
+        # No Last-Modified, so If-Unmodified-Since is ignored (RFC 9110
+        # Section 13.1.4).
         response = self.client.get("/condition/etag/")
-        self.assertEqual(response.status_code, 412)
+        self.assertFullResponse(response, check_last_modified=False)
 
     def test_single_condition_8(self):
         self.client.defaults["HTTP_IF_UNMODIFIED_SINCE"] = LAST_MODIFIED_STR
@@ -239,8 +256,10 @@ class ConditionalGet(SimpleTestCase):
         self.client.defaults["HTTP_IF_UNMODIFIED_SINCE"] = EXPIRED_LAST_MODIFIED_STR
         response = self.client.get("/condition/last_modified2/")
         self.assertEqual(response.status_code, 412)
+        # No Last-Modified, so If-Unmodified-Since is ignored (RFC 9110
+        # Section 13.1.4).
         response = self.client.get("/condition/etag2/")
-        self.assertEqual(response.status_code, 412)
+        self.assertFullResponse(response, check_last_modified=False)
 
     def test_single_condition_head(self):
         self.client.defaults["HTTP_IF_MODIFIED_SINCE"] = LAST_MODIFIED_STR

--- a/tests/conditional_processing/tests.py
+++ b/tests/conditional_processing/tests.py
@@ -75,12 +75,11 @@ class ConditionalGet(SimpleTestCase):
             EXPIRED_LAST_MODIFIED_STR,
             LAST_MODIFIED_INVALID_STR,
         ):
-            with self.subTest(header=header):
-                self.client.defaults["HTTP_IF_UNMODIFIED_SINCE"] = header
-                response = self.client.get("/condition/etag/")
-                self.assertFullResponse(response, check_last_modified=False)
-                response = self.client.put("/condition/etag/")
-                self.assertFullResponse(response, check_last_modified=False)
+            for method in ("get", "put"):
+                with self.subTest(header=header, method=method):
+                    self.client.defaults["HTTP_IF_UNMODIFIED_SINCE"] = header
+                    response = getattr(self.client, method)("/condition/etag/")
+                    self.assertFullResponse(response, check_last_modified=False)
 
     def test_if_none_match(self):
         self.client.defaults["HTTP_IF_NONE_MATCH"] = ETAG


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37252

#### Branch description
<!-- Provide a concise overview of the issue or rationale behind the proposed changes. Minimum five words. -->

Trac ticket: https://code.djangoproject.com/ticket/37252

Per [RFC 9110 §13.1.4](https://www.rfc-editor.org/rfc/rfc9110#section-13.1.4), a recipient MUST ignore `If-Unmodified-Since` if the selected representation has no `Last-Modified` date. `_if_unmodified_since_passes()` treated a missing date as a failed precondition (412); it now mirrors `_if_modified_since_passes()`, which already implements the ignore rule for its header.

Changes:

- `django/utils/cache.py`: the one-line fix.
- `tests/conditional_processing/tests.py`: new regression test (`If-Unmodified-Since` against an ETag-only view, GET and PUT, three date shapes); `test_single_condition_7` and `test_single_condition_9` previously asserted the pre-RFC-9110 412 on ETag-only views and were updated to expect a full response.

`conditional_processing`, `responses`, and `httpwrappers` suites pass.

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
<!-- If AI tools were used, provide which tools were used here. -->
Claude Code (Fable) + apodict

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [ x I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
