### PR TITLE
Fixed #37244 -- Propagated base field validators in ArrayField.formfield().

### DIFF
--- a/django/contrib/postgres/fields/array.py
+++ b/django/contrib/postgres/fields/array.py
@@ -238,7 +238,9 @@ class ArrayField(CheckPostgresInstalledMixin, CheckFieldDefaultMixin, Field):
         return super().formfield(
             **{
                 "form_class": SimpleArrayField,
-                "base_field": self.base_field.formfield(),
+                "base_field": self.base_field.formfield(
+                    validators=self.base_field._validators
+                ),
                 "max_length": self.size,
                 **kwargs,
             }

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -1251,6 +1251,34 @@ class TestSimpleFormField(PostgreSQLSimpleTestCase):
         self.assertIsInstance(form_field, SimpleArrayField)
         self.assertEqual(form_field.max_length, 4)
 
+    def test_model_field_formfield_base_field_validators(self):
+        model_field = ArrayField(
+            models.IntegerField(validators=[validators.MaxValueValidator(10)])
+        )
+        form_field = model_field.formfield()
+        with self.assertRaises(exceptions.ValidationError) as cm:
+            form_field.clean("51,1")
+        self.assertEqual(
+            cm.exception.messages,
+            [
+                "Item 1 in the array did not validate: Ensure this value is less "
+                "than or equal to 10."
+            ],
+        )
+
+    def test_model_field_formfield_base_field_validators_not_duplicated(self):
+        model_field = ArrayField(models.CharField(max_length=3))
+        form_field = model_field.formfield()
+        with self.assertRaises(exceptions.ValidationError) as cm:
+            form_field.clean("abcd")
+        self.assertEqual(
+            cm.exception.messages,
+            [
+                "Item 1 in the array did not validate: Ensure this value has at "
+                "most 3 characters (it has 4)."
+            ],
+        )
+
     def test_model_field_choices(self):
         model_field = ArrayField(models.IntegerField(choices=((1, "A"), (2, "B"))))
         form_field = model_field.formfield()


### PR DESCRIPTION
#### Trac ticket number

ticket-37244

#### Branch description

`ArrayField.formfield()` did not pass the base field's validators to the base form field, so validators declared on the base model field only ran during model validation. Errors from that path go through `BaseModelForm._update_errors()`, which replaces a message whenever its code matches a key in the form field's `error_messages`. `SimpleArrayField` defines `item_invalid`, but its value is only the prefix `"Item %(nth)s in the array did not validate:"`, so the composed message lost the validator's explanation:

```
model: Item 2 in the array did not validate: Only lowercase letters are allowed.
form:  Item 2 in the array did not validate:
```

Passing the explicitly declared validators means the error is now raised while cleaning the form field, where it is prefixed correctly and never reaches `_update_errors()`.

Only `base_field._validators` is propagated. `base_field.validators` would also include validators the model field adds automatically — `MaxLengthValidator` on `CharField`, `EmailValidator` and `MaxLengthValidator` on `EmailField`, `DecimalValidator` on `DecimalField` — which the corresponding form field already adds for itself, duplicating error messages. `test_model_field_formfield_base_field_validators_not_duplicated` fails if `.validators` is substituted.

I'd welcome direction if reaching into `_validators` is considered too private; I did not find a public accessor that excludes the automatically added validators (`Field.deconstruct()` reads from the same attribute).

Two notes:

- This does not address the underlying prefix/code collision in `_update_errors()`, which would still truncate an `item_invalid` error raised from a custom model-level `Field.validate()`. That looks like a larger change to core forms code and probably belongs in its own ticket.
- The model-side loop raises on the first bad item while `SimpleArrayField` collects all of them, so a form with two invalid items now shows two complete errors instead of one truncated one. Happy to add a release note if that is wanted.

No release note included, as this is a bug fix applied only to the `main` branch.

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude Opus 5 was used for this PR. I am aware and understand all the code changes

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
