### PR TITLE
 Fixed #37271 -- Added calendar versioning support to django.utils.version helpers.

### DIFF
--- a/django/utils/version.py
+++ b/django/utils/version.py
@@ -46,9 +46,12 @@ def get_version(version=None):
 
 
 def get_main_version(version=None):
-    """Return main version (X.Y[.Z]) from VERSION."""
+    """Return main version (X.Y[.Z] or YYYY[.N]) from VERSION."""
     version = get_complete_version(version)
-    parts = 2 if version[2] == 0 else 3
+    if version[0] >= 2028:
+        parts = 1 if version[1] == 0 else 2
+    else:
+        parts = 2 if version[2] == 0 else 3
     return ".".join(str(x) for x in version[:parts])
 
 
@@ -70,6 +73,8 @@ def get_docs_version(version=None):
     version = get_complete_version(version)
     if version[3] != "final":
         return "dev"
+    elif version[0] >= 2028:
+        return str(version[0])
     else:
         return "%d.%d" % version[:2]
 

--- a/tests/version/tests.py
+++ b/tests/version/tests.py
@@ -5,7 +5,9 @@ from django import get_version
 from django.test import SimpleTestCase
 from django.utils.version import (
     get_complete_version,
+    get_docs_version,
     get_git_changeset,
+    get_main_version,
     get_version_tuple,
 )
 
@@ -18,6 +20,10 @@ class VersionTests(SimpleTestCase):
         # of a git clone: 1.4.devYYYYMMDDHHMMSS or 1.4.
         ver_string = get_version(ver_tuple)
         self.assertRegex(ver_string, r"1\.4(\.dev[0-9]+)?")
+
+        ver_tuple_calver = (2028, 0, 0, "alpha", 0)
+        ver_string_calver = get_version(ver_tuple_calver)
+        self.assertRegex(ver_string_calver, r"2028(\.dev[0-9]+)?")
 
     @skipUnless(
         hasattr(django.utils.version, "__file__"),
@@ -41,14 +47,50 @@ class VersionTests(SimpleTestCase):
             ((1, 4, 0, "final", 0), "1.4"),
             ((1, 4, 1, "rc", 2), "1.4.1rc2"),
             ((1, 4, 1, "final", 0), "1.4.1"),
+            # CalVer (DEP 20)
+            ((2028, 0, 0, "alpha", 1), "2028a1"),
+            ((2028, 0, 0, "beta", 1), "2028b1"),
+            ((2028, 0, 0, "rc", 1), "2028rc1"),
+            ((2028, 0, 0, "final", 0), "2028"),
+            ((2028, 1, 0, "rc", 2), "2028.1rc2"),
+            ((2028, 1, 0, "final", 0), "2028.1"),
+            ((2028, 5, 0, "final", 0), "2028.5"),
         )
         for ver_tuple, ver_string in tuples_to_strings:
             self.assertEqual(get_version(ver_tuple), ver_string)
+
+    def test_get_main_version(self):
+        tests = (
+            ((1, 4, 0, "final", 0), "1.4"),
+            ((1, 4, 1, "final", 0), "1.4.1"),
+            ((2028, 0, 0, "final", 0), "2028"),
+            ((2028, 1, 0, "final", 0), "2028.1"),
+            ((2028, 5, 0, "final", 0), "2028.5"),
+        )
+        for ver_tuple, expected in tests:
+            self.assertEqual(get_main_version(ver_tuple), expected)
+
+    def test_get_docs_version(self):
+        tests = (
+            ((1, 4, 0, "alpha", 1), "dev"),
+            ((1, 4, 0, "final", 0), "1.4"),
+            ((1, 4, 1, "final", 0), "1.4"),
+            ((2028, 0, 0, "alpha", 1), "dev"),
+            ((2028, 0, 0, "final", 0), "2028"),
+            ((2028, 1, 0, "final", 0), "2028"),
+            ((2028, 5, 0, "final", 0), "2028"),
+        )
+        for ver_tuple, expected in tests:
+            self.assertEqual(get_docs_version(ver_tuple), expected)
 
     def test_get_version_tuple(self):
         self.assertEqual(get_version_tuple("1.2.3"), (1, 2, 3))
         self.assertEqual(get_version_tuple("1.2.3b2"), (1, 2, 3))
         self.assertEqual(get_version_tuple("1.2.3b2.dev0"), (1, 2, 3))
+        self.assertEqual(get_version_tuple("2028"), (2028,))
+        self.assertEqual(get_version_tuple("2028.1"), (2028, 1))
+        self.assertEqual(get_version_tuple("2028.1b2"), (2028, 1))
+        self.assertEqual(get_version_tuple("2028.1b2.dev0"), (2028, 1))
 
     def test_get_version_invalid_version(self):
         tests = [


### PR DESCRIPTION
 #### Trac ticket number

ticket-37271

#### Branch description

DEP 20 introduces Calendar Versioning (CalVer) in the form `YYYY.N` starting with Django `2028.0` in year 2028. 

This PR updates `django.utils.version.get_main_version()` and `get_docs_version()` to handle CalVer tuples where `version[0] >= 2028`:
- `get_main_version()` returns `YYYY` when `N == 0` (e.g. `2028`) and `YYYY.N` when `N > 0` (e.g. `2028.1`).
- `get_docs_version()` returns `YYYY` for all final releases of that year, and `dev` for pre-releases.

Tests covering CalVer development, release, and tuple conversions have been added to `tests/version/tests.py`.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
AI tools used: Google Gemini (Antigravity coding assistant).

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.

- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.