### PR TITLE
Fixed #19255, #18357 -- Fixed BaseGenericInlineFormSet not setting generic foreign keys during form initialization.

### DIFF
--- a/django/contrib/contenttypes/forms.py
+++ b/django/contrib/contenttypes/forms.py
@@ -51,6 +51,34 @@ class BaseGenericInlineFormSet(BaseModelFormSet):
             return 0
         return super().initial_form_count()
 
+    def _construct_form(self, i, **kwargs):
+        form = super()._construct_form(i, **kwargs)
+        if self.save_as_new:
+            mutable = getattr(form.data, "_mutable", None)
+            # Allow modifying an immutable QueryDict.
+            if mutable is not None:
+                form.data._mutable = True
+            # Remove the primary key from the form's data, we are only
+            # creating new instances
+            form.data[form.add_prefix(self._pk_field.name)] = None
+            # Remove the foreign keys from the form's data
+            form.data[form.add_prefix(self.ct_field.name)] = None
+            form.data[form.add_prefix(self.ct_fk_field.name)] = None
+            if mutable is not None:
+                form.data._mutable = mutable
+
+        if self.instance is not None:
+            # Set the fk values here so that the form can do its validation.
+            setattr(form.instance, self.ct_fk_field.attname, self.instance.pk)
+            setattr(
+                form.instance,
+                self.ct_field.attname,
+                ContentType.objects.get_for_model(
+                    self.instance, for_concrete_model=self.for_concrete_model
+                ).pk,
+            )
+        return form
+
     @classmethod
     def get_default_prefix(cls):
         opts = cls.model._meta

--- a/tests/generic_relations/test_forms.py
+++ b/tests/generic_relations/test_forms.py
@@ -365,3 +365,37 @@ class GenericInlineFormsetTests(TestCase):
         self.assertEqual(len(formset), 2)
         self.assertNotIn("DELETE", formset.forms[0].fields)
         self.assertNotIn("DELETE", formset.forms[1].fields)
+
+
+class TaggedItemFormWithClean(forms.ModelForm):
+    class Meta:
+        model = TaggedItem
+        fields = "__all__"
+
+    def clean(self):
+        cleaned_data = super().clean()
+        if getattr(self.instance, "content_type_id", None) is None:
+            raise forms.ValidationError("content_type is missing in form instance!")
+        if getattr(self.instance, "object_id", None) is None:
+            raise forms.ValidationError("object_id is missing in form instance!")
+        return cleaned_data
+
+
+class Ticket18357Test(TestCase):
+    def test_generic_inlineformset_validation_with_clean(self):
+        GenericFormSet = generic_inlineformset_factory(
+            TaggedItem, form=TaggedItemFormWithClean
+        )
+        platypus = Animal.objects.create(
+            common_name="Platypus", latin_name="Ornithorhynchus anatinus"
+        )
+
+        data = {
+            "generic_relations-taggeditem-content_type-object_id-TOTAL_FORMS": "1",
+            "generic_relations-taggeditem-content_type-object_id-INITIAL_FORMS": "0",
+            "generic_relations-taggeditem-content_type-object_id-MAX_NUM_FORMS": "10",
+            "generic_relations-taggeditem-content_type-object_id-0-tag": "shiny",
+        }
+
+        formset = GenericFormSet(data=data, instance=platypus)
+        self.assertTrue(formset.is_valid(), formset.errors)


### PR DESCRIPTION
#### Trac ticket number
ticket-19255

#### Branch description
BaseGenericInlineFormSet does not set generic foreign key fields (content_type and object_id) during form construction, unlike BaseInlineFormSet. This prevents model-level clean() methods from accessing the parent object or generic relation attributes during form validation. This change implements _construct_form() on BaseGenericInlineFormSet to set ct_field and ct_fk_field before validation and handle save_as_new. Also addresses duplicate ticket-18357.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
Used Claude for assistance with researching the issue and drafting the test case and implementation. All generated code and tests were manually reviewed, verified locally, and executed against the Django test suite.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.

- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
