### PR TITLE
Fixed #11541 -- Allowed assigning expressions to foreign key attributes.

### DIFF
--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -250,7 +250,14 @@ class ForwardManyToOneDescriptor:
             rel_obj = self.field.get_cached_value(instance)
         except KeyError:
             rel_obj = None
-            has_value = None not in self.field.get_local_related_value(instance)
+            local_values = self.field.get_local_related_value(instance)
+            if any(hasattr(value, "resolve_expression") for value in local_values):
+                raise ValueError(
+                    'Cannot access "%s.%s": it was assigned an expression that '
+                    "must first be resolved by saving the object."
+                    % (instance._meta.object_name, self.field.name)
+                )
+            has_value = None not in local_values
             if has_value:
                 model = self.field.model
                 for current_instance, ancestor in _traverse_ancestors(model, instance):
@@ -300,6 +307,25 @@ class ForwardManyToOneDescriptor:
         - ``instance`` is the ``child`` instance
         - ``value`` is the ``parent`` instance on the right of the equal sign
         """
+        # Expressions are resolved by the database at save() time, so they
+        # can't be validated as related instances or stored in the relation
+        # cache. Set the expression on the foreign key attribute so that it's
+        # picked up by save().
+        if value is not None and hasattr(value, "resolve_expression"):
+            if self.field.primary_key:
+                raise ValueError(
+                    'Cannot assign expression "%r": "%s.%s" is a primary key.'
+                    % (value, instance._meta.object_name, self.field.name)
+                )
+            if len(self.field.related_fields) > 1:
+                raise ValueError(
+                    'Cannot assign expression "%r": "%s.%s" is a multi-column '
+                    "relation." % (value, instance._meta.object_name, self.field.name)
+                )
+            if self.field.is_cached(instance):
+                self.field.delete_cached_value(instance)
+            setattr(instance, self.field.related_fields[0][0].attname, value)
+            return
         # An object must be an instance of the related class.
         if value is not None and not isinstance(
             value, self.field.remote_field.model._meta.concrete_model

--- a/docs/ref/models/expressions.txt
+++ b/docs/ref/models/expressions.txt
@@ -183,6 +183,29 @@ the field value of each one, and saving each one back to the database::
 * getting the database, rather than Python, to do work
 * reducing the number of queries some operations require
 
+.. _assigning-f-objects-to-related-fields:
+
+Assigning ``F()`` objects to related fields
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``F()`` objects can also be assigned to :class:`~django.db.models.ForeignKey`
+and :class:`~django.db.models.OneToOneField` attributes::
+
+    company = Company.objects.get(name="Test GmbH")
+    company.point_of_contact = F("ceo")
+    company.save()
+
+The expression is resolved by the database when the object is saved, so the
+related object cannot be accessed until then; accessing it earlier raises
+``ValueError``. Expressions cannot be assigned to primary keys (such as the
+parent links created by :ref:`multi-table inheritance
+<multi-table-inheritance>`) or when inserting new rows.
+
+.. versionchanged:: 6.2
+
+    Support for assigning ``F()`` objects to ``ForeignKey`` and
+    ``OneToOneField`` attributes was added.
+
 .. _slicing-using-f:
 
 Slicing ``F()`` expressions

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -196,7 +196,9 @@ Migrations
 Models
 ~~~~~~
 
-* ...
+* ``F()`` expressions can now be assigned to ``ForeignKey`` and
+  ``OneToOneField`` attributes on model instances. See
+  :ref:`assigning-f-objects-to-related-fields`.
 
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -474,19 +474,66 @@ class BasicExpressionsTests(TestCase):
             )
 
     def test_object_update_fk(self):
-        # F expressions cannot be used to update attributes which are foreign
-        # keys, or attributes which involve joins.
+        # F expressions can be used to update foreign key attributes on
+        # single objects.
         test_gmbh = Company.objects.get(pk=self.gmbh.pk)
-        msg = 'F(ceo)": "Company.point_of_contact" must be a "Employee" instance.'
-        with self.assertRaisesMessage(ValueError, msg):
-            test_gmbh.point_of_contact = F("ceo")
-
-        test_gmbh.point_of_contact = self.gmbh.ceo
+        test_gmbh.point_of_contact = F("ceo")
         test_gmbh.save()
+        test_gmbh.refresh_from_db()
+        self.assertEqual(test_gmbh.point_of_contact, self.max)
+        # Attributes which involve joins cannot be saved.
         test_gmbh.name = F("ceo__lastname")
         msg = "Joined field references are not permitted in this query"
         with self.assertRaisesMessage(FieldError, msg):
             test_gmbh.save()
+
+    def test_object_update_fk_attname(self):
+        # F expressions can be assigned to the underlying foreign key
+        # attribute.
+        test_gmbh = Company.objects.get(pk=self.gmbh.pk)
+        test_gmbh.point_of_contact_id = F("ceo")
+        test_gmbh.save()
+        test_gmbh.refresh_from_db()
+        self.assertEqual(test_gmbh.point_of_contact, self.max)
+
+    def test_object_update_fk_expression_access(self):
+        # The related object cannot be accessed until the assigned expression
+        # has been resolved by saving the object.
+        test_gmbh = Company.objects.get(pk=self.gmbh.pk)
+        test_gmbh.point_of_contact = self.max
+        test_gmbh.point_of_contact = F("ceo")
+        self.assertEqual(test_gmbh.point_of_contact_id, F("ceo"))
+        msg = (
+            'Cannot access "Company.point_of_contact": it was assigned an '
+            "expression that must first be resolved by saving the object."
+        )
+        with self.assertRaisesMessage(ValueError, msg):
+            test_gmbh.point_of_contact
+
+    def test_object_update_fk_parent_link(self):
+        remote = RemoteEmployee(
+            firstname="John", lastname="Doe", salary=10, adjusted_salary=100
+        )
+        msg = (
+            'Cannot assign expression "F(adjusted_salary)": '
+            '"RemoteEmployee.employee_ptr" is a primary key.'
+        )
+        with self.assertRaisesMessage(ValueError, msg):
+            remote.employee_ptr = F("adjusted_salary")
+
+    def test_object_create_fk_expression(self):
+        # F expressions on foreign keys cannot be used when inserting new
+        # rows.
+        acme = Company(
+            name="The Acme Widget Co.",
+            num_employees=12,
+            num_chairs=5,
+            ceo=self.max,
+            point_of_contact=F("ceo"),
+        )
+        msg = "F() expressions can only be used to update, not to insert."
+        with self.assertRaisesMessage(ValueError, msg):
+            acme.save()
 
     def test_update_inherited_field_value(self):
         msg = "Joined field references are not permitted in this query"

--- a/tests/foreign_object/tests.py
+++ b/tests/foreign_object/tests.py
@@ -5,7 +5,7 @@ from operator import attrgetter
 
 from django.core.exceptions import FieldError, ValidationError
 from django.db import connection, models
-from django.db.models import FETCH_PEERS
+from django.db.models import FETCH_PEERS, F
 from django.test import SimpleTestCase, TestCase, skipUnlessDBFeature
 from django.test.utils import CaptureQueriesContext, isolate_apps
 from django.utils import translation
@@ -60,6 +60,17 @@ class MultiColumnFKTests(TestCase):
 
         person = membership.person
         self.assertEqual((person.id, person.name), (self.bob.id, "Bob"))
+
+    def test_assign_expression(self):
+        # Expressions can't decompose into multiple columns, so they can't be
+        # assigned to multi-column relations.
+        membership = Membership()
+        msg = (
+            'Cannot assign expression "F(group_id)": "Membership.person" is a '
+            "multi-column relation."
+        )
+        with self.assertRaisesMessage(ValueError, msg):
+            membership.person = F("group_id")
 
     def test_get_fails_on_multicolumn_mismatch(self):
         # Membership objects returns DoesNotExist error when there is no


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-11541

#### Branch description
<!-- Provide a concise overview of the issue or rationale behind the proposed changes. Minimum five words. -->

Expressions assigned to a `ForeignKey` or `OneToOneField` are set on the underlying foreign key attribute and resolved by the database on `save()`, matching the behavior of expression assignment to ordinary fields. Accessing the related object before saving raises `ValueError`, as do assignments to primary keys (parent links) and multi-column relations.

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [X] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
<!-- If AI tools were used, provide which tools were used here. -->
This patch was prepared with assistance from Claude Code (Anthropic's Claude Fable 5 model), including researching ticket history, confirming no prior PR existed, drafting PR ( following [the approach proposed by Simon Charette](https://code.djangoproject.com/ticket/11541#comment:8) ), tests, documentation, and running full test suite. I directed the work, reviewed and verified all changes. The commit's Co-Authored-By trailer reflects this assistance.

#### Checklist
- [X] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [X] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [X] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
