### PR TITLE
Fixed #37280 -- Marked CSP nonce responses Cache-Control: private

### DIFF
--- a/django/middleware/csp.py
+++ b/django/middleware/csp.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.middleware import MiddlewareMixin
+from django.utils.cache import patch_cache_control
 from django.utils.csp import CSP, LazyNonce, build_policy
 
 
@@ -8,6 +9,9 @@ def get_nonce(request):
 
 
 class ContentSecurityPolicyMiddleware(MiddlewareMixin):
+    # Subclass and set to False if you handle nonce-safe caching yourself.
+    nonce_cache_control = True
+
     def process_request(self, request):
         request._csp_nonce = LazyNonce()
 
@@ -29,5 +33,9 @@ class ContentSecurityPolicyMiddleware(MiddlewareMixin):
             # An empty config means CSP headers are not added to the response.
             if config and header not in response:
                 response.headers[str(header)] = build_policy(config, nonce)
+
+        # A nonce is single-use; don't let a shared cache replay it.
+        if nonce and self.nonce_cache_control:
+            patch_cache_control(response, private=True)
 
         return response

--- a/docs/ref/csp.txt
+++ b/docs/ref/csp.txt
@@ -321,3 +321,6 @@ To ensure nonce-based policies remain effective:
 * If caching is necessary, use a strategy that injects a fresh nonce on each
   request, or consider refactoring your application to avoid inline scripts and
   styles altogether.
+* ``ContentSecurityPolicyMiddleware`` sets ``Cache-Control: private`` on
+  nonce-rendering responses automatically, though this doesn't cover
+  ``cache_page`` please see :ref:`this note <cache-page-response-middleware>`.

--- a/docs/ref/csp.txt
+++ b/docs/ref/csp.txt
@@ -323,4 +323,4 @@ To ensure nonce-based policies remain effective:
   styles altogether.
 * ``ContentSecurityPolicyMiddleware`` sets ``Cache-Control: private`` on
   nonce-rendering responses automatically, though this doesn't cover
-  ``cache_page`` please see :ref:`this note <cache-page-response-middleware>`.
+  ``cache_page``, since it caches the response before any middleware runs.

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -116,7 +116,10 @@ Cache
 CSP
 ~~~
 
-* ...
+* :class:`~django.middleware.csp.ContentSecurityPolicyMiddleware` now sets
+  ``Cache-Control: private`` on responses that render a nonce, to stop shared
+  caches replaying it to other users. Set ``nonce_cache_control = False`` on
+  a subclass to opt out.
 
 CSRF
 ~~~~

--- a/tests/middleware/test_csp.py
+++ b/tests/middleware/test_csp.py
@@ -2,11 +2,17 @@ from playwright_tests import PlaywrightTestCase
 from utils_tests.test_csp import basic_config, basic_policy
 
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from django.core.cache import DEFAULT_CACHE_ALIAS, caches
+from django.middleware.csp import ContentSecurityPolicyMiddleware
 from django.test import SimpleTestCase
 from django.test.utils import modify_settings, override_settings
 from django.utils.csp import CSP
 
 from .views import csp_reports
+
+
+class CSPMiddlewareCachingDisabled(ContentSecurityPolicyMiddleware):
+    nonce_cache_control = False
 
 
 @override_settings(
@@ -46,12 +52,46 @@ class CSPMiddlewareTest(SimpleTestCase):
     def test_csp_basic_with_nonce_but_unused(self):
         """
         Test if `request.csp_nonce` is never accessed, it is not added to the
-        header.
+        header, and caching is left untouched.
         """
         response = self.client.get("/csp-base/")
         nonce = response.text
         self.assertIsNotNone(nonce)
         self.assertEqual(response[CSP.HEADER_ENFORCE], basic_policy)
+        self.assertNotIn("Cache-Control", response)
+
+    @override_settings(SECURE_CSP={"default-src": [CSP.SELF, CSP.NONCE]})
+    def test_csp_nonce_overrides_explicit_public_cache_control(self):
+        """A rendered nonce overrides an explicit public Cache-Control."""
+        response = self.client.get("/csp-nonce-public/")
+        self.assertTrue(response.text)
+        self.assertIn("private", response["Cache-Control"])
+        self.assertNotIn("public", response["Cache-Control"])
+
+    @override_settings(
+        MIDDLEWARE=["middleware.test_csp.CSPMiddlewareCachingDisabled"],
+        SECURE_CSP={"default-src": [CSP.SELF, CSP.NONCE]},
+    )
+    def test_csp_nonce_cache_control_can_be_disabled(self):
+        """A project that opts out shouldn't get Cache-Control forced on it."""
+        response = self.client.get("/csp-nonce/")
+        self.assertTrue(response.text)
+        self.assertNotIn("Cache-Control", response)
+
+    @override_settings(
+        MIDDLEWARE=[
+            "django.middleware.cache.UpdateCacheMiddleware",
+            "django.middleware.csp.ContentSecurityPolicyMiddleware",
+            "django.middleware.cache.FetchFromCacheMiddleware",
+        ],
+        SECURE_CSP={"default-src": [CSP.SELF, CSP.NONCE]},
+    )
+    def test_csp_nonce_not_reused_across_cached_responses(self):
+        """A cached response must not replay one visitor's nonce to another."""
+        self.addCleanup(caches[DEFAULT_CACHE_ALIAS].clear)
+        first_nonce = self.client.get("/csp-nonce/").text
+        second_nonce = self.client.get("/csp-nonce/").text
+        self.assertNotEqual(first_nonce, second_nonce)
 
     @override_settings(SECURE_CSP=None, SECURE_CSP_REPORT_ONLY=basic_config)
     def test_csp_report_only_basic(self):

--- a/tests/middleware/urls.py
+++ b/tests/middleware/urls.py
@@ -16,6 +16,7 @@ urlpatterns = [
     path("csp-report/", views.csp_report_view),
     path("csp-base/", views.empty_view),
     path("csp-nonce/", views.csp_nonce),
+    path("csp-nonce-public/", views.csp_nonce_public),
     path("csp-disabled-both/", views.csp_disabled_both),
     path("csp-disabled-enforced/", views.csp_disabled_enforced),
     path("csp-disabled-report-only/", views.csp_disabled_ro),

--- a/tests/middleware/views.py
+++ b/tests/middleware/views.py
@@ -6,6 +6,7 @@ from django.middleware.csp import get_nonce
 from django.utils.csp import CSP
 from django.utils.decorators import method_decorator
 from django.views.debug import default_urlconf, technical_500_response
+from django.views.decorators.cache import cache_control
 from django.views.decorators.common import no_append_slash
 from django.views.decorators.csp import csp_override, csp_report_only_override
 from django.views.decorators.csrf import csrf_exempt
@@ -28,6 +29,11 @@ class SensitiveCBV(View):
 
 
 def csp_nonce(request):
+    return HttpResponse(get_nonce(request))
+
+
+@cache_control(public=True)
+def csp_nonce_public(request):
     return HttpResponse(get_nonce(request))
 
 


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37280

#### Branch description
<!-- Provide a concise overview of the issue or rationale behind the proposed changes. Minimum five words. -->
`ContentSecurityPolicyMiddleware` now marks a response `Cache-Control: private` whenever it renders a CSP nonce, so shared caches can't store the response and replay one visitor's nonce to another. Since a nonce is only supposed to be valid for a single response, letting it leak into a shared cache silently defeats the whole point of using one.

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [X] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
<!-- If AI tools were used, provide which tools were used here. -->
Claude code used to understand the issue it was fixing, what the patch needs to be and find out the places where the tests needed to be added. I have reviewed, ran the full test suite locally and verified the output.


#### Checklist
- [X] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [X] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
