### PR TITLE
Skipped tests involving 1-element GeometryCollections on Oracle 23.9.

### DIFF
--- a/django/contrib/gis/db/backends/oracle/features.py
+++ b/django/contrib/gis/db/backends/oracle/features.py
@@ -29,4 +29,17 @@ class DatabaseFeatures(BaseSpatialFeatures, OracleDatabaseFeatures):
                 },
             }
         )
+        if self.connection.oracle_version >= (23, 9):
+            skips.update(
+                {
+                    "Oracle 23ai unpacks 1-element geometry collections.": {
+                        "gis_tests.layermap.tests.LayerMapTest."
+                        "test_layermap_unique_multigeometry_fk",
+                        "gis_tests.layermap.tests.LayerMapTest."
+                        "test_null_geom_with_unique",
+                        "gis_tests.layermap.tests.LayerMapTest."
+                        "test_test_fid_range_step",
+                    },
+                },
+            )
         return skips


### PR DESCRIPTION
Because these Oracle versions unpack 1-element collections, `LayerMapping` unexpectedly received single geometries and failed when saving:
```py
  File "/django/source/django/contrib/gis/utils/layermapping.py", line 663, in _save
    geom.add(g)
    ^^^^^^^^
AttributeError: 'Polygon' object has no attribute 'add'
```
https://forums.oracle.com/ords/apexds/post/23ai-sdo-geometry-converts-1-element-multipolygon-to-polygo-3474