### PR TITLE
 Fixed #36049 -- Made upper template filter safe.

### DIFF
--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -355,7 +355,7 @@ def truncatewords_html(value, arg):
     return Truncator(value).words(length, html=True, truncate=" …")
 
 
-@register.filter(is_safe=False)
+@register.filter(is_safe=True)
 @stringfilter
 def upper(value):
     """Convert a string into all uppercase."""

--- a/tests/template_tests/filter_tests/test_upper.py
+++ b/tests/template_tests/filter_tests/test_upper.py
@@ -29,7 +29,7 @@ class UpperTests(SimpleTestCase):
         output = self.engine.render_to_string(
             "upper02", {"a": "a & b", "b": mark_safe("a &amp; b")}
         )
-        self.assertEqual(output, "A &amp; B A &amp;AMP; B")
+        self.assertEqual(output, "A &amp; B A &AMP; B")
 
 
 class FunctionTests(SimpleTestCase):


### PR DESCRIPTION
 #### Trac ticket number

ticket-36049

#### Branch description

This pull request changes the `upper` template filter to register with `is_safe=True`. This resolves an inconsistency with the `lower` template filter, which is already registered with `is_safe=True`. Uppercasing string values does not introduce unsafe HTML or script tags, and allowing the filter to be marked safe avoids double-escaping already-safe strings during rendering.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
AI tools used: Google Gemini (Antigravity coding assistant).

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.

- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.