### PR TITLE
Fixed #37324 -- Cannot assign expressions to spatial fields.

### DIFF
--- a/django/contrib/gis/db/backends/oracle/operations.py
+++ b/django/contrib/gis/db/backends/oracle/operations.py
@@ -18,6 +18,7 @@ from django.contrib.gis.geos.geometry import GEOSGeometry, GEOSGeometryBase
 from django.contrib.gis.geos.prototypes.io import wkb_r
 from django.contrib.gis.measure import Distance
 from django.db.backends.oracle.operations import DatabaseOperations
+from django.db.backends.oracle.utils import BoundVar
 from django.utils.functional import cached_property
 
 DEFAULT_TOLERANCE = "0.05"
@@ -226,6 +227,31 @@ class OracleOperations(BaseSpatialOperations, DatabaseOperations):
         from django.contrib.gis.db.backends.oracle.models import OracleSpatialRefSys
 
         return OracleSpatialRefSys
+
+    def returning_columns(self, fields):
+        """
+        Wrap spatial columns with TO_WKBGEOMETRY (via `self.select`) so
+        RETURNING hands back parseable WKB instead of SDO_GEOMETRY.
+        """
+        if not fields:
+            return "", ()
+        columns = []
+        params = []
+        for field in fields:
+            col = "%s.%s" % (
+                self.quote_name(field.model._meta.db_table),
+                self.quote_name(field.column),
+            )
+            param = BoundVar(field)
+            if hasattr(field, "geom_type"):
+                col = self.select % col
+                param.db_type = self.connection.Database.BLOB
+            columns.append(col)
+            params.append(param)
+        return "RETURNING %s INTO %s" % (
+            ", ".join(columns),
+            ", ".join(["%s"] * len(params)),
+        ), tuple(params)
 
     def modify_insert_params(self, placeholder, params):
         """Drop out insert parameters for NULL placeholder. Needed for Oracle

--- a/django/contrib/gis/db/backends/spatialite/operations.py
+++ b/django/contrib/gis/db/backends/spatialite/operations.py
@@ -217,6 +217,26 @@ class SpatiaLiteOperations(BaseSpatialOperations, DatabaseOperations):
         )
 
         return SpatialiteGeometryColumns
+    
+    def returning_columns(self, fields):
+        """
+        Wrap spatial columns with AsEWKB (via `self.select`) so RETURNING
+        hands back parseable EWKB instead of SpatiaLite's internal BLOB
+        format. Non-spatial columns (e.g. an AutoField pk) are returned
+        unwrapped, exactly as the base implementation does.
+        """
+        if not fields:
+            return "", ()
+        columns = []
+        for field in fields:
+            col = "%s.%s" % (
+                self.quote_name(field.model._meta.db_table),
+                self.quote_name(field.column),
+            )
+            if hasattr(field, "geom_type"):
+                col = self.select % col
+            columns.append(col)
+        return "RETURNING %s" % ", ".join(columns), ()
 
     def spatial_ref_sys(self):
         from django.contrib.gis.db.backends.spatialite.models import (

--- a/django/contrib/gis/db/backends/spatialite/operations.py
+++ b/django/contrib/gis/db/backends/spatialite/operations.py
@@ -217,7 +217,7 @@ class SpatiaLiteOperations(BaseSpatialOperations, DatabaseOperations):
         )
 
         return SpatialiteGeometryColumns
-    
+
     def returning_columns(self, fields):
         """
         Wrap spatial columns with AsEWKB (via `self.select`) so RETURNING

--- a/django/contrib/gis/db/models/proxy.py
+++ b/django/contrib/gis/db/models/proxy.py
@@ -76,7 +76,7 @@ class SpatialProxy(DeferredAttribute):
             pass
         elif isinstance(value, Combinable):
             # Query expressions (F(), functions, etc.) are resolved later
-            # during query compilation 
+            # during query compilation
             pass
         elif isinstance(value, self._klass):
             # The geometry type must match that of the field -- unless the

--- a/django/contrib/gis/db/models/proxy.py
+++ b/django/contrib/gis/db/models/proxy.py
@@ -6,6 +6,7 @@ objects corresponding to geographic model fields.
 Thanks to Robert Coup for providing this functionality (see #4322).
 """
 
+from django.db.models.expressions import Combinable
 from django.db.models.query_utils import DeferredAttribute
 
 
@@ -38,6 +39,10 @@ class SpatialProxy(DeferredAttribute):
 
         if isinstance(geo_value, self._klass):
             geo_obj = geo_value
+        elif isinstance(geo_value, Combinable):
+            # Query expressions (F(), functions, etc.) are resolved later
+            # during query compilation
+            return geo_value
         elif (geo_value is None) or (geo_value == ""):
             geo_obj = None
         else:
@@ -68,6 +73,10 @@ class SpatialProxy(DeferredAttribute):
         ):
             # For raster fields, ensure input is None or a string, dict, or
             # raster instance.
+            pass
+        elif isinstance(value, Combinable):
+            # Query expressions (F(), functions, etc.) are resolved later
+            # during query compilation 
             pass
         elif isinstance(value, self._klass):
             # The geometry type must match that of the field -- unless the

--- a/tests/gis_tests/geoapp/test_expressions.py
+++ b/tests/gis_tests/geoapp/test_expressions.py
@@ -67,10 +67,6 @@ class GeoExpressionsTests(TestCase):
         obj.save()
         obj.refresh_from_db()
 
-        print("P1", p1)
-        print("P2", p2)
-        print("obj.point2", obj.point2)
-
         self.assertEqual(obj.point2, p1)
 
     @skipUnlessDBFeature("has_Distance_function")

--- a/tests/gis_tests/geoapp/test_expressions.py
+++ b/tests/gis_tests/geoapp/test_expressions.py
@@ -53,7 +53,7 @@ class GeoExpressionsTests(TestCase):
             self.assertTrue(
                 obj.point3.equals_exact(p1.transform(3857, clone=True), 0.1)
             )
-    
+
     def test_assign_expression_to_field(self):
         p1 = Point(1, 1, srid=4326)
         p2 = Point(2, 2, srid=4326)
@@ -67,9 +67,9 @@ class GeoExpressionsTests(TestCase):
         obj.save()
         obj.refresh_from_db()
 
-        print('P1', p1)
-        print('P2', p2)
-        print('obj.point2', obj.point2)
+        print("P1", p1)
+        print("P2", p2)
+        print("obj.point2", obj.point2)
 
         self.assertEqual(obj.point2, p1)
 

--- a/tests/gis_tests/geoapp/test_expressions.py
+++ b/tests/gis_tests/geoapp/test_expressions.py
@@ -53,6 +53,25 @@ class GeoExpressionsTests(TestCase):
             self.assertTrue(
                 obj.point3.equals_exact(p1.transform(3857, clone=True), 0.1)
             )
+    
+    def test_assign_expression_to_field(self):
+        p1 = Point(1, 1, srid=4326)
+        p2 = Point(2, 2, srid=4326)
+        obj = ManyPointModel.objects.create(
+            point1=p1,
+            point2=p2,
+            point3=p2.transform(3857, clone=True),
+        )
+
+        obj.point2 = F("point1")
+        obj.save()
+        obj.refresh_from_db()
+
+        print('P1', p1)
+        print('P2', p2)
+        print('obj.point2', obj.point2)
+
+        self.assertEqual(obj.point2, p1)
 
     @skipUnlessDBFeature("has_Distance_function")
     def test_multiple_annotation(self):


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37324

#### Branch description
<!-- Provide a concise overview of the issue or rationale behind the proposed changes. Minimum five words. -->
To solve this, first updated the `__set__` method in `proxy.py`, and since `__set__` calls `pre_save`, edited `__get__` accordingly. This solved the type error for expressions, but SpatiaLite was returning geometry in a format causing an error. Thus, edited `spatialite/operations.py` to override the `returning_columns` method for SpatiaLite, since it needed the `CAST (AsEWKB("test_spatial_employee"."work") AS BLOB)` present in SpatiaLite operations.

Finally, added a test and verified it by running it successfully locally.
#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
<!-- If AI tools were used, provide which tools were used here. -->
Used Gemini (Web) For discussion.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
