### PR TITLE
Fixed #37264 -- Handled malformed _source_model values in admin popup add views.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -1594,10 +1594,10 @@ class ModelAdmin(BaseModelAdmin):
             source_model_name = request.POST.get(SOURCE_MODEL_VAR)
             source_admin = None
             if source_model_name:
-                app_label, model_name = source_model_name.split(".", 1)
                 try:
+                    app_label, model_name = source_model_name.split(".", 1)
                     source_model = apps.get_model(app_label, model_name)
-                except LookupError:
+                except (LookupError, ValueError):
                     msg = _('The app "%s" could not be found.') % source_model_name
                     self.message_user(request, msg, messages.ERROR)
                 else:

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -576,23 +576,29 @@ class AdminViewBasicTest(AdminViewBasicTestCase):
     def test_popup_add_POST_with_invalid_source_model(self):
         """
         Popup add with an invalid source_model (non-existent app/model)
-        shows an error message instead of crashing.
+        shows an error message on a subsequent page load instead of crashing.
         """
-        post_data = {
-            IS_POPUP_VAR: "1",
-            SOURCE_MODEL_VAR: "admin_views.nonexistent",
-            "title": "Test Article",
-            "content": "some content",
-            "date_0": "2010-09-10",
-            "date_1": "14:55:39",
-        }
-        response = self.client.post(reverse("admin:admin_views_article_add"), post_data)
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "data-popup-response")
-        messages = list(response.wsgi_request._messages)
-        self.assertEqual(len(messages), 1)
-        self.assertIn("admin_views.nonexistent", str(messages[0]))
-        self.assertIn("could not be found", str(messages[0]))
+        for invalid_model in ["admin_views.nonexistent", "invalid"]:
+            post_data = {
+                IS_POPUP_VAR: "1",
+                SOURCE_MODEL_VAR: invalid_model,
+                "title": "Test Article",
+                "content": "some content",
+                "date_0": "2010-09-10",
+                "date_1": "14:55:39",
+            }
+            with self.subTest(case=invalid_model):
+                popup_response = self.client.post(
+                    reverse("admin:admin_views_article_add"), post_data
+                )
+                self.assertEqual(popup_response.status_code, 200)
+                self.assertContains(popup_response, "data-popup-response")
+                # The message is visible on the next request.
+                response = self.client.get(reverse("admin:admin_views_article_add"))
+                messages = list(response.wsgi_request._messages)
+                self.assertEqual(len(messages), 1)
+                self.assertIn(invalid_model, str(messages[0]))
+                self.assertIn("could not be found", str(messages[0]))
 
     def test_popup_add_POST_with_unregistered_source_model(self):
         """


### PR DESCRIPTION
#### Trac ticket number

ticket-37264

#### Branch description

`ModelAdmin.response_add()` unpacked the `_source_model` `POST` parameter with `source_model_name.split(".", 1)` before any error handling, so a value without a dot separator, like `_source_model=foo`, raised `ValueError` and returned an HTTP 500 after the object had already been saved.

This fix handles the `ValueError` together with the existing `LookupError` branch for invalid values, falling back to the default popup response with an error message instead of crashing.

Regression in b1ffa9a9d78b0c2c5ad6ed5a1d84e380d5cfd010.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude 5 Fable did nearly all the work here, discovering the bug and writing the commit. I made minor edits. I agree with the report and approach.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
