### PR TITLE
Fixed #37309 -- Used _is_pk_set() in Model.__eq__ and the XML serializer.

### DIFF
--- a/django/core/serializers/xml_serializer.py
+++ b/django/core/serializers/xml_serializer.py
@@ -59,8 +59,7 @@ class Serializer(base.Serializer):
         self.indent(self.indent_level)
         attrs = {"model": str(obj._meta)}
         if not self.use_natural_primary_keys or not self._resolve_natural_key(obj):
-            obj_pk = obj.pk
-            if obj_pk is not None:
+            if obj._is_pk_set():
                 attrs["pk"] = obj._meta.pk.value_to_string(obj)
 
         try:

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -647,10 +647,9 @@ class Model(AltersData, metaclass=ModelBase):
             return NotImplemented
         if self._meta.concrete_model != other._meta.concrete_model:
             return False
-        my_pk = self.pk
-        if my_pk is None:
+        if not self._is_pk_set():
             return self is other
-        return my_pk == other.pk
+        return self.pk == other.pk
 
     def __hash__(self):
         if not self._is_pk_set():

--- a/docs/ref/models/instances.txt
+++ b/docs/ref/models/instances.txt
@@ -790,9 +790,18 @@ For example::
 
 The equality method is defined such that instances with the same primary
 key value and the same concrete class are considered equal, except that
-instances with a primary key value of ``None`` aren't equal to anything except
-themselves. For proxy models, concrete class is defined as the model's first
-non-proxy parent; for all other models it's simply the model's class.
+instances without a set primary key aren't equal to anything except
+themselves. Whether the primary key is set is determined by
+:meth:`~django.db.models.Model._is_pk_set`. For proxy models, concrete class
+is defined as the model's first non-proxy parent; for all other models it's
+simply the model's class.
+
+.. versionchanged:: 6.2
+
+    Equality now uses :meth:`~django.db.models.Model._is_pk_set` instead of
+    comparing ``pk is None``. Unsaved instances with a composite primary key
+    or a ``db_default`` primary key are compared by identity, matching simple
+    ``None`` primary keys.
 
 For example::
 

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -286,6 +286,12 @@ backends.
   :meth:`~django.contrib.gis.gdal.Field.as_datetime` is now a ``c_float``
   rather than a ``c_int``.
 
+Models
+------
+
+* Unsaved instances with a composite primary key or a ``db_default`` primary
+  key no longer compare equal to other instances.
+
 Tests
 -----
 

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -491,6 +491,10 @@ class ModelTest(TestCase):
         self.assertEqual(a, a)
         self.assertEqual(a, mock.ANY)
         self.assertNotEqual(Article(), a)
+        # DatabaseDefault is not None, but the pk is unset.
+        db_default = PrimaryKeyWithDbDefault()
+        self.assertEqual(db_default, db_default)
+        self.assertNotEqual(PrimaryKeyWithDbDefault(), db_default)
 
     def test_hash(self):
         # Value based on PK

--- a/tests/composite_pk/tests.py
+++ b/tests/composite_pk/tests.py
@@ -437,6 +437,11 @@ class CompositePKFixturesTests(TestCase):
         self.assertIn('<object model="composite_pk.user" pk=\'["1", "1"]\'>', result)
         self.assert_deserializer(format="xml", users=users, serialized_users=result)
 
+    def test_serialize_unsaved_user_xml_omits_pk(self):
+        result = serializers.serialize("xml", [User()])
+        self.assertIn('<object model="composite_pk.user">', result)
+        self.assertNotIn(" pk=", result)
+
     def test_serialize_post_uuid(self):
         posts = Post.objects.filter(pk=(2, "11111111-1111-1111-1111-111111111111"))
         result = serializers.serialize("json", posts)

--- a/tests/composite_pk/tests.py
+++ b/tests/composite_pk/tests.py
@@ -70,6 +70,18 @@ class CompositePKTests(TestCase):
         self.assertIsNotNone(post.id)
         self.assertIs(post._is_pk_set(), False)
 
+    def test_eq(self):
+        self.assertEqual(User(pk=(1, 2)), User(pk=(1, 2)))
+        self.assertEqual(User(tenant_id=2, id=3), User(tenant_id=2, id=3))
+        self.assertNotEqual(User(pk=(1, 2)), User(pk=(1, 3)))
+        self.assertNotEqual(User(pk=(1, 2)), object())
+        unset = User()
+        self.assertEqual(unset, unset)
+        self.assertNotEqual(User(), unset)
+        self.assertNotEqual(User(tenant_id=1), User(tenant_id=1))
+        self.assertNotEqual(User(id=1), User(id=1))
+        self.assertNotEqual(User(tenant_id=1), User(pk=(1, 2)))
+
     def test_hash(self):
         self.assertEqual(hash(User(pk=(1, 2))), hash((1, 2)))
         self.assertEqual(hash(User(tenant_id=2, id=3)), hash((2, 3)))


### PR DESCRIPTION
#### Trac ticket number

ticket-37309

#### Branch description

`Model.__eq__` still used `pk is None` to decide whether an instance was unsaved. That is wrong for composite primary keys (`pk` is a tuple such as `(None, None)`) and for `db_default` PKs (`DatabaseDefault` is not `None`), so distinct unsaved instances compared equal. `__hash__` already uses `_is_pk_set()`. This switches `__eq__` and the XML serializer to `_is_pk_set()` so unsaved composite/`db_default` instances are compared by identity and XML dumps omit the pk attribute when it is unset.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

xAI Grok was used to search the codebase, implement the `_is_pk_set()` switch, add tests, and prepare this PR. I reviewed and verified the final diff and ran the focused tests.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.

- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.