### PR TITLE
Fixed #37259 -- Restored support for old-signature Model.from_db() overrides.

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -6,7 +6,7 @@ import copy
 import operator
 import warnings
 from contextlib import nullcontext
-from functools import reduce
+from functools import partial, reduce
 from itertools import chain, islice
 from weakref import ref as weak_ref
 
@@ -52,6 +52,7 @@ from django.utils.deprecation import (
     warn_about_external_use,
 )
 from django.utils.functional import cached_property
+from django.utils.inspect import func_accepts_kwargs, func_supports_parameter
 from django.utils.warnings import django_file_prefixes
 
 # The maximum number of results to fetch in a get() query.
@@ -61,6 +62,34 @@ MAX_GET_RESULTS = 21
 REPR_OUTPUT_SIZE = 20
 
 DEFAULT_FETCH_MODE = FETCH_ONE
+
+
+# RemovedInDjango70Warning: When the deprecation ends, remove this function
+# and restore direct model_cls.from_db(..., fetch_mode=fetch_mode) calls at
+# its call sites.
+def _get_from_db(model_cls, fetch_mode):
+    """
+    Return a callable equivalent to model_cls.from_db with fetch_mode already
+    bound, accommodating deprecated from_db() overrides that don't accept the
+    fetch_mode keyword argument.
+    """
+    from django.db.models import Model
+
+    from_db = model_cls.from_db
+    if (
+        from_db.__func__ is Model.from_db.__func__
+        or func_supports_parameter(from_db, "fetch_mode")
+        or func_accepts_kwargs(from_db)
+    ):
+        return partial(from_db, fetch_mode=fetch_mode)
+    warnings.warn(
+        f"{model_cls.__qualname__}.from_db() must accept a fetch_mode keyword "
+        "argument. Support for from_db() methods that do not accept it is "
+        "deprecated.",
+        RemovedInDjango70Warning,
+        skip_file_prefixes=django_file_prefixes(),
+    )
+    return from_db
 
 
 class BaseIterable:
@@ -123,6 +152,10 @@ class ModelIterable(BaseIterable):
         init_list = [
             f[0].target.attname for f in select[model_fields_start:model_fields_end]
         ]
+        # RemovedInDjango70Warning: When the deprecation ends, remove this
+        # assignment and call model_cls.from_db(..., fetch_mode=fetch_mode)
+        # directly in the loop below.
+        from_db = _get_from_db(model_cls, fetch_mode)
         related_populators = get_related_populators(klass_info, select, db, fetch_mode)
         known_related_objects = [
             (
@@ -142,11 +175,10 @@ class ModelIterable(BaseIterable):
         ]
         peers = []
         for row in compiler.results_iter(results):
-            obj = model_cls.from_db(
+            obj = from_db(
                 db,
                 init_list,
                 row[model_fields_start:model_fields_end],
-                fetch_mode=fetch_mode,
             )
             if fetch_mode.track_peers:
                 peers.append(weak_ref(obj))
@@ -213,13 +245,16 @@ class RawModelIterable(BaseIterable):
                     query_iterator, cols
                 )
             fetch_mode = self.queryset._fetch_mode
+            # RemovedInDjango70Warning: When the deprecation ends, remove
+            # this assignment and call
+            # model_cls.from_db(..., fetch_mode=fetch_mode) directly in the
+            # loop below.
+            from_db = _get_from_db(model_cls, fetch_mode)
             peers = []
             for values in query_iterator:
                 # Associate fields to values
                 model_init_values = [values[pos] for pos in model_init_pos]
-                instance = model_cls.from_db(
-                    db, model_init_names, model_init_values, fetch_mode=fetch_mode
-                )
+                instance = from_db(db, model_init_names, model_init_values)
                 if fetch_mode.track_peers:
                     peers.append(weak_ref(instance))
                     instance._state.peers = peers
@@ -3044,6 +3079,11 @@ class RelatedPopulator:
             )
 
         self.model_cls = klass_info["model"]
+        # RemovedInDjango70Warning: When the deprecation ends, remove this
+        # assignment and call
+        # self.model_cls.from_db(..., fetch_mode=fetch_mode) directly in
+        # populate().
+        self.from_db = _get_from_db(self.model_cls, fetch_mode)
         # A primary key must have all of its constituents not-NULL as
         # NULL != NULL and thus NULL cannot be referenced through a foreign
         # relationship. Therefore checking for a single member of the primary
@@ -3063,11 +3103,10 @@ class RelatedPopulator:
         if obj_data[self.pk_idx] is None:
             obj = None
         else:
-            obj = self.model_cls.from_db(
+            obj = self.from_db(
                 self.db,
                 self.init_list,
                 obj_data,
-                fetch_mode=self.fetch_mode,
             )
             for rel_iter in self.related_populators:
                 rel_iter.populate(row, obj)

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -151,6 +151,9 @@ details on these changes.
 * The ``django.db.transaction.savepoint()`` alias to
   ``django.db.transaction.savepoint_create()`` will be removed.
 
+* Support for ``Model.from_db()`` methods that do not accept the
+  ``fetch_mode`` keyword argument will be removed.
+
 .. _deprecation-removed-in-6.1:
 
 6.1

--- a/docs/ref/models/instances.txt
+++ b/docs/ref/models/instances.txt
@@ -150,6 +150,11 @@ is done. In this case it would be possible to use a ``super()`` call in the
 
     The ``fetch_mode`` parameter was added.
 
+.. deprecated:: 6.1
+
+    Support for ``from_db()`` methods that do not accept the ``fetch_mode``
+    keyword argument is deprecated and will be removed in Django 7.0.
+
 .. _refreshing-objects:
 
 Refreshing objects from database

--- a/docs/releases/6.1.1.txt
+++ b/docs/releases/6.1.1.txt
@@ -34,3 +34,8 @@ Bugfixes
 * Fixed a bug in Django 6.1 where :class:`~django.db.models.DecimalField`
   without ``max_digits`` and ``decimal_places`` caused a crash when retrieving
   values on SQLite (:ticket:`37275`).
+
+* Fixed a regression in Django 6.1 that caused a crash when iterating a
+  ``QuerySet`` of a model overriding ``Model.from_db()`` without the new
+  ``fetch_mode`` keyword argument. Such overrides now work again, but are
+  deprecated and should be updated to accept ``fetch_mode`` (:ticket:`37259`).

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -661,6 +661,9 @@ Miscellaneous
   is deprecated. Pass an explicit field name, like
   ``values_list("pk", flat=True)``.
 
+* Support for ``Model.from_db()`` methods that do not accept the
+  ``fetch_mode`` keyword argument is deprecated.
+
 * The use of ``None`` to represent a top-level JSON scalar ``null`` when
   querying :class:`~django.db.models.JSONField` is now deprecated in favor of
   the new :class:`~django.db.models.JSONNull` expression. At the end of the

--- a/tests/basic/models.py
+++ b/tests/basic/models.py
@@ -61,3 +61,29 @@ class PrimaryKeyWithFalseyDbDefault(models.Model):
 
 class ChildPrimaryKeyWithDefault(PrimaryKeyWithDefault):
     pass
+
+
+# RemovedInDjango70Warning.
+class FromDbOldSignature(models.Model):
+    name = models.CharField(max_length=20)
+
+    @classmethod
+    def from_db(cls, db, field_names, values):
+        instance = super().from_db(db, field_names, values)
+        instance._loaded_values = dict(zip(field_names, values))
+        return instance
+
+
+# RemovedInDjango70Warning.
+class FromDbOldSignatureRelated(models.Model):
+    old = models.ForeignKey(FromDbOldSignature, models.CASCADE)
+
+
+class FromDbNewSignature(models.Model):
+    name = models.CharField(max_length=20)
+
+    @classmethod
+    def from_db(cls, db, field_names, values, *, fetch_mode=None):
+        instance = super().from_db(db, field_names, values, fetch_mode=fetch_mode)
+        instance._from_db_fetch_mode = fetch_mode
+        return instance

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -24,6 +24,7 @@ from django.test import (
 )
 from django.test.utils import CaptureQueriesContext
 from django.utils.connection import ConnectionDoesNotExist
+from django.utils.deprecation import RemovedInDjango70Warning
 from django.utils.translation import gettext_lazy
 
 from .models import (
@@ -31,6 +32,9 @@ from .models import (
     ArticleSelectOnSave,
     ChildPrimaryKeyWithDefault,
     FeaturedArticle,
+    FromDbNewSignature,
+    FromDbOldSignature,
+    FromDbOldSignatureRelated,
     PrimaryKeyWithDbDefault,
     PrimaryKeyWithDefault,
     PrimaryKeyWithFalseyDbDefault,
@@ -1120,3 +1124,54 @@ class ModelRefreshTests(TestCase):
         fa.refresh_from_db(from_queryset=from_queryset)
         self.assertEqual(fa._state.fetch_mode, models.FETCH_PEERS)
         self.assertEqual(fa.article._state.fetch_mode, models.FETCH_PEERS)
+
+
+class ModelFromDbTests(TestCase):
+    # RemovedInDjango70Warning: Remove the FromDbOldSignature tests when the
+    # deprecation ends.
+    deprecation_msg = (
+        "FromDbOldSignature.from_db() must accept a fetch_mode keyword "
+        "argument. Support for from_db() methods that do not accept it is "
+        "deprecated."
+    )
+
+    def test_old_signature_iteration(self):
+        obj = FromDbOldSignature.objects.create(name="test")
+        with self.assertWarnsMessage(RemovedInDjango70Warning, self.deprecation_msg):
+            instances = list(FromDbOldSignature.objects.all())
+        self.assertEqual(instances, [obj])
+        self.assertEqual(instances[0]._loaded_values, {"id": obj.pk, "name": "test"})
+
+    def test_old_signature_get(self):
+        obj = FromDbOldSignature.objects.create(name="test")
+        with self.assertWarnsMessage(RemovedInDjango70Warning, self.deprecation_msg):
+            fetched = FromDbOldSignature.objects.get(pk=obj.pk)
+        self.assertEqual(fetched._loaded_values, {"id": obj.pk, "name": "test"})
+
+    def test_old_signature_select_related(self):
+        obj = FromDbOldSignature.objects.create(name="test")
+        related = FromDbOldSignatureRelated.objects.create(old=obj)
+        with self.assertWarnsMessage(RemovedInDjango70Warning, self.deprecation_msg):
+            fetched = FromDbOldSignatureRelated.objects.select_related("old").get(
+                pk=related.pk
+            )
+        self.assertEqual(fetched.old._loaded_values, {"id": obj.pk, "name": "test"})
+
+    def test_old_signature_raw(self):
+        obj = FromDbOldSignature.objects.create(name="test")
+        with self.assertWarnsMessage(RemovedInDjango70Warning, self.deprecation_msg):
+            instances = list(
+                FromDbOldSignature.objects.raw("SELECT * FROM basic_fromdboldsignature")
+            )
+        self.assertEqual(instances, [obj])
+        self.assertEqual(instances[0]._loaded_values, {"id": obj.pk, "name": "test"})
+
+    def test_new_signature_receives_fetch_mode(self):
+        obj = FromDbNewSignature.objects.create(name="test")
+        fetched = FromDbNewSignature.objects.get(pk=obj.pk)
+        self.assertIs(fetched._from_db_fetch_mode, models.FETCH_ONE)
+
+    def test_new_signature_receives_fetch_mode_peers(self):
+        FromDbNewSignature.objects.create(name="test")
+        (fetched,) = FromDbNewSignature.objects.fetch_mode(models.FETCH_PEERS)
+        self.assertIs(fetched._from_db_fetch_mode, models.FETCH_PEERS)


### PR DESCRIPTION
#### Trac ticket number

ticket-37259

#### Branch description

The fetch modes feature made all query iteration paths (ModelIterable, RawModelIterable, and RelatedPopulator) call Model.from_db() with a fetch_mode keyword argument. This crashed with a TypeError for models overriding from_db() with the previously documented signature from_db(cls, db, field_names, values).

Query iteration now detects, once per query rather than per row, whether the model's from_db() accepts the fetch_mode keyword argument (or **kwargs) and calls old-style overrides without it, emitting a RemovedInDjango70Warning asking authors to add the argument.

Regression in e097e8a12f21a4e92594830f1ad1942b31916d0f.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude 5 Fable did nearly all the work here, discovering the bug and writing the commit. I made minor edits. I agree with the report and approach.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
