### PR TITLE
Fixed #36539 -- Fixed verbose_name on related fields being ignored for admin label generation.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -726,6 +726,7 @@ answer newbie questions, and generally made Django that much better:
     Matt Deacalion Stevens <matt@dirtymonkey.co.uk>
     Matt Dennenbaum
     Matthew Flanagan <https://wadofstuff.blogspot.com/>
+    Matthew Newton <https://www.mahnamahna.net/>
     Matthew Schinckel <matt@schinckel.net>
     Matthew Shirley <matt@mattshirley.net>
     Matthew Somerville <matthew-django@dracos.co.uk>

--- a/django/contrib/admin/utils.py
+++ b/django/contrib/admin/utils.py
@@ -395,6 +395,8 @@ def label_for_field(name, model, model_admin=None, return_attr=False, form=None)
 
             if hasattr(attr, "short_description"):
                 label = attr.short_description
+            elif hasattr(attr, "verbose_name") and attr.verbose_name != attr.name:
+                label = attr.verbose_name
             elif (
                 isinstance(attr, property)
                 and hasattr(attr, "fget")

--- a/tests/admin_utils/models.py
+++ b/tests/admin_utils/models.py
@@ -5,6 +5,7 @@ from django.utils.translation import gettext_lazy as _
 
 class Site(models.Model):
     domain = models.CharField(max_length=100)
+    owner = models.CharField(verbose_name=_("Site's owner"), blank=True, null=True)
     parent = models.ForeignKey(
         "self", models.CASCADE, related_name="children", blank=True, null=True
     )

--- a/tests/admin_utils/tests.py
+++ b/tests/admin_utils/tests.py
@@ -408,6 +408,8 @@ class UtilsTests(SimpleTestCase):
             label_for_field("site__domain", Article, return_attr=True),
             ("Site  domain", Site._meta.get_field("domain")),
         )
+        # Ensure explicit verbose_name on related field is respected.
+        self.assertEqual(label_for_field("site__owner", Article), "Site's owner")
 
     def test_label_for_field_failed_lookup(self):
         msg = "Unable to lookup 'site__unknown' on Article"


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-36539

#### Branch description
Admin list_display labels did not respect verbose_name on related fields. Now they do!

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [X] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
<!-- If AI tools were used, provide which tools were used here. -->

#### Checklist
- [X] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [X] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [X] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
