### PR TITLE
Fixed #37321 -- Documented BaseSpatialField.srid=-1 behavior.

### DIFF
--- a/docs/ref/contrib/gis/model-api.txt
+++ b/docs/ref/contrib/gis/model-api.txt
@@ -112,6 +112,10 @@ Sets the SRID [#fnogcsrid]_ (Spatial Reference System Identity) of the geometry
 field to the given value. Defaults to 4326 (also known as `WGS84`__, units are
 in degrees of longitude and latitude).
 
+Setting the SRID to ``-1`` disables automatic SRID transformations when saving
+geometries. The assigned geometry's SRID is set to ``-1``, discarding any
+explicit SRID it had.
+
 __ https://en.wikipedia.org/wiki/WGS84
 
 .. _selecting-an-srid:


### PR DESCRIPTION
#### Trac ticket number

ticket-37321

#### Branch description

Documented that setting `BaseSpatialField.srid` to `-1` disables automatic SRID transformations when saving spatial values and discards their explicit SRID. Added a PostGIS raster regression test to verify that this behavior applies to rasters as well as geometries.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

OpenAI Codex was used to inspect the relevant implementation and tests, help draft the documentation wording and raster regression test, and run available checks. I manually reviewed and verified the final change.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the main branch.
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
