### PR TITLE
Fixed #37250 -- Allowed nesting GEOS GeometryCollection objects.

### DIFF
--- a/django/contrib/gis/geos/collections.py
+++ b/django/contrib/gis/geos/collections.py
@@ -123,4 +123,5 @@ GeometryCollection._allowed = (
     MultiPoint,
     MultiLineString,
     MultiPolygon,
+    GeometryCollection,
 )

--- a/tests/gis_tests/geos_tests/test_geos.py
+++ b/tests/gis_tests/geos_tests/test_geos.py
@@ -1347,6 +1347,10 @@ class GEOSTest(SimpleTestCase, TestDataMixin):
         # And, they should be equal.
         self.assertEqual(gc1, gc2)
 
+        # GeometryCollections can themselves contain GeometryCollections.
+        gc3 = GeometryCollection(gc2)
+        self.assertEqual(gc1, gc3[0])
+
     def test_gdal(self):
         "Testing `ogr` and `srs` properties."
         g1 = fromstr("POINT(5 23)")


### PR DESCRIPTION
#### Trac ticket number
ticket-37250

#### Branch description
Before, a GEOS `GeometryCollection` could not be constructed from another one. This isn't a limitation of the data format.

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.

