### PR TITLE
Fixed #21540 -- Documented broken transactions when catching DB errors in TestCase.

### DIFF
--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -944,6 +944,38 @@ The class:
 
 * Checks deferrable database constraints at the end of each test.
 
+.. admonition:: Catching database errors inside a ``TestCase``
+
+    Because each test runs inside an ``atomic`` block, catching a database
+    error does not end the transaction it broke. Any query attempted before
+    the block exits then raises
+    :class:`~django.db.transaction.TransactionManagementError` rather than the
+    error you expected::
+
+        class UniqueTests(TestCase):
+            def test_unique_constraints(self):
+                with self.assertRaises(IntegrityError):
+                    Person.objects.create(email="jane@example.com")
+                # This raises TransactionManagementError, not IntegrityError,
+                # because the transaction is still broken.
+                with self.assertRaises(IntegrityError):
+                    Person.objects.create(email="john@example.com")
+
+    Wrap each one in its own ``atomic`` block so the failure is rolled back
+    before the next query runs::
+
+        class UniqueTests(TestCase):
+            def test_unique_constraints(self):
+                with self.assertRaises(IntegrityError), transaction.atomic():
+                    Person.objects.create(email="jane@example.com")
+                with self.assertRaises(IntegrityError), transaction.atomic():
+                    Person.objects.create(email="john@example.com")
+
+    This is the same behavior described in :doc:`/topics/db/transactions`
+    under "Avoid catching exceptions inside ``atomic``!"; it is easy to meet
+    for the first time in a test, because ``TestCase`` supplies the ``atomic``
+    block itself.
+
 It also provides an additional method:
 
 .. classmethod:: TestCase.setUpTestData()


### PR DESCRIPTION
#### Trac ticket number

ticket-21540

#### Branch description

Reproduced on `main` first — the ticket's case still behaves exactly as reported, twelve years on:

```python
class UniqueTestCase(TestCase):
    def setUp(self):
        NameModel.objects.create(first_name="John", last_name="Doe")

    def test_two_assert_raises_in_one_test(self):
        with self.assertRaises(IntegrityError):
            NameModel.objects.create(first_name="John", last_name="Roe")
        with self.assertRaises(IntegrityError):     # <- fails here
            NameModel.objects.create(first_name="Jane", last_name="Doe")
```

```
django.db.transaction.TransactionManagementError: An error occurred in the
current transaction. You can't execute queries until the end of the 'atomic' block.
```

Each `assertRaises` passes on its own; together the second fails.

**This is working as intended, so this is a docs change rather than a code one.** `TestCase` wraps each test in `atomic`, and catching a database error inside that block does not end the broken transaction — which is precisely what the transactions topic already warns about under *"Avoid catching exceptions inside ``atomic``!"*.

What was missing is the connection. The testing docs describe `TestCase` as wrapping tests in `atomic` but never mention the consequence, and `TransactionManagementError` did not appear in `docs/topics/testing/tools.txt` at all. Since `TestCase` supplies the `atomic` block itself, a test is very often where someone meets this for the first time — which fits this ticket, and the several duplicates linked from it.

So this adds an admonition to the `TestCase` docs showing the failing pattern and the fix — wrapping each `assertRaises` in its own `atomic` block — and points at the transactions topic for the underlying behavior.

This also matches how the ticket has been triaged: @aaugustin moved it to Documentation in comment:10, and it was moved back to Testing framework later without a code fix being proposed.

#### Testing

`sphinx -b dummy` over `docs/` builds with **no warnings**. I checked the cross-reference target rather than guessing at a label — the admonition in the transactions topic has no `_ref`, so this links to the document and names the section.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude Code was used to investigate the ticket and draft this change. The reproduction above was run against `main` inside Django's own test suite, and the docs build was run.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability.
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.

- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests. <!-- documentation only -->
- [x] I have added or updated relevant docs, including release notes if applicable.