### PR TITLE
Fixed #37279 -- Rejected null characters in URLValidator.

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -152,7 +152,7 @@ class URLValidator(RegexValidator):
     )
     message = _("Enter a valid URL.")
     schemes = ["http", "https", "ftp", "ftps"]
-    unsafe_chars = frozenset("\t\r\n")
+    unsafe_chars = frozenset("\t\r\n\x00")
     max_length = MAX_URL_LENGTH
 
     def __init__(self, schemes=None, **kwargs):

--- a/tests/validators/tests.py
+++ b/tests/validators/tests.py
@@ -265,6 +265,10 @@ INVALID_URLS = [
     "http://[::\rffff:192.9.5.5]",
     "http://\twww.djangoproject.com/",
     "http://\t[::ffff:192.9.5.5]",
+    # Null characters are not accepted.
+    "http://www.djangoproject.com/\x00",
+    "http://www.django\x00project.com/",
+    "http://www.djangoproject.com/\x00@example.com/",
     # Trailing junk does not take forever to reject.
     "http://www.asdasdasdasdsadfm.com.br ",
     "http://www.asdasdasdasdsadfm.com.br z",


### PR DESCRIPTION
#### Trac ticket number
ticket-37279

#### Branch description
`URLValidator.unsafe_chars` rejected tabs and newlines (#32713) but not null characters, so URLs containing `\x00` passed validation. This adds `\x00` to `unsafe_chars`, making `URLValidator` consistent with `forms.CharField`/`forms.URLField`, which already reject null characters via `ProhibitNullCharactersValidator` (#28201).

Reproduction on main before this patch:

```pycon
>>> from django.core.validators import URLValidator
>>> URLValidator()("http://www.djangoproject.com/\x00")
>>> URLValidator()("http://example.com/page\x00@example.com/")
```

Neither call raised `ValidationError`. With this patch both raise, covered by new entries in `INVALID_URLS` (null character in path, host, and userinfo positions). Null characters are invalid in URLs per RFC 3986 and cannot be stored in PostgreSQL string literals ("A string literal cannot contain NUL (0x00) characters").

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude (Anthropic) was used to help draft the patch, tests, and this description. The issue was reproduced manually and the fix was verified by running the validators test suite before and after the patch (fails without, passes with).

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.

- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
