### PR TITLE
Fixed #11379 -- Allowed disabling cache culling with MAX_ENTRIES=None.

### DIFF
--- a/django/core/cache/backends/base.py
+++ b/django/core/cache/backends/base.py
@@ -69,10 +69,13 @@ class BaseCache:
 
         options = params.get("OPTIONS", {})
         max_entries = params.get("max_entries", options.get("MAX_ENTRIES", 300))
-        try:
-            self._max_entries = int(max_entries)
-        except (ValueError, TypeError):
-            self._max_entries = 300
+        if max_entries is None:
+            self._max_entries = None
+        else:
+            try:
+                self._max_entries = int(max_entries)
+            except (ValueError, TypeError):
+                self._max_entries = 300
 
         cull_frequency = params.get("cull_frequency", options.get("CULL_FREQUENCY", 3))
         try:

--- a/django/core/cache/backends/db.py
+++ b/django/core/cache/backends/db.py
@@ -132,7 +132,11 @@ class DatabaseCache(BaseDatabaseCache):
                 tz = UTC if settings.USE_TZ else None
                 exp = datetime.fromtimestamp(timeout, tz=tz)
             exp = exp.replace(microsecond=0)
-            if self._cull_probability and random.random() <= self._cull_probability:
+            if (
+                self._max_entries is not None
+                and self._cull_probability
+                and random.random() <= self._cull_probability
+            ):
                 cursor.execute("SELECT COUNT(*) FROM %s" % table)
                 num = cursor.fetchone()[0]
                 if num > self._max_entries:

--- a/django/core/cache/backends/filebased.py
+++ b/django/core/cache/backends/filebased.py
@@ -108,7 +108,7 @@ class FileBasedCache(BaseCache):
         """
         filelist = self._list_cache_files()
         num_entries = len(filelist)
-        if num_entries < self._max_entries:
+        if self._max_entries is None or num_entries < self._max_entries:
             return  # return early if no culling is required
         if self._cull_frequency == 0:
             return self.clear()  # Clear the cache when CULL_FREQUENCY = 0

--- a/django/core/cache/backends/locmem.py
+++ b/django/core/cache/backends/locmem.py
@@ -43,7 +43,7 @@ class LocMemCache(BaseCache):
         return pickle.loads(pickled)
 
     def _set(self, key, value, timeout=DEFAULT_TIMEOUT):
-        if len(self._cache) >= self._max_entries:
+        if self._max_entries is not None and len(self._cache) >= self._max_entries:
             self._cull()
         self._cache[key] = value
         self._cache.move_to_end(key, last=False)

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -109,6 +109,9 @@ Asynchronous views
 Cache
 ~~~~~
 
+* The ``MAX_ENTRIES`` option may now be set to ``None`` to disable culling in
+  the ``locmem``, ``filesystem``, and ``database`` backends.
+
 * Subclasses of ``BaseDatabaseCache`` now support :ref:`culling
   <database-caching>` on a percentage of writes as an optimization. The
   default is 10%, and may be configured using the ``CULL_PROBABILITY`` option.

--- a/docs/topics/cache.txt
+++ b/docs/topics/cache.txt
@@ -497,7 +497,7 @@ behavior. These arguments are provided as additional keys in the
 
   * ``MAX_ENTRIES``: The maximum number of entries allowed in
     the cache before old values are deleted. This argument
-    defaults to ``300``.
+    defaults to ``300``. Set to ``None`` to disable culling.
 
   * ``CULL_FREQUENCY``: The fraction of entries that are culled
     when ``MAX_ENTRIES`` is reached. The actual ratio is

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -304,6 +304,7 @@ _caches_setting_base = {
     "zero_cull": {
         "OPTIONS": {"CULL_FREQUENCY": 0, "MAX_ENTRIES": 30, "CULL_PROBABILITY": 1.0}
     },
+    "no_cull": {"OPTIONS": {"MAX_ENTRIES": None, "CULL_PROBABILITY": 1.0}},
 }
 
 
@@ -711,6 +712,17 @@ class BaseCacheTests:
 
     def test_zero_cull(self):
         self._perform_cull_test("zero_cull", 50, 19)
+
+    def test_cull_unlimited(self):
+        cull_cache = caches["no_cull"]
+        try:
+            cull_cache._max_entries = None
+        except (AttributeError, TypeError):
+            self.skipTest("Culling isn't implemented.")
+        for i in range(1, 50):
+            cull_cache.set("cull%d" % i, "value", 1000)
+        for i in range(1, 50):
+            self.assertEqual(cull_cache.get("cull%d" % i), "value")
 
     def test_cull_delete_when_store_empty(self):
         try:
@@ -1314,6 +1326,21 @@ class DBCacheTests(BaseCacheTests, TransactionTestCase):
                 self.assertIn(connection.ops.quote_name("expires"), sql)
             if "cache_key" in sql:
                 self.assertIn(connection.ops.quote_name("cache_key"), sql)
+
+    def test_db_cull_unlimited_queries(self):
+        old_max_entries = cache._max_entries
+        old_cull_probability = cache._cull_probability
+        # Disable culling so no COUNT query should be executed.
+        cache._max_entries = None
+        cache._cull_probability = 1.0
+        with CaptureQueriesContext(connection) as captured_queries:
+            try:
+                cache.set("force_cull", "value", 1000)
+            finally:
+                cache._max_entries = old_max_entries
+                cache._cull_probability = old_cull_probability
+        num_count_queries = sum("COUNT" in query["sql"] for query in captured_queries)
+        self.assertEqual(num_count_queries, 0)
 
     def test_db_cull_optimized_off(self):
         # Check for expired entries every request if probability is 1.0.


### PR DESCRIPTION
#### Trac ticket number
ticket-11379

#### Branch description
Allow disabling cache culling by setting `MAX_ENTRIES` to `None` in a cache backend's `OPTIONS`, so projects with unbounded caches no longer need to pick an arbitrary entry cap.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
<!-- If AI tools were used, provide which tools were used here. -->
OpenCode (a local AI coding assistant) was used to draft and verify this change; the output was fully reviewed and the full cache test suite was run locally.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
