### PR TITLE
Fixed #37296 -- Included the invalid view type in path()/re_path() error.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -135,6 +135,7 @@ answer newbie questions, and generally made Django that much better:
     Aryeh Leib Taurog <http://www.aryehleib.com/>
     A S Alam <aalam@users.sf.net>
     Asif Saif Uddin <auvipy@gmail.com>
+    Aslan Osmanov <osmnvaslan@gmail.com>
     atlithorn <atlithorn@gmail.com>
     Audrey Roy <http://audreymroy.com/>
     av0000@mail.ru

--- a/django/urls/conf.py
+++ b/django/urls/conf.py
@@ -88,7 +88,8 @@ def _path(route, view, kwargs=None, name=None, Pattern=None):
         )
     else:
         raise TypeError(
-            "view must be a callable or a list/tuple in the case of include()."
+            "view must be a callable or a list/tuple in the case of "
+            f"include(), but got {view.__class__.__name__}."
         )
 
 

--- a/tests/urlpatterns/tests.py
+++ b/tests/urlpatterns/tests.py
@@ -218,7 +218,10 @@ class SimplifiedURLTests(SimpleTestCase):
             REGISTERED_CONVERTERS.pop("base64", None)
 
     def test_invalid_view(self):
-        msg = "view must be a callable or a list/tuple in the case of include()."
+        msg = (
+            "view must be a callable or a list/tuple in the case of include(), "
+            "but got str."
+        )
         with self.assertRaisesMessage(TypeError, msg):
             path("articles/", "invalid_view")
 


### PR DESCRIPTION
#### Trac ticket number

ticket-37296

#### Branch description

The fallback ``TypeError`` raised by ``path()`` and ``re_path()`` for an
invalid ``view`` argument did not report the received type, unlike the two
neighboring error branches in ``django/urls/conf.py`` (invalid ``kwargs``
argument, and a class-based view instance). This appends the received type
to the message, e.g. ``... in the case of include(), but got str.``, which
is helpful for the common case of accidentally passing a string view.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

AI tools used: Claude Code (identified the inconsistency, drafted the patch and the regression test); I reviewed, ran the tests, and verified the output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/dev/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.