### PR TITLE
Fixed #37261 -- Prevented error reporting emails from raising under MAILERS.

### DIFF
--- a/django/middleware/common.py
+++ b/django/middleware/common.py
@@ -3,7 +3,7 @@ from urllib.parse import urlsplit
 
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
-from django.core.mail import MailerDoesNotExist, mail_managers, mailers
+from django.core.mail import mail_managers, mailers
 from django.http import HttpResponsePermanentRedirect
 from django.middleware import MiddlewareMixin
 from django.urls import is_valid_path
@@ -154,7 +154,9 @@ class BrokenLinkEmailsMiddleware(MiddlewareMixin):
 
         try:
             mail_managers(subject, message, *args, using=self.using, **kwargs)
-        except MailerDoesNotExist:
+        except Exception:
+            # Ignore all errors, including an unavailable mailer and any
+            # failure sending the email, to avoid failing the response.
             pass
 
     def is_internal_request(self, domain, referer):

--- a/django/utils/log.py
+++ b/django/utils/log.py
@@ -174,7 +174,10 @@ class AdminEmailHandler(logging.Handler):
 
         try:
             mail.mail_admins(subject, message, *args, using=self.using, **kwargs)
-        except mail.MailerDoesNotExist:
+        except Exception:
+            # Ignore all errors, including an unavailable mailer and any
+            # failure sending the email, to avoid a cascading failure in the
+            # error handler.
             pass
 
     def format_subject(self, subject):

--- a/docs/releases/6.1.1.txt
+++ b/docs/releases/6.1.1.txt
@@ -9,4 +9,7 @@ Django 6.1.1 fixes several bugs in 6.1.
 Bugfixes
 ========
 
-* ...
+* Fixed a regression in Django 6.1 where ``AdminEmailHandler`` and
+  ``BrokenLinkEmailsMiddleware`` no longer ignored errors raised while sending
+  error reporting emails when the :setting:`MAILERS` setting was used, causing
+  cascading failures during error handling (:ticket:`37261`).

--- a/tests/logging_tests/tests.py
+++ b/tests/logging_tests/tests.py
@@ -445,6 +445,21 @@ class AdminEmailHandlerTest(SimpleTestCase):
 
     @override_settings(
         ADMINS=["admin@example.com"],
+        MAILERS={"default": {"BACKEND": "mail.custombackend.FailingEmailBackend"}},
+    )
+    def test_no_error_when_sending_fails(self):
+        """
+        An error sending the email is ignored to avoid a cascading failure in
+        the error handler (matching the fail_silently=True behavior of the
+        deprecated EMAIL_BACKEND setting).
+        """
+        self.addCleanup(FailingEmailBackend.reset)
+        # Does not raise the error from FailingEmailBackend.send_messages().
+        self.logger.error("All work and no play makes Jack a dull boy")
+        self.assertEqual(len(mail.outbox), 0)
+
+    @override_settings(
+        ADMINS=["admin@example.com"],
         MAILERS={
             "custom": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"}
         },

--- a/tests/middleware/tests.py
+++ b/tests/middleware/tests.py
@@ -527,6 +527,22 @@ class BrokenLinkEmailsMiddlewareTest(SimpleTestCase):
         self.assertEqual(len(mail.outbox), 0)
 
     @override_settings(
+        MAILERS={"default": {"BACKEND": "mail.custombackend.FailingEmailBackend"}}
+    )
+    def test_no_error_when_sending_fails(self):
+        """
+        An error sending the email is ignored and the response is returned
+        (matching the fail_silently=True behavior of the deprecated
+        EMAIL_BACKEND setting).
+        """
+        self.addCleanup(FailingEmailBackend.reset)
+        self.req.META["HTTP_REFERER"] = "/another/url/"
+        # Does not raise the error from FailingEmailBackend.send_messages().
+        response = BrokenLinkEmailsMiddleware(self.get_response)(self.req)
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(len(mail.outbox), 0)
+
+    @override_settings(
         MAILERS={
             "custom": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"}
         },


### PR DESCRIPTION
#### Trac ticket number

ticket-37261

#### Branch description

When `settings.MAILERS` is configured, `AdminEmailHandler.send_mail()` and `BrokenLinkEmailsMiddleware.send_mail()` caught only `MailerDoesNotExist`, so any transport error raised while sending (SMTP server down, DNS failure, authentication error, etc.) propagated out of `AdminEmailHandler.emit()` into the caller of `logger.error()` -- typically Django's own error handling of a 500 response -- and out of `BrokenLinkEmailsMiddleware.process_response()` on referred 404s. The legacy `EMAIL_BACKEND` path still passed `fail_silently=True`, which swallowed all such errors.

The fix is to catch `Exception` instead, per the 'Migrating email to mailers' documentation.

Regression in 0f581cd29d42d1b5ed1dafb67794c2f3ce6705c9.

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude 5 Fable did nearly all the work here, discovering the bug and writing the commit. I made minor edits. I agree with the report and approach.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
