### PR TITLE
Fixed #37070 - Added clear_messages() function to django.contrib.messages.

### DIFF
--- a/django/contrib/messages/api.py
+++ b/django/contrib/messages/api.py
@@ -3,6 +3,7 @@ from django.contrib.messages.storage import default_storage
 
 __all__ = (
     "add_message",
+    "clear_messages",
     "get_messages",
     "get_level",
     "set_level",
@@ -38,6 +39,24 @@ def add_message(request, level, message, extra_tags="", fail_silently=False):
             )
     else:
         return messages.add(level, message, extra_tags)
+
+
+def clear_messages(request):
+    """
+    Remove all messages from the message storage on the request.
+    """
+    try:
+        messages = request._messages
+    except AttributeError:
+        if not hasattr(request, "META"):
+            raise TypeError(
+                "clear_messages() argument must be an HttpRequest object, not "
+                f"'{request.__class__.__name__}'."
+            )
+        return False
+    else:
+        messages.clear()
+        return True
 
 
 def get_messages(request):

--- a/django/contrib/messages/storage/base.py
+++ b/django/contrib/messages/storage/base.py
@@ -157,6 +157,17 @@ class BaseStorage:
         message = Message(level, message, extra_tags=extra_tags)
         self._queued_messages.append(message)
 
+    def clear(self):
+        """
+        Clear all loaded and queued messages and mark storage as used so
+        backends flush any stored messages.
+        """
+        self._loaded_messages
+        self._loaded_data = []
+        self._queued_messages = []
+        self.used = True
+        self.added_new = False
+
     def _get_level(self):
         """
         Return the minimum recorded level.

--- a/docs/ref/contrib/messages.txt
+++ b/docs/ref/contrib/messages.txt
@@ -235,6 +235,21 @@ For instance, you can fetch all the messages to return them in a
 instance of the configured storage backend.
 
 
+Clearing messages
+-----------------
+
+.. function:: clear_messages(request)
+
+To explicitly remove all messages from the message storage on a request, call::
+
+    from django.contrib import messages
+
+    messages.clear_messages(request)
+
+This is particularly useful in automated testing or view logic where messages
+need to be cleared before processing subsequent steps or rendering.
+
+
 The ``Message`` class
 ---------------------
 

--- a/tests/messages_tests/base.py
+++ b/tests/messages_tests/base.py
@@ -143,6 +143,19 @@ class BaseTests:
         storing = self.stored_messages_count(storage, response)
         self.assertEqual(storing, 1)
 
+    def test_clear(self):
+        storage = self.get_existing_storage()
+        storage.add(constants.INFO, "Test message 3")
+        self.assertGreater(len(storage), 0)
+        storage.clear()
+        self.assertEqual(len(storage), 0)
+        self.assertTrue(storage.used)
+        self.assertFalse(storage.added_new)
+        response = self.get_response()
+        storage.update(response)
+        storing = self.stored_messages_count(storage, response)
+        self.assertEqual(storing, 0)
+
     @override_settings(MESSAGE_LEVEL=constants.DEBUG)
     def test_full_request_response_cycle(self):
         """

--- a/tests/messages_tests/test_api.py
+++ b/tests/messages_tests/test_api.py
@@ -40,6 +40,24 @@ class ApiTests(SimpleTestCase):
         )
         self.assertEqual(self.storage.store, [])
 
+    def test_clear_messages(self):
+        self.request._messages = self.storage
+        messages.add_message(self.request, messages.DEBUG, "some message")
+        self.assertEqual(len(self.storage.store), 1)
+        res = messages.clear_messages(self.request)
+        self.assertTrue(res)
+        self.assertEqual(self.storage.store, [])
+
+    def test_clear_messages_request_is_none(self):
+        msg = "clear_messages() argument must be an HttpRequest object, not 'NoneType'."
+        self.request._messages = self.storage
+        with self.assertRaisesMessage(TypeError, msg):
+            messages.clear_messages(None)
+
+    def test_clear_messages_middleware_missing(self):
+        res = messages.clear_messages(self.request)
+        self.assertFalse(res)
+
 
 class CustomRequest:
     def __init__(self, request):

--- a/tests/messages_tests/utils.py
+++ b/tests/messages_tests/utils.py
@@ -10,5 +10,8 @@ class DummyStorage:
     def add(self, level, message, extra_tags=""):
         self.store.append(Message(level, message, extra_tags))
 
+    def clear(self):
+        self.store = []
+
     def __iter__(self):
         return iter(self.store)


### PR DESCRIPTION
#### Trac ticket number
ticket-37070

#### Branch description
Adds the `clear_messages(request)` API function to `django.contrib.messages` and the `BaseStorage.clear()` method to message storage backends. This allows developers and automated test suites to explicitly purge queued and loaded flash messages from a request, preventing them from leaking into subsequent views or assertions across all storage backends (`CookieStorage`, `SessionStorage`, `FallbackStorage`).

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
Antigravity AI coding assistant(Google Gemini 3.6 Flash)  was used to draft code, tests, and documentation. All outputs were fully reviewed, tested, and verified.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.

- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
