### PR TITLE
Refs #37258, #36644 -- Fixed release note for clearing default ordering after combination.

### DIFF
--- a/docs/releases/6.1.txt
+++ b/docs/releases/6.1.txt
@@ -506,7 +506,7 @@ Models
   :meth:`~.QuerySet.intersection` raise ``DatabaseError`` when a field in
   :attr:`.Options.ordering` isn't selected by :meth:`~.QuerySet.values` or
   :meth:`~.QuerySet.values_list`. Call :meth:`~.QuerySet.order_by` without
-  arguments before combining to clear the default ordering.
+  arguments after combining to clear the default ordering.
 
 * SQL ``SELECT`` aliases originating from :meth:`.QuerySet.annotate`
   calls as well as table and ``JOIN`` aliases are now systematically quoted to


### PR DESCRIPTION
#### Trac ticket number
ticket-37258

#### Branch description
I didn't notice in review the release note said "before" rather than "after", which is the relevant behavior change.