### PR TITLE
Fixed #37281 -- Ordered AddField before AlterUniqueTogether on field-to-FK conversion.

### DIFF
--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -1777,6 +1777,18 @@ class MigrationAutodetector:
                                     self.to_state,
                                 )
                             )
+                        # Depend on the creation of every field named in the
+                        # constraint so that an AlterFooTogether for a field
+                        # being added (e.g. a field converted to a
+                        # ForeignKey) runs after the AddField.
+                        dependencies.append(
+                            OperationDependency(
+                                app_label,
+                                model_name,
+                                field_name,
+                                OperationDependency.Type.CREATE,
+                            )
+                        )
                 yield (
                     old_value,
                     new_value,

--- a/docs/releases/6.1.1.txt
+++ b/docs/releases/6.1.1.txt
@@ -34,3 +34,8 @@ Bugfixes
 * Fixed a bug in Django 6.1 where :class:`~django.db.models.DecimalField`
   without ``max_digits`` and ``decimal_places`` caused a crash when retrieving
   values on SQLite (:ticket:`37275`).
+
+* Fixed a regression in Django 5.0 where converting a field referenced in
+  ``unique_together`` to a ``ForeignKey`` could generate migrations that
+  ordered ``AlterUniqueTogether`` before ``AddField``, causing a
+  ``FieldDoesNotExist`` error when applying them (:ticket:`37281`).

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -1197,6 +1197,30 @@ class AutodetectorTests(BaseAutodetectorTests):
             "unique_together": {("title", "newfield2")},
         },
     )
+    book_unique_together_5 = ModelState(
+        "otherapp",
+        "Book",
+        [
+            ("id", models.AutoField(primary_key=True)),
+            ("type", models.CharField(max_length=20)),
+            ("version", models.IntegerField()),
+        ],
+        {
+            "unique_together": {("type", "version")},
+        },
+    )
+    book_unique_together_6 = ModelState(
+        "otherapp",
+        "Book",
+        [
+            ("id", models.AutoField(primary_key=True)),
+            ("a", models.ForeignKey("testapp.Author", models.CASCADE, null=True)),
+            ("version", models.IntegerField()),
+        ],
+        {
+            "unique_together": {("a", "version")},
+        },
+    )
     attribution = ModelState(
         "otherapp",
         "Attribution",
@@ -3712,6 +3736,40 @@ class AutodetectorTests(BaseAutodetectorTests):
             1,
             name="book",
             unique_together={("title", "newfield")},
+        )
+
+    def test_unique_together_convert_field_to_fk(self):
+        """
+        An AlterUniqueTogether for a field that is being added (converted to
+        a ForeignKey) is ordered after the AddField (Ticket #37281).
+        """
+        before = self.make_project_state(
+            [self.author_empty, self.book_unique_together_5]
+        )
+        after = self.make_project_state(
+            [self.author_empty, self.book_unique_together_6]
+        )
+        autodetector = MigrationAutodetector(
+            before,
+            after,
+            MigrationQuestioner({"ask_initial": True}),
+        )
+        changes = autodetector._detect_changes()
+        changes = autodetector.arrange_for_graph(changes, MigrationGraph())
+        self.assertNumberMigrations(changes, "otherapp", 1)
+        self.assertOperationTypes(
+            changes,
+            "otherapp",
+            0,
+            ["AddField", "AlterUniqueTogether", "RemoveField"],
+        )
+        self.assertOperationAttributes(
+            changes,
+            "otherapp",
+            0,
+            1,
+            name="book",
+            unique_together={("a", "version")},
         )
 
     def test_create_model_and_unique_together(self):


### PR DESCRIPTION
#### Trac ticket number

ticket-37281

#### Branch description

Converting a field that participates in `unique_together` into a `ForeignKey`
generates an unapplyable migration: `AlterUniqueTogether` is emitted before the
`AddField` that creates the referenced column, so `migrate` fails with
`FieldDoesNotExist`. This records a dependency on the creation of every field
named in the constraint so the operations sort as `AddField`,
`AlterUniqueTogether`, `RemoveField`.

#### AI Assistance Disclosure (REQUIRED)

- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Codebuff was used to prepare and verify this patch; its output was manually reviewed.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have added or updated relevant tests.