### PR TITLE
Fixed #37255 -- Avoided relying on implicit SELECT ordering in tests.

### DIFF
--- a/tests/admin_views/test_autocomplete_view.py
+++ b/tests/admin_views/test_autocomplete_view.py
@@ -341,7 +341,7 @@ class AutocompleteJsonViewTests(AdminViewBasicTestCase):
             {
                 "results": [
                     {"id": str(q.pk), "text": q.question}
-                    for q in Question.objects.all()[:PAGINATOR_SIZE]
+                    for q in Question.objects.order_by("pk")[:PAGINATOR_SIZE]
                 ],
                 "pagination": {"more": True},
             },
@@ -358,7 +358,7 @@ class AutocompleteJsonViewTests(AdminViewBasicTestCase):
             {
                 "results": [
                     {"id": str(q.pk), "text": q.question}
-                    for q in Question.objects.all()[PAGINATOR_SIZE:]
+                    for q in Question.objects.order_by("pk")[PAGINATOR_SIZE:]
                 ],
                 "pagination": {"more": False},
             },

--- a/tests/defer/tests.py
+++ b/tests/defer/tests.py
@@ -104,7 +104,7 @@ class DeferTests(AssertionMixin, TestCase):
         # User values() won't defer anything (you get the full list of
         # dictionaries back), but it still works.
         self.assertEqual(
-            Primary.objects.defer("name").values()[0],
+            Primary.objects.defer("name").values().get(pk=self.p1.pk),
             {
                 "id": self.p1.id,
                 "name": "p1",
@@ -115,7 +115,7 @@ class DeferTests(AssertionMixin, TestCase):
 
     def test_only_values_does_not_defer(self):
         self.assertEqual(
-            Primary.objects.only("name").values()[0],
+            Primary.objects.only("name").values().get(pk=self.p1.pk),
             {
                 "id": self.p1.id,
                 "name": "p1",
@@ -138,7 +138,9 @@ class DeferTests(AssertionMixin, TestCase):
         self.assert_delayed(obj, 0)
 
     def test_only_with_select_related(self):
-        obj = Primary.objects.select_related("related").only("related__first")[0]
+        obj = Primary.objects.select_related("related").only("related__first").get(
+            pk=self.p1.pk
+        )
         self.assert_delayed(obj, 2)
         self.assert_delayed(obj.related, 1)
         self.assertEqual(obj.related_id, self.s1.pk)

--- a/tests/expressions/test_queryset_values.py
+++ b/tests/expressions/test_queryset_values.py
@@ -33,7 +33,7 @@ class ValuesExpressionsTests(TestCase):
 
     def test_values_expression(self):
         self.assertSequenceEqual(
-            Company.objects.values(salary=F("ceo__salary")),
+            Company.objects.values(salary=F("ceo__salary")).order_by("salary"),
             [{"salary": 10}, {"salary": 20}, {"salary": 30}],
         )
 

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -813,7 +813,7 @@ class BasicExpressionsTests(TestCase):
             ),
         )
         self.assertSequenceEqual(
-            qs.values_list("ceo_company", flat=True),
+            qs.order_by("pk").values_list("ceo_company", flat=True),
             [self.example_inc.pk, self.foobar_ltd.pk, self.gmbh.pk],
         )
 

--- a/tests/foreign_object/tests.py
+++ b/tests/foreign_object/tests.py
@@ -494,8 +494,8 @@ class MultiColumnFKTests(TestCase):
         # Test model initialization with active_translation field.
         a3 = Article(id=a3.id, pub_date=a3.pub_date, active_translation=at3_en)
         a3.save()
-        self.assertEqual(
-            list(Article.objects.filter(active_translation__abstract=None)), [a1, a3]
+        self.assertCountEqual(
+            Article.objects.filter(active_translation__abstract=None), [a1, a3]
         )
         self.assertEqual(
             list(
@@ -508,8 +508,8 @@ class MultiColumnFKTests(TestCase):
         )
 
         with translation.override("en"):
-            self.assertEqual(
-                list(Article.objects.filter(active_translation__abstract=None)),
+            self.assertCountEqual(
+                Article.objects.filter(active_translation__abstract=None),
                 [a1, a2],
             )
 

--- a/tests/generic_relations/tests.py
+++ b/tests/generic_relations/tests.py
@@ -844,7 +844,7 @@ class GenericRelationsTests(TestCase):
         self.assertEqual(tag._state.fetch_mode, FETCH_PEERS)
 
     def test_fetch_mode_copied_reverse_fetching_many(self):
-        animals = list(Animal.objects.fetch_mode(FETCH_PEERS))
+        animals = list(Animal.objects.fetch_mode(FETCH_PEERS).order_by("pk"))
         animal = animals[0]
         self.assertEqual(animal._state.fetch_mode, FETCH_PEERS)
         tags = list(animal.tags.all())

--- a/tests/generic_relations_regress/tests.py
+++ b/tests/generic_relations_regress/tests.py
@@ -194,10 +194,10 @@ class GenericRelationTests(TestCase):
         self.assertSequenceEqual(HasLinkThing.objects.filter(links=l1), [hs3])
         self.assertSequenceEqual(HasLinkThing.objects.filter(links=l2), [hs4])
         self.assertSequenceEqual(
-            HasLinkThing.objects.exclude(links=l2), [hs1, hs2, hs3]
+            HasLinkThing.objects.exclude(links=l2).order_by("pk"), [hs1, hs2, hs3]
         )
         self.assertSequenceEqual(
-            HasLinkThing.objects.exclude(links=l1), [hs1, hs2, hs4]
+            HasLinkThing.objects.exclude(links=l1).order_by("pk"), [hs1, hs2, hs4]
         )
 
     def test_ticket_20564(self):

--- a/tests/known_related_objects/tests.py
+++ b/tests/known_related_objects/tests.py
@@ -182,5 +182,6 @@ class ExistingRelatedInstancesTests(TestCase):
                     style=FilteredRelation("pool__another_style"),
                 )
                 .select_related("style")
+                .order_by("pool__pk")
             )
             self.assertEqual(p[0].style.another_pool, self.p3)

--- a/tests/m2m_recursive/tests.py
+++ b/tests/m2m_recursive/tests.py
@@ -24,17 +24,19 @@ class RecursiveM2MTests(TestCase):
             (self.d, [self.a, self.c]),
         ):
             with self.subTest(person=person):
-                self.assertSequenceEqual(person.friends.all(), friends)
+                self.assertSequenceEqual(person.friends.order_by("name"), friends)
 
     def test_recursive_m2m_reverse_add(self):
         # Add m2m for Anne in reverse direction.
         self.b.friends.add(self.a)
-        self.assertSequenceEqual(self.a.friends.all(), [self.b, self.c, self.d])
+        self.assertSequenceEqual(
+            self.a.friends.order_by("name"), [self.b, self.c, self.d]
+        )
         self.assertSequenceEqual(self.b.friends.all(), [self.a])
 
     def test_recursive_m2m_remove(self):
         self.b.friends.remove(self.a)
-        self.assertSequenceEqual(self.a.friends.all(), [self.c, self.d])
+        self.assertSequenceEqual(self.a.friends.order_by("name"), [self.c, self.d])
         self.assertSequenceEqual(self.b.friends.all(), [])
 
     def test_recursive_m2m_clear(self):
@@ -94,7 +96,9 @@ class RecursiveSymmetricalM2MThroughTests(TestCase):
             (self.d, [self.a, self.c]),
         ):
             with self.subTest(person=person):
-                self.assertSequenceEqual(person.colleagues.all(), colleagues)
+                self.assertSequenceEqual(
+                    person.colleagues.order_by("name"), colleagues
+                )
 
     def test_recursive_m2m_reverse_add(self):
         # Add m2m for Anne in reverse direction.
@@ -109,7 +113,7 @@ class RecursiveSymmetricalM2MThroughTests(TestCase):
 
     def test_recursive_m2m_remove(self):
         self.b.colleagues.remove(self.a)
-        self.assertSequenceEqual(self.a.colleagues.all(), [self.c, self.d])
+        self.assertSequenceEqual(self.a.colleagues.order_by("name"), [self.c, self.d])
         self.assertSequenceEqual(self.b.colleagues.all(), [])
 
     def test_recursive_m2m_clear(self):

--- a/tests/m2m_through/tests.py
+++ b/tests/m2m_through/tests.py
@@ -483,7 +483,7 @@ class M2mThroughReferentialTests(TestCase):
             [anne, kate],
             through_defaults={"date_friended": date_friended_set},
         )
-        self.assertSequenceEqual(tony.sym_friends.all(), [anne, kate])
+        self.assertSequenceEqual(tony.sym_friends.order_by("name"), [anne, kate])
         self.assertSequenceEqual(anne.sym_friends.all(), [tony])
         self.assertSequenceEqual(kate.sym_friends.all(), [tony])
         self.assertEqual(

--- a/tests/many_to_one/tests.py
+++ b/tests/many_to_one/tests.py
@@ -828,7 +828,7 @@ class ManyToOneTests(TestCase):
         city = City.objects.prefetch_related("districts").get(id=c.id)
         self.assertSequenceEqual(city.districts.all(), [d1])
         d2 = city.districts.create(name="Goa")
-        self.assertSequenceEqual(city.districts.all(), [d1, d2])
+        self.assertCountEqual(city.districts.all(), [d1, d2])
 
     def test_clear_after_prefetch(self):
         c = City.objects.create(name="Musical City")

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -1601,7 +1601,7 @@ class MigrateTests(MigrationTestBase):
                 for migration in recorder.applied_migrations()
                 if migration[0] in ["migrations", "migrations2"]
             ]
-            self.assertEqual(
+            self.assertCountEqual(
                 applied_migrations,
                 [
                     ("migrations", "0001_squashed_0002"),

--- a/tests/model_fields/test_jsonfield.py
+++ b/tests/model_fields/test_jsonfield.py
@@ -1375,7 +1375,9 @@ class JSONNullTests(TestCase):
         obj = NullableJSONModel.objects.create(value=JSONNull())
         obj2 = NullableJSONModel.objects.create(value=[1])
         self.assertSequenceEqual(
-            NullableJSONModel.objects.filter(value__in=[JSONNull(), [1], "foo"]),
+            NullableJSONModel.objects.filter(
+                value__in=[JSONNull(), [1], "foo"]
+            ).order_by("pk"),
             [obj, obj2],
         )
 
@@ -1383,7 +1385,9 @@ class JSONNullTests(TestCase):
         obj1 = NullableJSONModel.objects.create(value={"key": None})
         obj2 = NullableJSONModel.objects.create(value={"key": [1]})
         self.assertSequenceEqual(
-            NullableJSONModel.objects.filter(value__key__in=[JSONNull(), [1], 0]),
+            NullableJSONModel.objects.filter(
+                value__key__in=[JSONNull(), [1], 0]
+            ).order_by("pk"),
             [obj1, obj2],
         )
 
@@ -1394,7 +1398,7 @@ class JSONNullTests(TestCase):
         obj2.value = JSONNull()
         NullableJSONModel.objects.bulk_update([obj1, obj2], fields=["value"])
         self.assertSequenceEqual(
-            NullableJSONModel.objects.filter(value=JSONNull()),
+            NullableJSONModel.objects.filter(value=JSONNull()).order_by("pk"),
             [obj1, obj2],
         )
 

--- a/tests/multiple_database/tests.py
+++ b/tests/multiple_database/tests.py
@@ -932,7 +932,11 @@ class QueryTestCase(TestCase):
             ["alice"],
         )
         self.assertEqual(
-            list(User.objects.using("other").values_list("username", flat=True)),
+            list(
+                User.objects.using("other")
+                .order_by("username")
+                .values_list("username", flat=True)
+            ),
             ["bob", "charlie"],
         )
         self.assertEqual(
@@ -940,7 +944,11 @@ class QueryTestCase(TestCase):
             ["chocolate"],
         )
         self.assertEqual(
-            list(UserProfile.objects.using("other").values_list("flavor", flat=True)),
+            list(
+                UserProfile.objects.using("other")
+                .order_by("flavor")
+                .values_list("flavor", flat=True)
+            ),
             ["crunchy frog", "spring surprise"],
         )
 
@@ -957,7 +965,11 @@ class QueryTestCase(TestCase):
             ["chocolate"],
         )
         self.assertEqual(
-            list(UserProfile.objects.using("other").values_list("flavor", flat=True)),
+            list(
+                UserProfile.objects.using("other")
+                .order_by("flavor")
+                .values_list("flavor", flat=True)
+            ),
             ["crunchy frog", "spring surprise"],
         )
 
@@ -968,7 +980,11 @@ class QueryTestCase(TestCase):
             ["chocolate"],
         )
         self.assertEqual(
-            list(UserProfile.objects.using("other").values_list("flavor", flat=True)),
+            list(
+                UserProfile.objects.using("other")
+                .order_by("flavor")
+                .values_list("flavor", flat=True)
+            ),
             ["crunchy frog", "spring surprise", "tofu"],
         )
 

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -302,7 +302,7 @@ class TestQuerying(PostgreSQLTestCase):
         )
 
     def test_gt(self):
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             NullableIntegerArrayModel.objects.filter(field__gt=[0]), self.objs[:4]
         )
 
@@ -312,7 +312,7 @@ class TestQuerying(PostgreSQLTestCase):
         )
 
     def test_in(self):
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             NullableIntegerArrayModel.objects.filter(field__in=[[1], [2]]),
             self.objs[:2],
         )
@@ -338,19 +338,19 @@ class TestQuerying(PostgreSQLTestCase):
         )
 
     def test_in_as_F_object(self):
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             NullableIntegerArrayModel.objects.filter(field__in=[models.F("field")]),
             self.objs[:4],
         )
 
     def test_contained_by(self):
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             NullableIntegerArrayModel.objects.filter(field__contained_by=[1, 2]),
             self.objs[:2],
         )
 
     def test_contained_by_including_F_object(self):
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             NullableIntegerArrayModel.objects.filter(
                 field__contained_by=[models.F("order"), 2]
             ),
@@ -358,7 +358,7 @@ class TestQuerying(PostgreSQLTestCase):
         )
 
     def test_contains(self):
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             NullableIntegerArrayModel.objects.filter(field__contains=[2]),
             self.objs[1:3],
         )
@@ -371,7 +371,7 @@ class TestQuerying(PostgreSQLTestCase):
             self.objs[2:3],
         )
         inner_qs = IntegerArrayModel.objects.filter(field__contains=OuterRef("field"))
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             NullableIntegerArrayModel.objects.filter(Exists(inner_qs)),
             self.objs[1:3],
         )
@@ -411,7 +411,7 @@ class TestQuerying(PostgreSQLTestCase):
         obj_1 = CharArrayModel.objects.create(field=["TEXT", "lower text"])
         obj_2 = CharArrayModel.objects.create(field=["lower text", "TEXT"])
         CharArrayModel.objects.create(field=["lower text", "text"])
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             CharArrayModel.objects.filter(
                 field__overlap=[
                     Upper(Value("text")),
@@ -493,12 +493,12 @@ class TestQuerying(PostgreSQLTestCase):
         )
 
     def test_index(self):
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             NullableIntegerArrayModel.objects.filter(field__0=2), self.objs[1:3]
         )
 
     def test_index_chained(self):
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             NullableIntegerArrayModel.objects.filter(field__0__lt=3), self.objs[0:3]
         )
 
@@ -535,13 +535,13 @@ class TestQuerying(PostgreSQLTestCase):
         )
 
     def test_overlap(self):
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             NullableIntegerArrayModel.objects.filter(field__overlap=[1, 2]),
             self.objs[0:3],
         )
 
     def test_len(self):
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             NullableIntegerArrayModel.objects.filter(field__len__lte=2), self.objs[0:3]
         )
 
@@ -552,7 +552,7 @@ class TestQuerying(PostgreSQLTestCase):
         )
 
     def test_slice(self):
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             NullableIntegerArrayModel.objects.filter(field__0_1=[2]), self.objs[1:3]
         )
 
@@ -639,7 +639,7 @@ class TestQuerying(PostgreSQLTestCase):
         queryset = NullableIntegerArrayModel.objects.annotate(
             subarray=F("field")[:1]
         ).filter(field__len=F("subarray__len"))
-        self.assertSequenceEqual(queryset, self.objs[:2])
+        self.assertCountEqual(queryset, self.objs[:2])
 
     def test_usage_in_subquery(self):
         self.assertSequenceEqual(
@@ -697,7 +697,7 @@ class TestQuerying(PostgreSQLTestCase):
         inner_qs = NullableIntegerArrayModel.objects.filter(
             field__len=models.OuterRef("field__len"),
         ).values("field")
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             NullableIntegerArrayModel.objects.alias(
                 same_sized_fields=ArraySubquery(inner_qs),
             ).filter(same_sized_fields__len__gt=1),

--- a/tests/postgres_tests/test_bulk_update.py
+++ b/tests/postgres_tests/test_bulk_update.py
@@ -42,7 +42,7 @@ class BulkSaveTests(PostgreSQLTestCase):
                 for instance in instances:
                     setattr(instance, field, new)
                 Model.objects.bulk_update(instances, [field])
-                self.assertSequenceEqual(
+                self.assertCountEqual(
                     Model.objects.filter(**{field: new}), instances
                 )
 

--- a/tests/postgres_tests/test_hstore.py
+++ b/tests/postgres_tests/test_hstore.py
@@ -91,13 +91,13 @@ class TestQuerying(PostgreSQLTestCase):
         )
 
     def test_contained_by(self):
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             HStoreModel.objects.filter(field__contained_by={"a": "b", "c": "d"}),
             self.objs[:4],
         )
 
     def test_contains(self):
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             HStoreModel.objects.filter(field__contains={"a": "b"}), self.objs[:2]
         )
 
@@ -110,7 +110,7 @@ class TestQuerying(PostgreSQLTestCase):
         )
 
     def test_has_key(self):
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             HStoreModel.objects.filter(field__has_key="c"), self.objs[1:3]
         )
 
@@ -120,18 +120,18 @@ class TestQuerying(PostgreSQLTestCase):
         )
 
     def test_has_any_keys(self):
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             HStoreModel.objects.filter(field__has_any_keys=["a", "c"]), self.objs[:3]
         )
 
     def test_key_transform(self):
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             HStoreModel.objects.filter(field__a="b"), self.objs[:2]
         )
 
     def test_key_transform_raw_expression(self):
         expr = RawSQL("%s::hstore", ["x => b, y => c"])
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             HStoreModel.objects.filter(field__a=KeyTransform("x", expr)), self.objs[:2]
         )
 
@@ -153,7 +153,7 @@ class TestQuerying(PostgreSQLTestCase):
         )
 
     def test_field_chaining_contains(self):
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             HStoreModel.objects.filter(field__a__contains="b"), self.objs[:2]
         )
 
@@ -170,7 +170,7 @@ class TestQuerying(PostgreSQLTestCase):
         )
 
     def test_field_chaining_istartswith(self):
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             HStoreModel.objects.filter(field__cat__istartswith="kit"),
             self.objs[7:],
         )
@@ -182,13 +182,13 @@ class TestQuerying(PostgreSQLTestCase):
         )
 
     def test_field_chaining_iendswith(self):
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             HStoreModel.objects.filter(field__cat__iendswith="ou"),
             self.objs[5:7],
         )
 
     def test_field_chaining_iexact(self):
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             HStoreModel.objects.filter(field__breed__iexact="persian"),
             self.objs[7:],
         )
@@ -200,7 +200,7 @@ class TestQuerying(PostgreSQLTestCase):
         )
 
     def test_field_chaining_iregex(self):
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             HStoreModel.objects.filter(field__cat__iregex=r"oU$"),
             self.objs[5:7],
         )
@@ -218,27 +218,27 @@ class TestQuerying(PostgreSQLTestCase):
         )
 
     def test_keys_contains(self):
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             HStoreModel.objects.filter(field__keys__contains=["a"]), self.objs[:2]
         )
 
     def test_values_overlap(self):
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             HStoreModel.objects.filter(field__values__overlap=["b", "d"]), self.objs[:3]
         )
 
     def test_key_isnull(self):
         obj = HStoreModel.objects.create(field={"a": None})
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             HStoreModel.objects.filter(field__a__isnull=True),
             self.objs[2:9] + [obj],
         )
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             HStoreModel.objects.filter(field__a__isnull=False), self.objs[:2]
         )
 
     def test_usage_in_subquery(self):
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             HStoreModel.objects.filter(id__in=HStoreModel.objects.filter(field__a="b")),
             self.objs[:2],
         )
@@ -263,7 +263,7 @@ class TestQuerying(PostgreSQLTestCase):
                 HStoreModel.objects.filter(pk=OuterRef("pk")).values("field")
             ),
         ).filter(value__a="b")
-        self.assertSequenceEqual(qs, self.objs[:2])
+        self.assertCountEqual(qs, self.objs[:2])
 
 
 @isolate_apps("postgres_tests")

--- a/tests/postgres_tests/test_ranges.py
+++ b/tests/postgres_tests/test_ranges.py
@@ -293,7 +293,7 @@ class TestQuerying(PostgreSQLTestCase):
         )
 
     def test_contains(self):
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             RangesModel.objects.filter(ints__contains=8),
             [self.objs[0], self.objs[1]],
         )
@@ -319,18 +319,18 @@ class TestQuerying(PostgreSQLTestCase):
             (15, [decimals[1], decimals[3]]),
         ]:
             with self.subTest(decimal_contains=contains):
-                self.assertSequenceEqual(
+                self.assertCountEqual(
                     RangesModel.objects.filter(decimals__contains=contains), objs
                 )
 
     def test_contained_by(self):
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             RangesModel.objects.filter(ints__contained_by=NumericRange(0, 20)),
             [self.objs[0], self.objs[1], self.objs[3]],
         )
 
     def test_overlap(self):
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             RangesModel.objects.filter(ints__overlap=NumericRange(3, 8)),
             [self.objs[0], self.objs[1]],
         )
@@ -354,13 +354,13 @@ class TestQuerying(PostgreSQLTestCase):
         )
 
     def test_not_gt(self):
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             RangesModel.objects.filter(ints__not_gt=NumericRange(5, 10)),
             [self.objs[0], self.objs[2]],
         )
 
     def test_adjacent_to(self):
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             RangesModel.objects.filter(ints__adjacent_to=NumericRange(0, 5)),
             [self.objs[1], self.objs[2]],
         )
@@ -378,7 +378,7 @@ class TestQuerying(PostgreSQLTestCase):
         )
 
     def test_startswith_chaining(self):
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             RangesModel.objects.filter(ints__startswith__gte=0),
             [self.objs[0], self.objs[1]],
         )
@@ -404,7 +404,7 @@ class TestQuerying(PostgreSQLTestCase):
         ]
         for lookup, filter_arg, excepted_result in tests:
             with self.subTest(lookup=lookup, filter_arg=filter_arg):
-                self.assertSequenceEqual(
+                self.assertCountEqual(
                     RangesModel.objects.filter(**{"decimals__%s" % lookup: filter_arg}),
                     excepted_result,
                 )
@@ -516,7 +516,7 @@ class TestQueryingWithRanges(PostgreSQLTestCase):
         objs = SmallAutoFieldModel.objects.bulk_create(
             [SmallAutoFieldModel() for i in range(1, 5)]
         )
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             SmallAutoFieldModel.objects.filter(
                 id__contained_by=NumericRange(objs[1].pk, objs[3].pk),
             ),
@@ -527,7 +527,7 @@ class TestQueryingWithRanges(PostgreSQLTestCase):
         objs = RangeLookupsModel.objects.bulk_create(
             [RangeLookupsModel() for i in range(1, 5)]
         )
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             RangeLookupsModel.objects.filter(
                 id__contained_by=NumericRange(objs[1].pk, objs[3].pk),
             ),
@@ -538,7 +538,7 @@ class TestQueryingWithRanges(PostgreSQLTestCase):
         objs = BigAutoFieldModel.objects.bulk_create(
             [BigAutoFieldModel() for i in range(1, 5)]
         )
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             BigAutoFieldModel.objects.filter(
                 id__contained_by=NumericRange(objs[1].pk, objs[3].pk),
             ),

--- a/tests/postgres_tests/test_search.py
+++ b/tests/postgres_tests/test_search.py
@@ -295,7 +295,7 @@ class MultipleFieldsTest(GrailTestData, PostgreSQLTestCase):
                 search_type="websearch",
             ),
         )
-        self.assertSequenceEqual(searched, [self.verse0, self.verse1])
+        self.assertCountEqual(searched, [self.verse0, self.verse1])
 
     def test_web_search_with_config(self):
         line_qs = Line.objects.annotate(
@@ -928,7 +928,7 @@ class TestLexemes(GrailTestData, PostgreSQLTestCase):
             )
         )
 
-        self.assertSequenceEqual(searched, [self.verse0, self.verse1])
+        self.assertCountEqual(searched, [self.verse0, self.verse1])
 
     def test_config_query_explicit(self):
         searched = Line.objects.annotate(

--- a/tests/proxy_models/tests.py
+++ b/tests/proxy_models/tests.py
@@ -297,7 +297,7 @@ class ProxyModelTests(TestCase):
         User.objects.create(name="Bruce")
         u2 = UserProxy.objects.create(name="George")
 
-        resp = [u.name for u in UserProxy.objects.all()]
+        resp = [u.name for u in UserProxy.objects.order_by("name")]
         self.assertEqual(resp, ["Bruce", "George"])
 
         u2.delete()

--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -91,9 +91,9 @@ class QuerySetSetOperationTests(TestCase):
 
     def test_union_empty_slice(self):
         qs = Number.objects.union()
-        self.assertNumbersEqual(qs[:1], [0])
+        self.assertNumbersEqual(qs.order_by("num")[:1], [0])
         qs = Number.objects.union(all=True)
-        self.assertNumbersEqual(qs[:1], [0])
+        self.assertNumbersEqual(qs.order_by("num")[:1], [0])
         self.assertNumbersEqual(qs.order_by("num")[0:], list(range(0, 10)))
 
     def test_union_all_none_slice(self):


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37255

#### Branch description
Many (~70) tests assert a specific row order for querysets whose SQL has no ORDER BY. SQL standard does not define that order.

On PostgreSQL the rows usually arrive in physical storage order, which on a freshly loaded table matches insertion order -- so these assertions pass by coincidence rather than by contract. That breaks when rows are updated or deleted and the space is reused, or when the planner picks a different access path such as an index scan. A test like this can start failing with no change to Django or to the test itself.

The patch made sure that most of these tests do not rely on unspecified unordered selection order.
<!-- Provide a concise overview of the issue or rationale behind the proposed changes. Minimum five words. -->

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [X] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude Opus 5, used via Claude Code, ran the test suite under `pg_disorder`,
and triaged the resulting failures. It did not author the test changes in this diff.
All output was reviewed and verified by me.


#### Checklist
- [X] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [X] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [X] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
