### PR TITLE
Fixed #37274 -- Allowed transforms in order_by() after alias().

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -1052,6 +1052,11 @@ class SQLCompiler:
             for target in targets:
                 if name in self.query.annotation_select:
                     result.append(self.connection.ops.quote_name(name))
+                elif name in self.query.annotations:
+                    raise FieldError(
+                        f"Cannot select the {name!r} alias. Use annotate() to "
+                        "promote it."
+                    )
                 else:
                     r, p = self.compile(transform_function(target, alias))
                     result.append(r)

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1800,8 +1800,8 @@ class Query(BaseExpression):
                     raise FieldDoesNotExist
                 field = opts.get_field(name)
             except FieldDoesNotExist:
-                if name in self.annotation_select:
-                    field = self.annotation_select[name].output_field
+                if name in self.annotations:
+                    field = self.annotations[name].output_field
                 elif name in self._filtered_relations and pos == 0:
                     filtered_relation = self._filtered_relations[name]
                     if LOOKUP_SEP in filtered_relation.relation_name:

--- a/tests/annotations/tests.py
+++ b/tests/annotations/tests.py
@@ -1481,6 +1481,12 @@ class AliasTests(TestCase):
         self.assertIs(hasattr(qs.first(), "other_age"), False)
         self.assertQuerySetEqual(qs, [34, 34, 35, 46, 57], lambda a: a.age)
 
+    def test_order_by_alias_transform(self):
+        qs = Book.objects.alias(other_pubdate=F("pubdate")).order_by(
+            "-other_pubdate__year"
+        )
+        self.assertQuerySetEqual(qs, [2008, 2007, 1995, 1991], lambda a: a.pubdate.year)
+
     def test_order_by_alias_aggregate(self):
         qs = (
             Author.objects.values("age")
@@ -1536,9 +1542,9 @@ class AliasTests(TestCase):
     @skipUnlessDBFeature("can_distinct_on_fields")
     def test_distinct_on_alias(self):
         qs = Book.objects.alias(rating_alias=F("rating") - 1)
-        msg = "Cannot resolve keyword 'rating_alias' into field."
+        msg = "Cannot select the 'rating_alias' alias. Use annotate() to promote it."
         with self.assertRaisesMessage(FieldError, msg):
-            qs.distinct("rating_alias").first()
+            qs.distinct("rating_alias").order_by("rating_alias").first()
 
     def test_values_alias(self):
         qs = Book.objects.alias(rating_alias=F("rating") - 1)


### PR DESCRIPTION
#### Trac ticket number
ticket-37274

#### Branch description
Before, only selected annotations (via `annotate()`) could have transforms chained in `order_by()`, not aliased ones (via `alias()`), but that's one of `.alias()`'s use cases -- avoiding selecting the expression, and just transforming elsewhere.

/cc @p-r-a-v-i-n, in case this allows any simplifications in #21636?

The other use of this method in `values()`...

https://github.com/django/django/blob/c6be0bf3bb744d234947cefd6def9f31d9655800/django/db/models/sql/query.py#L2627-L2631

seems not relevant, as the unselected-alias case is already filtered out above:
https://github.com/django/django/blob/c6be0bf3bb744d234947cefd6def9f31d9655800/django/db/models/sql/query.py#L2622-L2625

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.