### PR TITLE
Fixed #37244 -- Propagated base field validators in ArrayField.formfield().

### DIFF
--- a/django/contrib/postgres/fields/array.py
+++ b/django/contrib/postgres/fields/array.py
@@ -234,7 +234,9 @@ class ArrayField(CheckPostgresInstalledMixin, CheckFieldDefaultMixin, Field):
         return super().formfield(
             **{
                 "form_class": SimpleArrayField,
-                "base_field": self.base_field.formfield(),
+                "base_field": self.base_field.formfield(
+                    validators=self.base_field._validators
+                ),
                 "max_length": self.size,
                 **kwargs,
             }

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -1210,6 +1210,52 @@ class TestSimpleFormField(PostgreSQLSimpleTestCase):
             "Item 1 in the array did not validate: Enter a valid value.",
         )
 
+    @isolate_apps("postgres_tests")
+    def test_modelform_base_field_validators(self):
+        class MyModel(PostgreSQLModel):
+            field = ArrayField(
+                models.IntegerField(validators=[validators.MaxValueValidator(10)])
+            )
+
+        class Form(forms.ModelForm):
+            class Meta:
+                model = MyModel
+                fields = ("field",)
+
+        form = Form({"field": "51,1"})
+        self.assertIs(form.is_valid(), False)
+        self.assertEqual(
+            form.errors,
+            {
+                "field": [
+                    "Item 1 in the array did not validate: Ensure this value is "
+                    "less than or equal to 10."
+                ]
+            },
+        )
+
+    @isolate_apps("postgres_tests")
+    def test_modelform_base_field_validators_not_duplicated(self):
+        class MyModel(PostgreSQLModel):
+            field = ArrayField(models.CharField(max_length=3))
+
+        class Form(forms.ModelForm):
+            class Meta:
+                model = MyModel
+                fields = ("field",)
+
+        form = Form({"field": "abcd"})
+        self.assertIs(form.is_valid(), False)
+        self.assertEqual(
+            form.errors,
+            {
+                "field": [
+                    "Item 1 in the array did not validate: Ensure this value has "
+                    "at most 3 characters (it has 4)."
+                ]
+            },
+        )
+
     def test_delimiter(self):
         field = SimpleArrayField(forms.CharField(), delimiter="|")
         value = field.clean("a|b|c")


### PR DESCRIPTION
[Ticket #37244](https://code.djangoproject.com/ticket/37244)

## Problem

A `ModelForm` over a postgres `ArrayField` reports item validation failures with the reason stripped off:

```python
class Tag(models.Model):
    names = ArrayField(models.CharField(
        max_length=50,
        validators=[RegexValidator(r"^[a-z]+$", "Only lowercase letters are allowed.")],
    ))
```

```
model: Item 2 in the array did not validate: Only lowercase letters are allowed.
form:  Item 2 in the array did not validate:
```

## Cause

`ArrayField` wraps each item failure with `prefix_validation_error()`, tagging it `code="item_invalid"`. In a `ModelForm` that error reaches `BaseModelForm._update_errors()`, which replaces a message whenever its code matches a key in the form field's `error_messages`. `SimpleArrayField` declares `item_invalid`, but its value is only the prefix `"Item %(nth)s in the array did not validate:"` — so the composed message is overwritten by a sentence fragment.

That override is intentional and documented (form-level wording beats model-level wording). It misfires here only because `item_invalid` is a fragment meant for concatenation rather than a standalone message.

It surfaces exclusively when the failing validator is absent from the *form's* base field, since form-field errors never pass through `_update_errors()`. That was always the case: `ArrayField.formfield()` called `self.base_field.formfield()` with no arguments.

## Fix

Propagate the base field's explicitly declared validators, so the error is raised while cleaning the form field — prefixed correctly, and never reaching `_update_errors()`.

## Why `_validators` rather than `validators`

`base_field.validators` also carries validators the model field adds automatically, which the corresponding form field adds for itself:

| model field | `.validators` | `._validators` | form field already has |
|---|---|---|---|
| CharField | Regex, **MaxLength** | Regex | **MaxLength**, ProhibitNullChars |
| IntegerField | MaxValue, **MinValue** | MaxValue | — |
| DecimalField | **Decimal** | *(empty)* | **Decimal** |
| EmailField | **Email, MaxLength** | *(empty)* | **Email, MaxLength** |

Using `.validators` duplicates the bold entries and reports the same error twice. `test_modelform_base_field_validators_not_duplicated` pins this — it fails if `.validators` is substituted.

Happy to take direction if reaching into `_validators` is considered too private; I did not find a public accessor that excludes the automatically added validators (`Field.deconstruct()` reads from the same attribute).

## Notes

- This does not address the underlying prefix/code collision in `_update_errors()`, which would still truncate an `item_invalid` error raised from a custom model-level `Field.validate()`. That seems like a larger change to core forms code and probably belongs in its own ticket.
- Behaviour change worth a release note if wanted: the model-side loop raises on the first bad item while `SimpleArrayField` collects all of them, so a form with two invalid items now shows two complete errors instead of one truncated one.
- A base field with `choices` is unaffected — `Field.formfield()` drops kwargs outside its whitelist, and `TypedChoiceField` enforces the choices itself.

## Testing

Two tests added to `TestSimpleFormField`. The first fails on `main` and passes with the fix; the second fails if `.validators` is used instead of `._validators`. Full `postgres_tests` (641), plus `model_forms`, `validation`, `forms_tests` and `model_fields` (1836), pass against PostgreSQL. No existing test was modified.