### PR TITLE
Fixed #37291 -- Prevented TupleIn lookups from hanging on F() expressions.

### DIFF
--- a/django/db/models/fields/tuple_lookups.py
+++ b/django/db/models/fields/tuple_lookups.py
@@ -85,9 +85,12 @@ class TupleLookupMixin:
     def get_lhs_str(self):
         if isinstance(self.lhs, ColPairs):
             return repr(self.lhs.field.name)
-        else:
+        elif isinstance(self.lhs, (tuple, list, Tuple)):
             names = ", ".join(repr(f.name) for f in self.lhs)
             return f"({names})"
+        elif hasattr(self.lhs, "name"):
+            return repr(self.lhs.name)
+        return repr(self.lhs)
 
     def get_prep_lhs(self):
         if isinstance(self.lhs, (tuple, list)):
@@ -298,12 +301,20 @@ class TupleLessThanOrEqual(TupleLookupMixin, LessThanOrEqual):
 
 class TupleIn(TupleLookupMixin, In):
     def get_prep_lookup(self):
+        from django.db.models.query import QuerySet
+
+        if isinstance(self.rhs, QuerySet):
+            rhs = self.rhs.query.clone()
+            rhs._db = self.rhs._db
+            self.rhs = rhs
         if self.rhs_is_direct_value():
             self.check_rhs_is_tuple_or_list()
             self.check_rhs_is_collection_of_tuples_or_lists()
             self.check_rhs_elements_length_equals_lhs_length()
         else:
             self.check_rhs_is_query()
+            if isinstance(self.lhs, models.F):
+                return self.rhs
             super(TupleLookupMixin, self).get_prep_lookup()
 
         return self.rhs  # skip checks from mixin

--- a/docs/releases/6.1.2.txt
+++ b/docs/releases/6.1.2.txt
@@ -11,3 +11,5 @@ Bugfixes
 
 * Fixed a data loss issue in Django 4.0 where :ref:`network rasters
   <gdal-raster-network>` were deleted by GeoDjango when closed.
+* Fixed an infinite loop in ``TupleIn`` lookups when an ``F()`` expression was
+  used as the left-hand side.

--- a/tests/composite_pk/test_filter.py
+++ b/tests/composite_pk/test_filter.py
@@ -12,6 +12,7 @@ from django.db.models import (
     Value,
     When,
 )
+from django.db.models.fields.tuple_lookups import TupleIn
 from django.db.models.functions import Cast
 from django.db.models.lookups import Exact
 from django.test import TestCase, skipIfDBFeature, skipUnlessDBFeature
@@ -543,6 +544,12 @@ class CompositePKFilterTests(TestCase):
         self.assertEqual(
             Comment.objects.filter(pk=F("pk")).count(),
             Comment.objects.count(),
+        )
+
+    def test_filter_by_pk_in_rhs_f_object(self):
+        self.assertCountEqual(
+            Comment.objects.filter(TupleIn(F("pk"), Comment.objects.values("pk"))),
+            Comment.objects.all(),
         )
 
     @skipUnlessDBFeature("allow_sliced_subqueries_with_in")

--- a/tests/foreign_object/test_tuple_lookups.py
+++ b/tests/foreign_object/test_tuple_lookups.py
@@ -168,6 +168,27 @@ class TupleLookupsTests(TestCase):
             with self.subTest(customer=customer.id, query=str(qs.query)):
                 self.assertSequenceEqual(qs, contacts)
 
+    def test_tuple_in_subquery_f(self):
+        self.assertCountEqual(
+            Contact.objects.filter(TupleIn(F("pk"), Contact.objects.values("pk"))),
+            Contact.objects.all(),
+        )
+
+    def test_tuple_lookups_f_invalid_rhs(self):
+        lookups = (
+            TupleExact,
+            TupleGreaterThan,
+            TupleGreaterThanOrEqual,
+            TupleIn,
+            TupleLessThan,
+            TupleLessThanOrEqual,
+        )
+        for lookup in lookups:
+            with self.subTest(lookup=lookup.lookup_name):
+                msg = f"{lookup.lookup_name!r} lookup of 'pk' must be a tuple or a list"
+                with self.assertRaisesMessage(ValueError, msg):
+                    lookup(F("pk"), 1)
+
     def test_tuple_in_rhs_must_be_collection_of_tuples_or_lists(self):
         test_cases = (
             (1, 2, 3),


### PR DESCRIPTION
#### Trac ticket number

ticket-37291

#### Branch description

Normalized a directly supplied QuerySet before TupleIn validates its right-hand side. This prevents TupleIn from treating the QuerySet as a direct value and attempting to iterate an F() expression while formatting a validation error. The QuerySet's query is cloned and its database alias is preserved. Added the reported regression test.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

OpenAI Codex was used to investigate the report, prepare the patch and test, and run the focused test module. I manually reviewed and verified the final diff and test results.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.

- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
