### PR TITLE
Fixed #37300 -- Fixed database routing for custom forward prefetch querysets.

### DIFF
--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -180,6 +180,7 @@ class ForwardManyToOneDescriptor:
                     "length of 1."
                 )
             queryset = querysets[0]
+            queryset._add_hints(instance=instances[0])
         else:
             _cloning_disabled = True
             queryset = self.get_queryset(instance=instances[0])._disable_cloning()
@@ -480,6 +481,7 @@ class ReverseOneToOneDescriptor:
                     "length of 1."
                 )
             queryset = querysets[0]
+            queryset._add_hints(instance=instances[0])
         else:
             _cloning_disabled = True
             queryset = self.get_queryset(instance=instances[0])._disable_cloning()

--- a/docs/releases/6.1.1.txt
+++ b/docs/releases/6.1.1.txt
@@ -21,6 +21,11 @@ Bugfixes
   detect mixed ``on_delete`` variants for auto-created intermediate models for
   ``ManyToManyField``\s (:ticket:`37254`).
 
+* Fixed a regression in Django 6.1 where custom querysets used with
+  :class:`~django.db.models.Prefetch` for forward foreign key or reverse
+  one-to-one relationships were not routed using the parent queryset's
+  database (:ticket:`37300`).
+
 * Fixed a regression in Django 6.1 where HTML-safe strings, such as those
   created with :func:`~django.utils.safestring.mark_safe`, used as form media
   assets were treated as asset paths rather than being rendered verbatim

--- a/tests/prefetch_related/tests.py
+++ b/tests/prefetch_related/tests.py
@@ -1747,6 +1747,38 @@ class MultiDbTests(TestCase):
             )
         self.assertEqual(books, "Poems ()\n" "Sense and Sensibility ()\n")
 
+    def test_forward_fk_prefetch_custom_queryset_uses_parent_database(self):
+        book1 = Book.objects.using("default").create(title="Dive into Python")
+        Author.objects.using("default").create(name="Mark", first_book=book1)
+        book2 = Book.objects.using("other").create(title="Dive into Rust")
+        Author.objects.using("other").create(name="Mark", first_book=book2)
+
+        author = (
+            Author.objects.using("other")
+            .prefetch_related(Prefetch("first_book", queryset=Book.objects.all()))
+            .get(name="Mark")
+        )
+
+        self.assertEqual(author._state.db, "other")
+        self.assertEqual(author.first_book._state.db, "other")
+        self.assertEqual(author.first_book.title, "Dive into Rust")
+
+    def test_reverse_o2o_prefetch_custom_queryset_uses_parent_database(self):
+        BookWithYear.objects.using("default").create(title="Poems", published_year=2000)
+        BookWithYear.objects.using("other").create(title="Poems", published_year=2001)
+
+        book = (
+            Book.objects.using("other")
+            .prefetch_related(
+                Prefetch("bookwithyear", queryset=BookWithYear.objects.all())
+            )
+            .get(title="Poems")
+        )
+
+        self.assertEqual(book._state.db, "other")
+        self.assertEqual(book.bookwithyear._state.db, "other")
+        self.assertEqual(book.bookwithyear.published_year, 2001)
+
 
 class Ticket19607Tests(TestCase):
     @classmethod


### PR DESCRIPTION
#### Trac ticket number

ticket-37300

#### Branch description

Restored database routing hints for custom querysets used by forward `ForeignKey` and reverse `OneToOneField` prefetches.

In Django 6.1, custom prefetch querysets in these descriptor paths no longer received the parent instance hint, so routers could choose the wrong database for the related-object query. This change adds the missing hint in both descriptor paths and covers the behavior with multi-database regression tests.

Tested with:

```console
PYTHONPATH=. python tests/runtests.py multiple_database --verbosity 1 --parallel 1
```

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Codex was used to help inspect the issue, prepare the patch, and review the final diff. I manually reviewed and verified the generated changes and test coverage.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
