### PR TITLE
Fixed #25541 -- Improved error reporting when loading invalid JSON fixtures.

### DIFF
--- a/django/core/serializers/json.py
+++ b/django/core/serializers/json.py
@@ -69,7 +69,7 @@ class Deserializer(PythonDeserializer):
         try:
             objects = json.loads(stream_or_string)
         except Exception as exc:
-            raise DeserializationError() from exc
+            raise DeserializationError(exc) from exc
         super().__init__(objects, **options)
 
     def _handle_object(self, obj):

--- a/tests/serializers/test_json.py
+++ b/tests/serializers/test_json.py
@@ -93,9 +93,11 @@ class JsonSerializerTestCase(SerializersTestBase, TestCase):
         self.assertIn('"fields": {"score": "1"}', json_data)
 
     def test_json_deserializer_exception(self):
-        with self.assertRaises(DeserializationError):
+        with self.assertRaises(DeserializationError) as cm:
             for obj in serializers.deserialize("json", """[{"pk":1}"""):
                 pass
+        self.assertIsInstance(cm.exception.__cause__, json.JSONDecodeError)
+        self.assertEqual(str(cm.exception), str(cm.exception.__cause__))
 
     def test_helpful_error_message_invalid_pk(self):
         """


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-25541

#### Branch description
Previously, the JSON deserializer swallowed the native `JSONDecodeError`, obscuring the exact location of syntax failures. By passing the original exception directly into `DeserializationError`, the framework now accurately returns the line number, column number, and character position to the user.

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [X] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
<!-- If AI tools were used, provide which tools were used here. -->

#### Checklist
- [X] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [X] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [X] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
