### PR TITLE
Refs #36717 -- Noted RedirectURLMixin signature changes in 6.1 release notes.

### DIFF
--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -589,6 +589,14 @@ Miscellaneous
   entries containing non-standard or corrupted Base64 data may no longer be
   readable.
 
+* The undocumented ``get_success_url_allowed_hosts()`` and
+  ``get_redirect_url()`` methods of
+  ``django.contrib.auth.views.RedirectURLMixin``, used by
+  :class:`~django.contrib.auth.views.LoginView` and
+  :class:`~django.contrib.auth.views.LogoutView`, now accept an optional
+  ``request`` argument. Subclasses overriding these methods must add
+  ``request=None`` to their signatures to avoid a ``TypeError``.
+
 .. _deprecated-features-6.1:
 
 Features deprecated in 6.1


### PR DESCRIPTION
#### Trac ticket number

ticket-36717

#### Branch description

5401b125abca53200eacb62c8a10e602359b76d4 changed these private methods' signatures to add a `request` parameter. While the methods are private, I think this change is release-note-worthy because it’s possible they have been overriden by users, particularly `get_success_url_allowed_hosts()` where the related attribute `success_url_allowed_hosts` [is documented](https://docs.djangoproject.com/en/6.1/topics/auth/default/#django.contrib.auth.views.LoginView.success_url_allowed_hosts) and users needing some dynamism may have spotted and overridden the method.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude 5 Fable spotted this incompatibility and wrote the release note, under my command.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
