### PR TITLE
Fixed #12134 -- Made RelatedFieldWidgetWrapper.__deepcopy__() use the copied widget's attrs.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -392,6 +392,7 @@ answer newbie questions, and generally made Django that much better:
     Garry Lawrence
     Garry Polley <garrympolley@gmail.com>
     Garth Kidd <http://www.deadlybloodyserious.com/>
+    Garvit Sharma <giantgarvit@gmail.com>
     Gary Wilson <gary.wilson@gmail.com>
     Gasper Koren
     Gasper Zejn <zejn@kiberpipa.org>

--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -307,7 +307,7 @@ class RelatedFieldWidgetWrapper(forms.Widget):
     def __deepcopy__(self, memo):
         obj = copy.copy(self)
         obj.widget = copy.deepcopy(self.widget, memo)
-        obj.attrs = self.widget.attrs
+        obj.attrs = obj.widget.attrs
         memo[id(self)] = obj
         return obj
 

--- a/docs/releases/6.1.2.txt
+++ b/docs/releases/6.1.2.txt
@@ -9,4 +9,7 @@ Django 6.1.2 fixes several bugs in 6.1.1.
 Bugfixes
 ========
 
-* ...
+* Fixed a long-standing bug where copying an admin related field widget shared
+  the ``attrs`` dictionary with the original widget, so setting widget
+  attributes on one form instance leaked into others, for example across the
+  rows of a ``list_editable`` changelist (:ticket:`12134`).

--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -1,3 +1,4 @@
+import copy
 import gettext
 import os
 import re
@@ -977,6 +978,46 @@ class RelatedFieldWidgetWrapperTests(SimpleTestCase):
         </div>
         """
         self.assertHTMLEqual(output, expected)
+
+    def test_deepcopy_attrs_follow_copied_widget(self):
+        rel = Album._meta.get_field("band").remote_field
+        wrapper = widgets.RelatedFieldWidgetWrapper(
+            forms.Select(), rel, widget_admin_site
+        )
+        wrapper_copy = copy.deepcopy(wrapper)
+        self.assertIsNot(wrapper_copy.widget, wrapper.widget)
+        self.assertIs(wrapper_copy.attrs, wrapper_copy.widget.attrs)
+        self.assertIsNot(wrapper_copy.attrs, wrapper.widget.attrs)
+
+    def test_deepcopy_attrs_not_shared_between_copies(self):
+        rel = Album._meta.get_field("band").remote_field
+        wrapper = widgets.RelatedFieldWidgetWrapper(
+            forms.Select(), rel, widget_admin_site
+        )
+        wrapper_copy = copy.deepcopy(wrapper)
+        wrapper_copy.attrs["class"] = "copy-only"
+        self.assertNotIn("class", wrapper.attrs)
+        self.assertNotIn("class", wrapper.widget.attrs)
+        self.assertIn('class="copy-only"', wrapper_copy.render("band", None))
+        self.assertNotIn("copy-only", wrapper.render("band", None))
+
+    def test_attrs_set_per_form_instance_are_not_shared(self):
+        rel = Album._meta.get_field("band").remote_field
+        wrapper = widgets.RelatedFieldWidgetWrapper(
+            forms.Select(), rel, widget_admin_site
+        )
+
+        class AlbumForm(forms.Form):
+            band = forms.CharField(widget=wrapper)
+
+            def __init__(self, marker, **kwargs):
+                super().__init__(**kwargs)
+                self.fields["band"].widget.attrs["data-marker"] = marker
+
+        first, second = AlbumForm("first"), AlbumForm("second")
+        self.assertEqual(first.fields["band"].widget.attrs["data-marker"], "first")
+        self.assertEqual(second.fields["band"].widget.attrs["data-marker"], "second")
+        self.assertNotIn("data-marker", wrapper.attrs)
 
     def test_non_select_widget_cant_change_delete_related(self):
         main_band = Event._meta.get_field("main_band")


### PR DESCRIPTION
#### Trac ticket number

[ticket-12134](https://code.djangoproject.com/ticket/12134)

#### Branch description

`RelatedFieldWidgetWrapper.__deepcopy__()` binds the copy's `attrs` to the
**original** widget's dict rather than to the copy's own:

```python
obj.widget = copy.deepcopy(self.widget, memo)
obj.attrs = self.widget.attrs   # self, not obj
```

Two consequences: every copy shares one `attrs` dict with the original, and the
wrapper's alias to its *own* inner widget is severed.

|                                     | main  | this PR |
|-------------------------------------|-------|---------|
| `copy1.attrs is copy2.attrs`        | True  | False   |
| `copy1.attrs is copy1.widget.attrs` | False | True    |

**Re comment:2 on the ticket.** The analysis there assumes
`wrapper2.attrs is wrapper2.widget.attrs` holds after a deepcopy. It does not —
that is the bug. The 2009 patch was correctly rejected: `self.attrs.copy()`
gives the copy a private dict but breaks the alias, so per-instance attrs would
stop reaching the rendered HTML entirely. This patch instead binds to
`obj.widget.attrs`, which **preserves** the invariant comment:2 was protecting
while removing the sharing.

**User-visible symptom (#26213).** Rendering delegates to `self.widget`, whose
`attrs` is a snapshot taken at deepcopy time, while user code writes to the
shared dict. Attributes therefore appear one row late across a formset. A 3-row
`list_editable` changelist with attrs set in the form's `__init__`:

```
before:  row 1 -> (none)      row 2 -> row 1's     row 3 -> row 2's
after:   row 1 -> row 1's     row 2 -> row 2's     row 3 -> row 3's
```

With a conditional `disabled`, a row intended to be locked renders editable and
the next row renders locked.

Introduced in a19ed8aea3 (newforms-admin merge, 2008) and unchanged since;
present on 4.2 / 5.2 / 6.0 / 6.1 / main. Admin HTML output is unchanged except
that attributes land on the correct row.

This is a behaviour change for anyone unknowingly relying on the shifted attrs,
so I am happy to move the release note if main-only is preferred.

#### AI Assistance Disclosure (REQUIRED)

- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude (Anthropic) was used to help investigate the ticket, draft the fix and the
regression tests, and draft this description. I applied every change by hand,
ran the test suite locally — including confirming the three new tests fail on
`main` before the one-line fix and pass after it — and verified the reasoning
and the historical claims myself.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
