### PR TITLE
Fixed #37262 -- Restored rendering of html-safe strings in form media.

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -152,13 +152,13 @@ class Media:
 
     @staticmethod
     def _normalize_js(js):
-        return [Script(path) if isinstance(path, str) else path for path in js]
+        return [(path if hasattr(path, "__html__") else Script(path)) for path in js]
 
     @staticmethod
     def _normalize_css(css):
         return {
             medium: [
-                Stylesheet(path, media=medium) if isinstance(path, str) else path
+                (path if hasattr(path, "__html__") else Stylesheet(path, media=medium))
                 for path in paths
             ]
             for medium, paths in css.items()

--- a/docs/releases/6.1.1.txt
+++ b/docs/releases/6.1.1.txt
@@ -20,3 +20,8 @@ Bugfixes
 * Fixed a bug in Django 6.1 where the ``fields.E323`` system check did not
   detect mixed ``on_delete`` variants for auto-created intermediate models for
   ``ManyToManyField``\s (:ticket:`37254`).
+
+* Fixed a regression in Django 6.1 where HTML-safe strings, such as those
+  created with :func:`~django.utils.safestring.mark_safe`, used as form media
+  assets were treated as asset paths rather than being rendered verbatim
+  (:ticket:`37262`).

--- a/tests/forms_tests/tests/test_media.py
+++ b/tests/forms_tests/tests/test_media.py
@@ -3,6 +3,7 @@ from django.forms.widgets import MediaAsset, Script, Stylesheet
 from django.template import Context, Template
 from django.test import SimpleTestCase, override_settings
 from django.utils.html import html_safe
+from django.utils.safestring import mark_safe
 
 
 @override_settings(STATIC_URL="http://media.example.com/static/")
@@ -865,6 +866,56 @@ class FormsMediaTestCase(SimpleTestCase):
 
         with self.assertRaises(TypeError):
             Media() + InvalidType()
+
+    def test_html_safe_string_js(self):
+        tag = mark_safe('<script defer src="https://example.org/asset.js"></script>')
+        media = Media(js=[tag])
+        self.assertEqual(str(media), tag)
+
+    def test_html_safe_string_css(self):
+        tag = mark_safe('<link href="https://example.org/asset.css" rel="stylesheet">')
+        media = Media(css={"all": [tag]})
+        self.assertEqual(str(media), tag)
+
+    def test_html_safe_string_deduplication(self):
+        js_tag = mark_safe('<script defer src="https://example.org/asset.js"></script>')
+        css_tag = mark_safe(
+            '<link href="https://example.org/asset.css" rel="stylesheet">'
+        )
+        media = Media(
+            css={"all": [css_tag, css_tag, "/path/to/css1"]},
+            js=[js_tag, js_tag, Script("/path/to/js1")],
+        )
+        self.assertHTMLEqual(
+            str(media),
+            '<link href="https://example.org/asset.css" rel="stylesheet">\n'
+            '<link href="/path/to/css1" media="all" rel="stylesheet">\n'
+            '<script defer src="https://example.org/asset.js"></script>\n'
+            '<script src="/path/to/js1"></script>',
+        )
+
+    def test_html_safe_string_merging(self):
+        js_tag = mark_safe('<script defer src="https://example.org/asset.js"></script>')
+        css_tag = mark_safe(
+            '<link href="https://example.org/asset.css" rel="stylesheet">'
+        )
+        m1 = Media(
+            css={"all": [css_tag, "/path/to/css1"]},
+            js=["/path/to/js1", js_tag],
+        )
+        m2 = Media(
+            css={"all": [css_tag]},
+            js=[js_tag, Script("/path/to/js2")],
+        )
+        merged = m1 + m2
+        self.assertHTMLEqual(
+            str(merged),
+            '<link href="https://example.org/asset.css" rel="stylesheet">\n'
+            '<link href="/path/to/css1" media="all" rel="stylesheet">\n'
+            '<script src="/path/to/js1"></script>\n'
+            '<script defer src="https://example.org/asset.js"></script>\n'
+            '<script src="/path/to/js2"></script>',
+        )
 
     def test_render_js_with_attrs(self):
         media = Media(js=[Script("/path/to/js", integrity="sha256-abc")])


### PR DESCRIPTION
#### Trac ticket number

ticket-37262

#### Branch description

`Media.__init__()` normalized every string js/css entry into `Script` or `Stylesheet` objects. `SafeString` is a `str` subclass, so html-safe strings such as `mark_safe("<script defer src=...></script>")`, a previously-documented idiom for including complete asset tags, were treated as asset paths, run through `static()`, and percent-encoded instead of being rendered verbatim.

Leave objects providing `__html__()` un-normalized so that they take the verbatim rendering path, restoring the Django 6.0 behavior.

Regression in 8096b5251090bf7539c59956e398b027c7525529.

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
<!-- If AI tools were used, provide which tools were used here. -->

Claude 5 Fable did nearly all the work here, discovering the bug and writing the commit. I made minor edits. I agree with the report and approach.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
