### PR TITLE
Refs #37260 -- Added missing skip condition to test_fk_alter_on_delete_db_level.

### DIFF
--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -656,7 +656,11 @@ class SchemaTests(TransactionTestCase):
             editor.alter_field(Book, new_field, old_field, strict=True)
 
     @isolate_apps("schema")
-    @skipUnlessDBFeature("supports_foreign_keys", "can_introspect_foreign_keys")
+    @skipUnlessDBFeature(
+        "supports_foreign_keys",
+        "can_introspect_foreign_keys",
+        "supports_on_delete_db_cascade",
+    )
     def test_fk_alter_on_delete_db_level(self):
         class DBOnDeleteParent(Model):
             class Meta:


### PR DESCRIPTION
Failure observed on Snowflake (which has `DatabaseFeatures.supports_on_delete_db_cascade = False`):
```
======================================================================
ERROR: test_fk_alter_on_delete_db_level (schema.tests.SchemaTests.test_fk_alter_on_delete_db_level)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.12/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/usr/lib/python3.12/unittest/case.py", line 634, in run
    self._callTestMethod(testMethod)
    ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/unittest/case.py", line 589, in _callTestMethod
    if method() is not None:
    ^^^^^^^^^^^^^^^^^
  File "/home/runner/work/django-snowflake/django-snowflake/django_repo/django/test/utils.py", line 471, in inner
    return func(*args, **kwargs)
    ^^^^^^^^^^^^^^^^^
  File "/home/runner/work/django-snowflake/django-snowflake/django_repo/django/test/testcases.py", line 1591, in skip_wrapper
    return test_func(*args, **kwargs)
    ^^^^^^^^^^^^^^^^^
  File "/home/runner/work/django-snowflake/django-snowflake/django_repo/tests/schema/tests.py", line 700, in test_fk_alter_on_delete_db_level
    editor.alter_field(DBOnDeleteChild, old_field, new_field, strict=True)
    ^^^^^^^^^^^^^^^^^
  File "/home/runner/work/django-snowflake/django-snowflake/django_repo/django/db/backends/base/schema.py", line 962, in alter_field
    self._alter_field(
    ^^^^^^^^^^^^^^^^^
  File "/home/runner/.local/lib/python3.12/site-packages/django_snowflake/schema.py", line 137, in _alter_field
    super()._alter_field(
    ^^^^^^^^^^^^^^^^^
  File "/home/runner/work/django-snowflake/django-snowflake/django_repo/django/db/backends/base/schema.py", line 1012, in _alter_field
    raise ValueError(
ValueError: Found wrong number (0) of foreign key constraints for schema_dbondeletechild.parent_id

----------------------------------------------------------------------
```