### PR TITLE
Fixed #897 -- Allowed using reverse many to many fields in model forms.

### DIFF
--- a/django/contrib/admin/checks.py
+++ b/django/contrib/admin/checks.py
@@ -466,8 +466,8 @@ class BaseModelAdminChecks:
                 return []
             else:
                 if (
-                    isinstance(field, models.ManyToManyField)
-                    and not field.remote_field.through._meta.auto_created
+                    isinstance(field, (models.ManyToManyField, models.ManyToManyRel))
+                    and not field.through._meta.auto_created
                 ):
                     return [
                         checks.Error(
@@ -558,11 +558,11 @@ class BaseModelAdminChecks:
                 field=field_name, option=label, obj=obj, id="admin.E019"
             )
         else:
-            if not field.many_to_many or isinstance(field, models.ManyToManyRel):
+            if not field.many_to_many or field.hidden:
                 return must_be(
                     "a many-to-many field", option=label, obj=obj, id="admin.E020"
                 )
-            elif not field.remote_field.through._meta.auto_created:
+            elif not field.through._meta.auto_created:
                 return [
                     checks.Error(
                         f"The value of '{label}' cannot include the ManyToManyField "

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -2037,6 +2037,10 @@ class ManyToManyField(RelatedField):
     def reverse_path_infos(self):
         return self.get_reverse_path_info()
 
+    @property
+    def through(self):
+        return self.remote_field.through
+
     def _get_m2m_db_table(self, opts):
         """
         Function that can be curried to provide the m2m table name for this

--- a/django/db/models/fields/reverse_related.py
+++ b/django/db/models/fields/reverse_related.py
@@ -405,3 +405,17 @@ class ManyToManyRel(ForeignObjectRel):
                 if rel and rel.model == self.model:
                     break
         return field.foreign_related_fields[0]
+
+    def as_field(self):
+        from django.db.models import ManyToManyField
+
+        field = ManyToManyField(
+            self.related_model,
+            through=self.through,
+            blank=True,
+            editable=self.field.editable,
+        )
+        field.set_attributes_from_name(self.name)
+        field.attname = self.accessor_name
+        field.model = self.model
+        return field

--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -7,6 +7,7 @@ from itertools import chain
 
 from django.core.exceptions import (
     NON_FIELD_ERRORS,
+    FieldDoesNotExist,
     FieldError,
     ImproperlyConfigured,
     ValidationError,
@@ -96,6 +97,18 @@ def construct_instance(form, instance, fields=None, exclude=None):
 # ModelForms #################################################################
 
 
+def _reverse_many_to_many_fields(opts, fields):
+    from django.db.models import ManyToManyRel
+
+    for name in fields or ():
+        try:
+            rel = opts.get_field(name)
+        except FieldDoesNotExist:
+            continue
+        if isinstance(rel, ManyToManyRel) and not rel.hidden:
+            yield rel.as_field()
+
+
 def model_to_dict(instance, fields=None, exclude=None):
     """
     Return a dict containing the data in ``instance`` suitable for passing as
@@ -110,7 +123,12 @@ def model_to_dict(instance, fields=None, exclude=None):
     """
     opts = instance._meta
     data = {}
-    for f in chain(opts.concrete_fields, opts.private_fields, opts.many_to_many):
+    for f in chain(
+        opts.concrete_fields,
+        opts.private_fields,
+        opts.many_to_many,
+        _reverse_many_to_many_fields(opts, fields),
+    ):
         if not getattr(f, "editable", False):
             continue
         if fields is not None and f.name not in fields:
@@ -198,7 +216,12 @@ def fields_for_model(
         f for f in opts.private_fields if isinstance(f, ModelField)
     ]
     for f in sorted(
-        chain(opts.concrete_fields, sortable_private_fields, opts.many_to_many)
+        chain(
+            opts.concrete_fields,
+            sortable_private_fields,
+            opts.many_to_many,
+            _reverse_many_to_many_fields(opts, fields),
+        )
     ):
         if not getattr(f, "editable", False):
             if (
@@ -545,7 +568,11 @@ class BaseModelForm(BaseForm, AltersData):
         # Note that for historical reasons we want to include also
         # private_fields here. (GenericRelation was previously a fake
         # m2m field).
-        for f in chain(opts.many_to_many, opts.private_fields):
+        for f in chain(
+            opts.many_to_many,
+            opts.private_fields,
+            _reverse_many_to_many_fields(opts, fields),
+        ):
             if not hasattr(f, "save_form_data"):
                 continue
             if fields and f.name not in fields:

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -342,6 +342,26 @@ subclass::
     order as the fields are defined in the model, followed by any fields
     defined in :attr:`~ModelAdmin.readonly_fields`.
 
+    ``fields`` can also contain the name of a reverse many-to-many relation,
+    which makes the relation editable from the model that doesn't define the
+    :class:`~django.db.models.ManyToManyField`. In this example, ``Pizza``
+    defines the field and ``ToppingAdmin`` edits it from the other side::
+
+        class Pizza(models.Model):
+            toppings = models.ManyToManyField(Topping, related_name="pizzas")
+
+
+        class ToppingAdmin(admin.ModelAdmin):
+            fields = ["name", "pizzas"]
+            filter_horizontal = ["pizzas"]
+
+    A relation without a reverse accessor, such as a symmetrical
+    :class:`~django.db.models.ManyToManyField` to ``"self"``, can't be used.
+
+    .. versionchanged:: 6.2
+
+        Support for reverse many-to-many relations was added.
+
 .. attribute:: ModelAdmin.fieldsets
 
     Set ``fieldsets`` to control the layout of admin "add" and "change" pages.
@@ -466,6 +486,13 @@ subclass::
     within the options. The unselected and selected options appear in two boxes
     side by side. See :attr:`~ModelAdmin.filter_vertical` to use a vertical
     interface.
+
+    This list can also contain a reverse many-to-many relation that
+    :attr:`~ModelAdmin.fields` or :attr:`~ModelAdmin.fieldsets` names.
+
+    .. versionchanged:: 6.2
+
+        Support for reverse many-to-many relations was added.
 
 .. attribute:: ModelAdmin.filter_vertical
 
@@ -2316,6 +2343,14 @@ adds some of its own (the shared features are actually defined in the
 - :meth:`~ModelAdmin.formfield_for_foreignkey`
 - :meth:`~ModelAdmin.formfield_for_manytomany`
 - :meth:`~ModelAdmin.has_module_permission`
+
+As with :attr:`~ModelAdmin.fields` on a ``ModelAdmin``, ``fields`` and
+``fieldsets`` accept the name of a reverse many-to-many relation on the
+inline's own model.
+
+.. versionchanged:: 6.2
+
+    Support for reverse many-to-many relations was added.
 
 The ``InlineModelAdmin`` class adds or customizes:
 

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -37,6 +37,10 @@ Minor features
 :mod:`django.contrib.admin`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* :attr:`.ModelAdmin.fields` and :attr:`.ModelAdmin.fieldsets` now support
+  reverse many-to-many relations, which makes a relation editable from the
+  model that doesn't define the ``ManyToManyField``.
+
 * ...
 
 :mod:`django.contrib.admindocs`
@@ -155,6 +159,9 @@ File Uploads
 
 Forms
 ~~~~~
+
+* ``ModelForm`` now supports :ref:`reverse many-to-many relations
+  <modelforms-reverse-many-to-many>` named in ``Meta.fields``.
 
 * ...
 
@@ -317,6 +324,9 @@ Miscellaneous
   thread-sensitive thread, rather than on a shared thread pool, so that
   database connections used during error handling are managed by
   ``close_old_connections()``.
+
+* Private API ``django.forms.models.model_to_dict()`` now returns reverse
+  many-to-many relations named in ``fields``, which it previously ignored.
 
 .. _deprecated-features-6.2:
 

--- a/docs/topics/forms/modelforms.txt
+++ b/docs/topics/forms/modelforms.txt
@@ -515,6 +515,29 @@ not include that field.
 
 .. _section on saving forms: `The save() method`_
 
+.. _modelforms-reverse-many-to-many:
+
+Reverse many-to-many relations
+------------------------------
+
+.. versionadded:: 6.2
+
+To edit a many-to-many relation from the model that doesn't define the
+``ManyToManyField``, name the reverse relation in ``fields`` using its
+:attr:`~django.db.models.ForeignKey.related_query_name`. Since the ``Book``
+model above defines ``authors``, that name is ``book`` on ``Author``::
+
+    class AuthorForm(ModelForm):
+        class Meta:
+            model = Author
+            fields = ["name", "book"]
+
+Saving the form sets the relation on both models.
+
+Neither ``fields = '__all__'`` nor ``exclude`` includes a reverse relation. A
+relation without a reverse accessor, such as a symmetrical ``ManyToManyField``
+to ``'self'``, cannot be used.
+
 .. _modelforms-overriding-default-fields:
 
 Overriding the default fields

--- a/tests/admin_inlines/admin.py
+++ b/tests/admin_inlines/admin.py
@@ -42,6 +42,7 @@ from .models import (
     Person,
     Photo,
     Photographer,
+    Playlist,
     Poll,
     Profile,
     ProfileCollection,
@@ -57,6 +58,7 @@ from .models import (
     Teacher,
     Title,
     TitleCollection,
+    Track,
     UUIDChild,
     UUIDParent,
 )
@@ -531,6 +533,20 @@ site.register(CourseProxy1, ClassAdminTabularVertical)
 site.register(CourseProxy2, ClassAdminTabularHorizontal)
 site.register(ShowInlineParent, ShowInlineParentAdmin)
 site.register(UUIDParent, UUIDParentModelAdmin)
+
+
+class TrackInline(admin.TabularInline):
+    model = Track
+    fields = ["name", "favourited_in"]
+    filter_horizontal = ["favourited_in"]
+    extra = 0
+
+
+class PlaylistAdmin(admin.ModelAdmin):
+    inlines = [TrackInline]
+
+
+site.register(Playlist, PlaylistAdmin)
 # Used to test hidden fields in tabular and stacked inlines.
 site2 = admin.AdminSite(name="tabular_inline_hidden_field_admin")
 site2.register(SomeParentModel, inlines=[ChildHiddenFieldTabularInline])

--- a/tests/admin_inlines/models.py
+++ b/tests/admin_inlines/models.py
@@ -411,3 +411,14 @@ class UUIDChild(models.Model):
     id = models.UUIDField(default=uuid.uuid4, primary_key=True)
     title = models.CharField(max_length=128)
     parent = models.ForeignKey(UUIDParent, on_delete=models.CASCADE)
+
+
+class Playlist(models.Model):
+    favourites = models.ManyToManyField(
+        "Track", related_name="favourited_in", blank=True
+    )
+
+
+class Track(models.Model):
+    name = models.CharField(max_length=50)
+    playlist = models.ForeignKey(Playlist, models.CASCADE)

--- a/tests/admin_inlines/tests.py
+++ b/tests/admin_inlines/tests.py
@@ -38,6 +38,7 @@ from .models import (
     Parent,
     ParentModelWithCustomPk,
     Person,
+    Playlist,
     Poll,
     Profile,
     ProfileCollection,
@@ -47,6 +48,7 @@ from .models import (
     SomeChildModel,
     SomeParentModel,
     Teacher,
+    Track,
     UUIDChild,
     UUIDParent,
     VerboseNamePluralProfile,
@@ -2569,3 +2571,43 @@ class PlaywrightTests(AdminPlaywrightTestCase):
         select.select_option(index=0)
         selector.locator("p.selector-filter input").first.click()
         self.take_screenshot("focus_out")
+
+
+@override_settings(ROOT_URLCONF="admin_inlines.urls")
+class TestInlineReverseManyToMany(TestDataMixin, TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.playlist = Playlist.objects.create()
+        cls.other = Playlist.objects.create()
+        cls.track = Track.objects.create(name="One", playlist=cls.playlist)
+        cls.playlist.favourites.add(cls.track)
+        cls.url = reverse(
+            "admin:admin_inlines_playlist_change", args=(cls.playlist.pk,)
+        )
+
+    def setUp(self):
+        self.client.force_login(self.superuser)
+
+    def test_inline_renders_reverse_relation(self):
+        response = self.client.get(self.url)
+        formset = response.context["inline_admin_formsets"][0].formset
+        self.assertIn("favourited_in", formset.forms[0].fields)
+        self.assertEqual(formset.forms[0].initial["favourited_in"], [self.playlist])
+
+    def test_inline_saves_reverse_relation(self):
+        data = {
+            "track_set-TOTAL_FORMS": "1",
+            "track_set-INITIAL_FORMS": "1",
+            "track_set-MIN_NUM_FORMS": "0",
+            "track_set-MAX_NUM_FORMS": "1000",
+            "track_set-0-id": str(self.track.pk),
+            "track_set-0-playlist": str(self.playlist.pk),
+            "track_set-0-name": "One",
+            "track_set-0-favourited_in": [str(self.other.pk)],
+        }
+        response = self.client.post(self.url, data)
+        self.assertRedirects(
+            response, reverse("admin:admin_inlines_playlist_changelist")
+        )
+        self.assertSequenceEqual(self.track.favourited_in.all(), [self.other])

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -61,6 +61,7 @@ from .models import (
     CyclicTwo,
     DependentChild,
     DooHickey,
+    EditableTopping,
     EmptyModelHidden,
     EmptyModelMixin,
     EmptyModelVisible,
@@ -734,6 +735,11 @@ class ToppingAdmin(admin.ModelAdmin):
     readonly_fields = ("pizzas",)
 
 
+class EditableToppingAdmin(admin.ModelAdmin):
+    fields = ["name", "pizzas"]
+    filter_horizontal = ["pizzas"]
+
+
 class PizzaAdmin(admin.ModelAdmin):
     readonly_fields = ("toppings",)
 
@@ -1402,6 +1408,7 @@ site.register(ReadOnlyPizza, ReadOnlyPizzaAdmin)
 site.register(ReadablePizza)
 site.register(Course, CourseAdmin)
 site.register(Topping, ToppingAdmin)
+site.register(EditableTopping, EditableToppingAdmin)
 site.register(Album, AlbumAdmin)
 site.register(Song)
 site.register(Question, QuestionAdmin)

--- a/tests/admin_views/models.py
+++ b/tests/admin_views/models.py
@@ -677,6 +677,11 @@ class ReadOnlyPizza(Pizza):
         default_permissions = ()
 
 
+class EditableTopping(Topping):
+    class Meta:
+        proxy = True
+
+
 class Album(models.Model):
     owner = models.ForeignKey(User, models.SET_NULL, null=True, blank=True)
     title = models.CharField(max_length=30)

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -13,7 +13,7 @@ from django import forms
 from django.contrib import admin
 from django.contrib.admin import AdminSite, ModelAdmin
 from django.contrib.admin.helpers import ACTION_CHECKBOX_NAME
-from django.contrib.admin.models import ADDITION, DELETION, LogEntry
+from django.contrib.admin.models import ADDITION, CHANGE, DELETION, LogEntry
 from django.contrib.admin.options import SOURCE_MODEL_VAR, TO_FIELD_VAR
 from django.contrib.admin.templatetags.admin_urls import add_preserved_filters
 from django.contrib.admin.utils import quote
@@ -9732,3 +9732,52 @@ class AdminSiteFinalCatchAllPatternTests(TestCase):
         response = self.client.get(unknown_url)
         # Does not redirect to the admin login.
         self.assertEqual(response.status_code, 404)
+
+
+@override_settings(ROOT_URLCONF="admin_views.urls")
+class AdminReverseManyToManyViewTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.superuser = User.objects.create_superuser(
+            username="super", password="secret", email="super@example.com"
+        )
+        cls.margherita = Pizza.objects.create(name="Margherita")
+        cls.marinara = Pizza.objects.create(name="Marinara")
+        cls.cheese = Topping.objects.create(name="Cheese")
+        cls.margherita.toppings.add(cls.cheese)
+        cls.add_url = reverse("admin:admin_views_editabletopping_add")
+        cls.changelist_url = reverse("admin:admin_views_editabletopping_changelist")
+        cls.change_url = reverse(
+            "admin:admin_views_editabletopping_change", args=(cls.cheese.pk,)
+        )
+
+    def setUp(self):
+        self.client.force_login(self.superuser)
+
+    def test_change_view_initial(self):
+        response = self.client.get(self.change_url)
+        self.assertEqual(
+            response.context["adminform"].form.initial["pizzas"], [self.margherita]
+        )
+
+    def test_add_saves_relation(self):
+        response = self.client.post(
+            self.add_url, {"name": "Basil", "pizzas": [self.marinara.pk]}
+        )
+        self.assertRedirects(response, self.changelist_url)
+        basil = Topping.objects.get(name="Basil")
+        self.assertSequenceEqual(basil.pizzas.all(), [self.marinara])
+
+    def test_change_saves_relation_and_logs_it(self):
+        response = self.client.post(
+            self.change_url, {"name": "Cheese", "pizzas": [self.marinara.pk]}
+        )
+        self.assertRedirects(response, self.changelist_url)
+        self.assertSequenceEqual(self.cheese.pizzas.all(), [self.marinara])
+        self.assertSequenceEqual(self.margherita.toppings.all(), [])
+        log = LogEntry.objects.filter(action_flag=CHANGE).latest("id")
+        self.assertEqual(log.get_change_message(), "Changed Pizzas.")
+
+    def test_change_clears_relation(self):
+        self.client.post(self.change_url, {"name": "Cheese", "pizzas": []})
+        self.assertSequenceEqual(self.cheese.pizzas.all(), [])

--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -24,7 +24,7 @@ from django.db.models import (
     ManyToManyField,
     UUIDField,
 )
-from django.test import SimpleTestCase, TestCase, override_settings
+from django.test import RequestFactory, SimpleTestCase, TestCase, override_settings
 from django.test.utils import requires_tz_support
 from django.urls import reverse
 from django.utils import translation
@@ -2036,3 +2036,51 @@ class ImageFieldWidgetsPlaywrightTests(AdminWidgetPlaywrightTestCase):
         )
         # "Clear" persists checked.
         self.expect(self.page.locator(f"#{self.clear_checkbox_id}")).to_be_checked()
+
+
+@override_settings(ROOT_URLCONF="admin_widgets.urls")
+class AdminReverseManyToManyTests(TestDataMixin, TestCase):
+    def setUp(self):
+        self.request = RequestFactory().get("/")
+        self.request.user = self.superuser
+
+    def formfield(self, **admin_overrides):
+        attrs = {"fields": ["name", "current_schools"], **admin_overrides}
+        admin_class = type("MyModelAdmin", (admin.ModelAdmin,), attrs)
+        form = admin_class(Student, widget_admin_site).get_form(self.request)
+        return form.base_fields["current_schools"]
+
+    def test_filter_widgets(self):
+        for option, is_stacked in [
+            ("filter_horizontal", False),
+            ("filter_vertical", True),
+        ]:
+            with self.subTest(option=option):
+                ff = self.formfield(**{option: ["current_schools"]})
+                widget = ff.widget.widget
+                self.assertIsInstance(widget, widgets.FilteredSelectMultiple)
+                self.assertIs(widget.is_stacked, is_stacked)
+
+    def test_raw_id_field(self):
+        ff = self.formfield(raw_id_fields=["current_schools"])
+        self.assertIsInstance(ff.widget, widgets.ManyToManyRawIdWidget)
+        self.assertEqual(
+            ff.widget.get_context("current_schools", [], {})["related_url"],
+            "/admin_widgets/school/",
+        )
+
+    def test_autocomplete_field(self):
+        ff = self.formfield(autocomplete_fields=["current_schools"])
+        widget = ff.widget.widget
+        self.assertIsInstance(widget, widgets.AutocompleteSelectMultiple)
+        attrs = widget.build_attrs({})
+        self.assertEqual(attrs["data-app-label"], "admin_widgets")
+        self.assertEqual(attrs["data-model-name"], "student")
+        self.assertEqual(attrs["data-field-name"], "current_schools")
+
+    def test_widget_wrapper_points_at_related_model(self):
+        wrapper = self.formfield().widget
+        self.assertIsInstance(wrapper, widgets.RelatedFieldWidgetWrapper)
+        context = wrapper.get_context("current_schools", [], {})
+        self.assertEqual(context["add_related_url"], "/admin_widgets/school/add/")
+        self.assertIn("_source_model=admin_widgets.student", context["url_params"])

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from unittest import mock, skipUnless
 
 from django import forms
+from django.apps import apps
 from django.core.exceptions import (
     NON_FIELD_ERRORS,
     FieldError,
@@ -3784,3 +3785,172 @@ class ConstraintValidationTests(TestCase):
         full_form = AttnameConstraintsModelForm(data, instance=instance)
         self.assertFalse(full_form.is_valid())
         self.assertEqual(full_form.errors, {"right": ["This field is required."]})
+
+
+class ReverseManyToManyTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.category = Category.objects.create(
+            name="Entertainment", slug="entertainment", url="entertainment"
+        )
+        cls.writer = Writer.objects.create(name="Bob Woodward")
+        cls.form_class = modelform_factory(
+            Category, fields=["name", "slug", "url", "article"]
+        )
+
+    def make_article(self, headline, categories=()):
+        article = Article.objects.create(
+            headline=headline,
+            slug="a",
+            pub_date=datetime.date(2008, 3, 18),
+            writer=self.writer,
+            article="Test",
+        )
+        article.categories.set(categories)
+        return article
+
+    def post_data(self, name, articles):
+        return {
+            "name": name,
+            "slug": name.lower(),
+            "url": name.lower(),
+            "article": articles,
+        }
+
+    def test_not_included_by_default(self):
+        self.assertNotIn(
+            "article", modelform_factory(Category, fields="__all__").base_fields
+        )
+
+    def test_included_when_named(self):
+        form_class = modelform_factory(Category, fields=["article", "name"])
+        self.assertEqual(list(form_class.base_fields), ["article", "name"])
+        field = form_class.base_fields["article"]
+        self.assertIsInstance(field, forms.ModelMultipleChoiceField)
+        self.assertEqual(field.queryset.model, Article)
+        self.assertFalse(field.required)
+
+    def test_unavailable_before_models_are_ready(self):
+        msg = "Unknown field(s) (article) specified for Category"
+        with mock.patch.object(apps, "models_ready", False):
+            with self.assertRaisesMessage(FieldError, msg):
+                modelform_factory(Category, fields=["article"])
+
+    def test_excluded(self):
+        form_class = modelform_factory(
+            Category, fields=["name", "article"], exclude=["article"]
+        )
+        self.assertEqual(list(form_class.base_fields), ["name"])
+
+    def test_initial_from_instance(self):
+        article = self.make_article("First", [self.category])
+        self.assertEqual(
+            self.form_class(instance=self.category).initial["article"], [article]
+        )
+        self.assertEqual(self.form_class(instance=Category()).initial["article"], [])
+
+    def test_model_to_dict(self):
+        article = self.make_article("First", [self.category])
+        self.assertNotIn("article", model_to_dict(self.category))
+        self.assertEqual(
+            model_to_dict(self.category, fields=["article"]), {"article": [article]}
+        )
+
+    def test_save_on_add(self):
+        article = self.make_article("First")
+        form = self.form_class(data=self.post_data("News", [article.pk]))
+        self.assertTrue(form.is_valid(), form.errors)
+        category = form.save()
+        self.assertSequenceEqual(category.article_set.all(), [article])
+        self.assertSequenceEqual(article.categories.all(), [category])
+
+    def test_save_on_change(self):
+        first = self.make_article("First", [self.category])
+        second = self.make_article("Second")
+        form = self.form_class(
+            data=self.post_data("Entertainment", [second.pk]), instance=self.category
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertEqual(form.changed_data, ["article"])
+        form.save()
+        self.assertSequenceEqual(self.category.article_set.all(), [second])
+        self.assertSequenceEqual(first.categories.all(), [])
+
+    def test_save_clears_relation(self):
+        self.make_article("First", [self.category])
+        form = self.form_class(
+            data=self.post_data("Entertainment", []), instance=self.category
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        form.save()
+        self.assertSequenceEqual(self.category.article_set.all(), [])
+
+    def test_save_commit_false(self):
+        article = self.make_article("First")
+        form = self.form_class(data=self.post_data("News", [article.pk]))
+        self.assertTrue(form.is_valid(), form.errors)
+        category = form.save(commit=False)
+        category.save()
+        self.assertSequenceEqual(category.article_set.all(), [])
+        form.save_m2m()
+        self.assertSequenceEqual(category.article_set.all(), [article])
+
+    def test_meta_options_apply(self):
+        form_class = modelform_factory(
+            Category,
+            fields=["article"],
+            labels={"article": "Pieces"},
+            widgets={"article": forms.CheckboxSelectMultiple},
+        )
+        field = form_class.base_fields["article"]
+        self.assertEqual(field.label, "Pieces")
+        self.assertIsInstance(field.widget, forms.CheckboxSelectMultiple)
+
+    def test_declared_field_takes_precedence(self):
+        class CategoryForm(forms.ModelForm):
+            article = forms.ModelMultipleChoiceField(
+                queryset=Article.objects.none(), required=True
+            )
+
+            class Meta:
+                model = Category
+                fields = ["article"]
+
+        field = CategoryForm.base_fields["article"]
+        self.assertTrue(field.required)
+        self.assertSequenceEqual(field.queryset, [])
+
+    def test_forward_limit_choices_to_not_applied(self):
+        character = Character.objects.create(
+            username="user", last_action=datetime.datetime.today()
+        )
+        joke = StumpJoke.objects.create(most_recently_fooled=character)
+        form_class = modelform_factory(Character, fields=["username", "jokes_today"])
+        self.assertSequenceEqual(form_class.base_fields["jokes_today"].queryset, [joke])
+
+    @isolate_apps("model_forms")
+    def test_non_editable_relation_rejected(self):
+        class Ingredient(models.Model):
+            pass
+
+        class Recipe(models.Model):
+            ingredients = models.ManyToManyField(
+                Ingredient, related_name="recipes", editable=False
+            )
+
+        msg = (
+            "'recipes' cannot be specified for Ingredient model form as it is a "
+            "non-editable field"
+        )
+        with self.assertRaisesMessage(FieldError, msg):
+            modelform_factory(Ingredient, fields=["recipes"])
+        self.assertEqual(model_to_dict(Ingredient(pk=1), fields=["recipes"]), {})
+
+    @isolate_apps("model_forms")
+    def test_symmetrical_self_relation_rejected(self):
+        class Node(models.Model):
+            friends = models.ManyToManyField("self")
+
+        msg = "Unknown field(s) (friends_rel_+) specified for Node"
+        with self.assertRaisesMessage(FieldError, msg):
+            modelform_factory(Node, fields=["friends_rel_+"])

--- a/tests/modeladmin/test_checks.py
+++ b/tests/modeladmin/test_checks.py
@@ -276,6 +276,23 @@ class FieldsCheckTests(CheckTestCase):
             invalid_obj=ValidationTestInline,
         )
 
+    @isolate_apps("modeladmin")
+    def test_third_party_many_to_many_field(self):
+        class Through(Model):
+            pass
+
+        class Tags(Field):
+            many_to_many = True
+            through = Through
+
+        class Post(Model):
+            tags = Tags(null=True)
+
+        class TestModelAdmin(ModelAdmin):
+            fields = ["tags"]
+
+        self.assertIsValid(TestModelAdmin, Post)
+
 
 class FormCheckTests(CheckTestCase):
     def test_invalid_type(self):
@@ -349,22 +366,50 @@ class FilterVerticalCheckTests(CheckTestCase):
             "admin.E020",
         )
 
-    @isolate_apps("modeladmin")
-    def test_invalid_reverse_m2m_field_with_related_name(self):
-        class Contact(Model):
-            pass
+    def test_reverse_m2m_field(self):
+        class TestModelAdmin(ModelAdmin):
+            filter_vertical = ["featured"]
 
-        class Customer(Model):
-            contacts = ManyToManyField("Contact", related_name="customers")
+        self.assertIsValid(TestModelAdmin, Band)
+
+    @isolate_apps("modeladmin")
+    def test_invalid_symmetrical_self_m2m_field(self):
+        class Node(Model):
+            friends = ManyToManyField("self")
 
         class TestModelAdmin(ModelAdmin):
-            filter_vertical = ["customers"]
+            filter_vertical = ["friends_rel_+"]
 
         self.assertIsInvalid(
             TestModelAdmin,
-            Contact,
+            Node,
             "The value of 'filter_vertical[0]' must be a many-to-many field.",
             "admin.E020",
+        )
+
+    @isolate_apps("modeladmin")
+    def test_invalid_reverse_m2m_field_with_through(self):
+        class Artist(Model):
+            pass
+
+        class Band(Model):
+            members = ManyToManyField(
+                "Artist", through="Membership", related_name="bands"
+            )
+
+        class Membership(Model):
+            artist = ForeignKey(Artist, on_delete=CASCADE)
+            band = ForeignKey(Band, on_delete=CASCADE)
+
+        class TestModelAdmin(ModelAdmin):
+            filter_vertical = ["bands"]
+
+        self.assertIsInvalid(
+            TestModelAdmin,
+            Artist,
+            "The value of 'filter_vertical[0]' cannot include the ManyToManyField "
+            "'bands', because that field manually specifies a relationship model.",
+            "admin.E013",
         )
 
     @isolate_apps("modeladmin")
@@ -429,22 +474,50 @@ class FilterHorizontalCheckTests(CheckTestCase):
             "admin.E020",
         )
 
-    @isolate_apps("modeladmin")
-    def test_invalid_reverse_m2m_field_with_related_name(self):
-        class Contact(Model):
-            pass
+    def test_reverse_m2m_field(self):
+        class TestModelAdmin(ModelAdmin):
+            filter_horizontal = ["featured"]
 
-        class Customer(Model):
-            contacts = ManyToManyField("Contact", related_name="customers")
+        self.assertIsValid(TestModelAdmin, Band)
+
+    @isolate_apps("modeladmin")
+    def test_invalid_symmetrical_self_m2m_field(self):
+        class Node(Model):
+            friends = ManyToManyField("self")
 
         class TestModelAdmin(ModelAdmin):
-            filter_horizontal = ["customers"]
+            filter_horizontal = ["friends_rel_+"]
 
         self.assertIsInvalid(
             TestModelAdmin,
-            Contact,
+            Node,
             "The value of 'filter_horizontal[0]' must be a many-to-many field.",
             "admin.E020",
+        )
+
+    @isolate_apps("modeladmin")
+    def test_invalid_reverse_m2m_field_with_through(self):
+        class Artist(Model):
+            pass
+
+        class Band(Model):
+            members = ManyToManyField(
+                "Artist", through="Membership", related_name="bands"
+            )
+
+        class Membership(Model):
+            artist = ForeignKey(Artist, on_delete=CASCADE)
+            band = ForeignKey(Band, on_delete=CASCADE)
+
+        class TestModelAdmin(ModelAdmin):
+            filter_horizontal = ["bands"]
+
+        self.assertIsInvalid(
+            TestModelAdmin,
+            Artist,
+            "The value of 'filter_horizontal[0]' cannot include the ManyToManyField "
+            "'bands', because that field manually specifies a relationship model.",
+            "admin.E013",
         )
 
     @isolate_apps("modeladmin")


### PR DESCRIPTION
#### Trac ticket number

ticket-897

#### Branch description

Adds a bit of code so you can use reverse relations in `ModelForm`s. Mostly so you can use it in the admin, though you can also use it outside of the admin.

I tried a solution that only touched admin code, but it ended up more complex and difficult to read so I settled on this.

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude Code Opus 5, with much prodding and asking it to check for simplifications. Docs are mostly hand-written.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.


<img width="1126" height="745" alt="Screenshot 2026-08-22 at 21 13 00" src="https://github.com/user-attachments/assets/a9c4ea4c-3101-4383-9fbf-b9846847389e" />
