### PR TITLE
De-emphasized typo fixes in contributing docs.

### DIFF
--- a/docs/internals/contributing/new-contributors.txt
+++ b/docs/internals/contributing/new-contributors.txt
@@ -52,10 +52,9 @@ expected. Updating a patch is both useful and important! See more on
 Write some documentation
 ------------------------
 
-Django's documentation is great but it can always be improved. Did you find a
-typo? Do you think that something should be clarified? Go ahead and suggest a
-documentation patch! See also the guide on
-:doc:`/internals/contributing/writing-documentation`.
+Django's documentation is great, but it can always be improved. Do you think
+that something should be clarified? Go ahead and suggest a documentation patch!
+See also the guide on :doc:`/internals/contributing/writing-documentation`.
 
 .. note::
 

--- a/docs/internals/contributing/writing-code/submitting-patches.txt
+++ b/docs/internals/contributing/writing-code/submitting-patches.txt
@@ -11,9 +11,11 @@ without a solution.
 Typo fixes and trivial documentation changes
 ============================================
 
-If you are fixing a really trivial issue, for example changing a word in the
-documentation, the preferred way to provide the patch is using GitHub pull
-requests without a Trac ticket.
+If you've contributed to Django before and just want to fix a really trivial
+issue, for example changing a word in the documentation, the preferred way to
+provide the patch is using GitHub pull requests without a Trac ticket. If you
+haven't contributed before, go ahead and open a ticket to get used to our
+workflow.
 
 See :doc:`/internals/contributing/writing-code/working-with-git` for more
 details on how to use pull requests.


### PR DESCRIPTION
As part of adding useful friction in front of unwanted agentic contributions, all new contributors are being nudged to have tickets for their PRs. Update the contribution docs with this current practice.