### PR TITLE
Fiexed #37319 Omitted compressing responses that cannot contain body

### DIFF
--- a/django/middleware/gzip.py
+++ b/django/middleware/gzip.py
@@ -20,6 +20,10 @@ class GZipMiddleware(MiddlewareMixin):
         if not response.streaming and len(response.content) < 200:
             return response
 
+        # RFC 9112 Section 6.3
+        if 100 <= response.status_code < 200 or response.status_code in (204, 304):
+            return response
+
         # Avoid gzipping if we've already got a content-encoding.
         if response.has_header("Content-Encoding"):
             return response

--- a/tests/middleware/tests.py
+++ b/tests/middleware/tests.py
@@ -1058,6 +1058,18 @@ class GZipMiddlewareTest(SimpleTestCase):
         self.assertEqual(r.content, self.short_string)
         self.assertIsNone(r.get("Content-Encoding"))
 
+    def test_no_compress_on_responses_without_body(self):
+        """
+        Do not compress responses that cannot contain a body
+        according to RFC 9112 Section 6.3
+        """
+        for status_code in [101, 204, 304]:
+            with self.subTest(status_code=status_code):
+                self.resp.status_code = status_code
+                r = GZipMiddleware(self.get_response)(self.req)
+                self.assertEqual(r.content, self.compressible_string)
+                self.assertIsNone(r.get("Content-Encoding"))
+
     def test_no_compress_compressed_response(self):
         """
         Compression isn't performed on responses that are already compressed.


### PR DESCRIPTION
#### Trac ticket number
ticket-37319

#### Branch description
Shouldn't compress responses that cannot contain body according to RFC 9112 Section 6.3

#### AI Assistance Disclosure (REQUIRED)
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
