### PR TITLE
Fixed #31450 -- Fixed ArrayField(PointField) returning a string instead of a list.

### DIFF
--- a/django/contrib/gis/db/backends/postgis/base.py
+++ b/django/contrib/gis/db/backends/postgis/base.py
@@ -13,7 +13,7 @@ from django.db.backends.postgresql.operations import (
 )
 from django.db.backends.postgresql.psycopg_any import is_psycopg3
 
-from .adapter import PostGISAdapter
+from .adapter import GEOSGeometry, PostGISAdapter
 from .features import DatabaseFeatures
 from .introspection import PostGISIntrospection
 from .operations import PostGISOperations
@@ -87,6 +87,19 @@ if is_psycopg3:
 
         return PostGISTextDumper, PostGISBinaryDumper
 
+else:
+    import psycopg2
+
+
+# geometry array types caster for psycopg2
+def geometry_array_caster(value, cursor):
+    if value is None:
+        return value
+    text = value.strip("{}")
+    if text == "":
+        return []
+    return [None if item == "NULL" else GEOSGeometry(item) for item in text.split(":")]
+
 
 class DatabaseWrapper(PsycopgDatabaseWrapper):
     SchemaEditorClass = PostGISSchemaEditor
@@ -121,11 +134,16 @@ class DatabaseWrapper(PsycopgDatabaseWrapper):
                 # Ensure adapters are registers if PostGIS is used within this
                 # connection.
                 self.register_geometry_adapters(self.connection, True)
+            else:
+                # register caster for psycopg2
+                self.register_geometry_array_casters(self.connection)
 
     def get_new_connection(self, conn_params):
         connection = super().get_new_connection(conn_params)
         if is_psycopg3:
             self.register_geometry_adapters(connection)
+        else:
+            self.register_geometry_array_casters(connection)
         return connection
 
     if is_psycopg3:
@@ -159,3 +177,39 @@ class DatabaseWrapper(PsycopgDatabaseWrapper):
             )
             pg_connection.adapters.register_dumper(PostGISAdapter, PostGISTextDumper)
             pg_connection.adapters.register_dumper(PostGISAdapter, PostGISBinaryDumper)
+
+    # register geometry array type caster for psycopg2
+    def register_geometry_array_casters(self, connection):
+        """
+        Register psycopg2 type casters for geometry[] and geography[] values.
+
+        The array OIDs are looked up dynamically from pg_type because they may
+        vary between databases. If the corresponding PostgreSQL types aren't
+        available, no caster is registered.
+
+        Custom casters are created with new_type() so that the PostgreSQL array
+        value is passed to geometry_array_caster for explicit parsing.
+        """
+
+        old_autocommit = connection.autocommit
+        connection.autocommit = True
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT typname, typarray
+                    FROM pg_type
+                    WHERE typname IN (%s, %s)
+                    """,
+                    ("geometry", "geography"),
+                )
+                rows = dict(cursor.fetchall())
+        finally:
+            connection.autocommit = old_autocommit
+        for typname, array_oid in rows.items():
+            if not array_oid:
+                continue
+            caster = psycopg2.extensions.new_type(
+                (array_oid,), f"{typname.upper()}[]", geometry_array_caster
+            )
+            psycopg2.extensions.register_type(caster)

--- a/django/contrib/gis/db/models/fields.py
+++ b/django/contrib/gis/db/models/fields.py
@@ -353,6 +353,13 @@ class GeometryField(BaseSpatialField):
             return compiler.connection.ops.select % sql, params
         return sql, params
 
+    def from_db_value(self, value, expression, connection):
+        if value is None:
+            return value
+        if isinstance(value, GEOSGeometry):
+            return value
+        return GEOSGeometry(value)
+
 
 # The OpenGIS Geometry Type Fields
 class PointField(GeometryField):

--- a/tests/gis_tests/geoapp/models.py
+++ b/tests/gis_tests/geoapp/models.py
@@ -1,4 +1,9 @@
 from django.contrib.gis.db import models
+from django.contrib.gis.db.models.fields import PointField, PolygonField
+from django.db import connection
+
+if connection.vendor == "postgresql":
+    from django.contrib.postgres.fields.array import ArrayField
 
 from ..utils import gisfield_may_be_null
 
@@ -114,3 +119,15 @@ class Lines(models.Model):
 
 class GeometryCollectionModel(models.Model):
     geom = models.GeometryCollectionField(max_geom_collections=5)
+
+
+# see ticket #31450
+if connection.vendor == "postgresql":
+
+    class Foo(models.Model):
+        bar = ArrayField(models.TextField(), null=True)
+        baz = ArrayField(PointField(), null=True)  # PointField()
+        baz_geo = ArrayField(
+            PointField(geography=True), null=True
+        )  # PointField(geography=True)
+        pl = ArrayField(PolygonField(), null=True)  # PolygonField

--- a/tests/gis_tests/geoapp/test_regress.py
+++ b/tests/gis_tests/geoapp/test_regress.py
@@ -1,12 +1,17 @@
 from datetime import datetime
 
 from django.contrib.gis.db.models import Extent
+from django.contrib.gis.geos import Point, Polygon
 from django.contrib.gis.shortcuts import render_to_kmz
+from django.db import connection
 from django.db.models import Count, Min
 from django.test import TestCase, skipUnlessDBFeature
 
 from ..utils import skipUnlessGISLookup
 from .models import City, PennsylvaniaCity, State, Truth
+
+if connection.vendor == "postgresql":
+    from .models import Foo
 
 
 class GeoRegressionTests(TestCase):
@@ -109,3 +114,67 @@ class GeoRegressionTests(TestCase):
         # verify values
         self.assertIs(val1, True)
         self.assertIs(val2, False)
+
+    if connection.vendor == "postgresql":
+
+        def test_arrayfield_pointfield_return_list(self):
+            "Testing ArrayField(PointField()). See #31450."
+            srid = 4326
+            foo = Foo.objects.create(
+                bar=["fizz", "bazz"],
+                baz=[Point(34, 43, srid=srid), Point(2.21, 2.21, srid=srid)],
+            )
+            foo = Foo.objects.get(pk=foo.pk)
+
+            self.assertIsInstance(foo.baz, list)
+            self.assertEqual(len(foo.baz), 2)
+            for point in foo.baz:
+                self.assertIsInstance(point, Point)
+            self.assertEqual(foo.baz[0], Point(34, 43, srid=srid))
+            self.assertEqual(foo.baz[1], Point(2.21, 2.21, srid=srid))
+
+        def test_arrayfield_polygonfield_return_list(self):
+            "Testing ArrayField(PolygonField()). See #31450."
+            srid = 4326
+            poly1 = Polygon(((0, 0), (0, 5), (5, 5), (5, 0), (0, 0)), srid=srid)
+            poly2 = Polygon(
+                ((10, 10), (10, 15), (15, 15), (15, 10), (10, 10)), srid=srid
+            )
+            foo = Foo.objects.create(bar=[], pl=[poly1, poly2])
+            foo = Foo.objects.get(pk=foo.pk)
+            self.assertIsInstance(foo.pl, list)
+            self.assertEqual(len(foo.pl), 2)
+            for polygon in foo.pl:
+                self.assertIsInstance(polygon, Polygon)
+            self.assertEqual(foo.pl[0], poly1)
+            self.assertEqual(foo.pl[1], poly2)
+
+        def test_arrayfield_geometryfield_geography_return_list(self):
+            "Testing ArrayField(PointField(geography=True)). See #31450."
+            srid = 4326
+            foo = Foo.objects.create(
+                bar=[],
+                baz_geo=[Point(34, 43, srid=srid), Point(2.21, 2.21, srid=srid)],
+            )
+            foo = Foo.objects.get(pk=foo.pk)
+
+            self.assertIsInstance(foo.baz_geo, list)
+            self.assertEqual(len(foo.baz_geo), 2)
+            for point in foo.baz_geo:
+                self.assertIsInstance(point, Point)
+            self.assertEqual(foo.baz_geo[0], Point(34, 43, srid=srid))
+            self.assertEqual(foo.baz_geo[1], Point(2.21, 2.21, srid=srid))
+
+        def test_arrayfield_geometryfield_null_element(self):
+            "Testing ArrayField(PointField()) an null array. See #31450."
+            foo = Foo.objects.create(bar=[], baz=[Point(1, 1, srid=4326), None])
+            foo = Foo.objects.get(pk=foo.pk)
+            self.assertEqual(len(foo.baz), 2)
+            self.assertIsInstance(foo.baz[0], Point)
+            self.assertIsNone(foo.baz[1])
+
+        def test_arrayfield_geometryfield_empty_array(self):
+            "Testing ArrayField(PointField())  an empty array. See #31450."
+            foo = Foo.objects.create(bar=[], baz=[])
+            foo = Foo.objects.get(pk=foo.pk)
+            self.assertEqual(foo.baz, [])


### PR DESCRIPTION
Thank you Nitin Sangwan for the report.

#### Trac ticket number

ticket-31450

#### Branch description

Fix `ArrayField` with geometry fields by correctly converting PostgreSQL geometry array values into Django geometry objects. For psycopg2, I registered a custom array caster for geometry values. For psycopg3, I added `GeometryField.from_db_value()` handling for geometry array values.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

AI tools used: Claude. Claude was used during the investigation of the issue, to help with commit message wording, and to correct typos. I fully reviewed and verified the resulting code and tests.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.

- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.