### PR TITLE
Fixed pool_options in django configuration

### DIFF
--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -269,7 +269,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         if pool_key not in self._connection_pools:
             connect_kwargs = self.get_connection_params()
             pool_options = connect_kwargs.pop("pool")
-            if pool_options is not True:
+            if isinstance(pool_options, dict):
                 connect_kwargs.update(pool_options)
 
             pool = Database.create_pool(


### PR DESCRIPTION
Expected to be dictionary

#### Branch description
Recently django merged oracle pooling option, and there is small fix we need to apply to expect "OPTIONS" to be dictionary

#### AI Assistance Disclosure (REQUIRED)
**No AI tools were used** in preparing this PR.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
