### PR TITLE
Fixed #36945 -- Made .values() and .order_by() resolve FilteredRelation aliases correctly.

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -1073,7 +1073,7 @@ class SQLCompiler:
         """
         name, order = get_order_dir(name, default_order)
         descending = order == "DESC"
-        pieces = name.split(LOOKUP_SEP)
+        pieces = self.query.get_names_to_join(name)
         (
             field,
             targets,

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1485,6 +1485,13 @@ class Query(BaseExpression):
                 "permitted%s" % (unsupported_lookup, output_field.__name__, suggestion)
             )
 
+    def get_names_to_join(self, expr):
+        """
+        Helper method for the resolution of expressions that could either be a
+        FilteredRelation alias or a field lookup.
+        """
+        return [expr] if expr in self._filtered_relations else expr.split(LOOKUP_SEP)
+
     def build_filter(
         self,
         filter_expr,
@@ -2276,10 +2283,11 @@ class Query(BaseExpression):
         try:
             cols = []
             for name in field_names:
+                names_to_join = self.get_names_to_join(name)
                 # Join promotion note - we must not remove any rows here, so
                 # if there is no existing joins, use outer join.
                 join_info = self.setup_joins(
-                    name.split(LOOKUP_SEP), opts, alias, allow_many=allow_m2m
+                    names_to_join, opts, alias, allow_many=allow_m2m
                 )
                 targets, final_alias, joins = self.trim_joins(
                     join_info.targets,
@@ -2343,9 +2351,10 @@ class Query(BaseExpression):
                     continue
                 if self.extra and item in self.extra:
                     continue
+                names_to_join = self.get_names_to_join(item)
                 # names_to_path() validates the lookup. A descriptive
                 # FieldError will be raise if it's not.
-                self.names_to_path(item.split(LOOKUP_SEP), self.model._meta)
+                self.names_to_path(names_to_join, self.model._meta)
             elif not hasattr(item, "resolve_expression"):
                 errors.append(item)
             if getattr(item, "contains_aggregate", False):

--- a/tests/filtered_relation/tests.py
+++ b/tests/filtered_relation/tests.py
@@ -358,6 +358,29 @@ class FilteredRelationTests(TestCase):
             ],
         )
 
+    def test_lookup_sep_in_alias_values(self):
+        alias = "editor__name"
+        queryset = Book.objects.annotate(
+            **{alias: FilteredRelation("editor", condition=Q(editor__isnull=False))}
+        ).filter(title="The book by Alice")
+        self.assertSequenceEqual(queryset.values(alias), [{alias: self.editor_a.pk}])
+        self.assertSequenceEqual(queryset.values_list(alias), [(self.editor_a.pk,)])
+
+    def test_lookup_sep_in_alias_order_by(self):
+        alias = "editor__name"
+        editor_d = Editor.objects.create(name="d")
+        editor_c = Editor.objects.create(name="c")
+        book5 = Book.objects.create(
+            title="Poems from outer space", editor=editor_d, author=self.author1
+        )
+        book6 = Book.objects.create(
+            title="Stories from outer space", editor=editor_c, author=self.author1
+        )
+        queryset = Book.objects.annotate(
+            **{alias: FilteredRelation("editor", condition=Q(editor__isnull=False))}
+        ).filter(title__contains="outer space")
+        self.assertSequenceEqual(queryset.order_by(alias), [book5, book6])
+
     def test_extra(self):
         self.assertSequenceEqual(
             Author.objects.annotate(


### PR DESCRIPTION
Made Query.add_fields(), Query.add_ordering() and
SQLCompiler.find_ordering_name() look up FilteredRelation aliases
before splitting field names to relationship traversals. Added
.test_alias_values() and .test_alias_order_by() to
FilteredRelationTests.

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-36945

#### Branch description
<!-- Provide a concise overview of the issue or rationale behind the proposed changes. Minimum five words. -->
When .values()/.values_list()/.order_by() resolve aliases, they fail to account for annotations consisting of FilteredRelation, which are stored in a different internal data structure than other annotations, and therefore missed. This leads to resolving an alias that happens to contain __ as a relationship traversal instead of the alias that was requested.

The proposed solution is to look up FilteredRelation aliases stored in the Query object's _filtered_relations attribute before trying to split the field name by the lookup separator "__". For order_by(), this affects the compiling phase in addition to the resolving phase.

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
<!-- If AI tools were used, provide which tools were used here. -->
I used GitHub Copilot with Claude Sonnet 4.5 to help me understand how the field names are passed around different Query and SQLCompiler methods. All code changes are mine.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
