### PR TITLE
Fixed #37281 -- Ordered AlterUniqueTogether after AddField of referenced fields.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -625,6 +625,7 @@ answer newbie questions, and generally made Django that much better:
     Kim Soung Ryoul 김성렬 <kimsoungryoul@gmail.com>
     Klaas van Schelven <klaas@vanschelven.com>
     knox <christobzr@gmail.com>
+    Konstantinos Ginanopoulos <giannopoulosk.data@gmail.com>
     konrad@gwu.edu
     Kowito Charoenratchatabhan <kowito@felspar.com>
     Krišjānis Vaiders <krisjanisvaiders@gmail.com>

--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -1777,6 +1777,17 @@ class MigrationAutodetector:
                                     self.to_state,
                                 )
                             )
+                        # Fields added in the same migration must be created
+                        # before they can be used in the constraint.
+                        if (app_label, model_name, field_name) in self.new_field_keys:
+                            dependencies.append(
+                                OperationDependency(
+                                    app_label,
+                                    model_name,
+                                    field_name,
+                                    OperationDependency.Type.CREATE,
+                                )
+                            )
                 yield (
                     old_value,
                     new_value,

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -3714,6 +3714,23 @@ class AutodetectorTests(BaseAutodetectorTests):
             unique_together={("title", "newfield")},
         )
 
+    def test_add_field_and_alter_unique_together(self):
+        """
+        Fields added while updating unique_together are created before the
+        AlterUniqueTogether that references them (#37281).
+        """
+        changes = self.get_changes(
+            [self.author_empty, self.book_unique_together_4],
+            [self.author_empty, self.book_unique_together_3],
+        )
+        self.assertNumberMigrations(changes, "otherapp", 1)
+        self.assertOperationTypes(
+            changes,
+            "otherapp",
+            0,
+            ["AddField", "AlterUniqueTogether", "RemoveField"],
+        )
+
     def test_create_model_and_unique_together(self):
         author = ModelState(
             "otherapp",


### PR DESCRIPTION
#### Trac ticket number
ticket-37281

#### Branch description
When an existing field participating in `unique_together` is replaced by a
newly added field (for example a field converted to a ForeignKey), the
autodetector emitted `AlterUniqueTogether` before the `AddField` that creates
the referenced column, producing an unapplyable migration (FieldDoesNotExist).

This adds a dependency so the `AlterFooTogether` operation is ordered after the
`AddField` of any field it references that is created in the same migration. The
dependency is limited to newly added fields via new_field_keys, mirroring the
generated-field approach, and is not specific to foreign keys.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude (Anthropic) was used to help with reproduction, bisecting the regression,
and drafting the fix and test. I have reviewed and verified all output, and run
the test suite locally.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.