### PR TITLE
Fixed #37300 -- Restored db hints on custom prefetch querysets of FK/O2O relations.

### DIFF
--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -180,6 +180,7 @@ class ForwardManyToOneDescriptor:
                     "length of 1."
                 )
             queryset = querysets[0]
+            queryset._add_hints(instance=instances[0])
         else:
             _cloning_disabled = True
             queryset = self.get_queryset(instance=instances[0])._disable_cloning()
@@ -480,6 +481,7 @@ class ReverseOneToOneDescriptor:
                     "length of 1."
                 )
             queryset = querysets[0]
+            queryset._add_hints(instance=instances[0])
         else:
             _cloning_disabled = True
             queryset = self.get_queryset(instance=instances[0])._disable_cloning()

--- a/docs/releases/6.1.1.txt
+++ b/docs/releases/6.1.1.txt
@@ -39,3 +39,10 @@ Bugfixes
   ``QuerySet`` of a model overriding ``Model.from_db()`` without the new
   ``fetch_mode`` keyword argument. Such overrides now work again, but are
   deprecated and should be updated to accept ``fetch_mode`` (:ticket:`37259`).
+
+* Fixed a regression in Django 6.1 where ``QuerySet.prefetch_related()`` with
+  a ``Prefetch()`` object using a custom queryset did not provide database
+  hints to database routers when prefetching ``ForeignKey`` and
+  ``OneToOneField`` relations, causing the prefetch query to run on the
+  default database rather than the database of the instances being prefetched
+  (:ticket:`37300`).

--- a/tests/prefetch_related/tests.py
+++ b/tests/prefetch_related/tests.py
@@ -1696,6 +1696,56 @@ class MultiDbTests(TestCase):
 
         self.assertEqual(ages, "50, 49")
 
+    def test_using_is_honored_custom_qs_fkey(self):
+        B = Book.objects.using("other")
+        A = Author.objects.using("other")
+        book1 = B.create(title="Poems")
+        book2 = B.create(title="Sense and Sensibility")
+
+        A.create(name="Charlotte Bronte", first_book=book1)
+        A.create(name="Jane Austen", first_book=book2)
+
+        # Implicit hinting
+        with self.assertNumQueries(2, using="other"):
+            prefetch = Prefetch("first_book", queryset=Book.objects.all())
+            books = ", ".join(a.first_book.title for a in A.prefetch_related(prefetch))
+        self.assertEqual("Poems, Sense and Sensibility", books)
+
+        # Explicit using on the same db.
+        with self.assertNumQueries(2, using="other"):
+            prefetch = Prefetch("first_book", queryset=Book.objects.using("other"))
+            books = ", ".join(a.first_book.title for a in A.prefetch_related(prefetch))
+        self.assertEqual("Poems, Sense and Sensibility", books)
+
+        # Explicit using on a different db.
+        with (
+            self.assertNumQueries(1, using="default"),
+            self.assertNumQueries(1, using="other"),
+        ):
+            prefetch = Prefetch("first_book", queryset=Book.objects.using("default"))
+            list(A.prefetch_related(prefetch))
+
+    def test_using_is_honored_custom_qs_o2o(self):
+        B = BookWithYear.objects.using("other")
+        A = AuthorWithAge.objects.using("other")
+        book1 = B.create(title="Poems", published_year=2010)
+        A.create(name="Jane", first_book=book1, age=50)
+        A.create(name="Tom", first_book=book1, age=49)
+
+        # parent link
+        with self.assertNumQueries(2, using="other"):
+            prefetch = Prefetch("author", queryset=Author.objects.all())
+            authors = ", ".join(a.author.name for a in A.prefetch_related(prefetch))
+        self.assertEqual(authors, "Jane, Tom")
+
+        # child link
+        with self.assertNumQueries(2, using="other"):
+            prefetch = Prefetch("authorwithage", queryset=AuthorWithAge.objects.all())
+            ages = ", ".join(
+                str(a.authorwithage.age) for a in A.prefetch_related(prefetch)
+            )
+        self.assertEqual(ages, "50, 49")
+
     def test_using_is_honored_custom_qs(self):
         B = Book.objects.using("other")
         A = Author.objects.using("other")


### PR DESCRIPTION
Trac ticket number
------------------

ticket-37300

Branch description
------------------

Regression in 821619aa876158e8d6dcedebd0dbc2e0e0b41295: moving the instance hint into `get_queryset(instance=...)` on `ForwardManyToOneDescriptor` and `ReverseOneToOneDescriptor` left the custom-queryset branch of their `get_prefetch_querysets()` without `_add_hints()`, so a `Prefetch(queryset=...)` on a `ForeignKey`/`OneToOneField` relation stopped being routed to the database of the instances being prefetched and ran on the default database instead. The reverse-FK and m2m manager variants kept their hints and were unaffected.

This restores the hint in the custom-queryset branch (the no-queryset branch already gets it via `get_queryset(instance=...)`), adds multi-db regression tests for the forward FK and one-to-one link cases alongside the existing reverse-FK `test_using_is_honored_custom_qs`, and adds a 6.1.1 release note.

Checklist
---------

- [x] This PR targets the `main` branch.
- [x] The commit message includes the ticket number.
- [x] Tests added: `prefetch_related.tests.MultiDbTests.test_using_is_honored_custom_qs_fkey` / `test_using_is_honored_custom_qs_o2o` — both fail before the fix and pass after.
- [x] Docs/release notes updated (`docs/releases/6.1.1.txt`).

AI Assistance Disclosure
------------------------

This contribution was prepared with the assistance of an AI tool (Claude Code). The AI assisted with diagnosing the regression, drafting the patch, and writing the regression tests. All changes were reviewed by the contributor, and the tests were verified locally to fail before the fix and pass after it, alongside the `prefetch_related`, `multiple_database`, `one_to_one`, `many_to_one`, and `select_related_onetoone` test modules.
