### PR TITLE
Fixed #37310 -- Prevented attributed MediaAsset equality with strings.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -781,6 +781,7 @@ answer newbie questions, and generally made Django that much better:
     Mikko Hellsing <mikko@sorl.net>
     Mikołaj Siedlarek <mikolaj.siedlarek@gmail.com>
     Mikuláš Poul <mikulaspoul@gmail.com>
+    Milad Khoshdel <miladkhoshdel@gmail.com>
     milkomeda
     Milton Waddams
     mitakummaa@gmail.com

--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -78,7 +78,7 @@ class MediaAsset:
             self.__class__ is other.__class__
             and self._path == other._path
             and self.attributes == other.attributes
-        ) or (isinstance(other, str) and self._path == other)
+        ) or (isinstance(other, str) and not self.attributes and self._path == other)
 
     def __hash__(self):
         # Compare path and attrs to ensure performant comparison

--- a/tests/forms_tests/tests/test_media.py
+++ b/tests/forms_tests/tests/test_media.py
@@ -18,6 +18,7 @@ class MediaAssetTestCase(SimpleTestCase):
     def test_eq(self):
         self.assertEqual(MediaAsset("path/to/css"), MediaAsset("path/to/css"))
         self.assertEqual(MediaAsset("path/to/css"), "path/to/css")
+        self.assertNotEqual(MediaAsset("path/to/css", media="all"), "path/to/css")
         self.assertNotEqual(
             MediaAsset("path/to/css", media="all"), MediaAsset("path/to/css")
         )
@@ -786,17 +787,46 @@ class FormsMediaTestCase(SimpleTestCase):
         # c.css comes before a.css because widget1 + widget2 establishes this
         # order.
         self.assertEqual(
-            merged._css, {"screen": ["c.css", "a.css"], "all": ["d.css", "e.css"]}
+            merged._css,
+            {
+                "screen": [
+                    Stylesheet("c.css", media="screen"),
+                    Stylesheet("a.css", media="screen"),
+                ],
+                "all": [
+                    Stylesheet("d.css", media="all"),
+                    Stylesheet("e.css", media="all"),
+                ],
+            },
         )
         merged += widget3
         # widget3 contains an explicit ordering of c.css and a.css.
         self.assertEqual(
             merged._css,
-            {"screen": ["a.css", "b.css", "c.css"], "all": ["d.css", "e.css"]},
+            {
+                "screen": [
+                    Stylesheet("a.css", media="screen"),
+                    Stylesheet("b.css", media="screen"),
+                    Stylesheet("c.css", media="screen"),
+                ],
+                "all": [
+                    Stylesheet("d.css", media="all"),
+                    Stylesheet("e.css", media="all"),
+                ],
+            },
         )
         # Media ordering does not matter.
         merged = widget1 + widget4
-        self.assertEqual(merged._css, {"screen": ["c.css"], "all": ["d.css", "e.css"]})
+        self.assertEqual(
+            merged._css,
+            {
+                "screen": [Stylesheet("c.css", media="screen")],
+                "all": [
+                    Stylesheet("d.css", media="all"),
+                    Stylesheet("e.css", media="all"),
+                ],
+            },
+        )
 
     def test_add_js_deduplication(self):
         widget1 = Media(js=["a", "b", "c"])
@@ -825,24 +855,62 @@ class FormsMediaTestCase(SimpleTestCase):
         widget3 = Media(css={"screen": ["a.css"], "all": ["b.css", "c.css"]})
         widget4 = Media(css={"screen": ["a.css"], "all": ["c.css", "b.css"]})
         merged = widget1 + widget1
-        self.assertEqual(merged._css_lists, [{"screen": ["a.css"], "all": ["b.css"]}])
-        self.assertEqual(merged._css, {"screen": ["a.css"], "all": ["b.css"]})
+        self.assertEqual(
+            merged._css_lists,
+            [
+                {
+                    "screen": [Stylesheet("a.css", media="screen")],
+                    "all": [Stylesheet("b.css", media="all")],
+                }
+            ],
+        )
+        self.assertEqual(
+            merged._css,
+            {
+                "screen": [Stylesheet("a.css", media="screen")],
+                "all": [Stylesheet("b.css", media="all")],
+            },
+        )
         merged = widget1 + widget2
         self.assertEqual(
             merged._css_lists,
             [
-                {"screen": ["a.css"], "all": ["b.css"]},
-                {"screen": ["c.css"]},
+                {
+                    "screen": [Stylesheet("a.css", media="screen")],
+                    "all": [Stylesheet("b.css", media="all")],
+                },
+                {"screen": [Stylesheet("c.css", media="screen")]},
             ],
         )
-        self.assertEqual(merged._css, {"screen": ["a.css", "c.css"], "all": ["b.css"]})
+        self.assertEqual(
+            merged._css,
+            {
+                "screen": [
+                    Stylesheet("a.css", media="screen"),
+                    Stylesheet("c.css", media="screen"),
+                ],
+                "all": [Stylesheet("b.css", media="all")],
+            },
+        )
         merged = widget3 + widget4
         # Ordering within lists is preserved.
         self.assertEqual(
             merged._css_lists,
             [
-                {"screen": ["a.css"], "all": ["b.css", "c.css"]},
-                {"screen": ["a.css"], "all": ["c.css", "b.css"]},
+                {
+                    "screen": [Stylesheet("a.css", media="screen")],
+                    "all": [
+                        Stylesheet("b.css", media="all"),
+                        Stylesheet("c.css", media="all"),
+                    ],
+                },
+                {
+                    "screen": [Stylesheet("a.css", media="screen")],
+                    "all": [
+                        Stylesheet("c.css", media="all"),
+                        Stylesheet("b.css", media="all"),
+                    ],
+                },
             ],
         )
         msg = (
@@ -857,7 +925,9 @@ class FormsMediaTestCase(SimpleTestCase):
         media = Media(css={"screen": ["a.css"]}, js=["a"])
         empty_media = Media()
         merged = media + empty_media
-        self.assertEqual(merged._css_lists, [{"screen": ["a.css"]}])
+        self.assertEqual(
+            merged._css_lists, [{"screen": [Stylesheet("a.css", media="screen")]}]
+        )
         self.assertEqual(merged._js_lists, [["a"]])
 
     def test_add_invalid_type(self):


### PR DESCRIPTION
#### Trac ticket number

ticket-37310

#### Branch description
Updated MediaAsset equality so instances with attributes no longer compare equal to string paths, while preserving the existing behavior for attribute-free instances. This keeps equality consistent with attribute-aware hashing. Updated the affected media tests to compare against normalized Stylesheet instances.

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
<!-- If AI tools were used, provide which tools were used here. -->

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.