### PR TITLE
Fixed #37292 -- Prevented long upload extensions from breaking temporary files.

### DIFF
--- a/django/core/files/uploadedfile.py
+++ b/django/core/files/uploadedfile.py
@@ -78,6 +78,10 @@ class TemporaryUploadedFile(UploadedFile):
 
     def __init__(self, name, content_type, size, charset, content_type_extra=None):
         _, ext = os.path.splitext(name)
+        # Only keep the extension if it is a reasonable length, as longer ones
+        # can overflow NAME_MAX and raise OSError. 100 bytes is a safe limit.
+        if len(os.fsencode(ext)) > 100:
+            ext = ""
         file = tempfile.NamedTemporaryFile(
             suffix=".upload" + ext, dir=settings.FILE_UPLOAD_TEMP_DIR
         )

--- a/tests/files/tests.py
+++ b/tests/files/tests.py
@@ -288,6 +288,14 @@ class TemporaryUploadedFileTests(unittest.TestCase):
         with TemporaryUploadedFile("test.txt", "text/plain", 1, "utf8") as temp_file:
             self.assertTrue(temp_file.file.name.endswith(".upload.txt"))
 
+    def test_long_extension_dropped(self):
+        for filename in ("test." + "a" * 250, "test." + "🦊" * 100):
+            with self.subTest(filename=filename):
+                with TemporaryUploadedFile(
+                    filename, "text/plain", 1, "utf8"
+                ) as temp_file:
+                    self.assertTrue(temp_file.file.name.endswith(".upload"))
+
     def test_file_upload_temp_dir_pathlib(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             with override_settings(FILE_UPLOAD_TEMP_DIR=Path(tmp_dir)):


### PR DESCRIPTION
#### Trac ticket number

ticket-37292

#### Branch description

Prevented client-supplied upload extensions from making temporary filenames exceed filesystem limits. Ordinary extensions remain available on temporary uploads, while excessively long encoded extensions are omitted. Added regression coverage for long ASCII and multibyte extensions.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

OpenAI Codex was used to investigate the report, prepare the patch and tests, and run the focused test suite. I manually reviewed and verified the final diff and test results.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.

<!-- Set this after the Trac flag has been updated. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.

