### PR TITLE
Fixed #37245 -- ArrayField model validators stop validation at first failing array item.

### DIFF
--- a/django/contrib/postgres/fields/array.py
+++ b/django/contrib/postgres/fields/array.py
@@ -204,35 +204,49 @@ class ArrayField(CheckPostgresInstalledMixin, CheckFieldDefaultMixin, Field):
 
     def validate(self, value, model_instance):
         super().validate(value, model_instance)
+        error_list = []
         for index, part in enumerate(value):
             try:
                 self.base_field.validate(part, model_instance)
             except exceptions.ValidationError as error:
-                raise prefix_validation_error(
-                    error,
-                    prefix=self.error_messages["item_invalid"],
-                    code="item_invalid",
-                    params={"nth": index + 1},
+                error_list.append(
+                    prefix_validation_error(
+                        error,
+                        prefix=self.error_messages["item_invalid"],
+                        code="item_invalid",
+                        params={"nth": index + 1},
+                    )
                 )
         if isinstance(self.base_field, ArrayField):
             if len({len(i) for i in value}) > 1:
-                raise exceptions.ValidationError(
-                    self.error_messages["nested_array_mismatch"],
-                    code="nested_array_mismatch",
+                error_list.append(
+                    exceptions.ValidationError(
+                        self.error_messages["nested_array_mismatch"],
+                        code="nested_array_mismatch",
+                    )
                 )
+
+        if len(error_list) > 0:
+            raise exceptions.ValidationError(error_list)
 
     def run_validators(self, value):
         super().run_validators(value)
+        error_list = []
         for index, part in enumerate(value):
             try:
                 self.base_field.run_validators(part)
             except exceptions.ValidationError as error:
-                raise prefix_validation_error(
-                    error,
-                    prefix=self.error_messages["item_invalid"],
-                    code="item_invalid",
-                    params={"nth": index + 1},
+                error_list.append(
+                    prefix_validation_error(
+                        error,
+                        prefix=self.error_messages["item_invalid"],
+                        code="item_invalid",
+                        params={"nth": index + 1},
+                    )
                 )
+
+        if len(error_list) > 0:
+            raise exceptions.ValidationError(error_list)
 
     def formfield(self, **kwargs):
         return super().formfield(

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -69,6 +69,11 @@ Minor features
 :mod:`django.contrib.postgres`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* :class:`~django.contrib.postgres.fields.ArrayField` now collects and
+  reports validation errors for all invalid array items, rather than
+  stopping at the first one, when calling ``validate()`` or
+  ``run_validators()`` (:ticket:`37245`).
+
 * ...
 
 :mod:`django.contrib.redirects`

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -1072,12 +1072,22 @@ class TestValidation(PostgreSQLSimpleTestCase):
     def test_unbounded(self):
         field = ArrayField(models.IntegerField())
         with self.assertRaises(exceptions.ValidationError) as cm:
-            field.clean([1, None], None)
-        self.assertEqual(cm.exception.code, "item_invalid")
-        self.assertEqual(
-            cm.exception.message % cm.exception.params,
-            "Item 2 in the array did not validate: This field cannot be null.",
-        )
+            field.clean([1, None, None, 2], None)
+
+        self.assertEqual(len(cm.exception.error_list), 2)
+        expected = [
+            {
+                "message": "Item 2 in the array did not validate: "
+                "This field cannot be null.",
+            },
+            {
+                "message": "Item 3 in the array did not validate: "
+                "This field cannot be null.",
+            },
+        ]
+        for error, exp in zip(cm.exception.error_list, expected):
+            self.assertEqual(error.code, "item_invalid")
+            self.assertEqual(error.message, exp["message"])
 
     def test_blank_true(self):
         field = ArrayField(models.IntegerField(blank=True, null=True))
@@ -1103,27 +1113,42 @@ class TestValidation(PostgreSQLSimpleTestCase):
         field.clean([[1, 2], [3, 4]], None)
         with self.assertRaises(exceptions.ValidationError) as cm:
             field.clean([[1, 2], [3, 4, 5]], None)
-        self.assertEqual(cm.exception.code, "nested_array_mismatch")
+
+        self.assertEqual(len(cm.exception.error_list), 1)
+        self.assertEqual(cm.exception.error_list[0].code, "nested_array_mismatch")
         self.assertEqual(
-            cm.exception.messages[0], "Nested arrays must have the same length."
+            cm.exception.error_list[0].messages[0],
+            "Nested arrays must have the same length.",
         )
 
     def test_with_base_field_error_params(self):
         field = ArrayField(models.CharField(max_length=2))
         with self.assertRaises(exceptions.ValidationError) as cm:
-            field.clean(["abc"], None)
-        self.assertEqual(len(cm.exception.error_list), 1)
-        exception = cm.exception.error_list[0]
-        self.assertEqual(
-            exception.message,
-            "Item 1 in the array did not validate: Ensure this value has at most 2 "
-            "characters (it has 3).",
-        )
-        self.assertEqual(exception.code, "item_invalid")
-        self.assertEqual(
-            exception.params,
-            {"nth": 1, "value": "abc", "limit_value": 2, "show_value": 3},
-        )
+            field.clean(["abc", "aa", "defg"], None)
+
+        self.assertEqual(len(cm.exception.error_list), 2)
+        expected = [
+            {
+                "message": "Item 1 in the array did not validate:"
+                " Ensure this value has at most 2 characters (it has 3).",
+                "params": {"limit_value": 2, "show_value": 3, "value": "abc", "nth": 1},
+            },
+            {
+                "message": "Item 3 in the array did not validate: "
+                "Ensure this value has at most 2 characters (it has 4).",
+                "params": {
+                    "limit_value": 2,
+                    "show_value": 4,
+                    "value": "defg",
+                    "nth": 3,
+                },
+            },
+        ]
+
+        for error, exp in zip(cm.exception.error_list, expected):
+            self.assertEqual(error.code, "item_invalid")
+            self.assertEqual(error.message, exp["message"])
+            self.assertEqual(error.params, exp["params"])
 
     def test_with_validators(self):
         field = ArrayField(
@@ -1131,18 +1156,58 @@ class TestValidation(PostgreSQLSimpleTestCase):
         )
         field.clean([1, 2], None)
         with self.assertRaises(exceptions.ValidationError) as cm:
-            field.clean([0], None)
-        self.assertEqual(len(cm.exception.error_list), 1)
-        exception = cm.exception.error_list[0]
-        self.assertEqual(
-            exception.message,
-            "Item 1 in the array did not validate: Ensure this value is greater than "
-            "or equal to 1.",
+            field.clean([0, 1, -3, 4], None)
+        self.assertEqual(len(cm.exception.error_list), 2)
+        expected = [
+            {
+                "message": "Item 1 in the array did not validate: "
+                "Ensure this value is greater than or equal to 1.",
+                "params": {"limit_value": 1, "show_value": 0, "value": 0, "nth": 1},
+            },
+            {
+                "message": "Item 3 in the array did not validate: "
+                "Ensure this value is greater than or equal to 1.",
+                "params": {"limit_value": 1, "show_value": -3, "value": -3, "nth": 3},
+            },
+        ]
+
+        for error, exp in zip(cm.exception.error_list, expected):
+            self.assertEqual(error.code, "item_invalid")
+            self.assertEqual(error.message, exp["message"])
+            self.assertEqual(error.params, exp["params"])
+
+    def test_with_multiple_validators_same_item(self):
+        field = ArrayField(
+            models.IntegerField(
+                validators=[
+                    validators.MinValueValidator(0),
+                    validators.MinValueValidator(5),
+                ]
+            )
         )
-        self.assertEqual(exception.code, "item_invalid")
-        self.assertEqual(
-            exception.params, {"nth": 1, "value": 0, "limit_value": 1, "show_value": 0}
-        )
+        field.clean(value=[10], model_instance=None)
+        with self.assertRaises(exceptions.ValidationError) as cm:
+            field.clean(value=[15, -20], model_instance=None)
+
+        # Two fails value -20 is less than 0 and less than 5.
+        self.assertEqual(len(cm.exception.error_list), 2)
+        expected = [
+            {
+                "message": "Item 2 in the array did not validate: "
+                "Ensure this value is greater than or equal to 0.",
+                "params": {"limit_value": 0, "show_value": -20, "value": -20, "nth": 2},
+            },
+            {
+                "message": "Item 2 in the array did not validate: "
+                "Ensure this value is greater than or equal to 5.",
+                "params": {"limit_value": 5, "show_value": -20, "value": -20, "nth": 2},
+            },
+        ]
+
+        for error, exp in zip(cm.exception.error_list, expected):
+            self.assertEqual(error.code, "item_invalid")
+            self.assertEqual(error.message, exp["message"])
+            self.assertEqual(error.params, exp["params"])
 
 
 class TestSimpleFormField(PostgreSQLSimpleTestCase):


### PR DESCRIPTION
Thanks to chriskrusz for reporting the issue and Sidharth Nuthi for the error-reproducing script.

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->
ticket-37245

#### Branch description
This branch changes the error-collecting behavior of `ArrayField`, ensuring that all errors are collected in `error_list` instead of raising on the first failing element.

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Tool used: Claude — used for investigating the issue and helping update the release notes in `6.2.txt`.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.