### PR TITLE
Removed more versionadded/versionchanged directives for 6.1.

### DIFF
--- a/docs/ref/contrib/gis/db-api.txt
+++ b/docs/ref/contrib/gis/db-api.txt
@@ -157,11 +157,6 @@ file writing or network fetching is acceptable. For the rationale, see
 The general structure of geographic lookups is described below. A complete
 reference can be found in the :ref:`spatial lookup reference<spatial-lookups>`.
 
-.. versionchanged:: 5.2.17
-
-    In earlier versions, spatial lookups accepted ``str`` and ``dict`` types
-    for new rasters, allowing file writes and network fetches.
-
 Geometry Lookups
 ----------------
 

--- a/docs/ref/contrib/gis/forms-api.txt
+++ b/docs/ref/contrib/gis/forms-api.txt
@@ -41,8 +41,6 @@ GeoDjango form fields take the following optional arguments.
 
 .. attribute:: Field.max_geom_collections
 
-    .. versionadded:: 5.2.17
-
     The maximum number of geometry collections the field accepts before
     refusing to parse the input and raising a
     :exc:`~django.core.exceptions.ValidationError`. This guards against crashes

--- a/docs/ref/contrib/gis/gdal.txt
+++ b/docs/ref/contrib/gis/gdal.txt
@@ -2167,11 +2167,6 @@ values. When validating raster inputs, you should write custom validation.
 For defense-in-depth strategies for limiting the available raster drivers, see
 `GDAL security considerations <https://gdal.org/user/security.html>`_.
 
-.. versionchanged:: 5.2.17
-
-    In earlier versions, spatial lookups accepted ``str`` and ``dict`` types
-    for new rasters, allowing file writes and network fetches.
-
 Settings
 ========
 

--- a/docs/ref/contrib/gis/geos.txt
+++ b/docs/ref/contrib/gis/geos.txt
@@ -251,10 +251,6 @@ WKB / EWKB               ``memoryview``
 For the GeoJSON format, the SRID is set based on the ``crs`` member. If ``crs``
 isn't provided, the SRID defaults to 4326.
 
-.. versionchanged:: 5.2.17
-
-    The ``max_geom_collections`` parameter was added.
-
 .. classmethod:: GEOSGeometry.from_gml(gml_string)
 
     Constructs a :class:`GEOSGeometry` from the given GML string.

--- a/docs/ref/contrib/gis/model-api.txt
+++ b/docs/ref/contrib/gis/model-api.txt
@@ -228,8 +228,6 @@ details.
 
 .. attribute:: GeometryField.max_geom_collections
 
-.. versionadded:: 5.2.17
-
 This option is forwarded to the :attr:`form field
 <django.contrib.gis.forms.Field.max_geom_collections>` generated for this model
 field, bounding how many geometry collections may be contained in submitted

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -2851,8 +2851,6 @@ See also :setting:`DATE_FORMAT` and :setting:`SHORT_DATE_FORMAT`.
 ``SIGNED_COOKIE_LEGACY_SALT_FALLBACK``
 ---------------------------------------
 
-.. versionadded:: 5.2.15
-
 Default: ``False``
 
 Controls whether :meth:`~django.http.HttpRequest.get_signed_cookie` accepts


### PR DESCRIPTION
Keep the main branch spruced up by removing the versionchanged notices that were only meant for backports in recent security releases.