### PR TITLE
Docs: point to docs/README.rst in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ here's how we recommend you read the docs:
   next; from there you can jump to the HOWTOs (in ``docs/howto``) for specific
   problems, and check out the reference (``docs/ref``) for gory details.
 
-* See ``docs/README`` for instructions on building an HTML version of the docs.
+* See ``docs/README.rst`` for instructions on building an HTML version of the docs.
 
 Docs are updated rigorously. If you find any problems in the docs, or think
 they should be clarified in any way, please take 30 seconds to


### PR DESCRIPTION
### Description

This pull request fixes a minor documentation issue in the main `README.rst`.

Specifically, it corrects a typo and ensures that the reference to `docs/README.rst` is accurate and consistent.

### Type of change

* Documentation (non-breaking change)

### Checklist

* [x] I have read the contribution guidelines
* [x] This change does not affect code functionality
* [x] Documentation has been updated accordingly

Thank you for reviewing!
