### PR TITLE
Fixed #37044 -- Documented FileField access control.

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -1084,6 +1084,13 @@ underlying :class:`~django.core.files.storage.Storage` class.
 
 .. _file-upload-security:
 
+.. warning::
+
+    Restricting access to a model instance does not restrict access to the
+    underlying file of a :class:`FileField`. Anyone who knows or guesses the
+    file's URL can retrieve it. Configure the storage backend or file-serving
+    layer to restrict access when required.
+
 Note that whenever you deal with uploaded files, you should pay close attention
 to where you're uploading them and what type of files they are, to avoid
 security holes. *Validate all uploaded files* so that you're sure the files are


### PR DESCRIPTION
#### Trac ticket number

ticket-37044

https://code.djangoproject.com/ticket/37044

#### Branch description

Developers may restrict access to a model and assume that the same restriction protects files saved by `FileField`. It does not. `upload_to` only determines the path passed to the configured storage backend; access control remains the responsibility of the storage backend or file-serving layer.

This adds a concise `.. warning::` under `FileField.upload_to` in `docs/ref/models/fields.txt`, immediately after the callable example and before `FileField.storage`. The wording applies to both Django's default storage and custom storage backends. It addresses the accepted ticket without introducing a media-authentication API or a longer security essay.

No code, tests, public API behavior, or release notes change.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

The initial contribution was prepared with Cursor Grok 4.6 (Cursor Cloud Agent). It was used to read Trac ticket #37044 and Jacob Walls' acceptance comment, locate the `FileField.upload_to` documentation, draft the initial warning, run the documentation linter, and prepare the commit and pull request.

A follow-up review used Cad on Hermes Agent with GPT-5.6 Sol to inspect Django's `FileField.generate_filename()` and storage delegation semantics, update the warning so it remains correct for custom storage backends, rebase onto current `main`, and rerun the focused documentation checks.

I verified the final wording against the accepted ticket, Django's contribution and AI-assistance policies, `django/db/models/fields/files.py`, and the surrounding FileField documentation. Luis Felipe Abarca personally read, understood, and verified the contribution, including the warning. The final patch contains only the six-line documentation warning; the unsupported `AUTHORS` attribution was removed during re-review. Exact head: `1b8945b58fc8202c688c7308fedc9f2febd61a88`; tree: `0b19d59c9fe8d34d26d7b610d06b46209c699476`; stable patch ID: `9290863e71d6991507f98580aff3d0e9c9aa0aba`. The candidate passed:

```
python docs/lint.py docs/ref/models/fields.txt
sphinx-build -W --keep-going -b dummy docs <output-dir> docs/ref/models/fields.txt
git diff --check
```

No API, feature, or citation was invented.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.

This is a documentation-only clarification of existing behavior, so no regression test, release note, or screenshot is applicable. The Trac ticket links this pull request and currently records `Has patch: yes`.

## Human-in-the-loop

Luis Felipe Abarca personally read, understood, and verified the contribution at the exact-head boundary recorded in the AI disclosure above. He directs the workflow, authorizes publication and public follow-up, and remains accountable for the contribution.

Arca's agents assisted with research, drafting, source inspection, and checks. They do not independently decide what is submitted or merged. Upstream maintainers retain review and merge authority.

[Arca](https://arca.computer) · [Luis Felipe](https://felirami.com) · [X](https://x.com/felirami) · [GitHub](https://github.com/felirami)
