### PR TITLE
Fixed #37284 -- Raised minimum sqlparse version to 0.6.0.

### DIFF
--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -335,7 +335,7 @@ dependencies:
 * `gettext <https://www.gnu.org/software/gettext/manual/gettext.html>`_
   (:ref:`gettext_on_windows`)
 * :pypi:`selenium` 4.23.0+
-* :pypi:`sqlparse` 0.5.0+ (required)
+* :pypi:`sqlparse` 0.6.0+ (required)
 * :pypi:`tblib` 3.0.0+
 
 You can find these dependencies in `pip requirements files

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -305,6 +305,9 @@ Miscellaneous
 * The minimum supported version of ``asgiref`` is increased from 3.9.1 to
   3.12.1.
 
+* The minimum supported version of ``sqlparse`` is increased from 0.5.0 to
+  0.6.0.
+
 * In the asynchronous request path, error responses (such as those rendered by
   ``handler404`` and ``handler500``) are now rendered on the request's
   thread-sensitive thread, rather than on a shared thread pool, so that

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 requires-python = ">= 3.12"
 dependencies = [
     "asgiref>=3.12.1",
-    "sqlparse>=0.5.0",
+    "sqlparse>=0.6.0",
     "tzdata; sys_platform == 'win32'",
 ]
 authors = [

--- a/tests/requirements/py3-free-threading.txt
+++ b/tests/requirements/py3-free-threading.txt
@@ -18,6 +18,6 @@ pymemcache >= 3.4.0
 PyYAML >= 6.0.2; python_version >= '3.14'
 redis >= 5.1.0
 selenium >= 4.23.0
-sqlparse >= 0.5.0
+sqlparse >= 0.6.0
 tblib >= 3.0.0
 tzdata

--- a/tests/requirements/py3.txt
+++ b/tests/requirements/py3.txt
@@ -15,7 +15,7 @@ pywatchman; sys_platform != 'win32'
 PyYAML >= 6.0.2
 redis >= 5.1.0
 selenium >= 4.23.0
-sqlparse >= 0.5.0
+sqlparse >= 0.6.0
 tblib >= 3.0.0
 tzdata
 colorama >= 0.4.6; sys_platform == 'win32'


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37284

#### Branch description
<!-- Provide a concise overview of the issue or rationale behind the proposed changes. Minimum five words. -->

Raised the minimum supported version of sqlparse from 0.5.0 to 0.6.0, which fixes several denial-of-service vulnerabilities (CVE-2026-59893, CVE-2026-54284, CVE-2026-71491, GHSA-cfqr-cjx5-5jcm) and an output escaping issue (CVE-2026-59894). Django's sqlparse usage in `django.db.backends` (`sqlparse.split`/`format` in `BaseDatabaseOperations.prepare_sql_script` and `format_debug_sql`; `sqlparse.parse` in the MySQL/SQLite introspection) is exposed to these fixes. See #37284 for the mapping of each fix to the affected code paths.

No regression test is added: this is a dependency floor bump with no change to Django's own behavior, so there is no Django code path to regress.

Changelog: https://github.com/andialbrecht/sqlparse/blob/master/CHANGELOG

Files changed:
- `pyproject.toml` (`dependencies`)
- `tests/requirements/py3.txt`
- `tests/requirements/py3-free-threading.txt`
- `docs/internals/contributing/writing-code/unit-tests.txt`
- `docs/releases/6.2.txt` (backwards incompatible change note)

No Python-version conflict: Django requires `>=3.12` and sqlparse 0.6.0 requires `>=3.10`.

Test suite (`./runtests.py`): `Ran 19750 tests in 47.688s` / `OK (skipped=1402, expected failures=4)`. Targeted runs of `backends`, `migrations`, `fixtures`, `queries`, `schema` also pass.

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
<!-- If AI tools were used, provide which tools were used here. -->

This report was prepared with assistance from an AI tool, used to: analyze the sqlparse 0.6.0 changelog, generate the PR description in english. The findings, and test issue text were reviewed and verified by the reporter.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)). The underlying CVEs are in sqlparse and already publicly disclosed; this PR bumps the dependency floor on `main`.
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests. *(N/A — dependency floor bump, no Django behavior change, no regression test applicable)*
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes. *(N/A)*