### PR TITLE
Fixed #29023 -- Added a test for exception chains in the parallel test runner.

### DIFF
--- a/tests/test_runner/test_parallel.py
+++ b/tests/test_runner/test_parallel.py
@@ -3,6 +3,7 @@ import multiprocessing
 import os
 import pickle
 import sys
+import traceback
 import unittest
 from unittest import mock
 from unittest.case import TestCase
@@ -29,6 +30,16 @@ def _test_error_exc_info():
     try:
         raise ValueError("woops")
     except ValueError:
+        return sys.exc_info()
+
+
+def _test_chained_error_exc_info():
+    try:
+        try:
+            raise ValueError("inner cause")
+        except ValueError as exc:
+            raise RuntimeError("outer error") from exc
+    except RuntimeError:
         return sys.exc_info()
 
 
@@ -172,6 +183,32 @@ class RemoteTestResultTest(SimpleTestCase):
         error_type, _, _ = event[3]
         self.assertEqual(error_type, ValueError)
         self.assertIs(result.wasSuccessful(), False)
+
+    @unittest.skipUnless(tblib is not None, "requires tblib to be installed")
+    def test_error_preserves_exception_chain(self):
+        """
+        Chained exceptions (via __cause__/__context__) survive the transfer of
+        errors from a worker process to the main process, so the full traceback
+        is shown when running tests in parallel (#29023).
+        """
+        result = RemoteTestResult()
+        test = None
+        result.startTest(test)
+        try:
+            result.addError(test, _test_chained_error_exc_info())
+        finally:
+            result.stopTest(test)
+
+        # Simulate transferring the events from a worker to the main process.
+        events = pickle.loads(pickle.dumps(result.events))
+        _, _, err = next(event for event in events if event[0] == "addError")
+        formatted = "".join(traceback.format_exception(*err))
+        self.assertIn("ValueError: inner cause", formatted)
+        self.assertIn("RuntimeError: outer error", formatted)
+        self.assertIn(
+            "The above exception was the direct cause of the following exception",
+            formatted,
+        )
 
     def test_picklable(self):
         result = RemoteTestResult()


### PR DESCRIPTION
#### Trac ticket number

ticket-29023

#### Branch description

When running tests in parallel, `RemoteTestResult` sends errors from the worker processes to the main process by pickling them. The ticket reported that chained exceptions (linked via `__cause__`/`__context__`) were lost in this round trip, so only the outermost exception was shown instead of the full chain.

This is no longer the case. Django requires `tblib >= 3.0.0` (since 6.0), and tblib 3.x preserves exception chains through pickling. I confirmed the full traceback is shown under `--parallel=2`, so the 2018 proof-of-concept workaround on the ticket is no longer needed.

This PR adds the missing regression test so the behavior stays covered. The test builds a chained exception, runs it through `RemoteTestResult.addError()`, pickles the recorded events exactly as a worker sends them to the main process, and asserts that the formatted traceback contains both exceptions and the linking line. It is skipped when tblib is not installed, matching the other error tests in the module.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

AI tool used: Claude Code (Anthropic), which assisted with reproducing the issue and writing the regression test. All output was reviewed and verified, and the full `test_runner` suite passes.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
