### PR TITLE
Fixed #37304 -- Prevented serializing local classes in migrations.

### DIFF
--- a/django/db/migrations/serializer.py
+++ b/django/db/migrations/serializer.py
@@ -339,6 +339,11 @@ class TypeSerializer(BaseSerializer):
                 return string, set(imports)
         if hasattr(self.value, "__module__"):
             module = self.value.__module__
+            if "<" in self.value.__qualname__:
+                raise ValueError(
+                    "Cannot serialize class %s: local classes cannot be imported."
+                    % self.value.__name__
+                )
             if module == builtins.__name__:
                 return self.value.__name__, set()
             else:

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -2,6 +2,7 @@ import datetime
 import decimal
 import enum
 import functools
+import json
 import math
 import os
 import pathlib
@@ -970,6 +971,24 @@ class WriterTests(SimpleTestCase):
             MigrationWriter.serialize(models.Model),
             ("('models.Model', {'from django.db import models'})", set()),
         )
+
+    def test_serialize_type_local_class(self):
+        class LocalClass:
+            pass
+
+        msg = "Cannot serialize class LocalClass: local classes cannot be imported."
+        with self.assertRaisesMessage(ValueError, msg):
+            MigrationWriter.serialize(LocalClass)
+
+    def test_serialize_jsonfield_with_local_decoder(self):
+        class LocalJSONDecoder(json.JSONDecoder):
+            pass
+
+        msg = (
+            "Cannot serialize class LocalJSONDecoder: local classes cannot be imported."
+        )
+        with self.assertRaisesMessage(ValueError, msg):
+            MigrationWriter.serialize(models.JSONField(decoder=LocalJSONDecoder))
 
     def test_database_on_delete_serializer_value(self):
         db_level_on_delete_options = [


### PR DESCRIPTION
#### Trac ticket number

ticket-37304

#### Branch description

Prevented migration serialization from emitting invalid Python for local classes.

When a `JSONField` uses a decoder class defined in local scope, `TypeSerializer` currently serializes the class path with `<locals>`, which creates a syntactically invalid migration. `FunctionTypeSerializer` already rejects local functions, so this patch applies the same kind of early validation to local classes and raises a clear serialization error instead.

The regression tests cover both direct local-class serialization and the reported `JSONField(decoder=...)` case.

Tested with:

```console
PYTHONPATH=. python tests/runtests.py migrations.test_writer --verbosity 1 --parallel 1
```

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Codex was used to help inspect the ticket, prepare the patch, and review the final diff. I manually reviewed and verified the generated changes and test coverage.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
