### PR TITLE
Fixed #37257, Refs #35738 -- Prevented double-dot deprecation warnings for template literals.

### DIFF
--- a/django/template/base.py
+++ b/django/template/base.py
@@ -556,7 +556,7 @@ class Parser:
                 except TemplateSyntaxError as e:
                     raise self.error(token, e)
                 var_node = VariableNode(filter_expression)
-                if ".." in str(filter_expression.var):
+                if filter_expression.is_var and ".." in filter_expression.var.var:
                     warnings.warn(
                         "Support for double-dot lookups '..' which maps to a "
                         "lookup of the empty string is deprecated.\n"

--- a/docs/releases/6.1.1.txt
+++ b/docs/releases/6.1.1.txt
@@ -9,4 +9,6 @@ Django 6.1.1 fixes several bugs in 6.1.
 Bugfixes
 ========
 
-* ...
+* Fixed a regression in Django 6.1 where the deprecation of double-dot variable
+  lookups incorrectly applied to string and translated template literals
+  containing two consecutive dots, such as ``{{ "a..b" }}`` (:ticket:`37257`).

--- a/tests/template_tests/syntax_tests/test_basic.py
+++ b/tests/template_tests/syntax_tests/test_basic.py
@@ -431,6 +431,20 @@ class BasicSyntaxTests(SimpleTestCase):
     #     ):
     #         self.engine.render_to_string("template")
 
+    def test_double_dot_in_literal(self):
+        tests = [
+            ('{{ "hello..world" }}', "hello..world"),
+            ("{{ 'a..b'|upper }}", "A..B"),
+            ('{{ missing|default:"a..b" }}', "a..b"),
+            ('{{ _("a..b") }}', "a..b"),
+        ]
+        engine = Engine()
+        for template_string, expected in tests:
+            with self.subTest(template_string=template_string):
+                template = engine.from_string(template_string)
+                output = template.render(Context({}))
+                self.assertEqual(output, expected)
+
 
 class BlockContextTests(SimpleTestCase):
     def test_repr(self):


### PR DESCRIPTION
#### Trac ticket number

ticket-37257

#### Branch description

The deprecation warning for double-dot variable lookups checked `str(filter_expression.var)`, which for constants is the resolved literal value rather than a lookup expression. Templates containing string, translated, or numeric literals with two consecutive dots, such as `{{ "a..b" }}` or `{{ 'a..b'|upper }}`, therefore emitted a spurious `RemovedInDjango70Warning` even though no variable lookup was involved, breaking test suites run with -W error and putting valid templates on track to become hard errors in Django 7.0. The check now only fires when the filter expression's variable is an actual Variable lookup.

Regression in 5d911f2d2fecc703be91b2b9b28acc59d34b35f3.


#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude 5 Fable did nearly all the work here, discovering the bug and writing the commit. I made minor edits. I agree with the report and approach.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
