### PR TITLE
Fixed #37089 -- Made ignore_warnings() match substrings by default.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -438,6 +438,7 @@ answer newbie questions, and generally made Django that much better:
     Hasan Ramezani <hasan.r67@gmail.com>
     Hawkeye
     Helen Sherwood-Taylor <helen@rrdlabs.co.uk>
+    HelmiDev03 <helmipaty@gmail.com>
     Henrique Romano <onaiort@gmail.com>
     Henry Dang <henrydangprg@gmail.com>
     Hidde Bultsma

--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -758,7 +758,30 @@ class CaptureQueriesContext:
 
 
 class ignore_warnings(TestContextDecorator):
+    """
+    Ignore warnings matching the given criteria.
+
+    ``message`` and ``module`` are matched anywhere in the warning's message
+    and in the name of the module where the warning is raised, respectively,
+    for consistency with helpers such as
+    SimpleTestCase.assertWarnsMessage(). Pass ``message_re`` or ``module_re``
+    to match against a regular expression instead.
+    """
+
     def __init__(self, **kwargs):
+        for name in ("message", "module"):
+            regex_name = f"{name}_re"
+            if regex_name in kwargs:
+                if name in kwargs:
+                    raise TypeError(
+                        f"ignore_warnings() received both '{name}' and "
+                        f"'{regex_name}'; pass only one of them."
+                    )
+                kwargs[name] = kwargs.pop(regex_name)
+            elif name in kwargs:
+                # warnings.filterwarnings() anchors patterns at the start of
+                # the string, so allow any prefix to match anywhere.
+                kwargs[name] = ".*" + re.escape(kwargs[name])
         self.ignore_kwargs = kwargs
         if "message" in self.ignore_kwargs or "module" in self.ignore_kwargs:
             self.filter_func = warnings.filterwarnings

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -311,6 +311,12 @@ Miscellaneous
   database connections used during error handling are managed by
   ``close_old_connections()``.
 
+* The undocumented ``django.test.ignore_warnings()`` helper now matches each of
+  its ``message`` and ``module`` arguments as a literal substring, rather than
+  as a regular expression anchored at the start of the string, for consistency
+  with ``SimpleTestCase.assertWarnsMessage()``. Use the new ``message_re`` and
+  ``module_re`` arguments to match against a regular expression instead.
+
 .. _deprecated-features-6.2:
 
 Features deprecated in 6.2

--- a/tests/aggregation_regress/tests.py
+++ b/tests/aggregation_regress/tests.py
@@ -888,7 +888,7 @@ class AggregationTests(TestCase):
         # queryset and assertion can be removed.
         with ignore_warnings(
             category=RemovedInDjango70Warning,
-            message=r"Calling select_related\(\) with no arguments is deprecated\.",
+            message="Calling select_related() with no arguments is deprecated.",
         ):
             qs = (
                 Book.objects.filter(rating__lt=4.5)

--- a/tests/defer/tests.py
+++ b/tests/defer/tests.py
@@ -150,7 +150,7 @@ class DeferTests(AssertionMixin, TestCase):
         with self.assertNumQueries(1):
             with ignore_warnings(
                 category=RemovedInDjango70Warning,
-                message=r"Calling select_related\(\) with no arguments is deprecated\.",
+                message="Calling select_related() with no arguments is deprecated.",
             ):
                 obj = Primary.objects.defer("related").select_related()[0]
             self.assert_delayed(obj, 1)
@@ -334,7 +334,7 @@ class TestDefer2(AssertionMixin, TestCase):
         ChildProxy.objects.create(name="p1", value="xx", related=related)
         with ignore_warnings(
             category=RemovedInDjango70Warning,
-            message=r"Calling select_related\(\) with no arguments is deprecated\.",
+            message="Calling select_related() with no arguments is deprecated.",
         ):
             children = ChildProxy.objects.select_related().only("id", "name")
         self.assertEqual(len(children), 1)

--- a/tests/gis_tests/relatedapp/tests.py
+++ b/tests/gis_tests/relatedapp/tests.py
@@ -21,7 +21,7 @@ class RelatedGeoModelTest(TestCase):
         # queryset can be removed.
         with ignore_warnings(
             category=RemovedInDjango70Warning,
-            message=r"Calling select_related\(\) with no arguments is deprecated\.",
+            message="Calling select_related() with no arguments is deprecated.",
         ):
             qs2 = City.objects.order_by("id").select_related()
         qs3 = City.objects.order_by("id").select_related("location")

--- a/tests/mail/__init__.py
+++ b/tests/mail/__init__.py
@@ -32,7 +32,7 @@ class override_deprecated_email_settings(override_settings):
                 re.escape("{name}"), rf"(?:{deprecated_names_re})"
             )
             self.ignore_warnings = ignore_warnings(
-                category=RemovedInDjango70Warning, message=message_re
+                category=RemovedInDjango70Warning, message_re=message_re
             )
         else:
             self.ignore_warnings = nullcontext()
@@ -50,5 +50,5 @@ class override_deprecated_email_settings(override_settings):
 def ignore_no_default_mailer_warning():
     return ignore_warnings(
         category=RemovedInDjango70Warning,
-        message=re.escape(NO_DEFAULT_MAILER_WARNING),
+        message=NO_DEFAULT_MAILER_WARNING,
     )

--- a/tests/mail/test_backends.py
+++ b/tests/mail/test_backends.py
@@ -1,5 +1,4 @@
 import os
-import re
 import shutil
 import socket
 import ssl
@@ -236,9 +235,7 @@ class SharedEmailBackendTests(MailTestsMixin):
             self.assertWarnsMessage(RemovedInDjango70Warning, msg),
             ignore_warnings(
                 category=RemovedInDjango70Warning,
-                message=re.escape(
-                    "Directly creating EmailBackend instances is deprecated."
-                ),
+                message="Directly creating EmailBackend instances is deprecated.",
             ),
         ):
             # alias=None tells create_backend() to _omit_ the `alias` arg.
@@ -320,7 +317,7 @@ class LocmemBackendTests(SharedEmailBackendTests, SimpleTestCase):
 
 @ignore_warnings(
     category=RemovedInDjango70Warning,
-    message=r"The EMAIL_FILE_PATH setting is deprecated\.",
+    message="The EMAIL_FILE_PATH setting is deprecated.",
 )
 class FileBackendTests(SharedEmailBackendTests, SimpleTestCase):
     backend_class = filebased.EmailBackend
@@ -599,7 +596,8 @@ class SMTPHandler:
 
 @skipUnless(HAS_AIOSMTPD, "No aiosmtpd library detected.")
 @ignore_warnings(
-    category=RemovedInDjango70Warning, message=r"The EMAIL_\w+ setting is deprecated\."
+    category=RemovedInDjango70Warning,
+    message_re=r"The EMAIL_\w+ setting is deprecated\.",
 )
 class SMTPBackendTestsBase(SimpleTestCase):
     @classmethod
@@ -626,7 +624,7 @@ class SMTPBackendTestsBase(SimpleTestCase):
 @skipUnless(HAS_AIOSMTPD, "No aiosmtpd library detected.")
 @ignore_warnings(
     category=RemovedInDjango70Warning,
-    message=re.escape("Directly creating EmailBackend instances is deprecated."),
+    message="Directly creating EmailBackend instances is deprecated.",
 )
 class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
     backend_class = smtp.EmailBackend

--- a/tests/mail/test_deprecated.py
+++ b/tests/mail/test_deprecated.py
@@ -288,7 +288,7 @@ class DeprecatedEmailSettingsTests(SimpleTestCase):
             self.assertWarnsMessage(RemovedInDjango70Warning, msg),
             ignore_warnings(
                 category=RemovedInDjango70Warning,
-                message=re.escape("get_connection() is deprecated."),
+                message="get_connection() is deprecated.",
             ),
         ):
             get_connection()

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -2938,7 +2938,9 @@ class MailDeprecatedPositionalArgsTests(SimpleTestCase):
             ignore_no_default_mailer_warning(),
             ignore_warnings(
                 category=RemovedInDjango70Warning,
-                message=re.escape("get_connection() is deprecated."),
+                # Anchored at the start of the message, so that warnings about
+                # positional arguments to get_connection() aren't ignored too.
+                message_re=r"get_connection\(\) is deprecated\.",
             ),
         ):
             return mail.get_connection(*args, **kwargs)

--- a/tests/model_fields/test_booleanfield.py
+++ b/tests/model_fields/test_booleanfield.py
@@ -97,7 +97,7 @@ class BooleanFieldTests(TestCase):
         # of the test.
         with ignore_warnings(
             category=RemovedInDjango70Warning,
-            message=r"Calling select_related\(\) with no arguments is deprecated\.",
+            message="Calling select_related() with no arguments is deprecated.",
         ):
             mb = FksToBooleans.objects.select_related().get(pk=m1.id)
             mc = FksToBooleans.objects.select_related().get(pk=m2.id)

--- a/tests/model_inheritance_regress/tests.py
+++ b/tests/model_inheritance_regress/tests.py
@@ -258,7 +258,7 @@ class ModelInheritanceTest(TestCase):
         # be removed.
         with ignore_warnings(
             category=RemovedInDjango70Warning,
-            message=r"Calling select_related\(\) with no arguments is deprecated\.",
+            message="Calling select_related() with no arguments is deprecated.",
         ):
             wholesalers = list(Wholesaler.objects.select_related())
         self.assertEqual(wholesalers, [])

--- a/tests/modeladmin/tests.py
+++ b/tests/modeladmin/tests.py
@@ -1046,7 +1046,7 @@ class ModelAdminTests(TestCase):
     def test_list_select_related_true_deprecated_subclass(self):
         with ignore_warnings(
             category=RemovedInDjango70Warning,
-            message=r"Setting ModelAdmin.list_select_related to True is deprecated\.",
+            message="Setting ModelAdmin.list_select_related to True is deprecated.",
         ):
 
             class BaseTestModelAdmin(ModelAdmin):

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -2018,7 +2018,7 @@ class SelectRelatedTests(TestCase):
         # case.
         with ignore_warnings(
             category=RemovedInDjango70Warning,
-            message=r"Calling select_related\(\) with no arguments is deprecated\.",
+            message="Calling select_related() with no arguments is deprecated.",
         ):
             self.assertSequenceEqual(X.objects.select_related(), [])
 

--- a/tests/select_related/tests.py
+++ b/tests/select_related/tests.py
@@ -117,7 +117,7 @@ class SelectRelatedTests(TestCase):
         with self.assertNumQueries(1):
             with ignore_warnings(
                 category=RemovedInDjango70Warning,
-                message=r"Calling select_related\(\) with no arguments is deprecated\.",
+                message="Calling select_related() with no arguments is deprecated.",
             ):
                 world = Species.objects.select_related()
             families = [o.genus.family.name for o in world]

--- a/tests/select_related_onetoone/tests.py
+++ b/tests/select_related_onetoone/tests.py
@@ -94,7 +94,7 @@ class ReverseSelectRelatedTestCase(TestCase):
             self.assertNumQueries(2),
             ignore_warnings(
                 category=RemovedInDjango70Warning,
-                message=r"Calling select_related\(\) with no arguments is deprecated\.",
+                message="Calling select_related() with no arguments is deprecated.",
             ),
         ):
             u = User.objects.select_related().get(username="test")

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -1356,6 +1356,78 @@ class AssertWarnsMessageTests(SimpleTestCase):
             func1()
 
 
+class IgnoreWarningsTests(SimpleTestCase):
+    @contextmanager
+    def captured_warnings(self):
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always")
+            yield captured
+
+    def test_message_matched_anywhere(self):
+        with self.captured_warnings() as captured:
+            with ignore_warnings(message="is deprecated"):
+                warnings.warn("get_connection() is deprecated.", UserWarning)
+        self.assertEqual(captured, [])
+
+    def test_message_special_re_chars(self):
+        with self.captured_warnings() as captured:
+            with ignore_warnings(message="[.*x+]y?"):
+                warnings.warn("A message with [.*x+]y? in it.", UserWarning)
+        self.assertEqual(captured, [])
+
+    def test_message_not_matched(self):
+        with self.captured_warnings() as captured:
+            with ignore_warnings(message="is deprecated"):
+                warnings.warn("Expected message", UserWarning)
+        self.assertEqual(len(captured), 1)
+
+    def test_message_re(self):
+        with self.captured_warnings() as captured:
+            with ignore_warnings(message_re=r"get_\w+\(\) is deprecated\."):
+                warnings.warn("get_connection() is deprecated.", UserWarning)
+        self.assertEqual(captured, [])
+
+    def test_message_re_not_matched(self):
+        with self.captured_warnings() as captured:
+            with ignore_warnings(message_re=r"get_\w+\(\) is deprecated\."):
+                warnings.warn("Expected message", UserWarning)
+        self.assertEqual(len(captured), 1)
+
+    def test_module_matched_anywhere(self):
+        with self.captured_warnings() as captured:
+            with ignore_warnings(module="utils.tests"):
+                warnings.warn("Expected message", UserWarning)
+        self.assertEqual(captured, [])
+
+    def test_module_not_matched(self):
+        with self.captured_warnings() as captured:
+            with ignore_warnings(module="nonexistent.module"):
+                warnings.warn("Expected message", UserWarning)
+        self.assertEqual(len(captured), 1)
+
+    def test_module_re(self):
+        with self.captured_warnings() as captured:
+            with ignore_warnings(module_re=r"test_utils\.\w+"):
+                warnings.warn("Expected message", UserWarning)
+        self.assertEqual(captured, [])
+
+    def test_message_and_message_re(self):
+        msg = (
+            "ignore_warnings() received both 'message' and 'message_re'; pass "
+            "only one of them."
+        )
+        with self.assertRaisesMessage(TypeError, msg):
+            ignore_warnings(message="Expected message", message_re="Expected")
+
+    def test_module_and_module_re(self):
+        msg = (
+            "ignore_warnings() received both 'module' and 'module_re'; pass "
+            "only one of them."
+        )
+        with self.assertRaisesMessage(TypeError, msg):
+            ignore_warnings(module="test_utils.tests", module_re=r"test_utils\.\w+")
+
+
 class AssertFieldOutputTests(SimpleTestCase):
     def test_assert_field_output(self):
         error_invalid = ["Enter a valid email address."]


### PR DESCRIPTION
#### Trac ticket number

ticket-37089

#### Branch description

`ignore_warnings()` passes its `message` and `module` arguments straight to
`warnings.filterwarnings()`, which compiles them as regular expressions and
matches them with `re.match()`. That is inconsistent with the other test
helpers: `assertWarnsMessage()` does a substring check and `assertWarnsRegex()`
uses `re.search()`.

Two consequences bite callers:

* Regex metacharacters in a message are not matched literally, so
  `ignore_warnings(message="get_connection() is deprecated.")` silently fails
  to ignore the warning it names — `()` is parsed as an empty group.
* The pattern is anchored at the start, so a fragment such as
  `message="is deprecated"` never matches.

The workaround is to write `r".*" + re.escape(...)` by hand, and Django's own
test suite already carried a number of those, e.g.:

```python
ignore_warnings(
    category=RemovedInDjango70Warning,
    message=re.escape("Directly creating EmailBackend instances is deprecated."),
)
```

This PR makes `message` and `module` escaped, unanchored (substring) matches,
for consistency with `assertWarnsMessage()`, and adds `message_re` /
`module_re` for the cases that genuinely want a regular expression. Passing
both a plain and an `_re` variant of the same argument raises `TypeError`.

Callers in the test suite that pre-escaped their patterns were updated to pass
the literal message. Two call sites keep regex matching via the new arguments:

* `tests/mail/test_backends.py` — matches an alternation over setting names.
* `tests/mail/tests.py` — relies on the start-anchoring, so that
  `"...to get_connection() is deprecated."` warnings are *not* also ignored.
  That second case is a real behavior difference of substring matching, and it
  mirrors the same trade-off `assertWarnsMessage()` already has.

`ignore_warnings()` is undocumented, but it is importable from `django.test`,
so a release note is included. As discussed on the ticket, no deprecation path
is proposed since this is internal API.

The ticket is assigned to its reporter, but no patch had been posted in three
months — happy to close this if they would rather finish it themselves.

#### AI Assistance Disclosure (REQUIRED)

- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude Code (Claude Opus 5) was used to investigate the ticket, write the patch
and the tests, and run the test suite. The output has been reviewed and
verified.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.

- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
