### PR TITLE
Fixed #99999 -- Added a shortcut function to make toast.

### DIFF
--- a/django/shortcuts.py
+++ b/django/shortcuts.py
@@ -209,3 +209,7 @@ def resolve_url(to, *args, **kwargs):
 
     # Finally, fall back and assume it's a URL
     return to
+
+
+def make_toast():
+    return 'toast'

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -34,6 +34,11 @@ What's new in Django 6.2
 Minor features
 --------------
 
+:mod:`django.shortcuts`
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* The new :func:`django.shortcuts.make_toast` function returns ``'toast'``.
+
 :mod:`django.contrib.admin`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/topics/http/shortcuts.txt
+++ b/docs/topics/http/shortcuts.txt
@@ -393,3 +393,11 @@ This example is equivalent to::
         if not my_objects:
             raise Http404("No MyModel matches the given query.")
 
+``make_toast()``
+================
+
+.. function:: make_toast()
+
+.. versionadded:: 6.2
+
+Returns ``'toast'``.

--- a/tests/shortcuts/test_make_toast.py
+++ b/tests/shortcuts/test_make_toast.py
@@ -1,0 +1,7 @@
+from django.shortcuts import make_toast
+from django.test import SimpleTestCase
+
+
+class MakeToastTests(SimpleTestCase):
+    def test_make_toast(self):
+        self.assertEqual(make_toast(), 'toast')


### PR DESCRIPTION
#### Trac ticket number

<!-- Replace XXXXX with the corresponding Trac ticket number. -->

<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-99999

#### Branch description

<!-- Provide a concise overview of the issue or rationale behind the proposed changes. Minimum five words. -->

Added a shortcut function for rendering toast messages.

#### AI Assistance Disclosure (REQUIRED)

* [ ] **No AI tools were used** in preparing this PR.
* [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

AI tool used: ChatGPT. I reviewed and verified the generated guidance and code changes before submitting this PR.

#### Checklist

* [x] This PR follows the [[contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/)](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
* [x] This PR **does not** disclose a security vulnerability (see [[vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)](https://docs.djangoproject.com/en/stable/internals/security/)).
* [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
* [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [[guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
* [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->

* [x] I have checked the "Has patch" ticket flag in the Trac system.
* [x] I have added or updated relevant tests.
* [x] I have added or updated relevant docs, including release notes if applicable.