### PR TITLE
Fixed #32557 -- Fail tests when unraisable exceptions occur

### DIFF
--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -2,6 +2,7 @@ import argparse
 import ctypes
 import faulthandler
 import functools
+import gc
 import hashlib
 import io
 import itertools
@@ -1161,6 +1162,22 @@ class DiscoverRunner:
             )
         return databases
 
+    @contextmanager
+    def capture_unraisable_exceptions(self):
+        unraisable_exceptions = []
+        orig_hook = sys.unraisablehook
+
+        def hook(unraisable):
+            unraisable_exceptions.append(unraisable)
+            orig_hook(unraisable)
+
+        sys.unraisablehook = hook
+        try:
+            yield unraisable_exceptions
+        finally:
+            gc.collect()
+            sys.unraisablehook = orig_hook
+
     def run_tests(self, test_labels, **kwargs):
         """
         Run the unit tests for all the test labels in the provided list.
@@ -1183,24 +1200,28 @@ class DiscoverRunner:
                 serialized_aliases=suite.serialized_aliases,
             )
         run_failed = False
-        try:
-            self.run_checks(databases)
-            result = self.run_suite(suite)
-        except Exception:
-            run_failed = True
-            raise
-        finally:
+        unraisable_exceptions = []
+        with self.capture_unraisable_exceptions() as unraisable_exceptions:
             try:
-                with self.time_keeper.timed("Total database teardown"):
-                    self.teardown_databases(old_config)
-                self.teardown_test_environment()
+                self.run_checks(databases)
+                result = self.run_suite(suite)
             except Exception:
-                # Silence teardown exceptions if an exception was raised during
-                # runs to avoid shadowing it.
-                if not run_failed:
-                    raise
+                run_failed = True
+                raise
+            finally:
+                try:
+                    with self.time_keeper.timed("Total database teardown"):
+                        self.teardown_databases(old_config)
+                    self.teardown_test_environment()
+                except Exception:
+                    # Silence teardown exceptions if an exception was raised during
+                    # runs to avoid shadowing it.
+                    if not run_failed:
+                        raise
         self.time_keeper.print_results()
-        return self.suite_result(suite, result)
+        return self.suite_result(suite, result) + len(unraisable_exceptions)
+
+
 
 
 def try_importing(label):

--- a/tests/test_runner/tests.py
+++ b/tests/test_runner/tests.py
@@ -4,6 +4,7 @@ Tests for django test runner
 
 import collections.abc
 import functools
+import gc
 import multiprocessing
 import os
 import sys
@@ -1075,3 +1076,27 @@ class RunTestsExceptionHandlingTests(unittest.TestCase):
                     )
             self.assertTrue(teardown_databases.called)
             self.assertFalse(teardown_test_environment.called)
+
+    def test_unraisable_exception_causes_failure(self):
+        class NaughtyObject:
+            def __del__(self):
+                raise ValueError("Unraisable exception in __del__")
+
+        class SampleTest(unittest.TestCase):
+            def test_foo(self):
+                obj = NaughtyObject()
+                del obj
+                gc.collect()
+
+        suite = unittest.TestSuite([SampleTest("test_foo")])
+        with (
+            mock.patch("django.test.runner.DiscoverRunner.setup_test_environment"),
+            mock.patch("django.test.runner.DiscoverRunner.setup_databases"),
+            mock.patch("django.test.runner.DiscoverRunner.build_suite", return_value=suite),
+            mock.patch("django.test.runner.DiscoverRunner.run_checks"),
+            mock.patch("django.test.runner.DiscoverRunner.teardown_databases"),
+            mock.patch("django.test.runner.DiscoverRunner.teardown_test_environment"),
+        ):
+            runner = DiscoverRunner(verbosity=0, interactive=False)
+            failures = runner.run_tests([])
+            self.assertGreater(failures, 0)


### PR DESCRIPTION
#### Trac ticket number

ticket-32557

#### Branch description

Fixed #32557 by making Django's test runner detect unraisable exceptions during test execution and teardown.

The implementation temporarily installs a custom sys.unraisablehook, records unraisable exceptions, preserves the original hook behavior, and runs garbage collection before restoring the original hook so exceptions raised during finalization are captured.

Added a regression test demonstrating that an unraisable exception previously allowed the test run to pass.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

AI tools used: ChatGPT and Google Antigravity (Gemini). The generated suggestions and code were manually reviewed, tested, and verified against the Django test suite.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.