### PR TITLE
Fixed #37300 -- Fixed database routing for custom forward prefetch querysets.

### DIFF
--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -180,6 +180,7 @@ class ForwardManyToOneDescriptor:
                     "length of 1."
                 )
             queryset = querysets[0]
+            queryset._add_hints(instance=instances[0])
         else:
             _cloning_disabled = True
             queryset = self.get_queryset(instance=instances[0])._disable_cloning()
@@ -480,6 +481,7 @@ class ReverseOneToOneDescriptor:
                     "length of 1."
                 )
             queryset = querysets[0]
+            queryset._add_hints(instance=instances[0])
         else:
             _cloning_disabled = True
             queryset = self.get_queryset(instance=instances[0])._disable_cloning()

--- a/docs/releases/6.1.1.txt
+++ b/docs/releases/6.1.1.txt
@@ -39,3 +39,7 @@ Bugfixes
   ``QuerySet`` of a model overriding ``Model.from_db()`` without the new
   ``fetch_mode`` keyword argument. Such overrides now work again, but are
   deprecated and should be updated to accept ``fetch_mode`` (:ticket:`37259`).
+
+* Fixed a regression in Django 6.1 where custom querysets used with
+  ``Prefetch`` for forward foreign key or reverse one-to-one relationships were
+  not routed using the parent queryset's database (:ticket:`37300`).

--- a/tests/multiple_database/tests.py
+++ b/tests/multiple_database/tests.py
@@ -8,7 +8,7 @@ from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.core import management
 from django.db import DEFAULT_DB_ALIAS, router, transaction
-from django.db.models import signals
+from django.db.models import Prefetch, signals
 from django.db.utils import ConnectionRouter
 from django.test import SimpleTestCase, TestCase, override_settings
 
@@ -1273,6 +1273,39 @@ class QueryTestCase(TestCase):
 
         # The editor instance should have a db state
         self.assertEqual(book.editor._state.db, "other")
+
+    @override_settings(DATABASE_ROUTERS=["multiple_database.tests.TestRouter"])
+    def test_forward_fk_prefetch_custom_queryset_uses_parent_database(self):
+        mark = Person.objects.using("default").create(name="Mark Pilgrim")
+        Person.objects.using("other").create(pk=mark.pk, name="Other Mark")
+        Book.objects.using("default").create(
+            title="Dive into Python",
+            published=datetime.date(2009, 5, 4),
+            editor=mark,
+        )
+
+        book = Book.objects.using("default").prefetch_related(
+            Prefetch("editor", queryset=Person.objects.only("name"))
+        )[0]
+
+        self.assertEqual(book._state.db, "default")
+        self.assertEqual(book.editor._state.db, "default")
+        self.assertEqual(book.editor.name, "Mark Pilgrim")
+
+    @override_settings(DATABASE_ROUTERS=["multiple_database.tests.TestRouter"])
+    def test_reverse_o2o_prefetch_custom_queryset_uses_parent_database(self):
+        alice = User.objects.db_manager("default").create_user("alice")
+        User.objects.db_manager("other").create_user("other-alice", pk=alice.pk)
+        UserProfile.objects.using("default").create(user=alice, flavor="chocolate")
+        UserProfile.objects.using("other").create(user_id=alice.pk, flavor="vanilla")
+
+        user = User.objects.using("default").prefetch_related(
+            Prefetch("userprofile", queryset=UserProfile.objects.only("flavor"))
+        )[0]
+
+        self.assertEqual(user._state.db, "default")
+        self.assertEqual(user.userprofile._state.db, "default")
+        self.assertEqual(user.userprofile.flavor, "chocolate")
 
     def test_subquery(self):
         """Make sure as_sql works with subqueries and primary/replica."""


### PR DESCRIPTION
#### Trac ticket number

ticket-37300

#### Branch description

Restored database routing hints for custom querysets used by forward `ForeignKey` and reverse `OneToOneField` prefetches.

In Django 6.1, custom prefetch querysets in these descriptor paths no longer received the parent instance hint, so routers could choose the wrong database for the related-object query. This change adds the missing hint in both descriptor paths and covers the behavior with multi-database regression tests.

Tested with:

```console
PYTHONPATH=. python tests/runtests.py multiple_database --verbosity 1 --parallel 1
```

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Codex was used to help inspect the issue, prepare the patch, and review the final diff. I manually reviewed and verified the generated changes and test coverage.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
