### PR TITLE
Fixed #37297 -- Prevented crash on JSONField key lookups when an integer key is outside PostgreSQL's int4 range.

### DIFF
--- a/django/db/models/fields/json.py
+++ b/django/db/models/fields/json.py
@@ -291,6 +291,26 @@ class HasKeyOrArrayIndex(HasKey):
     def compile_json_path_final_key(self, connection, key_transform):
         return connection.ops.compile_json_path([key_transform], include_root=False)
 
+    def as_oracle(self, compiler, connection):
+        min_value, max_value = connection.ops.integer_field_range("IntegerField")
+        keys = [self.rhs]
+        previous = self.lhs
+        while isinstance(previous, KeyTransform):
+            keys.append(previous.key_name)
+            previous = previous.lhs
+        for key in keys:
+            try:
+                index = int(key)
+            except ValueError:
+                continue
+            if not (min_value <= index <= max_value):
+                # Oracle's JSON path parser cannot lex an array subscript
+                # this long ("ORA-40597: Array subscript too long"). An
+                # index this large can never exist in any real array, so
+                # the key/index can never be present.
+                return "(1=0)", ()
+        return super().as_oracle(compiler, connection)
+
 
 class CaseInsensitiveMixin:
     """

--- a/django/db/models/fields/json.py
+++ b/django/db/models/fields/json.py
@@ -498,6 +498,18 @@ class KeyTransform(ProcessJSONLHSMixin, Transform):
 
     def as_oracle(self, compiler, connection):
         lhs, params, key_transforms = self.preprocess_lhs(compiler, connection)
+        min_value, max_value = connection.ops.integer_field_range("IntegerField")
+        for key_transform in key_transforms:
+            try:
+                index = int(key_transform)
+            except ValueError:
+                continue
+            if not (min_value <= index <= max_value):
+                # Oracle's JSON path parser cannot lex an array subscript
+                # this long ("ORA-40597: Array subscript too long"). Treat
+                # it as a non-matching index, the same as Oracle itself
+                # treats an in-bounds-length but out-of-bounds index.
+                return "NULL", params
         return self._process_as_oracle(lhs, params, connection, key_transforms)
 
     def as_postgresql(self, compiler, connection):
@@ -507,6 +519,11 @@ class KeyTransform(ProcessJSONLHSMixin, Transform):
             return sql, (*params, key_transforms)
         try:
             lookup = int(self.key_name)
+            min_value, max_value = connection.ops.integer_field_range("IntegerField")
+            if not (min_value <= lookup <= max_value):
+                # No int4 overload of the operator can be bound to a value
+                # this large. Treat it as a non-matching index.
+                return "(%s %s NULL::integer)" % (lhs, self.postgres_operator), params
         except ValueError:
             lookup = self.key_name
         return "(%s %s %%s)" % (lhs, self.postgres_operator), (*params, lookup)

--- a/tests/model_fields/test_jsonfield.py
+++ b/tests/model_fields/test_jsonfield.py
@@ -1152,6 +1152,23 @@ class TestQuerying(TestCase):
             self.objs[4],
         )
 
+    def test_key_transform_int4_range_overflow(self):
+        # A purely numeric key segment is parsed as an array index. If that
+        # index is outside the range of integer this database's JSON path
+        # support can handle natively (PostgreSQL's int4 range; Oracle's JSON
+        # path parser has its own, much larger, limit), the lookup must not
+        # match rather than error.
+        out_of_range_key = max(connection.ops.integer_field_range("IntegerField")) + 1
+        key = str(out_of_range_key)
+        obj = NullableJSONModel.objects.create(value={key: "x"})
+        self.assertFalse(
+            NullableJSONModel.objects.filter(**{f"value__{key}": "x"}).exists()
+        )
+        if connection.features.supports_json_field_contains:
+            self.assertCountEqual(
+                NullableJSONModel.objects.filter(value__contains={key: "x"}), [obj]
+            )
+
     @skipUnlessDBFeature("has_json_operators")
     def test_key_sql_injection(self):
         with CaptureQueriesContext(connection) as queries:

--- a/tests/model_fields/test_jsonfield.py
+++ b/tests/model_fields/test_jsonfield.py
@@ -1169,6 +1169,29 @@ class TestQuerying(TestCase):
                 NullableJSONModel.objects.filter(value__contains={key: "x"}), [obj]
             )
 
+    def test_key_transform_int4_range_overflow_isnull(self):
+        # __isnull on a key segment outside the range in
+        # test_key_transform_int4_range_overflow() must not match rather than
+        # error, the same as an ordinary exact lookup on that key.
+        out_of_range_key = max(connection.ops.integer_field_range("IntegerField")) + 1
+        key = str(out_of_range_key)
+        obj = NullableJSONModel.objects.create(value={key: "x"})
+        self.assertTrue(
+            NullableJSONModel.objects.filter(
+                pk=obj.pk, **{f"value__{key}__isnull": True}
+            ).exists(),
+        )
+
+    def test_key_transform_int4_range_overflow_isnull_ancestor(self):
+        out_of_range_key = max(connection.ops.integer_field_range("IntegerField")) + 1
+        key = str(out_of_range_key)
+        obj = NullableJSONModel.objects.create(value={"other": {"x": "y"}})
+        self.assertTrue(
+            NullableJSONModel.objects.filter(
+                pk=obj.pk, **{f"value__{key}__x__isnull": True}
+            ).exists(),
+        )
+
     @skipUnlessDBFeature("has_json_operators")
     def test_key_sql_injection(self):
         with CaptureQueriesContext(connection) as queries:


### PR DESCRIPTION


#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37297

#### Branch description
<!-- Provide a concise overview of the issue or rationale behind the proposed changes. Minimum five words. -->
See attached ticket.

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
<!-- If AI tools were used, provide which tools were used here. -->
Used Claude Opus 5 to explore the possibility of reopening and fixing ticket-29504 (possible but impractical). Also used Claude to investigate the oracle failures and write the fix (with prodding and iterations).

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
