### PR TITLE
Fixed #37252 -- Allowed If-Unmodified-Since to pass when last_modified is missing.

### DIFF
--- a/django/utils/cache.py
+++ b/django/utils/cache.py
@@ -241,8 +241,7 @@ def _if_unmodified_since_passes(last_modified, if_unmodified_since):
     Test the If-Unmodified-Since comparison as defined in RFC 9110 Section
     13.1.4.
     """
-    return last_modified and last_modified <= if_unmodified_since
-
+    return not last_modified or last_modified <= if_unmodified_since
 
 def _if_none_match_passes(target_etag, etags):
     """

--- a/tests/conditional_processing/tests.py
+++ b/tests/conditional_processing/tests.py
@@ -228,7 +228,7 @@ class ConditionalGet(SimpleTestCase):
         response = self.client.get("/condition/last_modified/")
         self.assertEqual(response.status_code, 412)
         response = self.client.get("/condition/etag/")
-        self.assertEqual(response.status_code, 412)
+        self.assertEqual(response.status_code, 200)
 
     def test_single_condition_8(self):
         self.client.defaults["HTTP_IF_UNMODIFIED_SINCE"] = LAST_MODIFIED_STR
@@ -240,7 +240,7 @@ class ConditionalGet(SimpleTestCase):
         response = self.client.get("/condition/last_modified2/")
         self.assertEqual(response.status_code, 412)
         response = self.client.get("/condition/etag2/")
-        self.assertEqual(response.status_code, 412)
+        self.assertEqual(response.status_code, 200)
 
     def test_single_condition_head(self):
         self.client.defaults["HTTP_IF_MODIFIED_SINCE"] = LAST_MODIFIED_STR


### PR DESCRIPTION
ticket-37252

### Description
Per RFC 9110 (Section 13.1.4), the `If-Unmodified-Since` precondition should pass if a resource has no last-modified time available. Previously, Django evaluated `last_modified and last_modified <= if_unmodified_since`, which incorrectly caused views without a `last_modified` timestamp to fail with a `412 Precondition Failed` error when an `If-Unmodified-Since` header was sent. This PR fixes the condition to `not last_modified or last_modified <= if_unmodified_since` and updates the test suite to expect a `200 OK` response in this scenario.

### AI Assistance Disclosure
- [ ] No AI tools were used in preparing this PR.
- [x] If AI tools were used, I have disclosed which ones, and fully reviewed and verified their output.

*Details:* Used an AI assistant for git workflow and syntax guidance. All code changes, test cases, and test results have been manually reviewed and verified locally.

### Checklist
- [x] This PR targets the `main` branch.
- [x] The code follows the style guidelines of the Django project.
- [x] Tests have been added to prove that the fix is effective.
- [x] New and existing tests pass locally.