### PR TITLE
Fixed #37232 -- Added support for the HTTP QUERY method.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -2039,7 +2039,7 @@ class ModelAdmin(BaseModelAdmin):
 
     @csrf_protect_m
     def changeform_view(self, request, object_id=None, form_url="", extra_context=None):
-        if request.method in ("GET", "HEAD", "OPTIONS", "TRACE"):
+        if request.method in ("GET", "HEAD", "OPTIONS", "QUERY", "TRACE"):
             return self._changeform_view(request, object_id, form_url, extra_context)
 
         with transaction.atomic(using=router.db_for_write(self.model)):
@@ -2482,7 +2482,7 @@ class ModelAdmin(BaseModelAdmin):
 
     @csrf_protect_m
     def delete_view(self, request, object_id, extra_context=None):
-        if request.method in ("GET", "HEAD", "OPTIONS", "TRACE"):
+        if request.method in ("GET", "HEAD", "OPTIONS", "QUERY", "TRACE"):
             return self._delete_view(request, object_id, extra_context)
 
         with transaction.atomic(using=router.db_for_write(self.model)):

--- a/django/contrib/auth/admin.py
+++ b/django/contrib/auth/admin.py
@@ -112,7 +112,7 @@ class UserAdmin(admin.ModelAdmin):
 
     @method_decorator([sensitive_post_parameters(), csrf_protect])
     def add_view(self, request, form_url="", extra_context=None):
-        if request.method in ("GET", "HEAD", "OPTIONS", "TRACE"):
+        if request.method in ("GET", "HEAD", "OPTIONS", "QUERY", "TRACE"):
             return self._add_view(request, form_url, extra_context)
 
         with transaction.atomic(using=router.db_for_write(self.model)):

--- a/django/middleware/common.py
+++ b/django/middleware/common.py
@@ -78,12 +78,18 @@ class CommonMiddleware(MiddlewareMixin):
         Return the full path of the request with a trailing slash appended.
 
         Raise a RuntimeError if settings.DEBUG is True and request.method is
-        DELETE, POST, PUT, or PATCH.
+        DELETE, POST, PUT, PATCH, or QUERY.
         """
         new_path = request.get_full_path(force_append_slash=True)
         # Prevent construction of scheme relative urls.
         new_path = escape_leading_slashes(new_path)
-        if settings.DEBUG and request.method in ("DELETE", "POST", "PUT", "PATCH"):
+        if settings.DEBUG and request.method in (
+            "DELETE",
+            "POST",
+            "PUT",
+            "PATCH",
+            "QUERY",
+        ):
             raise RuntimeError(
                 "You called this URL via %(method)s, but the URL doesn't end "
                 "in a slash and you have APPEND_SLASH set. Django can't "

--- a/django/middleware/csrf.py
+++ b/django/middleware/csrf.py
@@ -420,9 +420,9 @@ class CsrfViewMiddleware(MiddlewareMixin):
         if getattr(callback, "csrf_exempt", False):
             return None
 
-        # Assume that anything not defined as 'safe' by RFC 9110 needs
-        # protection
-        if request.method in ("GET", "HEAD", "OPTIONS", "TRACE"):
+        # Assume that anything not defined as 'safe' by RFC 9110 and RFC 10008
+        # needs protection
+        if request.method in ("GET", "HEAD", "OPTIONS", "QUERY", "TRACE"):
             return self._accept(request)
 
         if getattr(request, "_dont_enforce_csrf_checks", False):

--- a/django/middleware/csrf.py
+++ b/django/middleware/csrf.py
@@ -420,8 +420,8 @@ class CsrfViewMiddleware(MiddlewareMixin):
         if getattr(callback, "csrf_exempt", False):
             return None
 
-        # Assume that anything not defined as 'safe' by RFC 9110 and RFC 10008
-        # needs protection
+        # Skip CSRF checks for methods defined as 'safe' by RFC 9110 and
+        # RFC 10008.
         if request.method in ("GET", "HEAD", "OPTIONS", "QUERY", "TRACE"):
             return self._accept(request)
 

--- a/django/middleware/http.py
+++ b/django/middleware/http.py
@@ -5,7 +5,7 @@ from django.utils.http import parse_http_date_safe, split_directive_names
 
 class ConditionalGetMiddleware(MiddlewareMixin):
     """
-    Handle conditional GET operations. If the response has an ETag or
+    Handle conditional GET and QUERY operations. If the response has an ETag or
     Last-Modified header and the request has If-None-Match or
     If-Modified-Since, replace the response with HttpNotModified. Add an ETag
     header if needed.
@@ -15,7 +15,7 @@ class ConditionalGetMiddleware(MiddlewareMixin):
         # It's too late to prevent an unsafe request with a 412 response, and
         # for a HEAD request, the response body is always empty so computing
         # an accurate ETag isn't possible.
-        if request.method != "GET":
+        if request.method not in ("GET", "QUERY"):
             return response
 
         if self.needs_etag(response) and not response.has_header("ETag"):

--- a/django/test/client.py
+++ b/django/test/client.py
@@ -633,6 +633,30 @@ class RequestFactory:
             **extra,
         )
 
+    def query(
+        self,
+        path,
+        data="",
+        content_type="application/octet-stream",
+        secure=False,
+        *,
+        headers=None,
+        query_params=None,
+        **extra,
+    ):
+        """Construct a QUERY request."""
+        data = self._encode_json(data, content_type)
+        return self.generic(
+            "QUERY",
+            path,
+            data,
+            content_type,
+            secure=secure,
+            headers=headers,
+            query_params=query_params,
+            **extra,
+        )
+
     def generic(
         self,
         method,
@@ -1350,6 +1374,41 @@ class Client(ClientMixin, RequestFactory):
             )
         return response
 
+    def query(
+        self,
+        path,
+        data="",
+        content_type="application/octet-stream",
+        follow=False,
+        secure=False,
+        *,
+        headers=None,
+        query_params=None,
+        **extra,
+    ):
+        """Send a QUERY request to the server."""
+        self.extra = extra
+        self.headers = headers
+        response = super().query(
+            path,
+            data=data,
+            content_type=content_type,
+            secure=secure,
+            headers=headers,
+            query_params=query_params,
+            **extra,
+        )
+        if follow:
+            response = self._handle_redirects(
+                response,
+                data=data,
+                content_type=content_type,
+                headers=headers,
+                query_params=query_params,
+                **extra,
+            )
+        return response
+
     def trace(
         self,
         path,
@@ -1688,6 +1747,41 @@ class AsyncClient(ClientMixin, AsyncRequestFactory):
         self.extra = extra
         self.headers = headers
         response = await super().delete(
+            path,
+            data=data,
+            content_type=content_type,
+            secure=secure,
+            headers=headers,
+            query_params=query_params,
+            **extra,
+        )
+        if follow:
+            response = await self._ahandle_redirects(
+                response,
+                data=data,
+                content_type=content_type,
+                headers=headers,
+                query_params=query_params,
+                **extra,
+            )
+        return response
+
+    async def query(
+        self,
+        path,
+        data="",
+        content_type="application/octet-stream",
+        follow=False,
+        secure=False,
+        *,
+        headers=None,
+        query_params=None,
+        **extra,
+    ):
+        """Send a QUERY request to the server."""
+        self.extra = extra
+        self.headers = headers
+        response = await super().query(
             path,
             data=data,
             content_type=content_type,

--- a/django/utils/cache.py
+++ b/django/utils/cache.py
@@ -195,7 +195,7 @@ def get_conditional_response(request, etag=None, last_modified=None, response=No
 
     # Step 3: Test the If-None-Match precondition.
     if if_none_match_etags and not _if_none_match_passes(etag, if_none_match_etags):
-        if request.method in ("GET", "HEAD"):
+        if request.method in ("GET", "HEAD", "QUERY"):
             return _not_modified(request, response)
         else:
             return _precondition_failed(request)
@@ -205,7 +205,7 @@ def get_conditional_response(request, etag=None, last_modified=None, response=No
         not if_none_match_etags
         and if_modified_since
         and not _if_modified_since_passes(last_modified, if_modified_since)
-        and request.method in ("GET", "HEAD")
+        and request.method in ("GET", "HEAD", "QUERY")
     ):
         return _not_modified(request, response)
 

--- a/django/views/decorators/http.py
+++ b/django/views/decorators/http.py
@@ -73,9 +73,9 @@ require_GET.__doc__ = "Decorator to require that a view only accepts the GET met
 require_POST = require_http_methods(["POST"])
 require_POST.__doc__ = "Decorator to require that a view only accepts the POST method."
 
-require_safe = require_http_methods(["GET", "HEAD"])
+require_safe = require_http_methods(["GET", "HEAD", "QUERY"])
 require_safe.__doc__ = (
-    "Decorator to require that a view only accepts safe methods: GET and HEAD."
+    "Decorator to require that a view only accepts safe methods: GET, HEAD, and QUERY."
 )
 
 
@@ -124,7 +124,7 @@ def condition(etag_func=None, last_modified_func=None):
         def _post_process_request(request, response, res_etag, res_last_modified):
             # Set relevant headers on the response if they don't already exist
             # and if the request method is safe.
-            if request.method in ("GET", "HEAD"):
+            if request.method in ("GET", "HEAD", "QUERY"):
                 if res_last_modified and not response.has_header("Last-Modified"):
                     response.headers["Last-Modified"] = http_date(res_last_modified)
                 if res_etag:

--- a/django/views/generic/base.py
+++ b/django/views/generic/base.py
@@ -49,6 +49,7 @@ class View:
         "head",
         "options",
         "trace",
+        "query",
     ]
 
     def __init__(self, **kwargs):
@@ -288,4 +289,7 @@ class RedirectView(View):
         return self.get(request, *args, **kwargs)
 
     def patch(self, request, *args, **kwargs):
+        return self.get(request, *args, **kwargs)
+
+    def query(self, request, *args, **kwargs):
         return self.get(request, *args, **kwargs)

--- a/docs/ref/class-based-views/base.txt
+++ b/docs/ref/class-based-views/base.txt
@@ -57,7 +57,21 @@ ancestor classes are  documented under the section title of **Ancestors
 
         Default::
 
-            ["get", "post", "put", "patch", "delete", "head", "options", "trace"]
+            [
+                "get",
+                "post",
+                "put",
+                "patch",
+                "delete",
+                "head",
+                "options",
+                "trace",
+                "query",
+            ]
+
+        .. versionchanged:: 6.2
+
+            ``"query"`` was added to the default list.
 
     **Methods**
 

--- a/docs/ref/csrf.txt
+++ b/docs/ref/csrf.txt
@@ -45,9 +45,10 @@ The CSRF protection is based on the following things:
 
    This part is done by the :ttag:`csrf_token` template tag.
 
-#. For all incoming requests that are not using HTTP GET, HEAD, OPTIONS or
-   TRACE, a CSRF cookie must be present, and the 'csrfmiddlewaretoken' field
-   must be present and correct. If it isn't, the user will get a 403 error.
+#. For all incoming requests that are not using HTTP GET, HEAD, OPTIONS,
+   QUERY, or TRACE, a CSRF cookie must be present, and the
+   'csrfmiddlewaretoken' field must be present and correct. If it isn't, the
+   user will get a 403 error.
 
    When validating the 'csrfmiddlewaretoken' field value, only the secret,
    not the full token, is compared with the secret in the cookie value.

--- a/docs/ref/middleware.txt
+++ b/docs/ref/middleware.txt
@@ -147,14 +147,18 @@ Conditional GET middleware
 
 .. class:: ConditionalGetMiddleware
 
-    Handles conditional GET operations. If the response doesn't have an
-    ``ETag`` header, the middleware adds one if needed. If the response has an
-    ``ETag`` or ``Last-Modified`` header, and the request has ``If-None-Match``
-    or ``If-Modified-Since``, the response is replaced by an
+    Handles conditional GET and QUERY operations. If the response doesn't
+    have an ``ETag`` header, the middleware adds one if needed. If the
+    response has an ``ETag`` or ``Last-Modified`` header, and the request has
+    ``If-None-Match`` or ``If-Modified-Since``, the response is replaced by an
     :class:`~django.http.HttpResponseNotModified`.
 
     You can handle conditional GET operations with individual views using the
     :func:`~django.views.decorators.http.conditional_page` decorator.
+
+    .. versionchanged:: 6.2
+
+        Handling of conditional ``QUERY`` requests was added.
 
 Locale middleware
 -----------------

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -78,6 +78,12 @@ All attributes should be considered read-only, unless stated otherwise.
         elif request.method == "POST":
             do_something_else()
 
+    Django treats the :rfc:`QUERY <10008#section-2>` method as safe and
+    idempotent, like ``GET`` and ``HEAD``: it's exempt from CSRF protection and
+    takes part in conditional request processing. The query content isn't
+    parsed into :attr:`HttpRequest.POST`; read it from :attr:`HttpRequest.body`
+    and parse it according to the request's ``Content-Type``.
+
 .. attribute:: HttpRequest.encoding
 
     A string representing the current encoding used to decode form submission

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -31,6 +31,49 @@ only officially support the latest release of each series.
 What's new in Django 6.2
 ========================
 
+Support for the HTTP ``QUERY`` method
+-------------------------------------
+
+Django now recognizes the :rfc:`QUERY <10008>` method, which performs a safe,
+idempotent query with the query content in the request body rather than in the
+URL's query string.
+
+``QUERY`` is treated as a safe method throughout Django: it is exempt from CSRF
+protection, it participates in conditional request processing via
+:class:`~django.middleware.http.ConditionalGetMiddleware` and
+:func:`~django.views.decorators.http.condition`, and it is accepted by
+:func:`~django.views.decorators.http.require_safe`.
+:attr:`View.http_method_names
+<django.views.generic.base.View.http_method_names>` now includes ``"query"``,
+so a class-based view handles ``QUERY`` requests by defining a ``query()``
+method::
+
+    import json
+
+    from django.http import JsonResponse
+    from django.views import View
+    from books.models import Book
+
+
+    class BookSearchView(View):
+        def query(self, request):
+            criteria = json.loads(request.body)
+            authors = criteria["authors"]
+            books = Book.objects.filter(authors__name__in=authors).distinct()
+            return JsonResponse({"books": list(books.values("title"))})
+
+The query content is available as :attr:`HttpRequest.body
+<django.http.HttpRequest.body>` and is not parsed into
+:attr:`HttpRequest.POST <django.http.HttpRequest.POST>`; parse it yourself
+according to the request's ``Content-Type``.
+
+Caching of ``QUERY`` responses is not supported yet. The cache key for a
+``QUERY`` request must incorporate the request content, which
+:class:`~django.middleware.cache.UpdateCacheMiddleware`,
+:class:`~django.middleware.cache.FetchFromCacheMiddleware`, and
+:func:`~django.views.decorators.cache.cache_page` don't do, so they continue to
+ignore ``QUERY`` requests.
+
 Minor features
 --------------
 
@@ -235,6 +278,10 @@ Tests
   :setting:`AUTHENTICATION_BACKENDS` not implementing ``(a)get_user()``, e.g.
   permission-only backends.
 
+* The new :meth:`.Client.query` method makes an HTTP ``QUERY`` request. It is
+  also available on ``AsyncClient``, ``RequestFactory``, and
+  ``AsyncRequestFactory``.
+
 URLs
 ~~~~
 
@@ -293,6 +340,20 @@ Tests
 
 Miscellaneous
 -------------
+
+* Views decorated with :func:`~django.views.decorators.http.require_safe` now
+  also accept the ``QUERY`` method, which :rfc:`RFC 10008 <10008#section-2>`
+  defines as safe and idempotent. Use ``require_http_methods(["GET", "HEAD"])``
+  to keep the previous behavior.
+
+* :class:`~django.middleware.http.ConditionalGetMiddleware` now computes
+  ``ETag`` headers for, and returns HTTP 304 responses to, conditional
+  ``QUERY`` requests.
+
+* With :setting:`DEBUG` and :setting:`APPEND_SLASH` enabled,
+  :class:`~django.middleware.common.CommonMiddleware` now raises a
+  ``RuntimeError`` for ``QUERY`` requests to a URL without a trailing slash, as
+  it already did for ``DELETE``, ``POST``, ``PUT``, and ``PATCH``.
 
 * To facilitate the deprecation of the ``safe`` parameter of
   :class:`~django.http.JsonResponse`, it now defaults to ``False``, because the

--- a/docs/topics/http/decorators.txt
+++ b/docs/topics/http/decorators.txt
@@ -43,10 +43,14 @@ a :class:`django.http.HttpResponseNotAllowed` if the conditions are not met.
 
 .. function:: require_safe()
 
-    Decorator to require that a view only accepts the GET and HEAD methods.
-    These methods are commonly considered "safe" because they should not have
-    the significance of taking an action other than retrieving the requested
-    resource.
+    Decorator to require that a view only accepts the GET, HEAD, and QUERY
+    methods. These methods are commonly considered "safe" because they should
+    not have the significance of taking an action other than retrieving the
+    requested resource.
+
+    .. versionchanged:: 6.2
+
+        The ``QUERY`` method was added to the accepted methods.
 
     .. note::
         Web servers should automatically strip the content of responses to HEAD

--- a/docs/topics/testing/advanced.txt
+++ b/docs/topics/testing/advanced.txt
@@ -22,7 +22,7 @@ restricted subset of the test client API:
 * It only has access to the HTTP methods :meth:`~Client.get`,
   :meth:`~Client.post`, :meth:`~Client.put`,
   :meth:`~Client.delete`, :meth:`~Client.head`,
-  :meth:`~Client.options`, and :meth:`~Client.trace`.
+  :meth:`~Client.options`, :meth:`~Client.trace`, and :meth:`~Client.query`.
 
 * These methods accept all the same arguments *except* for
   ``follow``. Since this is just a factory for producing

--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -400,6 +400,22 @@ Use the ``django.test.Client`` class to make requests.
         The ``follow``, ``secure``, ``headers``, ``query_params``, and
         ``extra`` parameters act the same as for :meth:`Client.get`.
 
+    .. method:: Client.query(path, data='', content_type='application/octet-stream', follow=False, secure=False, *, headers=None, query_params=None, **extra)
+
+        .. versionadded:: 6.2
+
+        Makes a :rfc:`QUERY <10008#section-2>` request on the provided ``path``
+        and returns a ``Response`` object. Useful for testing endpoints that
+        accept a safe, idempotent query in the request body.
+
+        When ``data`` is provided, it is used as the request body, and
+        a ``Content-Type`` header is set to ``content_type``. :rfc:`RFC 10008
+        <10008#section-2>` requires servers to reject QUERY requests without a
+        ``Content-Type``, so pass a type matching the query format you send.
+
+        The ``follow``, ``secure``, ``headers``, ``query_params``, and
+        ``extra`` parameters act the same as for :meth:`Client.get`.
+
     .. method:: Client.trace(path, follow=False, secure=False, *, headers=None, query_params=None, **extra)
 
         Makes a TRACE request on the provided ``path`` and returns a

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -26,6 +26,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core import mail
 from django.core.checks import Error
 from django.core.files import temp as tempfile
+from django.db import connection
 from django.db.models.utils import get_blank_choice_label
 from django.forms.utils import ErrorList
 from django.template.response import TemplateResponse
@@ -36,7 +37,7 @@ from django.test import (
     override_settings,
     skipUnlessDBFeature,
 )
-from django.test.utils import override_script_prefix
+from django.test.utils import CaptureQueriesContext, override_script_prefix
 from django.urls import NoReverseMatch, resolve, reverse
 from django.utils import formats, translation
 from django.utils.cache import get_max_age
@@ -324,6 +325,21 @@ class AdminViewBasicTest(AdminViewBasicTestCase):
         response = self.client.get(reverse("admin:admin_views_section_add"))
         self.assertIsInstance(response, TemplateResponse)
         self.assertEqual(response.status_code, 200)
+
+    def test_basic_add_QUERY(self):
+        """
+        QUERY on the add_view renders the form like GET
+        """
+        section_count = Section.objects.count()
+        with CaptureQueriesContext(connection) as ctx:
+            response = self.client.query(reverse("admin:admin_views_section_add"))
+        self.assertIsInstance(response, TemplateResponse)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Section.objects.count(), section_count)
+        self.assertNotIn(
+            "SAVEPOINT",
+            " ".join(query["sql"].upper() for query in ctx.captured_queries),
+        )
 
     def test_add_with_GET_args(self):
         response = self.client.get(

--- a/tests/conditional_processing/tests.py
+++ b/tests/conditional_processing/tests.py
@@ -18,7 +18,7 @@ class ConditionalGet(SimpleTestCase):
     def assertFullResponse(self, response, check_last_modified=True, check_etag=True):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, FULL_RESPONSE.encode())
-        if response.request["REQUEST_METHOD"] in ("GET", "HEAD"):
+        if response.request["REQUEST_METHOD"] in ("GET", "HEAD", "QUERY"):
             if check_last_modified:
                 self.assertEqual(response.headers["Last-Modified"], LAST_MODIFIED_STR)
             if check_etag:
@@ -246,6 +246,23 @@ class ConditionalGet(SimpleTestCase):
         self.client.defaults["HTTP_IF_MODIFIED_SINCE"] = LAST_MODIFIED_STR
         response = self.client.head("/condition/")
         self.assertNotModified(response)
+
+    def test_query_if_modified_since(self):
+        self.client.defaults["HTTP_IF_MODIFIED_SINCE"] = LAST_MODIFIED_STR
+        self.assertNotModified(self.client.query("/condition/"))
+        self.client.defaults["HTTP_IF_MODIFIED_SINCE"] = EXPIRED_LAST_MODIFIED_STR
+        self.assertFullResponse(self.client.query("/condition/"))
+
+    def test_query_if_none_match(self):
+        self.client.defaults["HTTP_IF_NONE_MATCH"] = ETAG
+        self.assertNotModified(self.client.query("/condition/"))
+        self.client.defaults["HTTP_IF_NONE_MATCH"] = EXPIRED_ETAG
+        self.assertFullResponse(self.client.query("/condition/"))
+
+    def test_query_if_unmodified_since(self):
+        self.client.defaults["HTTP_IF_UNMODIFIED_SINCE"] = EXPIRED_LAST_MODIFIED_STR
+        response = self.client.query("/condition/")
+        self.assertEqual(response.status_code, 412)
 
     def test_unquoted(self):
         """

--- a/tests/csrf_tests/tests.py
+++ b/tests/csrf_tests/tests.py
@@ -500,6 +500,14 @@ class CsrfViewMiddlewareTestMixin(CsrfFunctionTestMixin):
             resp = mw.process_view(req, post_form_view, (), {})
         self.assertForbiddenReason(resp, cm, REASON_NO_CSRF_COOKIE)
 
+    def test_query_accepted(self):
+        """
+        The HTTP QUERY method is safe (RFC 10008) and isn't CSRF protected.
+        """
+        req = self._get_request(method="QUERY")
+        mw = CsrfViewMiddleware(post_form_view)
+        self.assertIsNone(mw.process_view(req, post_form_view, (), {}))
+
     def test_put_and_delete_allowed(self):
         """
         HTTP PUT and DELETE can get through with X-CSRFToken and a cookie.

--- a/tests/decorators/test_http.py
+++ b/tests/decorators/test_http.py
@@ -72,6 +72,8 @@ class RequireSafeDecoratorTest(SimpleTestCase):
         self.assertIs(type(my_safe_view(request)), HttpResponse)
         request.method = "HEAD"
         self.assertIs(type(my_safe_view(request)), HttpResponse)
+        request.method = "QUERY"
+        self.assertIs(type(my_safe_view(request)), HttpResponse)
         request.method = "POST"
         self.assertIs(type(my_safe_view(request)), HttpResponseNotAllowed)
         request.method = "PUT"
@@ -88,6 +90,8 @@ class RequireSafeDecoratorTest(SimpleTestCase):
         request.method = "GET"
         self.assertIs(type(await async_view(request)), HttpResponse)
         request.method = "HEAD"
+        self.assertIs(type(await async_view(request)), HttpResponse)
+        request.method = "QUERY"
         self.assertIs(type(await async_view(request)), HttpResponse)
         request.method = "POST"
         self.assertIs(type(await async_view(request)), HttpResponseNotAllowed)

--- a/tests/decorators/test_http.py
+++ b/tests/decorators/test_http.py
@@ -42,6 +42,8 @@ class RequireHttpMethodsTest(SimpleTestCase):
         self.assertIs(type(my_view(request)), HttpResponseNotAllowed)
         request.method = "DELETE"
         self.assertIs(type(my_view(request)), HttpResponseNotAllowed)
+        request.method = "QUERY"
+        self.assertIs(type(my_view(request)), HttpResponseNotAllowed)
 
     async def test_require_http_methods_methods_async_view(self):
         @require_http_methods(["GET", "PUT"])
@@ -58,6 +60,8 @@ class RequireHttpMethodsTest(SimpleTestCase):
         request.method = "POST"
         self.assertIs(type(await my_view(request)), HttpResponseNotAllowed)
         request.method = "DELETE"
+        self.assertIs(type(await my_view(request)), HttpResponseNotAllowed)
+        request.method = "QUERY"
         self.assertIs(type(await my_view(request)), HttpResponseNotAllowed)
 
 

--- a/tests/generic_views/test_base.py
+++ b/tests/generic_views/test_base.py
@@ -31,6 +31,11 @@ class PostOnlyView(View):
         return HttpResponse("This view only accepts POST")
 
 
+class QueryView(View):
+    def query(self, request):
+        return HttpResponse(request.body)
+
+
 class CustomizableView(SimpleView):
     parameter = {}
 
@@ -135,6 +140,26 @@ class ViewTest(LoggingAssertionMixin, SimpleTestCase):
         """
         response = PostOnlyView.as_view()(self.rf.head("/"))
         self.assertEqual(response.status_code, 405)
+
+    def test_query(self):
+        """
+        A view supplying a query() method responds to QUERY with the query
+        content available as request.body.
+        """
+        request = self.rf.query(
+            "/", data=b"q=django", content_type="application/x-www-form-urlencoded"
+        )
+        response = QueryView.as_view()(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"q=django")
+
+    def test_query_not_allowed(self):
+        """
+        A view supplying no query() method responds to QUERY with HTTP 405.
+        """
+        response = SimpleView.as_view()(self.rf.query("/"))
+        self.assertEqual(response.status_code, 405)
+        self.assertNotIn("QUERY", response.headers["Allow"])
 
     def test_get_and_post(self):
         """
@@ -569,6 +594,12 @@ class RedirectViewTest(LoggingAssertionMixin, SimpleTestCase):
     def test_redirect_DELETE(self):
         "Default is a temporary redirect"
         response = RedirectView.as_view(url="/bar/")(self.rf.delete("/foo/"))
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, "/bar/")
+
+    def test_redirect_QUERY(self):
+        "Default is a temporary redirect"
+        response = RedirectView.as_view(url="/bar/")(self.rf.query("/foo/"))
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, "/bar/")
 

--- a/tests/middleware/tests.py
+++ b/tests/middleware/tests.py
@@ -114,8 +114,8 @@ class CommonMiddlewareTest(SimpleTestCase):
     def test_append_slash_no_redirect_in_DEBUG(self):
         """
         While in debug mode, an exception is raised with a warning
-        when a failed attempt is made to DELETE, POST, PUT, or PATCH to an URL
-        which would normally be redirected to a slashed version.
+        when a failed attempt is made to DELETE, POST, PUT, PATCH, or QUERY to
+        an URL which would normally be redirected to a slashed version.
         """
         msg = "maintaining %s data. Change your form to point to testserver/slash/"
         request = self.rf.get("/slash")
@@ -131,6 +131,9 @@ class CommonMiddlewareTest(SimpleTestCase):
         with self.assertRaisesMessage(RuntimeError, msg % request.method):
             CommonMiddleware(get_response_404)(request)
         request = self.rf.delete("/slash")
+        with self.assertRaisesMessage(RuntimeError, msg % request.method):
+            CommonMiddleware(get_response_404)(request)
+        request = self.rf.query("/slash")
         with self.assertRaisesMessage(RuntimeError, msg % request.method):
             CommonMiddleware(get_response_404)(request)
 
@@ -622,6 +625,18 @@ class ConditionalGetMiddlewareTest(SimpleTestCase):
                 self.resp_headers["Cache-Control"] = cc
                 response = ConditionalGetMiddleware(self.get_response)(self.req)
                 self.assertIs(response.has_header("ETag"), False)
+
+    def test_query_calculates_etag(self):
+        req = self.request_factory.query("/")
+        resp = ConditionalGetMiddleware(self.get_response)(req)
+        self.assertEqual(resp.status_code, 200)
+        self.assertNotEqual("", resp["ETag"])
+
+    def test_query_if_none_match_and_same_etag(self):
+        req = self.request_factory.query("/", headers={"if-none-match": '"spam"'})
+        self.resp_headers["ETag"] = '"spam"'
+        resp = ConditionalGetMiddleware(self.get_response)(req)
+        self.assertEqual(resp.status_code, 304)
 
     def test_if_none_match_and_no_etag(self):
         self.req.META["HTTP_IF_NONE_MATCH"] = "spam"

--- a/tests/middleware/tests.py
+++ b/tests/middleware/tests.py
@@ -626,18 +626,6 @@ class ConditionalGetMiddlewareTest(SimpleTestCase):
                 response = ConditionalGetMiddleware(self.get_response)(self.req)
                 self.assertIs(response.has_header("ETag"), False)
 
-    def test_query_calculates_etag(self):
-        req = self.request_factory.query("/")
-        resp = ConditionalGetMiddleware(self.get_response)(req)
-        self.assertEqual(resp.status_code, 200)
-        self.assertNotEqual("", resp["ETag"])
-
-    def test_query_if_none_match_and_same_etag(self):
-        req = self.request_factory.query("/", headers={"if-none-match": '"spam"'})
-        self.resp_headers["ETag"] = '"spam"'
-        resp = ConditionalGetMiddleware(self.get_response)(req)
-        self.assertEqual(resp.status_code, 304)
-
     def test_if_none_match_and_no_etag(self):
         self.req.META["HTTP_IF_NONE_MATCH"] = "spam"
         resp = ConditionalGetMiddleware(self.get_response)(self.req)
@@ -809,6 +797,17 @@ class ConditionalGetMiddlewareTest(SimpleTestCase):
         request = self.request_factory.head("/")
         conditional_get_response = ConditionalGetMiddleware(get_200_response)(request)
         self.assertNotIn("ETag", conditional_get_response)
+
+
+class ConditionalQueryMiddlewareTest(ConditionalGetMiddlewareTest):
+    """
+    ConditionalGetMiddleware handles a QUERY request (RFC 10008) the same way
+    as a GET request.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.req = self.request_factory.query("/")
 
 
 class XFrameOptionsMiddlewareTest(SimpleTestCase):

--- a/tests/test_client/tests.py
+++ b/tests/test_client/tests.py
@@ -199,6 +199,19 @@ class ClientTest(TestCase):
         self.assertEqual(response.context["data"], "{'foo': 'bar'}")
         self.assertEqual(response.context["Content-Length"], "14")
 
+    def test_query(self):
+        response = self.client.query(
+            "/query_view/",
+            data="q=django",
+            content_type="application/x-www-form-urlencoded",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.templates[0].name, "QUERY Template")
+        self.assertEqual(response.context["data"], "q=django")
+        self.assertEqual(
+            response.context["Content-Type"], "application/x-www-form-urlencoded"
+        )
+
     def test_trace(self):
         """TRACE a view"""
         response = self.client.trace("/trace_view/")
@@ -1307,6 +1320,14 @@ class AsyncClientTest(TestCase):
     async def test_post_data(self):
         response = await self.async_client.post("/post_view/", {"value": 37})
         self.assertContains(response, "Data received: 37 is the value.")
+
+    async def test_query_data(self):
+        response = await self.async_client.query(
+            "/query_view/",
+            data="q=django",
+            content_type="application/x-www-form-urlencoded",
+        )
+        self.assertContains(response, "Query received: q=django is the body.")
 
     async def test_body_read_on_get_data(self):
         response = await self.async_client.get("/post_view/")

--- a/tests/test_client/tests.py
+++ b/tests/test_client/tests.py
@@ -159,7 +159,7 @@ class ClientTest(TestCase):
 
     def test_json_serialization(self):
         """The test client serializes JSON data."""
-        methods = ("post", "put", "patch", "delete")
+        methods = ("post", "put", "patch", "delete", "query")
         tests = (
             ({"value": 37}, {"value": 37}),
             ([37, True], [37, True]),
@@ -367,7 +367,17 @@ class ClientTest(TestCase):
         """
         A 307 or 308 redirect preserves the request method after the redirect.
         """
-        methods = ("get", "post", "head", "options", "put", "patch", "delete", "trace")
+        methods = (
+            "get",
+            "post",
+            "head",
+            "options",
+            "put",
+            "patch",
+            "delete",
+            "trace",
+            "query",
+        )
         codes = (307, 308)
         for method, code in itertools.product(methods, codes):
             with self.subTest(method=method, code=code):
@@ -380,7 +390,7 @@ class ClientTest(TestCase):
                 self.assertEqual(response.request["REQUEST_METHOD"], method.upper())
 
     def test_follow_307_and_308_preserves_query_string(self):
-        methods = ("post", "options", "put", "patch", "delete", "trace")
+        methods = ("post", "options", "put", "patch", "delete", "trace", "query")
         codes = (307, 308)
         for method, code in itertools.product(methods, codes):
             with self.subTest(method=method, code=code):
@@ -1097,6 +1107,7 @@ class ClientTest(TestCase):
             "head",
             "options",
             "trace",
+            "query",
         )
         for method in tests:
             with self.subTest(method=method):
@@ -1259,6 +1270,7 @@ class RequestFactoryTest(SimpleTestCase):
             "head",
             "options",
             "trace",
+            "query",
         )
         for method in tests:
             with self.subTest(method=method):
@@ -1298,6 +1310,7 @@ class AsyncClientTest(TestCase):
             "head",
             "options",
             "trace",
+            "query",
         )
         for method_name in tests:
             with self.subTest(method=method_name):
@@ -1343,6 +1356,7 @@ class AsyncClientTest(TestCase):
             "head",
             "options",
             "trace",
+            "query",
         )
         for method in tests:
             with self.subTest(method=method):
@@ -1367,6 +1381,7 @@ class AsyncRequestFactoryTest(SimpleTestCase):
             "head",
             "options",
             "trace",
+            "query",
         )
         for method_name in tests:
             with self.subTest(method=method_name):
@@ -1457,6 +1472,7 @@ class AsyncRequestFactoryTest(SimpleTestCase):
             "head",
             "options",
             "trace",
+            "query",
         )
         for method in tests:
             with self.subTest(method=method):

--- a/tests/test_client/urls.py
+++ b/tests/test_client/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     path("post_view/", views.post_view),
     path("post_then_get_view/", views.post_then_get_view),
     path("put_view/", views.put_view),
+    path("query_view/", views.query_view),
     path("trace_view/", views.trace_view),
     path("header_view/", views.view_with_header),
     path("raw_post_view/", views.raw_post_view),

--- a/tests/test_client/views.py
+++ b/tests/test_client/views.py
@@ -75,6 +75,21 @@ def put_view(request):
     return HttpResponse(t.render(c))
 
 
+def query_view(request):
+    if request.method == "QUERY":
+        t = Template("Query received: {{ data }} is the body.", name="QUERY Template")
+        c = Context(
+            {
+                "Content-Type": request.META["CONTENT_TYPE"],
+                "data": request.body.decode(),
+            }
+        )
+    else:
+        t = Template("Viewing GET page.", name="Empty GET Template")
+        c = Context()
+    return HttpResponse(t.render(c))
+
+
 def post_view(request):
     """A view that expects a POST, and returns a different template depending
     on whether any POST data is available


### PR DESCRIPTION
#### Trac ticket number

ticket-37232

#### Branch description

Implements the HTTP QUERY method (RFC 10008) as a safe, idempotent method
throughout Django: exempt from CSRF protection, evaluated for request
preconditions as GET is, accepted by `require_safe()`, and dispatched by
`View` via a `query()` handler. `Client.query()` is added to the test client,
async client, and both request factories. Query content is exposed as
`HttpRequest.body` and is not parsed into `HttpRequest.POST`, per the
discussion in comment 5 on the ticket.

Caching is deliberately left for a follow-up. RFC 10008 Section 2.7 requires
the cache key to incorporate the request content, which the cache middleware
and `cache_page()` don't do, so they continue to ignore QUERY. This is stated
in the release notes so there are no silent incorrect cache hits.

Three points I'd like reviewer input on:

1. `require_safe` now accepts QUERY. The ticket asks for this, but it means
   existing views gain a method they didn't have. Noted in the release notes
   with `require_http_methods(["GET", "HEAD"])` as the opt-out.
2. APPEND_SLASH: I added QUERY to the DEBUG-time `RuntimeError` rather than
   blocking the redirect outright. RFC 10008 Section 2.5 states the POST-to-GET
   exception does not apply to QUERY, so a compliant client re-sends the
   QUERY with its content and the redirect is spec-conformant.
3. `Client.query()` defaults to `content_type="application/octet-stream"` to
   match `put()`/`patch()`/`delete()`, though RFC 10008 Section 2 requires a
   meaningful Content-Type. Happy to change the default.

Not addressed, and arguably a separate ticket: `follow=True` follows redirects
as GET for every method, so a 307/308 on QUERY is not replayed as QUERY.

#### AI Assistance Disclosure (REQUIRED)

- [x] **If AI tools were used**, I have disclosed which ones, and fully
      reviewed and verified their output.

Claude Code (Opus 5) was used to draft the implementation, tests, and docs.
I reviewed and verified the full diff, and ran the test suite and linters
locally.

#### Checklist

- [x] This PR follows the contribution guidelines.
- [x] This PR **does not** disclose a security vulnerability.
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket
      number, and ends with a period.
- [x] I have not requested, and will not request, an automated AI review
      for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes.
