### PR TITLE
Fixed #37260 -- Avoided DDL when altering only Python-level on_delete options.

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -601,6 +601,14 @@ class ForeignObject(RelatedField):
         obj.__dict__.pop("reverse_path_infos", None)
         return obj
 
+    @property
+    def non_db_attrs(self):
+        if isinstance(self.remote_field.on_delete, DatabaseOnDelete):
+            # Database-level on_delete options are part of the column
+            # definition.
+            return super().non_db_attrs
+        return super().non_db_attrs + ("on_delete",)
+
     def check(self, **kwargs):
         return [
             *super().check(**kwargs),

--- a/docs/releases/6.1.1.txt
+++ b/docs/releases/6.1.1.txt
@@ -25,3 +25,8 @@ Bugfixes
   created with :func:`~django.utils.safestring.mark_safe`, used as form media
   assets were treated as asset paths rather than being rendered verbatim
   (:ticket:`37262`).
+
+* Fixed a regression in Django 6.1 that caused ``AlterField`` operations that
+  changed only the Python-level ``on_delete`` option of ``ForeignKey`` or
+  ``OneToOneField`` fields to perform unnecessary schema changes
+  (:ticket:`37260`).

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -2573,6 +2573,33 @@ class OperationTests(OperationTestBase):
                 operation.database_forwards(app_label, editor, new_state, project_state)
         self.assertColumnExists(rider_table, "pony_id")
 
+    def test_alter_field_python_level_on_delete_noop(self):
+        """
+        AlterField operation is a noop when changing only the Python-level
+        on_delete option.
+        """
+        app_label = "test_alflodnoop"
+        project_state = self.set_up_test_model(app_label, related_model=True)
+        operation = migrations.AlterField(
+            "Rider", "pony", models.ForeignKey("Pony", models.PROTECT)
+        )
+        new_state = project_state.clone()
+        operation.state_forwards(app_label, new_state)
+        self.assertIs(
+            project_state.models[app_label, "rider"]
+            .fields["pony"]
+            .remote_field.on_delete,
+            models.CASCADE,
+        )
+        self.assertIs(
+            new_state.models[app_label, "rider"].fields["pony"].remote_field.on_delete,
+            models.PROTECT,
+        )
+        with connection.schema_editor() as editor, self.assertNumQueries(0):
+            operation.database_forwards(app_label, editor, project_state, new_state)
+        with connection.schema_editor() as editor, self.assertNumQueries(0):
+            operation.database_backwards(app_label, editor, new_state, project_state)
+
     def test_alter_field_foreignobject_noop(self):
         app_label = "test_alflfo_noop"
         project_state = self.set_up_test_model(app_label)

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -635,8 +635,55 @@ class SchemaTests(TransactionTestCase):
         ):
             editor.alter_field(Book, old_field, new_field)
         self.assertForeignKeyExists(Book, "author_id", "schema_author")
+        self.assertGreater(len(ctx.captured_queries), 0)
         self.assertIs(
             any("ON DELETE" in query["sql"] for query in ctx.captured_queries), False
+        )
+
+    @skipUnlessDBFeature("supports_foreign_keys", "can_introspect_foreign_keys")
+    def test_fk_alter_on_delete_python_level_noop(self):
+        with connection.schema_editor() as editor:
+            editor.create_model(Author)
+            editor.create_model(Book)
+        old_field = Book._meta.get_field("author")
+        new_field = ForeignKey(Author, PROTECT)
+        new_field.set_attributes_from_name("author")
+        # Changing between Python-level on_delete options doesn't require
+        # database changes.
+        with connection.schema_editor() as editor, self.assertNumQueries(0):
+            editor.alter_field(Book, old_field, new_field, strict=True)
+        with connection.schema_editor() as editor, self.assertNumQueries(0):
+            editor.alter_field(Book, new_field, old_field, strict=True)
+
+    @isolate_apps("schema")
+    @skipUnlessDBFeature("supports_foreign_keys", "can_introspect_foreign_keys")
+    def test_fk_alter_on_delete_db_level(self):
+        class DBOnDeleteParent(Model):
+            class Meta:
+                app_label = "schema"
+
+        class DBOnDeleteChild(Model):
+            parent = ForeignKey(DBOnDeleteParent, DB_CASCADE, null=True)
+
+            class Meta:
+                app_label = "schema"
+
+        self.isolated_local_models = [DBOnDeleteChild, DBOnDeleteParent]
+        with connection.schema_editor() as editor:
+            editor.create_model(DBOnDeleteParent)
+            editor.create_model(DBOnDeleteChild)
+        # Changing between database-level on_delete options requires database
+        # changes.
+        old_field = DBOnDeleteChild._meta.get_field("parent")
+        new_field = ForeignKey(DBOnDeleteParent, DB_SET_NULL, null=True)
+        new_field.set_attributes_from_name("parent")
+        with (
+            connection.schema_editor() as editor,
+            CaptureQueriesContext(connection) as ctx,
+        ):
+            editor.alter_field(DBOnDeleteChild, old_field, new_field, strict=True)
+        self.assertIs(
+            any("SET NULL" in query["sql"] for query in ctx.captured_queries), True
         )
 
     @isolate_apps("schema")
@@ -4926,7 +4973,7 @@ class SchemaTests(TransactionTestCase):
             error_messages={"invalid": "error message"},
             help_text="help text",
             limit_choices_to={"limit": "choice"},
-            on_delete=CASCADE,
+            on_delete=PROTECT,
             related_name="related_name",
             related_query_name="related_query_name",
             validators=[lambda x: x],


### PR DESCRIPTION
#### Trac ticket number

ticket-37260

#### Branch description

Regression in 0c487aa3a7b2417481bf48c1e5355c855873e210.

Support for database-level delete options removed "on_delete" from `Field.non_db_attrs` because changes to or from the new `DB_CASCADE`, `DB_SET_DEFAULT`, and `DB_SET_NULL` options require schema changes. As a consequence, an `AlterField` changing only a Python-level `on_delete` option (such as `CASCADE` to `PROTECT`) performs unnecessary schema changes when it was previously a no-op at the database level.

This commit makes `ForeignObject.non_db_attrs` a property that includes `"on_delete"`only when the option is not a database-level one, so that:

- Python-level to Python-level changes skip DDL again,
- changes to, from, or between database-level options still alter the field.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude 5 Fable did nearly all the work here, discovering the bug and writing the commit. I made minor edits. I agree with the report and approach.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
