### PR TITLE
Refs #37308 -- Fixed crash on transforms over unbound annotation fields.

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1939,6 +1939,11 @@ class Query(BaseExpression):
         def final_transformer(field, alias):
             if not self.alias_cols:
                 alias = None
+            if getattr(field, "model", None) is None and names[0] in self.annotations:
+                # annotate() may introduce fields that aren't attached to a
+                # model, and those have no column to build a Col from. Apply
+                # the transforms to the annotation expression instead.
+                return self.annotations[names[0]]
             return field.get_col(alias)
 
         # Try resolving all the names as fields first. If there's an error,

--- a/tests/annotations/tests.py
+++ b/tests/annotations/tests.py
@@ -10,6 +10,7 @@ from django.db.models import (
     Case,
     CharField,
     Count,
+    DateField,
     DateTimeField,
     DecimalField,
     Exists,
@@ -585,6 +586,22 @@ class NonAggregateAnnotationTestCase(TestCase):
         book = qs.annotate(other_isbn=F("isbn")).get(other_rating=4)
         self.assertEqual(book["other_rating"], 4)
         self.assertEqual(book["other_isbn"], "155860191")
+
+    def test_values_transform_on_annotation_with_unbound_output_field(self):
+        """
+        A transform can be applied to an annotation alias in values() when the
+        annotation's output_field is not attached to a model.
+        """
+        qs = Book.objects.annotate(
+            published=ExpressionWrapper(F("pubdate"), output_field=DateField())
+        ).values("published__year")
+        self.assertEqual(qs.get(pk=self.b1.pk)["published__year"], self.b1.pubdate.year)
+
+    def test_values_transform_on_value_annotation(self):
+        qs = Book.objects.annotate(
+            constant=Value(datetime.date(2026, 1, 1), output_field=DateField())
+        ).values("constant__year")
+        self.assertEqual(qs.get(pk=self.b1.pk)["constant__year"], 2026)
 
     def test_values_fields_annotations_order(self):
         qs = Book.objects.annotate(other_rating=F("rating") - 1).values(


### PR DESCRIPTION
#### Trac ticket number

ticket-37308

(Refs, not Fixes — see the note below on scope.)

#### Branch description

Applying a transform to an annotation alias crashes with `AttributeError` when the annotation's `output_field` is not attached to a model:

```python
Book.objects.annotate(
    published=ExpressionWrapper(F("pubdate"), output_field=DateField())
).values("published__year")
```
```
AttributeError: 'DateField' object has no attribute 'model'
```

`Value(..., output_field=DateField())` fails the same way. The crash comes from `django/db/models/sql/query.py`:

- `names_to_path()` resolves an annotation name to `self.annotations[name].output_field`
- `annotate()` does not require that field to be attached to a model
- `setup_joins()`'s `final_transformer()` calls `field.get_col(alias)`
- `Field.get_col()` dereferences `self.model`, which is not there

What makes this a bug rather than an unsupported operation is that the *same query* works when the annotation's `output_field` happens to be a model field:

| annotation | `.values("a__year")` |
|---|---|
| `annotate(a=F("pubdate"))` | works — `django_datetime_extract(year, "…"."pubdate")` |
| `annotate(a=ExpressionWrapper(F("pubdate"), output_field=DateField()))` | `AttributeError` |
| `annotate(a=Value(date(2026, 1, 1), output_field=DateField()))` | `AttributeError` |

The first and second mean the same thing to a user. The outcome depends on how the annotation was spelled, not on what it asks for. And an `AttributeError` escaping the ORM is not a usable error either way — `add_fields()` catches `FieldError` to build a helpful message, and this bypasses it.

`names_to_path()` already anticipates exactly this case a few lines earlier:

```python
try:
    model = field.model._meta.concrete_model
except AttributeError:
    # QuerySet.annotate() may introduce fields that aren't attached to a model.
    model = None
```

This makes `final_transformer()` consistent with that: when there is no model to build a `Col` from, apply the transforms to the annotation expression instead. The generated SQL for the `F()` case is unchanged; the two crashing cases now produce the transform over the annotation expression.

#### On scope

This does not close #37308, so it is filed as *Refs*. That ticket also covers lookups such as `alias + "__pk"` resolving to the wrong code path, and the suggestion in comment:2 to retry `names_to_path()` splitting right-to-left. I found this crash while reproducing that ticket, and it seemed worth separating: it is a hard failure with a narrow cause, whereas the rest of #37308 involves a design decision about whether lookups on aliases should be supported at all.

Happy to fold it into a broader change instead, or to move it to its own ticket if you would prefer that — I do not have a Trac account to file one, so I have gone with a PR against the existing ticket. That is also why the "Has patch" checkbox below is unticked; I cannot set the flag.

#### Testing

Two regression tests in `tests/annotations/tests.py`. Reverting only `query.py` and keeping the tests fails exactly those two with the `AttributeError` above, and nothing else.

Full suite on SQLite: **19817 tests, OK** (1939 skipped, 4 expected failures) — 2 more than the 19815 on the unpatched tree, which are the two added here. `black`, `flake8` and `isort` clean.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude Code was used to investigate the ticket, reduce the failure to the three cases above, and draft the change. I have reviewed the diff, and every result quoted here was produced by running the code — the SQL in the table, the causal revert check, and the suite counts.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.

- [ ] I have checked the "Has patch" ticket flag in the Trac system. <!-- no Trac account; would appreciate someone setting it -->
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable. <!-- bug fix in unreleased behaviour; happy to add a release note if wanted -->