### PR TITLE
Fixed #37325 -- Bumped minimum oracledb version to 4.0.2.

### DIFF
--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -993,7 +993,7 @@ Oracle notes
 ============
 
 Django supports `Oracle Database Server`_ versions 19c and higher. Version
-2.3.0 or higher of the `oracledb`_ Python driver is required.
+4.0.2 or higher of the `oracledb`_ Python driver is required.
 
 .. _`Oracle Database Server`: https://www.oracle.com/
 .. _`oracledb`: https://oracle.github.io/python-oracledb/

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -329,6 +329,9 @@ Miscellaneous
 * The minimum supported version of ``asgiref`` is increased from 3.9.1 to
   3.12.1.
 
+* The minimum supported version of ``oracledb`` is increased from 2.3.0 to
+  4.0.2.
+
 * In the asynchronous request path, error responses (such as those rendered by
   ``handler404`` and ``handler500``) are now rendered on the request's
   thread-sensitive thread, rather than on a shared thread pool, so that

--- a/tests/requirements/oracle.txt
+++ b/tests/requirements/oracle.txt
@@ -1,1 +1,1 @@
-oracledb >= 2.3.0
+oracledb >= 4.0.2


### PR DESCRIPTION
ticket-37325

4.0.2 supports up to Python 3.14. (2.3.0 only supported up to 3.12.)