### PR TITLE
Fixed #32061 - Removed Oracle password from exception.

### DIFF
--- a/django/db/backends/oracle/client.py
+++ b/django/db/backends/oracle/client.py
@@ -1,4 +1,5 @@
 import shutil
+import subprocess
 
 from django.db.backends.base.client import BaseDatabaseClient
 
@@ -25,3 +26,11 @@ class DatabaseClient(BaseDatabaseClient):
             args = [wrapper_path, *args]
         args.extend(parameters)
         return args, None
+
+    def runshell(self, parameters):
+        try:
+            super().runshell(parameters)
+        except subprocess.CalledProcessError as exc:
+            # SQL*Plus arguments contain credentials; omit them.
+            exc.cmd = [self.executable_name]
+            raise

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -195,6 +195,9 @@ Management Commands
   model renames. After upgrading, you will see new migrations detected for
   unmanaged models that have changed since their creation.
 
+* On Oracle the :djadmin:`dbshell` no longer exposes the database password in
+  exception context when the client has a nonzero exit.
+
 * Whether to suppress an :exc:`ImportError` escaping from a settings module is
   configurable by the new :attr:`.BaseCommand.requires_settings` attribute
   (default ``True``). In previous versions, such errors were always suppressed.

--- a/tests/dbshell/test_oracle.py
+++ b/tests/dbshell/test_oracle.py
@@ -1,3 +1,5 @@
+import subprocess
+import traceback
 from unittest import mock, skipUnless
 
 from django.db import connection
@@ -14,6 +16,35 @@ class OracleDbshellTests(SimpleTestCase):
             "shutil.which", return_value="/usr/bin/rlwrap" if rlwrap else None
         ):
             return DatabaseClient.settings_to_cmd_args_env(settings_dict, parameters)
+
+    def test_runshell_error_password_does_not_leak(self):
+        settings_dict = {**connection.settings_dict, "PASSWORD": "somepassword"}
+        client = DatabaseClient(mock.Mock(settings_dict=settings_dict))
+
+        def fail(args, **kwargs):
+            self.assertIn(client.connect_string(settings_dict), args)
+            raise subprocess.CalledProcessError(7, args)
+
+        for wrapper in (None, "/usr/bin/rlwrap"):
+            with self.subTest(wrapper=wrapper):
+                with (
+                    mock.patch("shutil.which", return_value=wrapper),
+                    mock.patch("subprocess.run", side_effect=fail),
+                    self.assertRaises(subprocess.CalledProcessError) as ctx,
+                ):
+                    try:
+                        client.runshell([])
+                    except subprocess.CalledProcessError as exc:
+                        formatted_traceback = "".join(traceback.format_exception(exc))
+                        raise
+                self.assertEqual(ctx.exception.returncode, 7)
+                for surface, output in (
+                    ("cmd", str(ctx.exception.cmd)),
+                    ("message", str(ctx.exception)),
+                    ("traceback", formatted_traceback),
+                ):
+                    with self.subTest(surface=surface):
+                        self.assertNotIn("somepassword", output)
 
     def test_without_rlwrap(self):
         expected_args = [


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-32061

#### Branch description
The Postgres client and MySQL client both have tests that assert the database password is not included in the subprocess exception context.
https://github.com/django/django/blob/b3f4d83aad7f589f165a6d8b020b7acba4936f35/tests/dbshell/test_postgresql.py#L177-L187
https://github.com/django/django/blob/b3f4d83aad7f589f165a6d8b020b7acba4936f35/tests/dbshell/test_mysql.py#L203-L223
However, Oracle is missing a similar test and does include the password in the exception context when it has a nonzero exit. This can cause the database password to be printed in the logs. Unfortunately the SQL*Plus utility does not accept an environment variable password so it is not possible to take the same approach as how this is mitigated in the Postgres/MySQL clients. 

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
<!-- If AI tools were used, provide which tools were used here. -->

Opencode + Sol/Astra to write the test and fix. The changes are straightforward though and I confirmed manually that the test fails without the changes. I did not use AI to write this report.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [ ] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
  - This is a security vulnerability, but it has been publicly disclosed in the issue tracker for 6 years and the security team confirmed a public PR is appropriate
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
