### PR TITLE
Fixed Playwright test flakiness in admin collapse filter tests.

### DIFF
--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -2046,6 +2046,17 @@ class PlaywrightTests(AdminPlaywrightTestCase):
     def setUp(self):
         User.objects.create_superuser(username="super", password="secret", email=None)
 
+    def collapse_filter(self, detail):
+        """Collapse a filter and wait for its state to be stored."""
+        title = detail.get_attribute("data-filter-title")
+        detail.locator("summary").click()
+        self.expect(detail).not_to_have_attribute("open")
+        self.page.wait_for_function(
+            "title => JSON.parse(sessionStorage.getItem("
+            "'django.admin.filtersState'))?.[title] === false",
+            arg=title,
+        )
+
     def test_add_row_selection(self):
         """
         The status line for selected rows gets updated correctly (#22038).
@@ -2254,8 +2265,7 @@ class PlaywrightTests(AdminPlaywrightTestCase):
             self.expect(detail).to_have_attribute("open")
         # Collapse "staff' and "superuser" filters.
         for detail in details[:2]:
-            detail.locator("summary").click()
-            self.expect(detail).not_to_have_attribute("open")
+            self.collapse_filter(detail)
         # Filters are in the same state after refresh.
         self.page.reload()
         self.expect(
@@ -2271,7 +2281,8 @@ class PlaywrightTests(AdminPlaywrightTestCase):
         self.page.goto(
             self.live_server_url + reverse("admin:admin_changelist_band_changelist")
         )
-        self.page.locator("summary").click()
+        detail = self.page.locator("[data-filter-title='number of members']")
+        self.collapse_filter(detail)
         # Go to Users view and then, back again to Bands view.
         self.page.goto(self.live_server_url + reverse("admin:auth_user_changelist"))
         self.page.goto(
@@ -2288,8 +2299,7 @@ class PlaywrightTests(AdminPlaywrightTestCase):
         self.page.goto(self.live_server_url + changelist_url)
         # Title is escaped.
         filter_title = self.page.locator("[data-filter-title='It\\'s OK']")
-        filter_title.locator("summary").click()
-        self.expect(filter_title).not_to_have_attribute("open")
+        self.collapse_filter(filter_title)
         # Filter is in the same state after refresh.
         self.page.reload()
         self.expect(


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

N/A

#### Branch description

This PR fixes flaky tests mentioned in https://github.com/django/django/pull/21596#issuecomment-5545315143 which were  failing apparently due to page navigation/reload before sessionStorage is set.

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
<!-- If AI tools were used, provide which tools were used here. -->

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
