### PR TITLE
Fixed #37265 -- Restored support for old ModelAdmin.get_action() and get_action_choices() overrides.

### DIFF
--- a/django/contrib/admin/checks.py
+++ b/django/contrib/admin/checks.py
@@ -1,4 +1,5 @@
 import collections
+import warnings
 from itertools import chain
 
 from django.apps import apps
@@ -13,6 +14,7 @@ from django.db.models.expressions import Combinable
 from django.forms.models import BaseModelForm, BaseModelFormSet, _get_foreign_key
 from django.template import engines
 from django.template.backends.django import DjangoTemplates
+from django.utils.deprecation import RemovedInDjango70Warning
 from django.utils.module_loading import import_string
 
 
@@ -1244,7 +1246,12 @@ class ModelAdminChecks(BaseModelAdminChecks):
 
     def _check_actions(self, obj):
         errors = []
-        actions = obj._get_base_actions()
+        # RemovedInDjango70Warning: When the deprecation ends, replace with:
+        # actions = obj._get_base_actions()
+        with warnings.catch_warnings(
+            action="ignore", category=RemovedInDjango70Warning
+        ):
+            actions = obj._get_base_actions()
 
         # Actions with an allowed_permission attribute require the ModelAdmin
         # to implement a has_<perm>_permission() method for each permission.

--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -1083,8 +1083,14 @@ class ModelAdmin(BaseModelAdmin):
     def _get_base_actions(self, action_location=ActionLocation.CHANGE_LIST):
         """Return the list of actions, prior to any request-based filtering."""
         actions = []
+        # RemovedInDjango70Warning: When the deprecation ends, replace with:
+        # base_actions = (
+        #     self.get_action(action, action_location) for action in
+        #     self.actions or []
+        # )
         base_actions = (
-            self.get_action(action, action_location) for action in self.actions or []
+            self._get_action_with_action_location(action, action_location)
+            for action in self.actions or []
         )
         # get_action might have returned None, so filter any of those out.
         base_actions = [action for action in base_actions if action]
@@ -1166,11 +1172,15 @@ class ModelAdmin(BaseModelAdmin):
         default_choices=None,
         action_location=ActionLocation.CHANGE_LIST,
     ):
+        # Don't pass default_choices=None explicitly, so that overrides of
+        # get_action_choices() use the default value from their signature, as
+        # was the case when Django itself called get_action_choices().
+        kwargs = {} if default_choices is None else {"default_choices": default_choices}
         if "action_location" in get_func_args(self.get_action_choices):
             return self.get_action_choices(
                 request,
-                default_choices=default_choices,
                 action_location=action_location,
+                **kwargs,
             )
         else:
             warn_about_implementation(
@@ -1181,7 +1191,7 @@ class ModelAdmin(BaseModelAdmin):
                 RemovedInDjango70Warning,
                 self.get_action_choices,
             )
-            return self.get_action_choices(request, default_choices=default_choices)
+            return self.get_action_choices(request, **kwargs)
 
     def _get_choice_description(self, action, action_location):
         if action_location == ActionLocation.CHANGE_LIST:
@@ -1217,11 +1227,40 @@ class ModelAdmin(BaseModelAdmin):
             choices.append(choice)
         return choices
 
+    # RemovedInDjango70Warning: When the deprecation ends, remove.
+    def _get_action_with_action_location(
+        self, action, action_location=ActionLocation.CHANGE_LIST
+    ):
+        if "action_location" in get_func_args(self.get_action):
+            return self.get_action(action, action_location)
+        warn_about_implementation(
+            "Overriding get_action() without the 'action_location' parameter "
+            "is deprecated. Update the signature to get_action(self, action, "
+            "action_location=ActionLocation.CHANGE_LIST).",
+            RemovedInDjango70Warning,
+            self.get_action,
+        )
+        action = self.get_action(action)
+        if action is None:
+            return None
+        if isinstance(action, tuple):
+            func, name, description = action
+            action = Action(
+                func=func,
+                name=name,
+                description=description,
+                plural_description=getattr(func, "plural_description", description),
+                locations=getattr(func, "locations", [ActionLocation.CHANGE_LIST]),
+            )
+        if action_location not in action.locations:
+            return None
+        return action
+
     def get_action(self, action, action_location=ActionLocation.CHANGE_LIST):
         """
         Return a given action from a parameter, which can either be a callable,
-        or the name of a method on the ModelAdmin. Return is a tuple of
-        (callable, name, description).
+        or the name of a method on the ModelAdmin. Return is an Action object,
+        or None if the action isn't available in the given action_location.
         """
         # If the action is a callable, just use it.
         if callable(action):

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -148,6 +148,10 @@ details on these changes.
 * Support for overriding ``ModelAdmin.get_action_choices()`` without the new
   ``action_location`` parameter will be removed.
 
+* Support for overriding ``ModelAdmin.get_action()`` without the new
+  ``action_location`` parameter will be removed, along with support for
+  returning a ``(callable, name, description)`` tuple from it.
+
 * The ``django.db.transaction.savepoint()`` alias to
   ``django.db.transaction.savepoint_create()`` will be removed.
 

--- a/docs/releases/6.1.1.txt
+++ b/docs/releases/6.1.1.txt
@@ -9,4 +9,7 @@ Django 6.1.1 fixes several bugs in 6.1.
 Bugfixes
 ========
 
-* ...
+* Fixed a regression in Django 6.1 that caused a crash of the admin when
+  ``ModelAdmin.get_action()`` or ``ModelAdmin.get_action_choices()`` were
+  overridden with their pre-6.1 signatures. Such overrides now work again but
+  are deprecated (:ticket:`37265`).

--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -717,6 +717,10 @@ Miscellaneous
 * Overriding ``ModelAdmin.get_action_choices()`` without the new
   ``action_location`` parameter is deprecated.
 
+* Overriding ``ModelAdmin.get_action()`` without the new ``action_location``
+  parameter is deprecated, as well as returning a
+  ``(callable, name, description)`` tuple from it.
+
 * :func:`django.db.transaction.savepoint` is deprecated in favor of
   :func:`~django.db.transaction.savepoint_create`.
 

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -1293,6 +1293,8 @@ class CourseAdmin(admin.ModelAdmin):
 
 # RemovedInDjango70Warning: When the deprecation ends, remove.
 class OverriddenActionAdmin(admin.ModelAdmin):
+    actions = ["test_action"]
+
     def get_actions(self, request):
         actions = super().get_actions(request)
         func, name, _ = actions["delete_selected"]
@@ -1301,7 +1303,14 @@ class OverriddenActionAdmin(admin.ModelAdmin):
         return actions
 
     def get_action_choices(self, request, default_choices=models.BLANK_CHOICE_DASH):
-        return super().get_action_choices(request, default_choices)
+        return super().get_action_choices(request, [*default_choices])
+
+    def get_action(self, action):
+        result = super().get_action(action)
+        if result is None:
+            return None
+        func, name, description = result
+        return func, name, description + " (tuple)"
 
     @admin.action(location=[ActionLocation.CHANGE_LIST, ActionLocation.CHANGE_FORM])
     def test_action(self, request, selected):

--- a/tests/admin_views/test_actions.py
+++ b/tests/admin_views/test_actions.py
@@ -896,6 +896,9 @@ class AdminDetailActionsTest(TestCase):
                 "parameter is deprecated. Update the signature to "
                 "get_action_choices(self, request, default_choices=None, "
                 "action_location=ActionLocation.CHANGE_LIST).",
+                "Overriding get_action() without the 'action_location' parameter "
+                "is deprecated. Update the signature to get_action(self, action, "
+                "action_location=ActionLocation.CHANGE_LIST).",
                 "Unpacking an action tuple is deprecated. "
                 "Use Action attributes instead.",
                 "Using indexes on an action tuple is deprecated. "
@@ -906,6 +909,9 @@ class AdminDetailActionsTest(TestCase):
                 {warning.filename for warning in warning_list}, {admin_filename}
             )
         self.assertContains(response, "Delete selected model actions (extra)")
+        # The (func, name, description) tuple returned by the get_action()
+        # override is converted into an Action object.
+        self.assertContains(response, "Test action (tuple)")
 
         action_data = {
             ACTION_CHECKBOX_NAME: [obj.pk],

--- a/tests/modeladmin/test_actions.py
+++ b/tests/modeladmin/test_actions.py
@@ -1,7 +1,10 @@
 from django.contrib import admin
+from django.contrib.admin.options import Action, ActionLocation
 from django.contrib.auth.models import Permission, User
 from django.contrib.contenttypes.models import ContentType
-from django.test import TestCase
+from django.db import models
+from django.test import TestCase, ignore_warnings
+from django.utils.deprecation import RemovedInDjango70Warning
 
 from .models import Band
 
@@ -148,3 +151,122 @@ class AdminActionsTests(TestCase):
                 "Local admin action 2.",
             ],
         )
+
+
+# RemovedInDjango70Warning: When the deprecation ends, remove.
+class AdminActionsDeprecationTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.superuser = User.objects.create_superuser(
+            username="super", password="secret", email="super@example.com"
+        )
+
+    def setUp(self):
+        class MockRequest:
+            GET = {}
+
+        self.request = MockRequest()
+        self.request.user = self.superuser
+
+    def test_get_action_choices_overridden_without_new_parameters(self):
+        class BandAdmin(admin.ModelAdmin):
+            def get_action_choices(self, request):
+                choices = super().get_action_choices(request)
+                choices.append(("custom", "Custom choice"))
+                return choices
+
+        ma = BandAdmin(Band, admin.AdminSite())
+        msg = (
+            "Overriding get_action_choices() without the 'action_location' "
+            "parameter is deprecated. Update the signature to "
+            "get_action_choices(self, request, default_choices=None, "
+            "action_location=ActionLocation.CHANGE_LIST)."
+        )
+        with self.assertWarnsMessage(RemovedInDjango70Warning, msg) as warning:
+            choices = ma._get_action_choices_with_action_location(self.request)
+        self.assertEqual(warning.filename, __file__)
+        self.assertEqual(
+            [choice[0] for choice in choices], ["", "delete_selected", "custom"]
+        )
+
+    def test_get_action_choices_overridden_with_default_choices(self):
+        class BandAdmin(admin.ModelAdmin):
+            def get_action_choices(
+                self, request, default_choices=models.BLANK_CHOICE_DASH
+            ):
+                return [*default_choices, ("custom", "Custom choice")]
+
+        ma = BandAdmin(Band, admin.AdminSite())
+        msg = (
+            "Overriding get_action_choices() without the 'action_location' "
+            "parameter is deprecated. Update the signature to "
+            "get_action_choices(self, request, default_choices=None, "
+            "action_location=ActionLocation.CHANGE_LIST)."
+        )
+        with self.assertWarnsMessage(RemovedInDjango70Warning, msg) as warning:
+            choices = ma._get_action_choices_with_action_location(self.request)
+        self.assertEqual(warning.filename, __file__)
+        # The BLANK_CHOICE_DASH-based default value from the overridden
+        # method's signature is used.
+        self.assertEqual(choices, [("", "---------"), ("custom", "Custom choice")])
+
+    def test_get_action_overridden_without_action_location(self):
+        class BandAdmin(admin.ModelAdmin):
+            actions = ["custom_action"]
+
+            @admin.action(description="Custom action")
+            def custom_action(self, request, queryset):
+                pass
+
+            def get_action(self, action):
+                return super().get_action(action)
+
+        ma = BandAdmin(Band, admin.AdminSite())
+        msg = (
+            "Overriding get_action() without the 'action_location' parameter "
+            "is deprecated. Update the signature to get_action(self, action, "
+            "action_location=ActionLocation.CHANGE_LIST)."
+        )
+        with self.assertWarnsMessage(RemovedInDjango70Warning, msg) as warning:
+            actions = ma.get_actions(self.request)
+        self.assertEqual(warning.filename, __file__)
+        self.assertEqual(list(actions), ["delete_selected", "custom_action"])
+        self.assertEqual(actions["custom_action"].description, "Custom action")
+
+    def test_get_action_overridden_returning_tuple(self):
+        def custom_action(modeladmin, request, queryset):
+            pass
+
+        class BandAdmin(admin.ModelAdmin):
+            actions = [custom_action]
+
+            def get_action(self, action):
+                if callable(action):
+                    return (action, action.__name__, "Custom description")
+                return super().get_action(action)
+
+        ma = BandAdmin(Band, admin.AdminSite())
+        msg = (
+            "Overriding get_action() without the 'action_location' parameter "
+            "is deprecated. Update the signature to get_action(self, action, "
+            "action_location=ActionLocation.CHANGE_LIST)."
+        )
+        with self.assertWarnsMessage(RemovedInDjango70Warning, msg) as warning:
+            actions = ma.get_actions(self.request)
+        self.assertEqual(warning.filename, __file__)
+        # The returned (callable, name, description) tuple is converted into
+        # an Action object.
+        action = actions["custom_action"]
+        self.assertIsInstance(action, Action)
+        self.assertIs(action.func, custom_action)
+        self.assertEqual(action.name, "custom_action")
+        self.assertEqual(action.description, "Custom description")
+        self.assertEqual(action.plural_description, "Custom description")
+        self.assertEqual(action.locations, [ActionLocation.CHANGE_LIST])
+        # Actions from old-style get_action() overrides don't appear on the
+        # change form.
+        with ignore_warnings(category=RemovedInDjango70Warning):
+            form_actions = ma.get_actions(
+                self.request, action_location=ActionLocation.CHANGE_FORM
+            )
+        self.assertEqual(form_actions, {})


### PR DESCRIPTION
#### Trac ticket number

ticket-37265

#### Branch description

`ModelAdmin.get_action()` and `ModelAdmin.get_action_choices()` overrides using the pre-6.1 signatures crashed the admin with a `TypeError`:

- `get_action()` overrides without the new `action_location` parameter crashed system checks and every page using actions, because `_get_base_actions()` called `get_action()` with two arguments and no deprecation shim existed. Overrides returning the old `(callable, name, description)` tuple also broke later attribute access on `Action` objects.

- The `get_action_choices()` deprecation shim always passed `default_choices` explicitly, defaulting to `None`. Overrides without the parameter raised "unexpected keyword argument", and overrides using the old `BLANK_CHOICE_DASH`-based default received `None` instead of their signature's default value.

Old-style overrides of both methods now work again and emit `RemovedInDjango70Warning`: `get_action()` is shimmed through the new `_get_action_with_action_location()`, which calls old-style overrides with a single argument and converts returned 3-tuples into `Action` objects, and the `get_action_choices()` shim no longer passes `default_choices` when it is unset so the overridden method's own default applies. System checks ignore the deprecation warnings when validating `ModelAdmin.actions`.

Regression in f30acb184f75fd9260cfd6ddc48a3bbbd49f9c1d.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude 5 Fable did nearly all the work here, discovering the bug and writing the commit. I made minor edits. I agree with the report and approach.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
