### PR TITLE
Fixed #37258, Refs #36644 -- Documented error when default ordering fields are missing in combined queries.

### DIFF
--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -501,6 +501,13 @@ Models
   primary key when a ``QuerySet``'s ordering has been forcibly cleared by
   calling :meth:`~.QuerySet.order_by` with no arguments.
 
+* As default model ordering is now applied to combined querysets,
+  :meth:`~.QuerySet.union`, :meth:`~.QuerySet.difference`, and
+  :meth:`~.QuerySet.intersection` raise ``DatabaseError`` when a field in
+  :attr:`.Options.ordering` isn't selected by :meth:`~.QuerySet.values` or
+  :meth:`~.QuerySet.values_list`. Call :meth:`~.QuerySet.order_by` without
+  arguments before combining to clear the default ordering.
+
 * SQL ``SELECT`` aliases originating from :meth:`.QuerySet.annotate`
   calls as well as table and ``JOIN`` aliases are now systematically quoted to
   prevent special character collisions. Because quoted aliases are

--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -21,6 +21,7 @@ from .models import (
     Article,
     Author,
     Celebrity,
+    Cover,
     ExtraInfo,
     Note,
     Number,
@@ -755,6 +756,16 @@ class QuerySetSetOperationTests(TestCase):
             list(qs1.union(qs2).order_by(F("num").desc()))
         # switched order, now 'exists' again:
         list(qs2.union(qs1).order_by("num"))
+
+    def test_order_by_non_selected_column_from_default_ordering(self):
+        qs = Cover.objects.values("title")
+        msg = "ORDER BY term does not match any column in the result set"
+        with self.assertRaisesMessage(DatabaseError, msg):
+            list(qs.union(qs))
+        with self.assertRaisesMessage(DatabaseError, msg):
+            list(qs.intersection(qs))
+        with self.assertRaisesMessage(DatabaseError, msg):
+            list(qs.difference(qs))
 
     @skipUnlessDBFeature("supports_select_difference", "supports_select_intersection")
     def test_qs_with_subcompound_qs(self):


### PR DESCRIPTION
Thank you Adam Johnson for the report.
Alternative to https://github.com/django/django/pull/21748, which only documents the change and adds a test

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37258