### PR TITLE
Fixed #37310 -- Made MediaAsset hashes consistent with string equality.

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -81,10 +81,7 @@ class MediaAsset:
         ) or (isinstance(other, str) and self._path == other)
 
     def __hash__(self):
-        # Compare path and attrs to ensure performant comparison
-        # in Media.merge.
-        if self.attributes:
-            return hash(self._path) ^ hash(frozenset(self.attributes.items()))
+        # Hash the path only to match equality with string paths.
         return hash(self._path)
 
     def __str__(self):

--- a/tests/forms_tests/tests/test_media.py
+++ b/tests/forms_tests/tests/test_media.py
@@ -29,14 +29,13 @@ class MediaAssetTestCase(SimpleTestCase):
         )
 
     def test_hash(self):
-        self.assertEqual(hash(MediaAsset("path/to/css")), hash("path/to/css"))
-        self.assertEqual(
-            hash(MediaAsset("path/to/css")), hash(MediaAsset("path/to/css"))
-        )
-        self.assertNotEqual(
-            hash(MediaAsset("path/to/css", rel="stylesheet")),
-            hash(MediaAsset("path/to/css")),
-        )
+        path = "path/to/css"
+        self.assertEqual(hash(MediaAsset(path)), hash(path))
+        self.assertEqual(hash(MediaAsset(path)), hash(MediaAsset(path)))
+        asset = MediaAsset(path, rel="stylesheet")
+        self.assertEqual(asset, path)
+        self.assertEqual(hash(asset), hash(path))
+        self.assertIn(path, {asset})
 
     def test_str(self):
         self.assertEqual(


### PR DESCRIPTION
#### Trac ticket number

ticket-37310

#### Branch description
Restore path-only hashing for MediaAsset so instances that compare equal to string paths also have equal hashes. updated the regression test to cover attributed assets and set membership.

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
<!-- If AI tools were used, provide which tools were used here. -->

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
