### PR TITLE
Fixed #36304 - Enabled symbol entries in Sphinx TOCs and added header markup.

### DIFF
--- a/docs/_ext/djangodocs.py
+++ b/docs/_ext/djangodocs.py
@@ -106,6 +106,10 @@ class DjangoHTMLTranslator(HTMLTranslator):
     Django-specific reST to HTML tweaks.
     """
 
+    def __init__(self, document, builder):
+        super().__init__(document, builder)
+        self._desc_nesting_level = 0
+
     # Don't use border=1, which docutils does by default.
     def visit_table(self, node):
         self.context.append(self.compact_p)
@@ -141,6 +145,23 @@ class DjangoHTMLTranslator(HTMLTranslator):
 
     def depart_desc_parameterlist(self, node):
         self.body.append(")")
+
+    # Add ARIA attributes to class, function, etc descriptions so they appear
+    # to screen readers as headings. See #36304
+    def visit_desc(self, node):
+        self._desc_nesting_level += 1
+        super().visit_desc(node)
+
+    def depart_desc(self, node):
+        self._desc_nesting_level -= 1
+        super().depart_desc(node)
+
+    def visit_desc_name(self, node):
+        attributes = {
+            "role": "heading",
+            "aria-level": min(self.section_level + self._desc_nesting_level, 6),
+        }
+        self.body.append(self.starttag(node, "span", "", False, **attributes))
 
     #
     # Turn the "new in version" stuff (versionadded/versionchanged) into a

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -108,7 +108,8 @@ root_doc = "contents"
 
 # Disable auto-created table of contents entries for all domain objects (e.g.
 # functions, classes, attributes, etc.) in Sphinx 5.2+.
-toc_object_entries = False
+toc_object_entries = True
+toc_object_entries_show_parents = "hide"
 
 # General substitutions.
 project = "Django"

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -14,9 +14,6 @@ system checks, see the :doc:`System check topic guide </topics/checks>`.
 API reference
 =============
 
-``CheckMessage``
-----------------
-
 .. class:: CheckMessage(level, msg, hint=None, obj=None, id=None)
 
     The warnings and errors raised by system checks must be instances of

--- a/docs/ref/forms/fields.txt
+++ b/docs/ref/forms/fields.txt
@@ -9,29 +9,29 @@ Form fields
 
 .. class:: Field
 
-When you create a ``Form`` class, the most important part is defining the
-fields of the form. Each field has custom validation logic, along with a few
-other hooks.
+    When you create a ``Form`` class, the most important part is defining the
+    fields of the form. Each field has custom validation logic, along with a
+    few other hooks.
 
-.. method:: Field.clean(value)
+    .. method:: Field.clean(value)
 
-Although the primary way you'll use ``Field`` classes is in ``Form`` classes,
-you can also instantiate them and use them directly to get a better idea of
-how they work. Each ``Field`` instance has a ``clean()`` method, which takes
-a single argument and either raises a
-``django.core.exceptions.ValidationError`` exception or returns the clean
-value:
+    Although the primary way you'll use ``Field`` classes is in ``Form``
+    classes, you can also instantiate them and use them directly to get a
+    better idea of how they work. Each ``Field`` instance has a ``clean()``
+    method, which takes a single argument and either raises a
+    ``django.core.exceptions.ValidationError`` exception or returns the clean
+    value:
 
-.. code-block:: pycon
+    .. code-block:: pycon
 
-    >>> from django import forms
-    >>> f = forms.EmailField()
-    >>> f.clean("foo@example.com")
-    'foo@example.com'
-    >>> f.clean("invalid email address")
-    Traceback (most recent call last):
-    ...
-    ValidationError: ['Enter a valid email address.']
+        >>> from django import forms
+        >>> f = forms.EmailField()
+        >>> f.clean("foo@example.com")
+        'foo@example.com'
+        >>> f.clean("invalid email address")
+        Traceback (most recent call last):
+        ...
+        ValidationError: ['Enter a valid email address.']
 
 .. _core-field-arguments:
 
@@ -41,9 +41,6 @@ Core field arguments
 Each ``Field`` class constructor takes at least these arguments. Some
 ``Field`` classes take additional, field-specific arguments, but the following
 should *always* be accepted:
-
-``required``
-------------
 
 .. attribute:: Field.required
 
@@ -102,9 +99,6 @@ Widgets of required form fields have the ``required`` HTML attribute. Set the
 ``required`` attribute isn't included on forms of formsets because the browser
 validation may not be correct when adding and deleting formsets.
 
-``label``
----------
-
 .. attribute:: Field.label
 
 The ``label`` argument lets you specify the "human-friendly" label for this
@@ -133,9 +127,6 @@ We've specified ``auto_id=False`` to simplify the output:
     <div>Your website:<input type="url" name="url"></div>
     <div>Comment:<input type="text" name="comment" required></div>
 
-``label_suffix``
-----------------
-
 .. attribute:: Field.label_suffix
 
 The ``label_suffix`` argument lets you override the form's
@@ -153,9 +144,6 @@ The ``label_suffix`` argument lets you override the form's
     <div><label for="id_age">Age?</label><input type="number" name="age" required id="id_age"></div>
     <div><label for="id_nationality">Nationality?</label><input type="text" name="nationality" required id="id_nationality"></div>
     <div><label for="id_captcha_answer">2 + 2 =</label><input type="number" name="captcha_answer" required id="id_captcha_answer"></div>
-
-``initial``
------------
 
 .. attribute:: Field.initial
 
@@ -243,16 +231,10 @@ Instead of a constant, you can also pass any callable:
 The callable will be evaluated only when the unbound form is displayed, not
 when it is defined.
 
-``widget``
-----------
-
 .. attribute:: Field.widget
 
 The ``widget`` argument lets you specify a ``Widget`` class to use when
 rendering this ``Field``. See :doc:`/ref/forms/widgets` for more information.
-
-``help_text``
--------------
 
 .. attribute:: Field.help_text
 
@@ -320,9 +302,6 @@ inside ``aria-describedby``:
     >>> print(f["username"])
     <input type="text" name="username" aria-describedby="custom-description id_username_helptext" maxlength="255" id="id_username" required>
 
-``error_messages``
-------------------
-
 .. attribute:: Field.error_messages
 
 The ``error_messages`` argument lets you override the default messages that the
@@ -351,18 +330,12 @@ And here is a custom error message:
 In the `built-in Field classes`_ section below, each ``Field`` defines the
 error message keys it uses.
 
-``validators``
---------------
-
 .. attribute:: Field.validators
 
 The ``validators`` argument lets you provide a list of validation functions
 for this field.
 
 See the :doc:`validators documentation </ref/validators>` for more information.
-
-``localize``
-------------
 
 .. attribute:: Field.localize
 
@@ -372,18 +345,12 @@ as the rendered output.
 See the :doc:`format localization documentation </topics/i18n/formatting>` for
 more information.
 
-``disabled``
-------------
-
 .. attribute:: Field.disabled
 
 The ``disabled`` boolean argument, when set to ``True``, disables a form field
 using the ``disabled`` HTML attribute so that it won't be editable by users.
 Even if a user tampers with the field's value submitted to the server, it will
 be ignored in favor of the value from the form's initial data.
-
-``template_name``
------------------
 
 .. attribute:: Field.template_name
 
@@ -393,9 +360,6 @@ default this value is set to ``"django/forms/field.html"``. Can be changed per
 field by overriding this attribute or more generally by overriding the default
 template, see also :ref:`overriding-built-in-field-templates`.
 
-``bound_field_class``
----------------------
-
 .. attribute:: Field.bound_field_class
 
 The ``bound_field_class`` attribute allows a per-field override of
@@ -403,9 +367,6 @@ The ``bound_field_class`` attribute allows a per-field override of
 
 Checking if the field data has changed
 ======================================
-
-``has_changed()``
------------------
 
 .. method:: Field.has_changed()
 
@@ -426,9 +387,6 @@ For each field, we describe the default widget used if you don't specify
 ``widget``. We also specify the value returned when you provide an empty value
 (see the section on ``required`` above to understand what that means).
 
-``BooleanField``
-----------------
-
 .. class:: BooleanField(**kwargs)
 
     * Default widget: :class:`CheckboxInput`
@@ -445,9 +403,6 @@ For each field, we describe the default widget used if you don't specify
         boolean in your form that can be either ``True`` or ``False`` (e.g. a
         checked or unchecked checkbox), you must remember to pass in
         ``required=False`` when creating the ``BooleanField``.
-
-``CharField``
--------------
 
 .. class:: CharField(**kwargs)
 
@@ -475,9 +430,6 @@ For each field, we describe the default widget used if you don't specify
     .. attribute:: empty_value
 
        The value to use to represent "empty". Defaults to an empty string.
-
-``ChoiceField``
----------------
 
 .. class:: ChoiceField(**kwargs)
 
@@ -509,9 +461,6 @@ For each field, we describe the default widget used if you don't specify
         other data types, such as integers or booleans, consider using
         :class:`TypedChoiceField` instead.
 
-``DateField``
--------------
-
 .. class:: DateField(**kwargs)
 
     * Default widget: :class:`DateInput`
@@ -532,9 +481,6 @@ For each field, we describe the default widget used if you don't specify
     taken from the active locale format ``DATE_INPUT_FORMATS`` key, or from
     :setting:`DATE_INPUT_FORMATS` if localization is disabled. See also
     :doc:`format localization </topics/i18n/formatting>`.
-
-``DateTimeField``
------------------
 
 .. class:: DateTimeField(**kwargs)
 
@@ -569,9 +515,6 @@ For each field, we describe the default widget used if you don't specify
     ``DATE_INPUT_FORMATS`` keys, or from :setting:`DATETIME_INPUT_FORMATS` and
     :setting:`DATE_INPUT_FORMATS` if localization is disabled. See also
     :doc:`format localization </topics/i18n/formatting>`.
-
-``DecimalField``
-----------------
 
 .. class:: DecimalField(**kwargs)
 
@@ -618,9 +561,6 @@ For each field, we describe the default widget used if you don't specify
         ``min_value`` is also provided, it's added as an offset to determine if
         the step size matches.
 
-``DurationField``
------------------
-
 .. class:: DurationField(**kwargs)
 
     * Default widget: :class:`TextInput`
@@ -633,9 +573,6 @@ For each field, we describe the default widget used if you don't specify
 
     Accepts any format understood by
     :func:`~django.utils.dateparse.parse_duration`.
-
-``EmailField``
---------------
 
 .. class:: EmailField(**kwargs)
 
@@ -650,9 +587,6 @@ For each field, we describe the default widget used if you don't specify
     Has the optional arguments ``max_length``, ``min_length``, and
     ``empty_value`` which work just as they do for :class:`CharField`. The
     ``max_length`` argument defaults to 320 (see :rfc:`3696#section-3`).
-
-``FileField``
--------------
 
 .. class:: FileField(**kwargs)
 
@@ -679,9 +613,6 @@ For each field, we describe the default widget used if you don't specify
     message for that key, ``%(max)d`` will be replaced with the maximum
     filename length and ``%(length)d`` will be replaced with the current
     filename length.
-
-``FilePathField``
------------------
 
 .. class:: FilePathField(**kwargs)
 
@@ -742,9 +673,6 @@ For each field, we describe the default widget used if you don't specify
                     super().__init__(*args, **kwargs)
                     self.fields["my_file"].set_choices()
 
-``FloatField``
---------------
-
 .. class:: FloatField(**kwargs)
 
     * Default widget: :class:`NumberInput` when :attr:`Field.localize` is
@@ -773,9 +701,6 @@ For each field, we describe the default widget used if you don't specify
         Limit valid inputs to an integral multiple of ``step_size``. If
         ``min_value`` is also provided, it's added as an offset to determine if
         the step size matches.
-
-``GenericIPAddressField``
--------------------------
 
 .. class:: GenericIPAddressField(**kwargs)
 
@@ -813,9 +738,6 @@ For each field, we describe the default widget used if you don't specify
 
         Defaults to 39, and behaves the same way as it does for
         :class:`CharField`.
-
-``ImageField``
---------------
 
 .. class:: ImageField(**kwargs)
 
@@ -881,9 +803,6 @@ For each field, we describe the default widget used if you don't specify
 
 .. _Image: https://pillow.readthedocs.io/en/latest/reference/Image.html
 
-``IntegerField``
-----------------
-
 .. class:: IntegerField(**kwargs)
 
     * Default widget: :class:`NumberInput` when :attr:`Field.localize` is
@@ -916,9 +835,6 @@ For each field, we describe the default widget used if you don't specify
         Limit valid inputs to an integral multiple of ``step_size``. If
         ``min_value`` is also provided, it's added as an offset to determine if
         the step size matches.
-
-``JSONField``
--------------
 
 .. class:: JSONField(encoder=None, decoder=None, **kwargs)
 
@@ -969,9 +885,6 @@ For each field, we describe the default widget used if you don't specify
         it is a useful way to format data from a client-side widget for
         submission to the server.
 
-``MultipleChoiceField``
------------------------
-
 .. class:: MultipleChoiceField(**kwargs)
 
     * Default widget: :class:`SelectMultiple`
@@ -986,9 +899,6 @@ For each field, we describe the default widget used if you don't specify
 
     Takes one extra required argument, ``choices``, as for
     :class:`ChoiceField`.
-
-``NullBooleanField``
---------------------
 
 .. class:: NullBooleanField(**kwargs)
 
@@ -1010,9 +920,6 @@ For each field, we describe the default widget used if you don't specify
                 ]
             )
         )
-
-``RegexField``
---------------
 
 .. class:: RegexField(**kwargs)
 
@@ -1038,9 +945,6 @@ For each field, we describe the default widget used if you don't specify
         Defaults to ``False``. If enabled, stripping will be applied before the
         regex validation.
 
-``SlugField``
--------------
-
 .. class:: SlugField(**kwargs)
 
    * Default widget: :class:`TextInput`
@@ -1065,9 +969,6 @@ For each field, we describe the default widget used if you don't specify
 
        The value to use to represent "empty". Defaults to an empty string.
 
-``TimeField``
--------------
-
 .. class:: TimeField(**kwargs)
 
     * Default widget: :class:`TimeInput`
@@ -1088,9 +989,6 @@ For each field, we describe the default widget used if you don't specify
     taken from the active locale format ``TIME_INPUT_FORMATS`` key, or from
     :setting:`TIME_INPUT_FORMATS` if localization is disabled. See also
     :doc:`format localization </topics/i18n/formatting>`.
-
-``TypedChoiceField``
---------------------
 
 .. class:: TypedChoiceField(**kwargs)
 
@@ -1122,9 +1020,6 @@ For each field, we describe the default widget used if you don't specify
         be coerced by the function given in the ``coerce`` argument, so choose
         it accordingly.
 
-``TypedMultipleChoiceField``
-----------------------------
-
 .. class:: TypedMultipleChoiceField(**kwargs)
 
     Just like a :class:`MultipleChoiceField`, except
@@ -1145,9 +1040,6 @@ For each field, we describe the default widget used if you don't specify
     Takes two extra arguments, ``coerce`` and ``empty_value``, as for
     :class:`TypedChoiceField`.
 
-``URLField``
-------------
-
 .. class:: URLField(**kwargs)
 
     * Default widget: :class:`URLInput`
@@ -1167,9 +1059,6 @@ For each field, we describe the default widget used if you don't specify
         provided value is ``"example.com"``, the normalized value will be
         ``"https://example.com"``.
 
-``UUIDField``
--------------
-
 .. class:: UUIDField(**kwargs)
 
     * Default widget: :class:`TextInput`
@@ -1182,9 +1071,6 @@ For each field, we describe the default widget used if you don't specify
 
 Slightly complex built-in ``Field`` classes
 ===========================================
-
-``ComboField``
---------------
 
 .. class:: ComboField(**kwargs)
 
@@ -1212,9 +1098,6 @@ Slightly complex built-in ``Field`` classes
             Traceback (most recent call last):
             ...
             ValidationError: ['Ensure this value has at most 20 characters (it has 28).']
-
-``MultiValueField``
--------------------
 
 .. class:: MultiValueField(fields=(), **kwargs)
 
@@ -1309,9 +1192,6 @@ Slightly complex built-in ``Field`` classes
 
         This method must be implemented in the subclasses.
 
-``SplitDateTimeField``
-----------------------
-
 .. class:: SplitDateTimeField(**kwargs)
 
     * Default widget: :class:`SplitDateTimeWidget`
@@ -1368,9 +1248,6 @@ method::
 Both ``ModelChoiceField`` and ``ModelMultipleChoiceField`` have an ``iterator``
 attribute which specifies the class used to iterate over the queryset when
 generating choices. See :ref:`iterating-relationship-choices` for details.
-
-``ModelChoiceField``
---------------------
 
 .. class:: ModelChoiceField(**kwargs)
 
@@ -1486,9 +1363,6 @@ generating choices. See :ref:`iterating-relationship-choices` for details.
             def label_from_instance(self, obj):
                 return "My Object #%i" % obj.id
 
-``ModelMultipleChoiceField``
-----------------------------
-
 .. class:: ModelMultipleChoiceField(**kwargs)
 
     * Default widget: :class:`SelectMultiple`
@@ -1599,9 +1473,6 @@ This will render the ``Pizza.topping`` select as:
 For more advanced usage you may subclass ``ModelChoiceIterator`` in order to
 customize the yielded 2-tuple choices.
 
-``ModelChoiceIterator``
-~~~~~~~~~~~~~~~~~~~~~~~
-
 .. class:: ModelChoiceIterator(field)
 
     The default class assigned to the ``iterator`` attribute of
@@ -1622,9 +1493,6 @@ customize the yielded 2-tuple choices.
         Yields 2-tuple choices, in the ``(value, label)`` format used by
         :attr:`ChoiceField.choices`. The first ``value`` element is a
         :class:`ModelChoiceIteratorValue` instance.
-
-``ModelChoiceIteratorValue``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. class:: ModelChoiceIteratorValue(value, instance)
 

--- a/docs/ref/schema-editor.txt
+++ b/docs/ref/schema-editor.txt
@@ -40,68 +40,41 @@ syntax a little.
 Methods
 =======
 
-``execute()``
--------------
-
 .. method:: BaseDatabaseSchemaEditor.execute(sql, params=())
 
 Executes the SQL statement passed in, with parameters if supplied. This
 is a wrapper around the normal database cursors that allows capture of the SQL
 to a ``.sql`` file if the user wishes.
 
-``create_model()``
-------------------
-
 .. method:: BaseDatabaseSchemaEditor.create_model(model)
 
 Creates a new table in the database for the provided model, along with any
 unique constraints or indexes it requires.
-
-``delete_model()``
-------------------
 
 .. method:: BaseDatabaseSchemaEditor.delete_model(model)
 
 Drops the model's table in the database along with any unique constraints
 or indexes it has.
 
-``add_index()``
----------------
-
 .. method:: BaseDatabaseSchemaEditor.add_index(model, index)
 
 Adds ``index`` to ``model``’s table.
-
-``remove_index()``
-------------------
 
 .. method:: BaseDatabaseSchemaEditor.remove_index(model, index)
 
 Removes ``index`` from ``model``’s table.
 
-``rename_index()``
-------------------
-
 .. method:: BaseDatabaseSchemaEditor.rename_index(model, old_index, new_index)
 
 Renames ``old_index`` from ``model``’s table to ``new_index``.
-
-``add_constraint()``
---------------------
 
 .. method:: BaseDatabaseSchemaEditor.add_constraint(model, constraint)
 
 Adds ``constraint`` to ``model``'s table.
 
-``remove_constraint()``
------------------------
-
 .. method:: BaseDatabaseSchemaEditor.remove_constraint(model, constraint)
 
 Removes ``constraint`` from ``model``'s table.
-
-``alter_unique_together()``
----------------------------
 
 .. method:: BaseDatabaseSchemaEditor.alter_unique_together(model, old_unique_together, new_unique_together)
 
@@ -109,37 +82,22 @@ Changes a model's :attr:`~django.db.models.Options.unique_together` value; this
 will add or remove unique constraints from the model's table until they match
 the new value.
 
-``alter_index_together()``
---------------------------
-
 .. method:: BaseDatabaseSchemaEditor.alter_index_together(model, old_index_together, new_index_together)
 
 Changes a model's ``index_together`` value; this will add or remove indexes
 from the model's table until they match the new value.
 
-``alter_db_table()``
---------------------
-
 .. method:: BaseDatabaseSchemaEditor.alter_db_table(model, old_db_table, new_db_table)
 
 Renames the model's table from ``old_db_table`` to ``new_db_table``.
-
-``alter_db_table_comment()``
-----------------------------
 
 .. method:: BaseDatabaseSchemaEditor.alter_db_table_comment(model, old_db_table_comment, new_db_table_comment)
 
 Change the ``model``’s table comment to ``new_db_table_comment``.
 
-``alter_db_tablespace()``
--------------------------
-
 .. method:: BaseDatabaseSchemaEditor.alter_db_tablespace(model, old_db_tablespace, new_db_tablespace)
 
 Moves the model's table from one tablespace to another.
-
-``add_field()``
----------------
 
 .. method:: BaseDatabaseSchemaEditor.add_field(model, field)
 
@@ -154,9 +112,6 @@ of creating a column, it will make a table to represent the relationship. If
 If the field is a ``ForeignKey``, this will also add the foreign key
 constraint to the column.
 
-``remove_field()``
-------------------
-
 .. method:: BaseDatabaseSchemaEditor.remove_field(model, field)
 
 Removes the column(s) representing the field from the model's table, along
@@ -166,9 +121,6 @@ that field.
 If the field is a ManyToManyField without a value for ``through``, it will
 remove the table created to track the relationship. If
 ``through`` is provided, it is a no-op.
-
-``alter_field()``
------------------
 
 .. method:: BaseDatabaseSchemaEditor.alter_field(model, old_field, new_field, strict=False)
 
@@ -193,9 +145,6 @@ Attributes
 ==========
 
 All attributes should be considered read-only unless stated otherwise.
-
-``connection``
---------------
 
 .. attribute:: SchemaEditor.connection
 


### PR DESCRIPTION
#### Trac ticket number

[ticket-36304](https://code.djangoproject.com/ticket/36304)

#### Branch description
To improve accessibility of the documentation it has been suggested to manually add headings beside symbols (classes, methods, etc) so they appear in the heading hierarchy of the page for screen readers.

This branch suggests an alternative approach where we enable the `toc_object_entries` and post process the HTML to include aria attributes that screen readers interpret as headings.

There are some tradeoffs though, and this PR is being submitted as a way to evaluate these before proceeding too far. The PR provides a convenient way to compare documentation impact via the readthedocs task in the github checks 👇 

The main visual change from removing manual headings is shown below. Although this makes the delineation seem less obvious, that's mainly due to an existing styling issue. Resolving https://github.com/django/djangoproject.com/issues/2754 would alleviate that.

<table>
  <tr>
    <td valign="top">
<img width="300" alt="Screenshot 2026-08-30 at 17 35 21" src="https://github.com/user-attachments/assets/94f2ddeb-f4d6-42ea-a677-da453408720c" />
</td>
    <td valign="top">
<img width="300" alt="Screenshot 2026-08-30 at 17 35 42" src="https://github.com/user-attachments/assets/633bf354-9b53-4e12-b066-1cdec7193df3" />
</td>
</tr>
</table>

For examples of TOCs that include additional entries but otherwise look ok without further modification:

- refs/applications

<table>
  <tr>
    <td valign="top"><img width="200" alt="Screenshot 2026-08-30 at 17 30 14" src="https://github.com/user-attachments/assets/fd76adbd-0835-440f-a595-51b8154347ba" /></td>
    <td valign="top"><img width="200" alt="Screenshot 2026-08-30 at 17 30 22" src="https://github.com/user-attachments/assets/4fd9bd70-fc41-43b4-b2ff-bf093dc39868" />
</td>
</tr>
</table>

For TOCs that have had manual headings removed to avoid default entries:

- refs/checks
- refs/schema-editor
- refs/forms/fields

For TOCs left as is to demonstrate duplicate entries unless we remove manual headings:

- refs/signals

<table>
  <tr>
    <td valign="top">
<img width="200" alt="Screenshot 2026-08-30 at 17 36 23" src="https://github.com/user-attachments/assets/99b24372-2c5d-4d79-8a3b-f2bd1f84751a" />

</td>
    <td valign="top">
<img width="200" alt="Screenshot 2026-08-30 at 17 36 36" src="https://github.com/user-attachments/assets/11fa25e6-ba5c-45dc-8a7e-5231223ef34d" />
</td>
</tr>
</table>

By way of reviewing the approach the suggested patch takes, perhaps most helpful to do that on the [forum thread](https://forum.djangoproject.com/t/set-toc-object-entries-true-to-auto-add-functions-classes-to-the-pages-table-of-contents/38902/7). Any comments on the coding though, feel free to put that here on the PR.

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
<!-- If AI tools were used, provide which tools were used here. -->

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
