### PR TITLE
Fixed #31255 -- Optimized redundant RemoveField operation with DeleteModel operation.

### DIFF
--- a/django/db/migrations/operations/fields.py
+++ b/django/db/migrations/operations/fields.py
@@ -193,11 +193,10 @@ class RemoveField(FieldOperation):
     def reduce(self, operation, app_label):
         from .models import DeleteModel
 
-        if (
-            isinstance(operation, DeleteModel)
-            and operation.name_lower == self.model_name_lower
-        ):
-            return [operation]
+        if isinstance(operation, DeleteModel):
+            if operation.name_lower == self.model_name_lower:
+                return [operation]
+            return True
         return super().reduce(operation, app_label)
 
 

--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -408,6 +408,14 @@ class DeleteModel(ModelOperation):
         # related fields.
         return True
 
+    def reduce(self, operation, app_label):
+        if (
+            isinstance(operation, RemoveField)
+            and self.name_lower == operation.model_name_lower
+        ):
+            return [self]
+        return super().reduce(operation, app_label)
+
     def describe(self):
         return "Delete model %s" % self.name
 

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -3236,7 +3236,6 @@ class AutodetectorTests(BaseAutodetectorTests):
             [
                 "RemoveIndex",
                 "RemoveConstraint",
-                "RemoveField",
                 "DeleteModel",
                 "DeleteModel",
             ],
@@ -4704,13 +4703,10 @@ class AutodetectorTests(BaseAutodetectorTests):
         # Right number/type of migrations?
         self.assertNumberMigrations(changes, "otherapp", 1)
         self.assertOperationTypes(
-            changes, "otherapp", 0, ["RemoveField", "DeleteModel", "DeleteModel"]
+            changes, "otherapp", 0, ["DeleteModel", "DeleteModel"]
         )
-        self.assertOperationAttributes(
-            changes, "otherapp", 0, 0, name="authors", model_name="book"
-        )
-        self.assertOperationAttributes(changes, "otherapp", 0, 1, name="Attribution")
-        self.assertOperationAttributes(changes, "otherapp", 0, 2, name="Book")
+        self.assertOperationAttributes(changes, "otherapp", 0, 0, name="Attribution")
+        self.assertOperationAttributes(changes, "otherapp", 0, 1, name="Book")
 
     def test_m2m_w_through_multistep_remove(self):
         """
@@ -4729,16 +4725,10 @@ class AutodetectorTests(BaseAutodetectorTests):
             changes,
             "testapp",
             0,
-            ["RemoveField", "RemoveField", "DeleteModel", "DeleteModel"],
+            ["DeleteModel", "DeleteModel"],
         )
-        self.assertOperationAttributes(
-            changes, "testapp", 0, 0, name="author", model_name="contract"
-        )
-        self.assertOperationAttributes(
-            changes, "testapp", 0, 1, name="publisher", model_name="contract"
-        )
-        self.assertOperationAttributes(changes, "testapp", 0, 2, name="Author")
-        self.assertOperationAttributes(changes, "testapp", 0, 3, name="Contract")
+        self.assertOperationAttributes(changes, "testapp", 0, 0, name="Author")
+        self.assertOperationAttributes(changes, "testapp", 0, 1, name="Contract")
 
     def test_concrete_field_changed_to_many_to_many(self):
         """
@@ -4835,13 +4825,10 @@ class AutodetectorTests(BaseAutodetectorTests):
         # Right number/type of migrations?
         self.assertNumberMigrations(changes, "testapp", 1)
         self.assertOperationTypes(
-            changes, "testapp", 0, ["RemoveField", "DeleteModel", "DeleteModel"]
+            changes, "testapp", 0, ["DeleteModel", "DeleteModel"]
         )
-        self.assertOperationAttributes(
-            changes, "testapp", 0, 0, name="author", model_name="publisher"
-        )
-        self.assertOperationAttributes(changes, "testapp", 0, 1, name="Author")
-        self.assertOperationAttributes(changes, "testapp", 0, 2, name="Publisher")
+        self.assertOperationAttributes(changes, "testapp", 0, 0, name="Author")
+        self.assertOperationAttributes(changes, "testapp", 0, 1, name="Publisher")
 
     def test_alter_model_options(self):
         """Changing a model's options should make a change."""

--- a/tests/migrations/test_optimizer.py
+++ b/tests/migrations/test_optimizer.py
@@ -837,6 +837,81 @@ class OptimizerTests(OptimizerTestBase):
             ],
         )
 
+    def test_remove_field_delete_model(self):
+        """
+        DeleteModel should absorb RemoveField of same model
+        """
+        self.assertOptimizesTo(
+            [
+                migrations.RemoveField("Foo", "age"),
+                migrations.DeleteModel("Foo"),
+            ],
+            [
+                migrations.DeleteModel("Foo"),
+            ],
+        )
+        self.assertOptimizesTo(
+            [
+                migrations.RemoveField("foo", "age"),
+                migrations.DeleteModel("FOO"),
+            ],
+            [
+                migrations.DeleteModel("FOO"),
+            ],
+        )
+        self.assertOptimizesTo(
+            [
+                migrations.DeleteModel("Foo"),
+                migrations.RemoveField("Foo", "age"),
+            ],
+            [
+                migrations.DeleteModel("Foo"),
+            ],
+        )
+
+    def test_remove_field_delete_model_different_models(self):
+        """
+        DeleteModel on ModelB should not absorb RemoveField on ModelA
+        """
+        self.assertDoesNotOptimize(
+            [
+                migrations.RemoveField("Foo", "age"),
+                migrations.DeleteModel("Bar"),
+            ],
+        )
+
+    def test_multiple_remove_field_delete_model(self):
+        """
+        DeleteModel should absorb multiple RemoveField on the same model
+        """
+        self.assertOptimizesTo(
+            [
+                migrations.RemoveField("Foo", "age"),
+                migrations.RemoveField("Foo", "name"),
+                migrations.DeleteModel("Foo"),
+            ],
+            [
+                migrations.DeleteModel("Foo"),
+            ],
+        )
+
+    def test_remove_field_delete_model_intervening_delete_model(self):
+        """
+        DeleteModel should absorb RemoveField when an intervening DeleteModel
+        is present.
+        """
+        self.assertOptimizesTo(
+            [
+                migrations.RemoveField("ModelC", "related_field"),
+                migrations.DeleteModel("ModelB"),
+                migrations.DeleteModel("ModelC"),
+            ],
+            [
+                migrations.DeleteModel("ModelB"),
+                migrations.DeleteModel("ModelC"),
+            ],
+        )
+
     def _test_create_alter_foo_field(self, alter):
         """
         CreateModel, AlterFooTogether/AlterOrderWithRespectTo followed by an


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-31255

#### Branch description
<!-- Provide a concise overview of the issue or rationale behind the proposed changes. Minimum five words. -->
Achieved by updating existing RemoveField.reduce method and introducing new DeleteModel.reduce method. In reduce method we checked if the removefield and delemodel are from same model, if so, we absord the removefield operation. 
And also added related tests for this check. And updated two existing test to match this condition.
So, our system had like: 
```python
class Migration(migrations.Migration):

    dependencies = [
        ("test_model", "0001_initial"),
    ]

    operations = [
        migrations.RemoveField(
            model_name="modelc",
            name="related_field",
        ),
        migrations.DeleteModel(
            name="ModelB",
        ),
        migrations.DeleteModel(
            name="ModelC",
        ),
    ]
```
And, our updated code results in:
```python
class Migration(migrations.Migration):

    dependencies = [
        ("test_app", "0001_initial"),
    ]

    operations = [
        migrations.DeleteModel(
            name="ModelB",
        ),
        migrations.DeleteModel(
            name="ModelC",
        ),
    ] 
```
Along with tests, I have checked by creating migration manually by running `makemigrations` command.


#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
<!-- If AI tools were used, provide which tools were used here. -->

Gemini used for discussion about the reduction approach.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
