### PR TITLE
Fixed #17664 -- Handled filter exceptions where they occur in {% if %}.

### DIFF
--- a/django/template/defaulttags.py
+++ b/django/template/defaulttags.py
@@ -915,7 +915,18 @@ class TemplateLiteral(Literal):
         return self.text
 
     def eval(self, context):
-        return self.value.resolve(context, ignore_failures=True)
+        try:
+            return self.value.resolve(context, ignore_failures=True)
+        except VariableDoesNotExist:
+            # ignore_failures=True only covers a failed lookup of the variable
+            # being filtered, not one in a filter's argument. Without this,
+            # `{% if missing|default:missing or True %}` lets the exception
+            # escape as far as the `or` operator, which catches everything and
+            # returns False -- so an expression ending in `or True` renders as
+            # falsey, and swapping the operands changes the result. Treating a
+            # failed lookup here the same way ignore_failures does keeps the
+            # exception where it happened. Refs #17664.
+            return None
 
 
 class TemplateIfParser(IfParser):

--- a/tests/template_tests/syntax_tests/test_if.py
+++ b/tests/template_tests/syntax_tests/test_if.py
@@ -710,6 +710,59 @@ class IfTagTests(SimpleTestCase):
         output = self.engine.render_to_string("template", {})
         self.assertEqual(output, "no")
 
+    # Filter exceptions (refs #17664)
+
+    @setup(
+        {
+            "template": (
+                "{% if missing|default:missing or True %}yes{% else %}no{% endif %}"
+            )
+        }
+    )
+    def test_if_filter_argument_missing_with_or_true(self):
+        # A failed lookup in a filter *argument* used to escape as far as the
+        # `or` operator, which catches everything and returns False -- so this
+        # rendered "no", even though anything `or True` is truthy.
+        output = self.engine.render_to_string("template", {})
+        self.assertEqual(output, "yes")
+
+    @setup(
+        {
+            "template": (
+                "{% if True or missing|default:missing %}yes{% else %}no{% endif %}"
+            )
+        }
+    )
+    def test_if_filter_argument_missing_with_true_or(self):
+        # The same expression with the operands swapped already rendered
+        # "yes", because `or` short-circuits before evaluating the filter.
+        output = self.engine.render_to_string("template", {})
+        self.assertEqual(output, "yes")
+
+    @setup({"template": "{% if missing|default:missing %}yes{% else %}no{% endif %}"})
+    def test_if_filter_argument_missing_alone(self):
+        # On its own the expression is falsey, which is unchanged.
+        output = self.engine.render_to_string("template", {})
+        self.assertEqual(output, "no")
+
+    @setup(
+        {
+            "template": (
+                "{% if missing|default:missing and True %}yes{% else %}no{% endif %}"
+            )
+        }
+    )
+    def test_if_filter_argument_missing_with_and(self):
+        output = self.engine.render_to_string("template", {})
+        self.assertEqual(output, "no")
+
+    @setup(
+        {"template": "{% if not missing|default:missing %}yes{% else %}no{% endif %}"}
+    )
+    def test_if_filter_argument_missing_with_not(self):
+        output = self.engine.render_to_string("template", {})
+        self.assertEqual(output, "yes")
+
 
 class IfNodeTests(SimpleTestCase):
     def test_repr(self):


### PR DESCRIPTION
#### Trac ticket number

ticket-17664

#### Branch description

`TemplateLiteral.eval()` resolves with `ignore_failures=True`, which covers a failed lookup of the variable being filtered but **not** one in a filter's *argument*. That exception escapes to the enclosing operator, and `infix()` / `prefix()` in `smartif.py` catch everything and return `False`:

```
{% if missing|default:missing or True %}   ->  no      (before)
{% if True or missing|default:missing %}   ->  yes
```

The first is logically impossible — anything `or True` is truthy — and the two differ only in operand order, because `or` short-circuits before evaluating the filter in the second case.

This is the approach @lilyfoote proposed in comment:33:

> Part of the problem here is that exceptions are swallowed in a counter-intuitive location. […] If we added exception handling around the filter evaluation (like we have for variable evaluation), I think the behaviour would become much more intuitive.

Catching `VariableDoesNotExist` at the literal keeps the failure where it happens rather than letting it reach an operator that cannot tell a missing variable from a genuine error.

#### Deliberately narrow

The previous attempt, #12752, made `{% if %}` raise on undefined variables and was rejected — @carltongibson in comment:30:

> I still can't see that we can introduce the radical breaking change. Limited raising of exceptions that don't reasonably pertain to variable resolution seems as far as we can go.

Nothing here changes that. Resolution outside `{% if %}` is untouched, so `{{ missing|default:missing }}` still raises exactly as before, and `{% if missing|default:missing %}` on its own is still falsey. The only behaviour that changes is an expression whose *filter argument* lookup previously leaked into a surrounding operator.

Verified before and after:

| template | before | after |
|---|---|---|
| `{% if missing\|default:missing or True %}` | `no` | **`yes`** |
| `{% if True or missing\|default:missing %}` | `yes` | `yes` |
| `{% if missing\|default:missing %}` | `no` | `no` |
| `{{ missing\|default:missing }}` | raises | raises |

#### Testing

Five tests in `template_tests/syntax_tests/test_if.py`, covering the `or`, `and`, `not`, standalone and swapped-operand cases. Reverting only `django/template/defaulttags.py` and keeping the tests fails exactly two of them — the `or True` and `not` cases — and nothing else.

Full suite: **19820 tests, OK** (1628 skipped, 4 expected failures). `black`, `flake8` and `isort` clean.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude Code was used to investigate the ticket, write the change and its tests, and draft this description. Every figure above came from running the code, and I read the full ticket history — including the rejection of #12752 — before choosing this approach rather than the broader one.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability.
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.

- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable. <!-- happy to add a release note if wanted -->