### PR TITLE
Clarified object-level permission checks in the admin.

### DIFF
--- a/docs/ref/contrib/admin/actions.txt
+++ b/docs/ref/contrib/admin/actions.txt
@@ -407,7 +407,8 @@ decorator and passing the ``permissions`` argument::
         queryset.update(status="p")
 
 The ``make_published()`` action will only be available to users that pass the
-:meth:`.ModelAdmin.has_change_permission` check.
+:meth:`.ModelAdmin.has_change_permission` check when it is called with
+``obj=None``.
 
 If ``permissions`` has more than one permission, the action will be available
 as long as the user passes at least one of the checks.
@@ -440,6 +441,21 @@ For example::
             opts = self.opts
             codename = get_permission_codename("publish", opts)
             return request.user.has_perm("%s.%s" % (opts.app_label, codename))
+
+The admin doesn't automatically check object-level permissions for each
+selected object when executing an action. To limit which objects an action may
+modify based on object-level permissions, perform those checks in the action
+itself. For example::
+
+    class ArticleAdmin(admin.ModelAdmin):
+        actions = ["make_published"]
+
+        @admin.action(permissions=["change"])
+        def make_published(self, request, queryset):
+            for obj in queryset:
+                if self.has_change_permission(request, obj=obj):
+                    obj.status = "p"
+                    obj.save(update_fields=["status"])
 
 .. _admin-action-availability:
 

--- a/docs/ref/contrib/admin/actions.txt
+++ b/docs/ref/contrib/admin/actions.txt
@@ -460,7 +460,7 @@ itself. For example::
 .. _admin-action-availability:
 
 Controlling where actions are available
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------------------
 
 .. versionadded:: 6.1
 

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1959,14 +1959,23 @@ default templates used by the :class:`ModelAdmin` views:
 
 .. method:: ModelAdmin.has_view_permission(request, obj=None)
 
-    Should return ``True`` if viewing ``obj`` is permitted, ``False``
-    otherwise. If obj is ``None``, should return ``True`` or ``False`` to
-    indicate whether viewing of objects of this type is permitted in general
-    (e.g., ``False`` will be interpreted as meaning that the current user is
-    not permitted to view any object of this type).
+    Should return ``True`` if the user is permitted to access the change or
+    history view for ``obj``, and ``False`` otherwise. If obj is ``None``,
+    should return ``True`` or ``False`` to indicate whether viewing of objects
+    of this type is permitted in general (e.g., ``False`` will be interpreted
+    as meaning that the current user is not permitted to view any object of
+    this type).
 
     The default implementation returns ``True`` if the user has either the
     "change" or "view" permission.
+
+    .. admonition:: Object-level view permissions aren't visibility filters
+
+        Object-level view permissions don't prevent information about an object
+        from appearing elsewhere in the admin, including in the admin
+        changelist, related field choices, autocomplete results, and recent
+        actions. To restrict this information, customize the querysets used by
+        the relevant views and form fields.
 
 .. method:: ModelAdmin.has_add_permission(request)
 


### PR DESCRIPTION
This is often a topic that is included in security reports. I have tried to better document the scope of permissions.
When folks assume that "view" permission is visibility in all possible ways and places, we get a mixture of bug and security reports here. 