### PR TITLE
Fixed #36398 -- Honored "self" in select_for_update(of).

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -1474,6 +1474,9 @@ class SQLCompiler:
             klass_info = self.klass_info
             if name == "self":
                 col = _get_first_selected_col_from_model(klass_info)
+                if col is None:
+                    concrete_model = klass_info["model"]._meta.concrete_model
+                    col = concrete_model._meta.pk.get_col(self.query.base_table)
             else:
                 for part in name.split(LOOKUP_SEP):
                     klass_infos = (

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -1979,7 +1979,15 @@ using the same fields syntax as :meth:`select_related`. Use the value
 
     If you want to lock models and specify selected fields, e.g. using
     :meth:`values`, you must select at least one field from each model in the
-    ``of`` argument. Models without selected fields will not be locked.
+    ``of`` argument. Models without selected fields will not be locked, except
+    for the queryset's model when ``'self'`` is specified and only related
+    model field names are selected.
+
+    .. versionchanged:: 6.2
+
+        ``select_for_update(of=("self",))`` now limits row locking to the
+        queryset's model when only related model field names are selected using
+        :meth:`values` or :meth:`values_list`.
 
 On PostgreSQL only, you can pass ``no_key=True`` in order to acquire a weaker
 lock, that still allows creating rows that merely reference locked rows

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -196,7 +196,10 @@ Migrations
 Models
 ~~~~~~
 
-* ...
+* :meth:`.QuerySet.select_for_update` with ``of=("self",)`` now limits row
+  locking to the queryset's model when only related model field names are
+  selected using :meth:`.QuerySet.values` or
+  :meth:`.QuerySet.values_list`.
 
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/select_for_update/tests.py
+++ b/tests/select_for_update/tests.py
@@ -284,13 +284,19 @@ class SelectForUpdateTests(TransactionTestCase):
         select_for_update(of=['self']) when the only columns selected are from
         related tables.
         """
-        with transaction.atomic():
+        with transaction.atomic(), CaptureQueriesContext(connection) as ctx:
+            # Note: select_related() is canceled by values().
             values = list(
-                Person.objects.select_related("born")
-                .select_for_update(of=("self",))
-                .values("born__name")
+                Person.objects.select_for_update(of=("self",)).values("born__name")
             )
         self.assertEqual(values, [{"born__name": self.city1.name}])
+        features = connections["default"].features
+        if features.select_for_update_of_column:
+            expected = ['select_for_update_person"."id']
+        else:
+            expected = ["select_for_update_person"]
+        expected = [connection.ops.quote_name(value) for value in expected]
+        self.assertTrue(self.has_for_update_sql(ctx.captured_queries, of=expected))
 
     @skipUnlessDBFeature(
         "has_select_for_update_of",


### PR DESCRIPTION
When values() or values_list() selected only related model field names, Django lost the "self" lock target and generated a bare FOR UPDATE clause. This could lock unintended joined tables or fail for nullable outer joins.

Thanks OutOfFocus4 for the report, and Shai Berger, James Bligh, and Jacob Walls for reviews.

#### Trac ticket number

ticket-36398

#### Branch description

This change fixes an issue where `select_for_update(of=("self",))` lost
the `"self"` lock target when `values()` or `values_list()` selected only
related model fields.

It also ensures that Django generates a targeted `FOR UPDATE OF` clause
instead of a bare `FOR UPDATE` clause that could lock joined tables or fail
on nullable outer joins.

#### AI Assistance Disclosure (REQUIRED)
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
<!-- If AI tools were used, provide which tools were used here. -->

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
