### PR TITLE
Fixed #37258 -- Fixed a crash when combining values() with Meta.ordering.

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -2023,6 +2023,10 @@ class QuerySet(AltersData):
             and
             # A default ordering doesn't affect GROUP BY queries.
             not self.query.group_by
+            and
+            # A default ordering cannot be applied to combined queries with a
+            # limited list of selected fields, e.g. through values().
+            not (self.query.combinator and self.query.has_select_fields)
         ):
             return True
         else:

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -343,7 +343,14 @@ class SQLCompiler:
             ordering = self.query.order_by
         elif self.query.order_by:
             ordering = self.query.order_by
-        elif (meta := self.query.get_meta()) and meta.ordering:
+        elif (
+            (meta := self.query.get_meta())
+            and meta.ordering
+            # Default ordering cannot be applied to combined queries with a
+            # limited list of selected fields, e.g. through values(), because
+            # the ordering fields may not be present in the result set.
+            and not (self.query.combinator and self.query.has_select_fields)
+        ):
             ordering = meta.ordering
             self._meta_ordering = ordering
         else:

--- a/docs/releases/6.1.1.txt
+++ b/docs/releases/6.1.1.txt
@@ -16,3 +16,9 @@ Bugfixes
 * Fixed a regression in Django 6.1 where :attr:`.ModelAdmin.list_display`
   entries that traverse multiple relations using ``__`` could crash or display
   incorrect values (:ticket:`37270`).
+
+* Fixed a regression in Django 6.1 that caused a crash when combining
+  querysets with :meth:`.QuerySet.values` or :meth:`.QuerySet.values_list`,
+  e.g. through :meth:`.QuerySet.union`, on models with ``Meta.ordering``
+  when the ordering columns were not part of the selected fields
+  (:ticket:`37258`).

--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -1,5 +1,6 @@
 import operator
 from datetime import datetime
+from unittest import mock
 
 from django.db import DatabaseError, NotSupportedError, connection
 from django.db.models import (
@@ -444,6 +445,57 @@ class QuerySetSetOperationTests(TestCase):
         qs1 = Tag.objects.filter(name__in=["A", "B"])[:1]
         qs2 = Tag.objects.filter(name__in=["C"])[:1]
         self.assertSequenceEqual(qs1.union(qs2), [a, c])
+
+    @skipUnlessDBFeature("supports_slicing_ordering_in_compound")
+    def test_union_first_last_with_default_ordering(self):
+        Tag.objects.create(name="B")
+        a = Tag.objects.create(name="A")
+        c = Tag.objects.create(name="C")
+        qs = Tag.objects.all().union(Tag.objects.all())
+        self.assertEqual(qs.first(), a)
+        self.assertEqual(qs.last(), c)
+
+    @skipUnlessDBFeature("supports_slicing_ordering_in_compound")
+    def test_union_with_values_and_default_ordering(self):
+        # The default ordering is not applied to combined queries with select
+        # fields when the ordering columns are not part of the result set.
+        tag1 = Tag.objects.create(name="t1")
+        tag2 = Tag.objects.create(name="t2")
+        qs1 = Tag.objects.values("id")
+        qs2 = Tag.objects.values("id")
+        self.assertCountEqual(qs1.union(qs2), [{"id": tag1.pk}, {"id": tag2.pk}])
+        qs1 = Tag.objects.values_list("id", flat=True)
+        qs2 = Tag.objects.values_list("id", flat=True)
+        self.assertCountEqual(qs1.union(qs2), [tag1.pk, tag2.pk])
+
+    def test_union_with_values_and_default_ordering_sql(self):
+        tests = [
+            Tag.objects.values("id").union(Tag.objects.values("id")),
+            Tag.objects.values_list("id").union(Tag.objects.values_list("id")),
+            Tag.objects.all().union(Tag.objects.all()).values("id"),
+        ]
+        for i, qs in enumerate(tests):
+            with (
+                self.subTest(query_index=i),
+                mock.patch.object(
+                    connection.features,
+                    "supports_slicing_ordering_in_compound",
+                    True,
+                ),
+            ):
+                sql, _ = qs.query.get_compiler(connection=connection).as_sql()
+                self.assertNotIn(") ORDER BY", sql)
+
+    def test_union_with_values_and_default_ordering_ordered_attribute(self):
+        self.assertIs(Tag.objects.all().union(Tag.objects.all()).ordered, True)
+        self.assertIs(
+            Tag.objects.values("id").union(Tag.objects.values("id")).ordered,
+            False,
+        )
+        self.assertIs(
+            Tag.objects.values("name").union(Tag.objects.values("name")).ordered,
+            False,
+        )
 
     def test_union_multiple_models_with_values_list_and_order(self):
         reserved_name = ReservedName.objects.create(name="rn1", order=0)


### PR DESCRIPTION
#### Trac ticket number

ticket-37258

#### Branch description

Combining querysets restricted with values()/values_list() on a model with Meta.ordering crashed at SQL compilation with DatabaseError("ORDER BY term does not match any column in the result set.") on backends supporting ordering in compound statements (PostgreSQL, MySQL, Oracle) whenever the model's default ordering columns were not part of the selected columns. The implicit Meta.ordering, now applied after the combination, cannot be injected into combined queries with a limited list of selected fields.

The default ordering (and QuerySet.ordered) is now only applied to combined queries without selected fields, restoring the pre-6.1 behavior for values()/values_list() combinations while preserving the deterministic default ordering of plain combined querysets.

Regression in 087bb9e8f3478d53f12b1737af865992af17c5f2.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude 5 Fable did nearly all the work here, discovering the bug and writing the commit. I made minor edits. I agree with the report and approach.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
