### PR TITLE
Fixed #15396 -- Fully qualified middleware class names in docs/ref/middleware.txt.

### DIFF
--- a/docs/ref/middleware.txt
+++ b/docs/ref/middleware.txt
@@ -18,9 +18,9 @@ Cache middleware
 .. module:: django.middleware.cache
    :synopsis: Middleware for the site-wide cache.
 
-.. class:: UpdateCacheMiddleware
+.. class:: django.middleware.cache.UpdateCacheMiddleware
 
-.. class:: FetchFromCacheMiddleware
+.. class:: django.middleware.cache.FetchFromCacheMiddleware
 
 Enable the site-wide cache. If these are enabled, each Django-powered page will
 be cached for as long as the :setting:`CACHE_MIDDLEWARE_SECONDS` setting
@@ -32,7 +32,7 @@ defines. See the :doc:`cache documentation </topics/cache>`.
 .. module:: django.middleware.common
    :synopsis: Middleware adding "common" conveniences for perfectionists.
 
-.. class:: CommonMiddleware
+.. class:: django.middleware.common.CommonMiddleware
 
     .. attribute:: response_redirect_class
 
@@ -81,7 +81,7 @@ Adds a few conveniences for perfectionists:
 
 * Sets the ``Content-Length`` header for non-streaming responses.
 
-.. class:: BrokenLinkEmailsMiddleware
+.. class:: django.middleware.common.BrokenLinkEmailsMiddleware
 
 * Sends broken link notification emails to :setting:`MANAGERS` (see
   :doc:`/howto/error-reporting`).
@@ -92,7 +92,7 @@ GZip middleware
 .. module:: django.middleware.gzip
    :synopsis: Middleware to serve GZipped content for performance.
 
-.. class:: GZipMiddleware
+.. class:: django.middleware.gzip.GZipMiddleware
 
     .. attribute:: max_random_bytes
 
@@ -145,7 +145,7 @@ Conditional GET middleware
 .. module:: django.middleware.http
    :synopsis: Middleware handling advanced HTTP features.
 
-.. class:: ConditionalGetMiddleware
+.. class:: django.middleware.http.ConditionalGetMiddleware
 
     Handles conditional GET operations. If the response doesn't have an
     ``ETag`` header, the middleware adds one if needed. If the response has an
@@ -162,7 +162,7 @@ Locale middleware
 .. module:: django.middleware.locale
    :synopsis: Middleware to enable language selection based on the request.
 
-.. class:: LocaleMiddleware
+.. class:: django.middleware.locale.LocaleMiddleware
 
     .. attribute:: LocaleMiddleware.response_redirect_class
 
@@ -180,7 +180,7 @@ Message middleware
 .. module:: django.contrib.messages.middleware
    :synopsis: Message middleware.
 
-.. class:: MessageMiddleware
+.. class:: django.contrib.messages.middleware.MessageMiddleware
 
     Enables cookie- and session-based message support. See the
     :doc:`messages documentation </ref/contrib/messages>`.
@@ -200,7 +200,7 @@ Security middleware
     by Django (such as static media or user-uploaded files), they will have
     the same protections as requests to your Django application.
 
-.. class:: SecurityMiddleware
+.. class:: django.middleware.security.SecurityMiddleware
 
    The ``django.middleware.security.SecurityMiddleware`` provides several
    security enhancements to the request/response cycle. Each one can be
@@ -470,7 +470,7 @@ Session middleware
 .. module:: django.contrib.sessions.middleware
    :synopsis: Session middleware.
 
-.. class:: SessionMiddleware
+.. class:: django.contrib.sessions.middleware.SessionMiddleware
 
     Enables session support. See the :doc:`session documentation
     </topics/http/sessions>`.
@@ -481,7 +481,7 @@ Site middleware
 .. module:: django.contrib.sites.middleware
   :synopsis: Site middleware.
 
-.. class:: CurrentSiteMiddleware
+.. class:: django.contrib.sites.middleware.CurrentSiteMiddleware
 
     Adds the ``site`` attribute representing the current site to every incoming
     ``HttpRequest`` object. See the :ref:`sites documentation <site-middleware>`.
@@ -492,13 +492,13 @@ Authentication middleware
 .. module:: django.contrib.auth.middleware
   :synopsis: Authentication middleware.
 
-.. class:: AuthenticationMiddleware
+.. class:: django.contrib.auth.middleware.AuthenticationMiddleware
 
     Adds the ``user`` attribute, representing the currently-logged-in user, to
     every incoming ``HttpRequest`` object. See :ref:`Authentication in web
     requests <auth-web-requests>`.
 
-.. class:: LoginRequiredMiddleware
+.. class:: django.contrib.auth.middleware.LoginRequiredMiddleware
 
     Subclass the middleware and override the following attributes and methods
     to customize behavior for unauthenticated requests.
@@ -573,13 +573,13 @@ Customize the login URL or field name for authenticated views with the
     :ref:`enabled unauthenticated requests
     <disable-login-required-middleware-for-views>` to your login view.
 
-.. class:: RemoteUserMiddleware
+.. class:: django.contrib.auth.middleware.RemoteUserMiddleware
 
     Middleware for utilizing web server provided authentication. See
     :doc:`/howto/auth-remote-user` for usage details, including security
     considerations.
 
-.. class:: PersistentRemoteUserMiddleware
+.. class:: django.contrib.auth.middleware.PersistentRemoteUserMiddleware
 
     Middleware for utilizing web server provided authentication when enabled
     only on the login page. See :ref:`persistent-remote-user-middleware-howto`
@@ -590,7 +590,7 @@ CSRF protection middleware
 
 .. currentmodule:: django.middleware.csrf
 
-.. class:: CsrfViewMiddleware
+.. class:: django.middleware.csrf.CsrfViewMiddleware
 
     Adds protection against Cross Site Request Forgeries by adding hidden form
     fields to POST forms and checking requests for the correct value. See the
@@ -604,7 +604,7 @@ CSRF protection middleware
 
 .. currentmodule:: django.middleware.clickjacking
 
-.. class:: XFrameOptionsMiddleware
+.. class:: django.middleware.clickjacking.XFrameOptionsMiddleware
 
     Simple :doc:`clickjacking protection via the X-Frame-Options header
     </ref/clickjacking/>`.
@@ -614,7 +614,7 @@ Content Security Policy middleware
 
 .. currentmodule:: django.middleware.csp
 
-.. class:: ContentSecurityPolicyMiddleware
+.. class:: django.middleware.csp.ContentSecurityPolicyMiddleware
 
 Adds support for Content Security Policy (CSP), which helps mitigate risks such
 as Cross-Site Scripting (XSS) and data injection attacks by controlling the


### PR DESCRIPTION
#### Trac ticket number

ticket-15396

#### Branch description

Fully qualify middleware class names in `docs/ref/middleware.txt` to make middleware class references explicit and easier to understand. This change improves the clarity and consistency of the middleware documentation by replacing ambiguous class references with fully qualified class names.

#### AI Assistance Disclosure (REQUIRED)

- [x] If AI tools were used, I have disclosed which ones, and fully reviewed and verified their output.

AI tools used: ChatGPT and Claude.

#### Checklist

- [x] This PR follows the contribution guidelines.
- [x] This PR does not disclose a security vulnerability.
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.