### PR TITLE
Fixed #36533 -- Allowed startapp to use existing target directories with manage.py.

### DIFF
--- a/django/core/management/templates.py
+++ b/django/core/management/templates.py
@@ -106,7 +106,9 @@ class TemplateCommand(BaseCommand):
         else:
             top_dir = os.path.abspath(os.path.expanduser(target))
             if app_or_project == "app":
-                self.validate_name(os.path.basename(top_dir), "directory")
+                self.validate_name(
+                    os.path.basename(top_dir), "directory", target=top_dir
+                )
             if not os.path.exists(top_dir):
                 try:
                     os.makedirs(top_dir)
@@ -260,7 +262,7 @@ class TemplateCommand(BaseCommand):
             "couldn't handle %s template %s." % (self.app_or_project, template)
         )
 
-    def validate_name(self, name, name_or_dir="name"):
+    def validate_name(self, name, name_or_dir="name", target=None):
         if name is None:
             raise CommandError(
                 "you must provide {an} {app} name".format(
@@ -278,18 +280,28 @@ class TemplateCommand(BaseCommand):
                     type=name_or_dir,
                 )
             )
-        # Check that __spec__ doesn't exist.
-        if find_spec(name) is not None:
-            raise CommandError(
-                "'{name}' conflicts with the name of an existing Python "
-                "module and cannot be used as {an} {app} {type}. Please try "
-                "another {type}.".format(
-                    name=name,
-                    an=self.a_or_an,
-                    app=self.app_or_project,
-                    type=name_or_dir,
-                )
+        # Check that the name does not conflict with an existing Python module.
+        spec = find_spec(name)
+        if spec is not None:
+            is_target_namespace = (
+                target is not None
+                and os.path.isdir(target)
+                and spec.loader is None
+                and spec.submodule_search_locations is not None
+                and len(spec.submodule_search_locations) == 1
+                and os.path.samefile(spec.submodule_search_locations[0], target)
             )
+            if not is_target_namespace:
+                raise CommandError(
+                    "'{name}' conflicts with the name of an existing Python "
+                    "module and cannot be used as {an} {app} {type}. Please try "
+                    "another {type}.".format(
+                        name=name,
+                        an=self.a_or_an,
+                        app=self.app_or_project,
+                        type=name_or_dir,
+                    )
+                )
 
     def download(self, url):
         """

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -3155,6 +3155,55 @@ class StartApp(AdminScriptTestCase):
             "another directory.",
         )
 
+    def test_importable_target_name_with_manage(self):
+        """startapp rejects importable target names when run with manage.py."""
+        os.mkdir(os.path.join(self.test_dir, "os"))
+
+        _, err = self.run_manage(["startapp", "app", "os"])
+
+        self.assertOutput(
+            err,
+            "CommandError: 'os' conflicts with the name of an existing Python "
+            "module and cannot be used as an app directory. Please try "
+            "another directory.",
+        )
+
+    def test_existing_target_directory_with_manage(self):
+        """
+        startapp allows an existing target directory when run with manage.py.
+        """
+        app_dir = os.path.join(self.test_dir, "destination")
+        os.mkdir(app_dir)
+
+        out, err = self.run_manage(["startapp", "app", "destination"])
+
+        self.assertNoOutput(out)
+        self.assertNoOutput(err)
+        self.assertTrue(os.path.exists(os.path.join(app_dir, "apps.py")))
+
+    def test_existing_target_directory_conflicts_with_namespace_package(self):
+        """
+        startapp rejects a target that conflicts with another namespace
+        package.
+        """
+        app_dir = os.path.join(self.test_dir, "destination")
+        os.mkdir(app_dir)
+
+        namespace_dir = os.path.join(
+            os.path.dirname(self.test_dir),
+            "destination",
+        )
+        os.mkdir(namespace_dir)
+
+        _, err = self.run_manage(["startapp", "app", "destination"])
+
+        self.assertOutput(
+            err,
+            "CommandError: 'destination' conflicts with the name of an existing "
+            "Python module and cannot be used as an app directory. Please try "
+            "another directory.",
+        )
+
     def test_trailing_slash_in_target_app_directory_name(self):
         app_dir = os.path.join(self.test_dir, "apps", "app1")
         os.makedirs(app_dir)


### PR DESCRIPTION
#### Trac ticket number

ticket-36533

#### Branch description
<!-- Provide a concise overview of the issue or rationale behind the proposed changes. Minimum five words. -->
Fixes manage.py startapp incorrectly rejecting an existing target directory  when python discovers it as a namespace package.

I referenced past pr attempts for this ticket (#20407 and #19708) I liked @jacobtylerwalls 's suggestion of an allow_empty parameter. I built on that idea by passing the target directory path to the validation function. The validation now check the returned module spec to determine whether the namespace package points to the requested target directory

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
<!-- If AI tools were used, provide which tools were used here. -->
I used ChatGPT to assist with analyzing the ticket and review the code changes I was making.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
