### PR TITLE
Refs #6148 -- Added schema-qualified table references.

### DIFF
--- a/django/core/management/commands/migrate.py
+++ b/django/core/management/commands/migrate.py
@@ -447,6 +447,8 @@ class Command(BaseCommand):
 
         def model_installed(model):
             opts = model._meta
+            if not opts.managed:
+                return False
             converter = connection.introspection.identifier_converter
             max_name_length = connection.ops.max_name_length()
             return not (

--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -5,6 +5,9 @@ from django.utils.functional import cached_property
 class BaseDatabaseFeatures:
     # An optional tuple indicating the minimum supported database version.
     minimum_database_version = None
+    # Does this backend support namespace-style SQL schemas that can qualify
+    # table references, e.g. "schema"."table"?
+    supports_schema_qualified_table_references = False
     gis_enabled = False
     # Oracle can't group by LOB (large object) data types.
     allows_group_by_lob = True

--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -389,7 +389,7 @@ class BaseDatabaseOperations:
         columns = [
             "%s.%s"
             % (
-                self.quote_name(field.model._meta.db_table),
+                self.quote_table_name(field.model._meta.db_table),
                 self.quote_name(field.column),
             )
             for field in fields
@@ -412,6 +412,11 @@ class BaseDatabaseOperations:
         if self._cache is None:
             self._cache = import_module(self.compiler_module)
         return getattr(self._cache, compiler_name)
+
+    def quote_table_name(self, table_name):
+        if hasattr(table_name, "as_sql_name"):
+            return table_name.as_sql_name(self.connection)
+        return self.quote_name(table_name)
 
     def quote_name(self, name):
         """

--- a/django/db/backends/postgresql/features.py
+++ b/django/db/backends/postgresql/features.py
@@ -25,6 +25,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     has_select_for_no_key_update = True
     can_release_savepoints = True
     supports_comments = True
+    supports_schema_qualified_table_references = True
     supports_tablespaces = True
     supports_transactions = True
     can_introspect_materialized_views = True

--- a/django/db/models/__init__.py
+++ b/django/db/models/__init__.py
@@ -59,6 +59,7 @@ from django.db.models.query import (
     prefetch_related_objects,
 )
 from django.db.models.query_utils import FilteredRelation, Q
+from django.db.models.table_references import SchemaQualifiedTable
 
 # Imports that would create circular imports if sorted
 from django.db.models.base import DEFERRED, Model  # isort:skip
@@ -84,6 +85,7 @@ __all__ += [
     "DO_NOTHING",
     "PROTECT",
     "RESTRICT",
+    "SchemaQualifiedTable",
     "SET",
     "SET_DEFAULT",
     "SET_NULL",

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -58,6 +58,7 @@ from django.db.models.signals import (
     pre_init,
     pre_save,
 )
+from django.db.models.table_references import SchemaQualifiedTable
 from django.db.models.utils import AltersData, make_model_tuple
 from django.utils.encoding import force_str
 from django.utils.hashable import make_hashable
@@ -1939,6 +1940,16 @@ class Model(AltersData, metaclass=ModelBase):
                         id="models.E017",
                     )
                 )
+        elif isinstance(cls._meta.db_table, SchemaQualifiedTable) and cls._meta.managed:
+            errors.append(
+                checks.Error(
+                    "'managed' must be False when 'db_table' is a "
+                    "SchemaQualifiedTable.",
+                    hint="Set 'managed = False' in the model's Meta class.",
+                    obj=cls,
+                    id="models.E051",
+                )
+            )
         return errors
 
     @classmethod

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -22,6 +22,7 @@ from django.db.models.sql.constants import (
     ROW_COUNT,
     SINGLE,
 )
+from django.db.models.sql.datastructures import table_as_sql
 from django.db.models.sql.query import Query, get_order_dir
 from django.db.transaction import TransactionManagementError
 from django.utils.deprecation import RemovedInDjango70Warning
@@ -1804,7 +1805,12 @@ class SQLInsertCompiler(SQLCompiler):
         insert_statement = self.connection.ops.insert_statement(
             on_conflict=self.query.on_conflict,
         )
-        result = ["%s %s" % (insert_statement, qn(opts.db_table))]
+        table_sql, table_params = table_as_sql(opts.db_table, self, self.connection)
+        if table_params:
+            raise ValueError(
+                "Table references used in INSERT queries cannot contain parameters."
+            )
+        result = ["%s %s" % (insert_statement, table_sql)]
 
         if fields := list(self.query.fields):
             from django.db.models.expressions import DatabaseDefault
@@ -1998,7 +2004,12 @@ class SQLDeleteCompiler(SQLCompiler):
         )
 
     def _as_sql(self, query):
-        delete = "DELETE FROM %s" % self.quote_name(query.base_table)
+        table_sql, table_params = self.compile(query.alias_map[query.base_table])
+        if table_params:
+            raise ValueError(
+                "Table references used in DELETE queries cannot contain parameters."
+            )
+        delete = "DELETE FROM %s" % table_sql
         try:
             where, params = self.compile(query.where)
         except FullResultSet:
@@ -2090,8 +2101,13 @@ class SQLUpdateCompiler(SQLCompiler):
                 values.append(f"{quoted_name} = %s")
                 update_params.append(val)
         table = self.query.base_table
+        table_sql, table_params = self.compile(self.query.alias_map[table])
+        if table_params:
+            raise ValueError(
+                "Table references used in UPDATE queries cannot contain parameters."
+            )
         result = [
-            "UPDATE %s SET" % qn(table),
+            "UPDATE %s SET" % table_sql,
             ", ".join(values),
         ]
         try:

--- a/django/db/models/sql/datastructures.py
+++ b/django/db/models/sql/datastructures.py
@@ -7,6 +7,16 @@ from django.core.exceptions import FullResultSet
 from django.db.models.sql.constants import INNER, LOUTER
 
 
+def table_as_sql(table_name, compiler, connection):
+    if hasattr(table_name, "as_sql"):
+        return table_name.as_sql(compiler, connection)
+    return compiler.quote_name(table_name), []
+
+
+def table_requires_alias(table_name):
+    return getattr(table_name, "always_alias", False)
+
+
 class MultiJoin(Exception):
     """
     Used by join construction code to indicate the point at which a
@@ -119,18 +129,20 @@ class Join:
                 "joining columns or extra restrictions." % declared_field.__class__
             )
         on_clause_sql = " AND ".join(join_conditions)
+        table_sql, table_params = table_as_sql(self.table_name, compiler, connection)
         alias_str = (
             ""
             if self.table_alias == self.table_name
+            and not table_requires_alias(self.table_name)
             else (" %s" % qn(self.table_alias))
         )
         sql = "%s %s%s ON (%s)" % (
             self.join_type,
-            qn(self.table_name),
+            table_sql,
             alias_str,
             on_clause_sql,
         )
-        return sql, params
+        return sql, [*table_params, *params]
 
     def relabeled_clone(self, change_map):
         new_parent_alias = change_map.get(self.parent_alias, self.parent_alias)
@@ -199,10 +211,11 @@ class BaseTable:
         alias_str = (
             ""
             if self.table_alias == self.table_name
+            and not table_requires_alias(self.table_name)
             else (" %s" % qn(self.table_alias))
         )
-        base_sql = qn(self.table_name)
-        return base_sql + alias_str, []
+        base_sql, params = table_as_sql(self.table_name, compiler, connection)
+        return base_sql + alias_str, params
 
     def relabeled_clone(self, change_map):
         return self.__class__(

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -41,7 +41,13 @@ from django.db.models.query_utils import (
     refs_expression,
 )
 from django.db.models.sql.constants import INNER, LOUTER, ORDER_DIR, SINGLE
-from django.db.models.sql.datastructures import BaseTable, Empty, Join, MultiJoin
+from django.db.models.sql.datastructures import (
+    BaseTable,
+    Empty,
+    Join,
+    MultiJoin,
+    table_requires_alias,
+)
 from django.db.models.sql.where import AND, OR, ExtraWhere, NothingNode, WhereNode
 from django.utils.deprecation import RemovedInDjango70Warning
 from django.utils.functional import cached_property
@@ -916,10 +922,12 @@ class Query(BaseExpression):
             alias = "%s%d" % (self.alias_prefix, len(self.alias_map) + 1)
             alias_list.append(alias)
         else:
-            # The first occurrence of a table uses the table name directly.
-            alias = (
-                filtered_relation.alias if filtered_relation is not None else table_name
-            )
+            if filtered_relation is not None:
+                alias = filtered_relation.alias
+            elif table_requires_alias(table_name):
+                alias = "%s%d" % (self.alias_prefix, len(self.alias_map) + 1)
+            else:
+                alias = table_name
             self.table_map[table_name] = [alias]
         self.alias_refcount[alias] = 1
         return alias, True

--- a/django/db/models/sql/subqueries.py
+++ b/django/db/models/sql/subqueries.py
@@ -20,7 +20,8 @@ class DeleteQuery(Query):
     compiler = "SQLDeleteCompiler"
 
     def do_query(self, table, where, using):
-        self.alias_map = {table: self.alias_map[table]}
+        table_alias = self.table_map[table][0]
+        self.alias_map = {table_alias: self.alias_map[table_alias]}
         self.where = where
         return self.get_compiler(using).execute_sql(ROW_COUNT)
 

--- a/django/db/models/table_references.py
+++ b/django/db/models/table_references.py
@@ -1,0 +1,56 @@
+from django.db import NotSupportedError
+from django.utils.deconstruct import deconstructible
+
+
+@deconstructible(path="django.db.models.SchemaQualifiedTable")
+class SchemaQualifiedTable:
+    """
+    A schema-qualified database table reference.
+
+    This renders table references such as:
+
+        "billing"."customer"
+
+    on backends that support schema-qualified table references.
+    """
+
+    always_alias = True
+
+    def __init__(self, table, *, schema):
+        if not isinstance(table, str) or not table:
+            raise ValueError("table must be a non-empty string.")
+        if not isinstance(schema, str) or not schema:
+            raise ValueError("schema must be a non-empty string.")
+        self.table = table
+        self.schema = schema
+
+    @property
+    def identity(self):
+        return self.__class__, self.schema, self.table
+
+    def as_sql_name(self, connection):
+        if not connection.features.supports_schema_qualified_table_references:
+            raise NotSupportedError(
+                "%s doesn't support schema-qualified table references."
+                % connection.display_name
+            )
+        qn = connection.ops.quote_name
+        return "%s.%s" % (qn(self.schema), qn(self.table))
+
+    def as_sql(self, compiler, connection):
+        return self.as_sql_name(connection), []
+
+    def __repr__(self):
+        return "%s(%r, schema=%r)" % (
+            self.__class__.__name__,
+            self.table,
+            self.schema,
+        )
+
+    def __eq__(self, other):
+        if not isinstance(other, SchemaQualifiedTable):
+            return NotImplemented
+        return self.identity == other.identity
+
+    def __hash__(self):
+        return hash(self.identity)

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -471,6 +471,8 @@ Models
   not supported for that option.
 * **models.E050**: The model cannot have related fields with both
   database-level and Python-level ``on_delete`` variants.
+* **models.E051**: ``managed`` must be ``False`` when ``db_table`` is a
+  ``SchemaQualifiedTable``.
 
 Management Commands
 -------------------

--- a/docs/ref/models/options.txt
+++ b/docs/ref/models/options.txt
@@ -46,7 +46,7 @@ Available ``Meta`` options
 
 .. attribute:: Options.db_table
 
-    The name of the database table to use for the model::
+    The database table to use for the model. This is usually a string::
 
         db_table = "music_album"
 
@@ -90,6 +90,44 @@ OK. Django quotes column and table names behind the scenes.
    Such quoted names can also be used with Django's other supported database
    backends; except for Oracle, however, the quotes have no effect. See the
    :ref:`Oracle notes <oracle-notes>` for more details.
+
+.. _schema-qualified-table-references:
+
+Schema-qualified table references
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. class:: SchemaQualifiedTable(table, *, schema)
+
+    A reference to an existing table in a database schema. PostgreSQL supports
+    schema-qualified table references.
+
+Set ``db_table`` to a ``SchemaQualifiedTable`` and :attr:`.managed` to
+``False`` to map an unmanaged model to an existing schema-qualified table. For
+example:
+
+.. code-block:: python
+
+    from django.db import models
+
+
+    class Customer(models.Model):
+        name = models.CharField(max_length=100)
+
+        class Meta:
+            db_table = models.SchemaQualifiedTable(
+                "customer",
+                schema="billing",
+            )
+            managed = False
+
+This maps the model to the SQL table reference ``"billing"."customer"``.
+
+This is useful when the same table name exists in multiple schemas in the same
+database.
+
+The schema and table must already exist. Django doesn't create, alter, or
+delete schemas or tables referenced by ``SchemaQualifiedTable``. It also
+doesn't provide dynamic per-request schema selection.
 
 ``db_table_comment``
 --------------------

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -196,7 +196,9 @@ Migrations
 Models
 ~~~~~~
 
-* ...
+* The new :class:`~django.db.models.SchemaQualifiedTable` class allows
+  unmanaged models to query existing PostgreSQL tables outside the default
+  schema.
 
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -265,7 +267,10 @@ Database backend API
 This section describes changes that may be needed in third-party database
 backends.
 
-* ...
+* Third-party database backends that support
+  :class:`~django.db.models.SchemaQualifiedTable` should set
+  ``BaseDatabaseFeatures.supports_schema_qualified_table_references`` to
+  ``True``.
 
 :mod:`django.contrib.admin`
 ---------------------------

--- a/tests/schema_qualified_tables/models.py
+++ b/tests/schema_qualified_tables/models.py
@@ -1,0 +1,29 @@
+from django.db import models
+
+
+class BillingCustomer(models.Model):
+    name = models.CharField(max_length=100)
+
+    class Meta:
+        app_label = "schema_qualified_tables"
+        db_table = models.SchemaQualifiedTable("customer", schema="billing")
+        managed = False
+
+
+class BillingInvoice(models.Model):
+    customer = models.ForeignKey(BillingCustomer, models.CASCADE)
+    reference = models.CharField(max_length=100)
+
+    class Meta:
+        app_label = "schema_qualified_tables"
+        db_table = models.SchemaQualifiedTable("invoice", schema="billing")
+        managed = False
+
+
+class SalesCustomer(models.Model):
+    name = models.CharField(max_length=100)
+
+    class Meta:
+        app_label = "schema_qualified_tables"
+        db_table = models.SchemaQualifiedTable("customer", schema="sales")
+        managed = False

--- a/tests/schema_qualified_tables/tests.py
+++ b/tests/schema_qualified_tables/tests.py
@@ -1,0 +1,231 @@
+from unittest import mock
+
+from django.db import NotSupportedError, connection, models
+from django.db.migrations.writer import MigrationWriter
+from django.db.models import sql
+from django.test import TestCase, TransactionTestCase, skipUnlessDBFeature
+from django.test.utils import isolate_apps
+
+from .models import BillingCustomer, BillingInvoice, SalesCustomer
+
+
+class SchemaQualifiedTableTests(TestCase):
+    def set_schema_qualified_table_references_support(self, value):
+        original = connection.features.supports_schema_qualified_table_references
+        connection.features.supports_schema_qualified_table_references = value
+        self.addCleanup(
+            setattr,
+            connection.features,
+            "supports_schema_qualified_table_references",
+            original,
+        )
+
+    def table_sql(self, model):
+        return model._meta.db_table.as_sql_name(connection)
+
+    def test_schema_qualified_table_renders_sql_name(self):
+        self.set_schema_qualified_table_references_support(True)
+        table = BillingCustomer._meta.db_table
+        qn = connection.ops.quote_name
+
+        self.assertEqual(
+            table.as_sql_name(connection),
+            "%s.%s" % (qn("billing"), qn("customer")),
+        )
+
+    def test_schema_qualified_table_requires_backend_support(self):
+        self.set_schema_qualified_table_references_support(False)
+
+        table = BillingCustomer._meta.db_table
+
+        with self.assertRaisesMessage(
+            NotSupportedError,
+            "doesn't support schema-qualified table references",
+        ):
+            table.as_sql_name(connection)
+
+    def test_select_uses_schema_qualified_table(self):
+        self.set_schema_qualified_table_references_support(True)
+
+        sql_string = str(BillingCustomer.objects.all().query)
+
+        self.assertIn(self.table_sql(BillingCustomer), sql_string)
+
+    def test_same_table_name_can_be_qualified_by_different_schemas(self):
+        self.set_schema_qualified_table_references_support(True)
+
+        billing_sql = str(BillingCustomer.objects.all().query)
+        sales_sql = str(SalesCustomer.objects.all().query)
+
+        self.assertIn(self.table_sql(BillingCustomer), billing_sql)
+        self.assertIn(self.table_sql(SalesCustomer), sales_sql)
+
+    def test_join_uses_schema_qualified_table(self):
+        self.set_schema_qualified_table_references_support(True)
+
+        sql_string = str(BillingInvoice.objects.select_related("customer").query)
+
+        self.assertIn(self.table_sql(BillingInvoice), sql_string)
+        self.assertIn(self.table_sql(BillingCustomer), sql_string)
+
+    def test_insert_uses_schema_qualified_table(self):
+        self.set_schema_qualified_table_references_support(True)
+        query = sql.InsertQuery(BillingCustomer)
+        query.insert_values(
+            [BillingCustomer._meta.get_field("name")],
+            [BillingCustomer(name="Acme")],
+        )
+
+        sql_string, params = query.get_compiler(connection=connection).as_sql()[0]
+
+        self.assertIn(
+            "INSERT INTO %s" % self.table_sql(BillingCustomer),
+            sql_string,
+        )
+        self.assertEqual(params, ("Acme",))
+
+    @skipUnlessDBFeature("supports_schema_qualified_table_references")
+    def test_returning_columns_uses_schema_qualified_table(self):
+        sql_string, params = connection.ops.returning_columns(
+            [BillingCustomer._meta.pk]
+        )
+
+        self.assertIn(self.table_sql(BillingCustomer), sql_string)
+        self.assertEqual(params, ())
+
+    def test_update_uses_schema_qualified_table(self):
+        self.set_schema_qualified_table_references_support(True)
+        query = BillingCustomer.objects.all().query.chain(sql.UpdateQuery)
+        query.add_update_values({"name": "Acme"})
+
+        sql_string, params = query.get_compiler(connection=connection).as_sql()
+
+        self.assertIn(
+            "UPDATE %s %s SET"
+            % (
+                self.table_sql(BillingCustomer),
+                connection.ops.quote_name("T1"),
+            ),
+            sql_string,
+        )
+        self.assertEqual(params, ("Acme",))
+
+    def test_delete_uses_schema_qualified_table(self):
+        self.set_schema_qualified_table_references_support(True)
+        query = BillingCustomer.objects.filter(name="Acme").query.chain(sql.DeleteQuery)
+
+        sql_string, params = query.get_compiler(connection=connection).as_sql()
+
+        self.assertIn(
+            "DELETE FROM %s %s"
+            % (
+                self.table_sql(BillingCustomer),
+                connection.ops.quote_name("T1"),
+            ),
+            sql_string,
+        )
+        self.assertEqual(params, ("Acme",))
+
+    def test_delete_batch_uses_schema_qualified_table(self):
+        compiler_class = connection.ops.compiler("SQLDeleteCompiler")
+        query = sql.DeleteQuery(BillingCustomer)
+
+        with mock.patch.object(compiler_class, "execute_sql", return_value=1):
+            deleted = query.delete_batch([1], connection.alias)
+
+        self.assertEqual(deleted, 1)
+        self.assertEqual(list(query.alias_map), [query.base_table])
+
+    def test_schema_qualified_table_can_be_serialized_in_migrations(self):
+        table = BillingCustomer._meta.db_table
+
+        serialized, imports = MigrationWriter.serialize(table)
+
+        self.assertEqual(
+            serialized,
+            "models.SchemaQualifiedTable('customer', schema='billing')",
+        )
+        self.assertEqual(imports, {"from django.db import models"})
+
+    @isolate_apps("schema_qualified_tables")
+    def test_schema_qualified_table_requires_unmanaged_model(self):
+        class ManagedCustomer(models.Model):
+            class Meta:
+                app_label = "schema_qualified_tables"
+                db_table = models.SchemaQualifiedTable(
+                    "customer",
+                    schema="billing",
+                )
+
+        errors = ManagedCustomer.check()
+
+        self.assertEqual(errors[0].id, "models.E051")
+        self.assertEqual(
+            errors[0].msg,
+            "'managed' must be False when 'db_table' is a SchemaQualifiedTable.",
+        )
+
+
+@skipUnlessDBFeature("supports_schema_qualified_table_references")
+class SchemaQualifiedTableDatabaseTests(TransactionTestCase):
+    available_apps = ["schema_qualified_tables"]
+
+    def setUp(self):
+        with connection.cursor() as cursor:
+            cursor.execute("CREATE SCHEMA billing")
+            cursor.execute("CREATE SCHEMA sales")
+            cursor.execute("""
+                CREATE TABLE billing.customer (
+                    id integer GENERATED BY DEFAULT AS IDENTITY PRIMARY KEY,
+                    name varchar(100) NOT NULL
+                )
+                """)
+            cursor.execute("""
+                CREATE TABLE billing.invoice (
+                    id integer GENERATED BY DEFAULT AS IDENTITY PRIMARY KEY,
+                    customer_id integer NOT NULL REFERENCES billing.customer (id),
+                    reference varchar(100) NOT NULL
+                )
+                """)
+            cursor.execute("""
+                CREATE TABLE sales.customer (
+                    id integer GENERATED BY DEFAULT AS IDENTITY PRIMARY KEY,
+                    name varchar(100) NOT NULL
+                )
+                """)
+        self.addCleanup(self.drop_schemas)
+
+    def drop_schemas(self):
+        with connection.cursor() as cursor:
+            cursor.execute("DROP SCHEMA billing CASCADE")
+            cursor.execute("DROP SCHEMA sales CASCADE")
+
+    def test_crud_and_join(self):
+        billing_customer = BillingCustomer.objects.create(name="Billing customer")
+        sales_customer = SalesCustomer.objects.create(name="Sales customer")
+        invoice = BillingInvoice.objects.create(
+            customer=billing_customer,
+            reference="INV-001",
+        )
+
+        invoice = BillingInvoice.objects.select_related("customer").get(pk=invoice.pk)
+        self.assertEqual(
+            invoice.customer,
+            billing_customer,
+        )
+        self.assertEqual(
+            SalesCustomer.objects.get(pk=sales_customer.pk),
+            sales_customer,
+        )
+        self.assertEqual(
+            BillingCustomer.objects.filter(pk=billing_customer.pk).update(
+                name="Updated customer"
+            ),
+            1,
+        )
+        billing_customer.refresh_from_db()
+        self.assertEqual(billing_customer.name, "Updated customer")
+        self.assertEqual(
+            BillingInvoice.objects.filter(pk=invoice.pk).delete()[0],
+            1,
+        )


### PR DESCRIPTION
#### Trac ticket number

[ticket-6148
](https://code.djangoproject.com/ticket/6148)
#### Branch description

Added `SchemaQualifiedTable` for referencing existing schema-qualified database tables from unmanaged Django models.

`SchemaQualifiedTable` stores the table and schema names separately so that database backends can quote each identifier correctly. PostgreSQL enables this feature through `supports_schema_qualified_table_references`.

The ORM supports schema-qualified references in `SELECT`, `JOIN`, `INSERT`, `UPDATE`, and `DELETE` queries. The change also supports migration serialization and prevents these existing tables from being managed by Django.

Tests run locally:

```
python tests/runtests.py schema_qualified_tables --verbosity 2 --parallel 1
python tests/runtests.py schema_qualified_tables queries migrations check_framework.test_model_checks --verbosity 1 --parallel 1
python docs/lint.py
make -C docs html SPHINXOPTS=-W
```

The PostgreSQL integration test is skipped when running with SQLite and will be exercised by the PostgreSQL test environment.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.

- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

I used ChatGPT to help analyze the ticket discussion, plan the patch, and review the tests and documentation. I reviewed the changes and ran the tests locally before submission.

#### Checklist

- [x] This PR follows the [[contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/)](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [[vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [[guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->

- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.