### PR TITLE
Skipped more tests for 1-element GeometryCollections on Oracle 23.9.

### DIFF
--- a/django/contrib/gis/db/backends/oracle/features.py
+++ b/django/contrib/gis/db/backends/oracle/features.py
@@ -33,6 +33,8 @@ class DatabaseFeatures(BaseSpatialFeatures, OracleDatabaseFeatures):
             skips.update(
                 {
                     "Oracle 23ai unpacks 1-element geometry collections.": {
+                        "gis_tests.geogapp.tests.GeographyTest."
+                        "test05_geography_layermapping",
                         "gis_tests.layermap.tests.LayerMapTest."
                         "test_layermap_unique_multigeometry_fk",
                         "gis_tests.layermap.tests.LayerMapTest."


### PR DESCRIPTION
Follow-up to cccc004b46f71b4e54d87b376be691a17de6b903.
```py
ERROR: test05_geography_layermapping (gis_tests.geogapp.tests.GeographyTest.test05_geography_layermapping)
Testing LayerMapping support on models with geography fields.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/django/source/tests/gis_tests/geogapp/tests.py", line 107, in test05_geography_layermapping
    lm.save(silent=True, strict=True)
    ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/django/source/django/contrib/gis/utils/layermapping.py", line 737, in save
    _save()
    ~~~~~^^
  File "/django/source/django/contrib/gis/utils/layermapping.py", line 663, in _save
    geom.add(g)
    ^^^^^^^^
AttributeError: 'Polygon' object has no attribute 'add'
```