### PR TITLE
Corrected indentation in docs/refs/models/instances.txt.

### DIFF
--- a/docs/ref/models/instances.txt
+++ b/docs/ref/models/instances.txt
@@ -146,9 +146,9 @@ The example above shows a full ``from_db()`` implementation to clarify how that
 is done. In this case it would be possible to use a ``super()`` call in the
 ``from_db()`` method.
 
-    .. versionchanged:: 6.1
+.. versionchanged:: 6.1
 
-       The ``fetch_mode`` parameter was added.
+    The ``fetch_mode`` parameter was added.
 
 .. _refreshing-objects:
 


### PR DESCRIPTION
I discovered why I kept misunderstanding this: the window of time you have to make an indented entry after a method declaration ends _not with the next declaration_ but with the next deindent, which in this case, happened immediately.

I'm having this tattooed to my wrist for easy reference.