### PR TITLE
Fixed #37305 -- Prevented annotation aliases from shadowing lookups.

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1932,6 +1932,47 @@ class QuerySet(AltersData):
                     "The annotation '%s' conflicts with a field on "
                     "the model." % alias
                 )
+            if LOOKUP_SEP in alias and not isinstance(annotation, FilteredRelation):
+                query = clone.query.chain()
+                query.annotations = {}
+                try:
+                    _, final_field, targets, lookups = query.names_to_path(
+                        alias.split(LOOKUP_SEP),
+                        query.get_meta(),
+                    )
+                except exceptions.FieldError:
+                    conflict = None
+                else:
+                    if not lookups:
+                        conflict = "field path"
+                    else:
+                        if len(targets) == 1:
+                            lhs = targets[0].get_col(None, final_field)
+                        else:
+                            lhs = ColPairs(None, targets, targets, final_field)
+                        *transforms, lookup_name = lookups
+                        for transform_name in transforms:
+                            transform_class = lhs.get_transform(transform_name)
+                            if transform_class is None:
+                                conflict = None
+                                break
+                            lhs = transform_class(lhs)
+                        else:
+                            if lhs.get_lookup(lookup_name) is not None:
+                                conflict = "lookup"
+                            elif (
+                                transform_class := lhs.get_transform(lookup_name)
+                            ) is not None and transform_class(lhs).get_lookup(
+                                "exact"
+                            ) is not None:
+                                conflict = "transform"
+                            else:
+                                conflict = None
+                if conflict:
+                    raise ValueError(
+                        "The annotation '%s' conflicts with a %s on the model."
+                        % (alias, conflict)
+                    )
             if isinstance(annotation, FilteredRelation):
                 clone.query.add_filtered_relation(annotation, alias)
             else:

--- a/tests/annotations/tests.py
+++ b/tests/annotations/tests.py
@@ -1267,6 +1267,50 @@ class NonAggregateAnnotationTestCase(TestCase):
         with self.assertRaisesMessage(RemovedInDjango70Warning, msg):
             Book.objects.annotate(**{"alias%": Value(1)})
 
+    def test_annotation_alias_conflicts_with_lookup(self):
+        msg = (
+            "The annotation 'publisher__name' conflicts with a field path on the "
+            "model."
+        )
+        with self.assertRaisesMessage(ValueError, msg):
+            Book.objects.annotate(publisher__name=Value("shadowed"))
+
+    def test_annotation_alias_conflicts_with_transform(self):
+        msg = "The annotation 'pubdate__year' conflicts with a transform on the model."
+        with self.assertRaisesMessage(ValueError, msg):
+            Book.objects.annotate(pubdate__year=Value(1))
+
+    def test_annotation_alias_conflicts_with_lookup_suffix(self):
+        msg = "The annotation 'rating__gt' conflicts with a lookup on the model."
+        with self.assertRaisesMessage(ValueError, msg):
+            Book.objects.annotate(rating__gt=Value(1))
+
+    def test_annotation_alias_conflicts_with_lookup_with_restricted_rhs(self):
+        msg = (
+            "The annotation 'publisher__name__isnull' conflicts with a lookup on "
+            "the model."
+        )
+        with self.assertRaisesMessage(ValueError, msg):
+            Book.objects.annotate(publisher__name__isnull=Value(True))
+
+    def test_annotation_alias_with_lookup_sep_allowed_when_not_lookup(self):
+        qs = Book.objects.annotate(not_a_field__alias=Value("test")).values(
+            "not_a_field__alias"
+        )
+        self.assertEqual(qs[0]["not_a_field__alias"], "test")
+
+    def test_annotation_default_alias_with_lookup_sep_allowed_when_not_lookup(self):
+        qs = Book.objects.annotate(Count("authors")).values("authors__count")
+        self.assertGreaterEqual(qs[0]["authors__count"], 0)
+
+    def test_alias_conflicts_with_lookup(self):
+        msg = (
+            "The annotation 'publisher__name' conflicts with a field path on the "
+            "model."
+        )
+        with self.assertRaisesMessage(ValueError, msg):
+            Book.objects.alias(publisher__name=Value("shadowed"))
+
     @skipUnless(connection.vendor == "postgresql", "PostgreSQL tests")
     @skipUnlessDBFeature("supports_json_field")
     def test_set_returning_functions(self):


### PR DESCRIPTION
#### Trac ticket number

ticket-37305

#### Branch description

Prevents annotation and alias names from shadowing existing model lookups, transforms, and related field paths. The change keeps non-conflicting annotation aliases containing double underscores working, including default aggregate aliases such as `authors__count`.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

AI tools used: ChatGPT Codex was used to help investigate the issue, edit the patch, and run tests. I reviewed and verified the final changes.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.

- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.