### PR TITLE
Fixed #37270, #24580 -- Fixed incorrect values for second-degree relations in ModelAdmin.list_display.

### DIFF
--- a/django/contrib/admin/templatetags/admin_list.py
+++ b/django/contrib/admin/templatetags/admin_list.py
@@ -228,7 +228,7 @@ def items_for_result(cl, result, form):
             empty_value_display = getattr(
                 attr, "empty_value_display", empty_value_display
             )
-            # Find boolean fields on relations.
+            # Find a terminal field from a chain of relations.
             if f is None and isinstance(field_name, str) and LOOKUP_SEP in field_name:
                 try:
                     f = get_fields_from_path(cl.model, field_name)[-1]
@@ -246,11 +246,10 @@ def items_for_result(cl, result, form):
                     row_classes.append("nowrap")
             else:
                 if isinstance(f.remote_field, models.ManyToOneRel):
-                    field_val = getattr(result, f.name)
-                    if field_val is None:
+                    if value is None:
                         result_repr = empty_value_display
                     else:
-                        result_repr = field_val
+                        result_repr = value
                 else:
                     result_repr = display_for_field(
                         value,

--- a/docs/releases/6.1.1.txt
+++ b/docs/releases/6.1.1.txt
@@ -12,3 +12,7 @@ Bugfixes
 * Fixed a regression in Django 6.1 where the deprecation of double-dot variable
   lookups incorrectly applied to string and translated template literals
   containing two consecutive dots, such as ``{{ "a..b" }}`` (:ticket:`37257`).
+
+* Fixed a regression in Django 6.1 where :attr:`.ModelAdmin.list_display`
+  entries that traverse multiple relations using ``__`` could crash or display
+  incorrect values (:ticket:`37270`).

--- a/tests/admin_changelist/models.py
+++ b/tests/admin_changelist/models.py
@@ -47,6 +47,7 @@ class Band(models.Model):
 class Musician(models.Model):
     name = models.CharField(max_length=30)
     age = models.IntegerField(null=True, blank=True)
+    genre = models.ForeignKey(Genre, null=True, on_delete=models.SET_NULL)
 
     def __str__(self):
         return self.name

--- a/tests/admin_changelist/models.py
+++ b/tests/admin_changelist/models.py
@@ -23,6 +23,7 @@ class Child(models.Model):
 class GrandChild(models.Model):
     parent = models.ForeignKey(Child, models.SET_NULL, editable=False, null=True)
     name = models.CharField(max_length=30, blank=True)
+    sibling = models.ForeignKey("self", models.SET_NULL, editable=False, null=True)
 
     def __str__(self):
         return self.name

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -1807,6 +1807,39 @@ class ChangeListTests(TestCase):
         response = m.changelist_view(request)
         self.assertContains(response, '<h2 class="main">I am your grandchild')
 
+    def test_list_display_second_degree_relation(self):
+        parent = Parent.objects.create(name="I am your parent")
+        child = Child.objects.create(name="I am your child", parent=parent)
+        GrandChild.objects.create(name="I am your grandchild", parent=child)
+
+        class GrandChildAdmin(admin.ModelAdmin):
+            list_display = ["name", "parent__parent"]
+
+        m = GrandChildAdmin(GrandChild, custom_site)
+        request = self._mocked_authenticated_request("/grandchild/", self.superuser)
+        response = m.changelist_view(request)
+        self.assertNotContains(response, "Child object")
+        self.assertContains(response, "Parent object")
+
+    def test_list_display_related_field_uses_display_for_field(self):
+        # Related fields must be rendered with display_for_field(), not
+        # display_for_value(), so field-specific formatting, such as FileField
+        # links, is preserved.
+        genre = Genre.objects.create(name="Rock", file="documents/test.txt")
+        Musician.objects.create(name="John", genre=genre)
+
+        class MusicianAdmin(admin.ModelAdmin):
+            list_display = ["name", "genre__file"]
+
+        m = MusicianAdmin(Musician, custom_site)
+        request = self._mocked_authenticated_request("/musician/", self.superuser)
+        response = m.changelist_view(request)
+        self.assertContains(
+            response,
+            '<a href="/documents/test.txt">documents/test.txt</a>',
+            html=True,
+        )
+
     def test_list_display_related_field_boolean_display(self):
         """
         Related boolean fields (parent__is_active) display boolean icons.

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -1793,6 +1793,20 @@ class ChangeListTests(TestCase):
         cl = m.get_changelist_instance(request)
         self.assertEqual(cl.get_ordering_field_columns(), {2: "asc"})
 
+    def test_list_display_first_degree_relation(self):
+        parent = Parent.objects.create(name="I am your parent")
+        child = Child.objects.create(name="I am your child", parent=parent)
+        grand = GrandChild.objects.create(name="I am your grandchild", parent=child)
+        GrandChild.objects.create(name="has sibling", parent=child, sibling=grand)
+
+        class GrandChildAdmin(admin.ModelAdmin):
+            list_display = ["name", "sibling"]
+
+        m = GrandChildAdmin(GrandChild, custom_site)
+        request = self._mocked_authenticated_request("/grandchild/", self.superuser)
+        response = m.changelist_view(request)
+        self.assertContains(response, '<h2 class="main">I am your grandchild')
+
     def test_list_display_related_field_boolean_display(self):
         """
         Related boolean fields (parent__is_active) display boolean icons.


### PR DESCRIPTION
#### Trac ticket number
ticket-37270
ticket-24580

#### Branch description
Django 6.1 shows icons on second-degree `BooleanField`s in `list_display`. In an attempt to avoid over-specializing on `BooleanField`, this exposed an infelicity in the branch for second-degree `ForeignKey` fields that wasn't problematic before.

Follow-up to 92470ad3742524902b29769d2c822dbe791630db, which did not solve the issue.

Regression in 4b2b4bf0ac2707dc9c4d51cabfa72168eaea95fe.

cc/ @RobKuipers, does it work for you?

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.