### PR TITLE
Fixed #37289 -- Avoided deleting network rasters.

### DIFF
--- a/django/contrib/gis/gdal/raster/source.py
+++ b/django/contrib/gis/gdal/raster/source.py
@@ -217,7 +217,7 @@ class GDALRaster(GDALRasterBase):
             )
 
     def __del__(self):
-        if self.is_vsi_based:
+        if self._is_vsimem_based:
             # Remove the temporary file from the VSI in-memory filesystem.
             capi.unlink_vsi_file(force_bytes(self.name))
         super().__del__()
@@ -276,9 +276,7 @@ class GDALRaster(GDALRasterBase):
 
     @property
     def vsi_buffer(self):
-        if not (
-            self.is_vsi_based and self.name.startswith(VSI_MEM_FILESYSTEM_BASE_PATH)
-        ):
+        if not self._is_vsimem_based:
             return None
         # Prepare an integer that will contain the buffer length.
         out_length = c_int()
@@ -294,6 +292,10 @@ class GDALRaster(GDALRasterBase):
     @cached_property
     def is_vsi_based(self):
         return self._ptr and self.name.startswith(VSI_FILESYSTEM_PREFIX)
+
+    @cached_property
+    def _is_vsimem_based(self):
+        return self._ptr and self.name.startswith(VSI_MEM_FILESYSTEM_BASE_PATH)
 
     @property
     def name(self):

--- a/docs/ref/contrib/gis/gdal.txt
+++ b/docs/ref/contrib/gis/gdal.txt
@@ -1688,7 +1688,7 @@ bands: one for red, one for green, and one for blue.
     .. attribute:: vsi_buffer
 
         A ``bytes`` representation of this raster. Returns ``None`` for rasters
-        that are not stored in GDAL's virtual filesystem.
+        that are not stored in GDAL's in-memory virtual filesystem.
 
     .. attribute:: is_vsi_based
 
@@ -2115,6 +2115,8 @@ can directly access compressed files using the ``/vsizip/``, ``/vsigzip/``, or
    >>> rst = GDALRaster("/vsizip/path/to/your/file.zip/path/to/raster.tif")
    >>> rst = GDALRaster("/vsigzip/path/to/your/file.gz")
    >>> rst = GDALRaster("/vsitar/path/to/your/file.tar/path/to/raster.tif")
+
+.. _gdal-raster-network:
 
 Network rasters
 ^^^^^^^^^^^^^^^

--- a/docs/releases/5.2.18.txt
+++ b/docs/releases/5.2.18.txt
@@ -1,10 +1,10 @@
-==========================
-Django 6.1.2 release notes
-==========================
+===========================
+Django 5.2.18 release notes
+===========================
 
 *Expected October 6, 2026*
 
-Django 6.1.2 fixes one data loss issue in 4.0 and several bugs in 6.1.1.
+Django 5.2.18 fixes one data loss issue in 4.0.
 
 Bugfixes
 ========

--- a/docs/releases/6.0.9.txt
+++ b/docs/releases/6.0.9.txt
@@ -1,10 +1,10 @@
 ==========================
-Django 6.1.2 release notes
+Django 6.0.9 release notes
 ==========================
 
 *Expected October 6, 2026*
 
-Django 6.1.2 fixes one data loss issue in 4.0 and several bugs in 6.1.1.
+Django 6.0.9 fixes one data loss issue in 4.0.
 
 Bugfixes
 ========

--- a/docs/releases/index.txt
+++ b/docs/releases/index.txt
@@ -41,6 +41,7 @@ versions of the documentation contain the release notes for any later releases.
 .. toctree::
    :maxdepth: 1
 
+   6.0.9
    6.0.8
    6.0.7
    6.0.6
@@ -56,6 +57,7 @@ versions of the documentation contain the release notes for any later releases.
 .. toctree::
    :maxdepth: 1
 
+   5.2.18
    5.2.17
    5.2.16
    5.2.15

--- a/tests/gis_tests/gdal_tests/test_raster.py
+++ b/tests/gis_tests/gdal_tests/test_raster.py
@@ -8,6 +8,7 @@ from unittest import mock
 
 from django.contrib.gis.gdal import GDAL_VERSION, GDALRaster, SpatialReference
 from django.contrib.gis.gdal.error import GDALException
+from django.contrib.gis.gdal.prototypes import raster as capi
 from django.contrib.gis.gdal.raster.band import GDALBand
 from django.contrib.gis.shortcuts import numpy
 from django.core.files.temp import NamedTemporaryFile
@@ -192,7 +193,10 @@ class GDALRasterTests(SimpleTestCase):
 
     def test_nonexistent_file(self):
         msg = 'Unable to read raster source input "nonexistent.tif".'
-        with self.assertRaisesMessage(GDALException, msg):
+        with (
+            self.assertNoLogs("django.contrib.gis", "ERROR"),
+            self.assertRaisesMessage(GDALException, msg),
+        ):
             GDALRaster("nonexistent.tif")
 
     def test_vsi_raster_creation(self):
@@ -283,6 +287,19 @@ class GDALRasterTests(SimpleTestCase):
         self.assertEqual(rst.name, rst_path)
         self.assertIs(rst.is_vsi_based, True)
         self.assertIsNone(rst.vsi_buffer)
+
+    def test_non_vsimem_raster_not_unlinked(self):
+        """Closing a non-/vsimem/ raster doesn't unlink its source."""
+        rst_zipfile = NamedTemporaryFile(suffix=".zip")
+        self.addCleanup(rst_zipfile.close)
+        with zipfile.ZipFile(rst_zipfile, mode="w") as zf:
+            zf.write(self.rs_path, "raster.tif")
+        rst_path = "/vsizip/" + os.path.join(rst_zipfile.name, "raster.tif")
+        rst = GDALRaster(rst_path)
+        self.assertIs(rst._is_vsimem_based, False)
+        with mock.patch.object(capi, "unlink_vsi_file") as unlink_vsi_file:
+            del rst
+        unlink_vsi_file.assert_not_called()
 
     def test_offset_size_and_shape_on_raster_creation(self):
         rast = GDALRaster(


### PR DESCRIPTION
#### Trac ticket number
ticket-37289

#### Branch description
`GDALRaster.__del__()` issues an unlink call to GDAL to remove temporary files from the in-memory virtual filesystem. When ticket-32670 allowed using any virtual filesystem, including commercial storage ones like `vsis3` for Amazon S3, this meant network rasters could be unintentionally deleted.

Thanks "garden_" for the report.

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

I used Codex to rule out some alternative regression tests and rule out my original idea on the ticket to observe the `write=True` argument somehow. (I don't think we need to implement any sort of deletion for network rasters.)

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
