### PR TITLE
Fixed #37267 -- Rejected unrelated querysets in reverse FK prefetches.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -356,6 +356,7 @@ answer newbie questions, and generally made Django that much better:
     Fabian Büchler <fabian.buechler@inoqo.com>
     Fabian Braun <fsbraun@gmx.de>
     Fabrice Aneche <akh@nobugware.com>
+    Faisal Mehboob <https://github.com/beingfaisal>
     Faishal Manzar <https://github.com/faishal882>
     Farhaan Bukhsh <farhaan.bukhsh@gmail.com>
     favo@exoweb.net

--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -818,6 +818,14 @@ def create_reverse_many_to_one_manager(superclass, rel):
                         "length of 1."
                     )
                 queryset = querysets[0]
+                if not issubclass(queryset.model, self.model):
+                    raise ValueError(
+                        'Expected a QuerySet of "%s", but got a QuerySet of "%s".'
+                        % (
+                            self.model._meta.label,
+                            queryset.model._meta.label,
+                        )
+                    )
             else:
                 _cloning_disabled = True
                 queryset = super().get_queryset()._disable_cloning()

--- a/tests/prefetch_related/tests.py
+++ b/tests/prefetch_related/tests.py
@@ -151,6 +151,22 @@ class PrefetchRelatedTests(TestDataMixin, TestCase):
 
         self.assertSequenceEqual(self.book2.authors.all(), [self.author1])
 
+    def test_foreignkey_reverse_incompatible_queryset_model(self):
+        FavoriteAuthors.objects.create(
+            author=self.author1,
+            likes_author=self.author2,
+        )
+        queryset = Author.objects.prefetch_related(
+            Prefetch("addresses", queryset=FavoriteAuthors.objects.all())
+        )
+
+        msg = (
+            'Expected a QuerySet of "prefetch_related.AuthorAddress", but got a '
+            'QuerySet of "prefetch_related.FavoriteAuthors".'
+        )
+        with self.assertRaisesMessage(ValueError, msg):
+            list(queryset)
+
     def test_onetoone_reverse_no_match(self):
         # Regression for #17439
         with self.assertNumQueries(2):


### PR DESCRIPTION
#### Trac ticket number

ticket-37267

#### Branch description

Prevent reverse foreign key prefetches from accepting querysets for unrelated models. Subclasses of the expected relationship model remain supported. Includes a regression test using existing prefetch-related test models.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

OpenAI Codex (GPT-5) assisted with analysing the problem and regressions tests. I manually reviewed the changes and verified that the test fails without the fix and passes with it.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability.
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.

- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.