### PR TITLE
Fixed #37249 -- Resolved race condition in file-session backend save().

### DIFF
--- a/django/contrib/sessions/backends/file.py
+++ b/django/contrib/sessions/backends/file.py
@@ -1,7 +1,6 @@
 import datetime
 import logging
 import os
-import shutil
 import tempfile
 
 from django.conf import settings
@@ -130,13 +129,13 @@ class SessionStore(SessionBase):
         session_file_name = self._key_to_file()
 
         try:
-            # Make sure the file exists. If it does not already exist, an
-            # empty placeholder file is created.
+            # Open the session file and keep the fd alive for the duration
+            # of the save. Using the fd, we can make a atomic check and
+            # write by checking the existence of file.
             flags = os.O_WRONLY | getattr(os, "O_BINARY", 0)
             if must_create:
                 flags |= os.O_EXCL | os.O_CREAT
             fd = os.open(session_file_name, flags)
-            os.close(fd)
         except FileNotFoundError:
             if not must_create:
                 raise UpdateError
@@ -172,16 +171,22 @@ class SessionStore(SessionBase):
                 finally:
                     os.close(output_file_fd)
 
-                # This will atomically rename the file (os.rename) if the OS
-                # supports it. Otherwise this will result in a shutil.copy2
-                # and os.unlink (for example on Windows). See #9084.
-                shutil.move(output_file_name, session_file_name)
+                # Check whether the session file was unlinked (e.g. by a
+                # concurrent logout) while we were writing to the temp
+                # file.
+                # st_nlink == 0: path was deleted, do NOT resurrect it.
+                # st_nlink >= 1: path is still alive, safe to rename.
+                if not must_create and os.fstat(fd).st_nlink == 0:
+                    raise UpdateError
+                os.rename(output_file_name, session_file_name)
                 renamed = True
             finally:
                 if not renamed:
                     os.unlink(output_file_name)
         except (EOFError, OSError):
             pass
+        finally:
+            os.close(fd)
 
     async def asave(self, must_create=False):
         return self.save(must_create=must_create)

--- a/tests/sessions_tests/tests.py
+++ b/tests/sessions_tests/tests.py
@@ -987,6 +987,24 @@ class FileSessionTests(SessionTestsMixin, SimpleTestCase):
         # ... and two are deleted.
         self.assertEqual(1, count_sessions())
 
+    def test_save_raises_update_error_if_deleted_mid_save(self):
+        self.session["foo"] = "bar"
+        self.session.save()
+        self.assertTrue(self.session.exists(self.session.session_key))
+
+        original_encode = self.session.encode
+
+        def deleting_encode(session_data):
+            self.session.delete()
+            self.assertFalse(self.session.exists(self.session.session_key))
+            return original_encode(session_data)
+
+        with mock.patch.object(self.session, "encode", deleting_encode):
+            with self.assertRaises(UpdateError):
+                self.session.save()
+
+        self.assertFalse(self.session.exists(self.session.session_key))
+
 
 class FileSessionPathLibTests(FileSessionTests):
     def mkdtemp(self):


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37249

#### Branch description
File session backend `save()` followed a check and write, allowing a window for the file to be unlinked which opens possibility for race condition. Currently, save method holds the file-descriptor(fd) until writing to the disk, allowing a check for file's existence in the disk prior to `os.rename()`. 

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Verified the usage of file-descriptor and if it can be relied on for atomic checks, using Claude for making the fix possible without locks.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [ ] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
