### PR TITLE
Fixed test_asgeojson() on MySQL 9.5.

### DIFF
--- a/django/contrib/gis/db/backends/mysql/features.py
+++ b/django/contrib/gis/db/backends/mysql/features.py
@@ -13,7 +13,12 @@ class DatabaseFeatures(BaseSpatialFeatures, MySQLDatabaseFeatures):
     supports_transform = False
     supports_null_geometries = False
     supports_num_points_poly = False
-    unsupported_geojson_options = {"crs"}
+
+    @cached_property
+    def unsupported_geojson_options(self):
+        if self.connection.mysql_is_mariadb or self.connection.mysql_version < (9, 5):
+            return {"crs"}
+        return set()
 
     @cached_property
     def supports_geometry_field_unique_index(self):

--- a/docs/ref/contrib/gis/functions.txt
+++ b/docs/ref/contrib/gis/functions.txt
@@ -456,7 +456,7 @@ Keyword Argument       Description
 
 ``crs``                Set this to ``True`` if you want the coordinate
                        reference system to be included in the returned
-                       GeoJSON. Ignored on MySQL and Oracle.
+                       GeoJSON. Ignored on MySQL < 9.5, MariaDB, and Oracle.
 
 ``precision``          It may be used to specify the number of significant
                        digits for the coordinates in the GeoJSON

--- a/tests/gis_tests/geoapp/test_functions.py
+++ b/tests/gis_tests/geoapp/test_functions.py
@@ -66,6 +66,9 @@ class GISFunctionsTests(FuncTestMixin, TestCase):
         if "crs" in connection.features.unsupported_geojson_options:
             del houston_json["crs"]
             del chicago_json["crs"]
+        elif connection.ops.mysql:
+            for expected_json in (houston_json, chicago_json):
+                expected_json["crs"]["properties"]["name"] = "MySQL:0"
         if "bbox" in connection.features.unsupported_geojson_options:
             del chicago_json["bbox"]
             del victoria_json["bbox"]


### PR DESCRIPTION
#### Branch description
MySQL 9.5 added support for the "crs" attribute in GeoJSON:
https://dev.mysql.com/doc/relnotes/mysql/9.7/en/news-9-5-0.html#:~:text=ST_AsGeoJSON%20function

Fixes this failure:
```py
======================================================================
FAIL: test_asgeojson (gis_tests.geoapp.test_functions.GISFunctionsTests.test_asgeojson)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/django/source/tests/gis_tests/geoapp/test_functions.py", line 92, in test_asgeojson
    self.assertJSONEqual(
    ~~~~~~~~~~~~~~~~~~~~^
        City.objects.annotate(json=functions.AsGeoJSON("point", crs=True))
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<2 lines>...
        houston_json,
        ^^^^^^^^^^^^^
    )
    ^
AssertionError: {'crs': {'type': 'name', 'properties': {'na[69 chars]374]} != {'type': 'Point', 'coordinates': [-95.363151, 29.763374]}
- {'coordinates': [-95.363151, 29.763374],
+ {'coordinates': [-95.363151, 29.763374], 'type': 'Point'}
?                                         +++++++++++++++++

-  'crs': {'properties': {'name': 'MySQL:0'}, 'type': 'name'},
-  'type': 'Point'}

----------------------------------------------------------------------
```

#### AI Assistance Disclosure (REQUIRED)
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.