### PR TITLE
Fixed #22088 -- Preserved significant whitespace in XML serialization.

### DIFF
--- a/django/core/serializers/xml_serializer.py
+++ b/django/core/serializers/xml_serializer.py
@@ -85,21 +85,27 @@ class Serializer(base.Serializer):
         """
         self.indent_level += 1
         self.indent(self.indent_level)
-        self.xml.startElement(
-            "field",
-            {
-                "name": field.name,
-                "type": field.get_internal_type(),
-            },
-        )
+        attrs = {
+            "name": field.name,
+            "type": field.get_internal_type(),
+        }
 
         # Get a "string version" of the object's data.
+        value = None
         if getattr(obj, field.name) is not None:
             value = field.value_to_string(obj)
             if field.get_internal_type() == "JSONField":
                 # Dump value since JSONField.value_to_string() doesn't output
                 # strings.
                 value = json.dumps(value, cls=field.encoder)
+            if value.strip() != value:
+                # Deserialization strips surrounding whitespace so that
+                # hand-indented fixtures load as intended. Mark values whose
+                # own whitespace is significant, so they survive a round trip.
+                attrs["xml:space"] = "preserve"
+
+        self.xml.startElement("field", attrs)
+        if value is not None:
             try:
                 self.xml.characters(value)
             except UnserializableContentError:
@@ -331,7 +337,7 @@ class Deserializer(base.Deserializer):
                 if getChildrenByTagName(field_node, "None"):
                     value = None
                 else:
-                    value = field.to_python(getInnerText(field_node).strip())
+                    value = field.to_python(getFieldText(field_node))
                     # Load value since JSONField.to_python() outputs strings.
                     if field.get_internal_type() == "JSONField":
                         value = json.loads(value, cls=field.decoder)
@@ -486,6 +492,20 @@ def getInnerText(node):
     return "".join(
         [child.data for child in node.childNodes if check_element_type(child)]
     )
+
+
+def getFieldText(node):
+    """
+    Return the text of a <field> node.
+
+    Surrounding whitespace is stripped, so that hand-indented fixtures load as
+    intended, unless the node is marked xml:space="preserve" -- which the
+    serializer does for values whose own whitespace would otherwise be lost.
+    """
+    text = getInnerText(node)
+    if node.getAttribute("xml:space") == "preserve":
+        return text
+    return text.strip()
 
 
 # Below code based on Christian Heimes' defusedxml

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -311,6 +311,12 @@ Miscellaneous
   ``datetime.datetime(2000, 1, 1, 0, 0, 0, 1)`` now serializes to
   ``"2000-01-01T00:00:00"`` rather than ``"2000-01-01T00:00:00.000"``.
 
+* The XML serializer now sets ``xml:space="preserve"`` on ``<field>`` elements
+  whose value has leading or trailing whitespace, so that such values survive a
+  :djadmin:`dumpdata`/:djadmin:`loaddata` round trip. Previously the
+  deserializer stripped them. Field text is still stripped when the attribute is
+  absent, so existing fixtures load unchanged.
+
 * :func:`.utils.module_loading.import_string` now deterministically favors
   submodules in ambiguous cases where depending on prior import state, a
   same-named attribute of the parent module might have been returned instead.

--- a/tests/serializers/test_xml.py
+++ b/tests/serializers/test_xml.py
@@ -100,6 +100,39 @@ class XmlSerializerTestCase(SerializersTestBase, TestCase):
         with self.assertRaises(DTDForbidden):
             next(serializers.deserialize("xml", xml))
 
+    def test_significant_whitespace_survives_round_trip(self):
+        """
+        Leading and trailing whitespace in a field value is preserved by a
+        serialize/deserialize round trip.
+        """
+        self.a1.headline = "\tLeading and trailing  "
+        serial_str = serializers.serialize(self.serializer_name, [self.a1])
+        self.assertIn('xml:space="preserve"', serial_str)
+        obj = next(serializers.deserialize(self.serializer_name, serial_str)).object
+        self.assertEqual(obj.headline, "\tLeading and trailing  ")
+
+    def test_whitespace_marker_omitted_when_not_needed(self):
+        """xml:space is only emitted for values that need it."""
+        self.a1.headline = "No surrounding whitespace"
+        serial_str = serializers.serialize(self.serializer_name, [self.a1])
+        self.assertNotIn("xml:space", serial_str)
+
+    def test_field_text_without_marker_is_stripped(self):
+        """
+        Field text is still stripped when xml:space="preserve" is absent, so
+        that hand-indented fixtures keep loading as intended.
+        """
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<django-objects version="1.0">
+    <object model="serializers.category" pk="1">
+        <field type="CharField" name="name">
+            Reference
+        </field>
+    </object>
+</django-objects>"""
+        obj = next(serializers.deserialize(self.serializer_name, xml)).object
+        self.assertEqual(obj.name, "Reference")
+
 
 class XmlSerializerTransactionTestCase(
     SerializersTransactionTestBase, TransactionTestCase


### PR DESCRIPTION
#### Trac ticket number

ticket-22088

#### Branch description

The XML deserializer stripped the text of every `<field>` element, so a value
with leading or trailing whitespace did not survive a `dumpdata`/`loaddata`
round trip. The serializer wrote the value out correctly; it was lost on the way
back in.

```pycon
>>> ct = ContentType(pk=1, app_label="\tBaz", model="  lead_and_trail  ")
>>> xml = serializers.serialize("xml", [ct])
>>> # written correctly:
>>> # <field name="app_label" type="CharField">\tBaz</field>
>>> back = list(serializers.deserialize("xml", xml))[0].object
>>> back.app_label, back.model
('Baz', 'lead_and_trail')
```

The `.strip()` in the deserializer cannot simply be removed. It is what allows a
hand-indented fixture to load as intended:

```xml
<field name="name" type="CharField">
    Reference
</field>
```

Without it, that value would load as `"\n    Reference\n"`.

So the two cases have to be told apart, and XML already has the mechanism for
saying "the whitespace here is mine": `xml:space="preserve"`. The serializer now
sets it on fields whose value would otherwise not round trip, and the
deserializer strips only when the marker is absent.

Consequences:

* Values with significant whitespace round trip exactly.
* Fixtures without the attribute behave exactly as before, so existing fixtures
  and hand-written XML are unaffected.
* The attribute is only emitted when needed, so ordinary dumps are byte-for-byte
  unchanged.

The `xml:` prefix is bound by the XML spec itself, so no namespace declaration
is needed and the output stays valid.

`getFieldText()` is applied to the regular field path, which is what the ticket
reports. The natural-key and m2m paths still strip unconditionally; I left them
alone to keep the change scoped, and can extend it if reviewers prefer.

A release note is included under *Backwards incompatible changes → Miscellaneous*,
alongside the `DjangoJSONEncoder` entry, since this changes serializer output.

#### AI Assistance Disclosure (REQUIRED)

- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.


#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.

- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
