### PR TITLE
Fixed #32558 -- Caught unhandled thread and unraisable exceptions in test suite.

### DIFF
--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -23,7 +23,7 @@ import django
 from django.core.management import call_command
 from django.db import connections
 from django.test import SimpleTestCase, TestCase
-from django.test.utils import NullTimeKeeper, TimeKeeper, iter_test_cases
+from django.test.utils import NullTimeKeeper, TimeKeeper, _TestState, iter_test_cases
 from django.test.utils import setup_databases as _setup_databases
 from django.test.utils import setup_test_environment
 from django.test.utils import teardown_databases as _teardown_databases
@@ -542,6 +542,14 @@ def _run_subsuite(args):
     runner_class, subsuite_index, subsuite, failfast, buffer = args
     runner = runner_class(failfast=failfast, buffer=buffer)
     result = runner.run(subsuite)
+    if hasattr(_TestState, "saved_data"):
+        unhandled = getattr(_TestState.saved_data, "unhandled_thread_exceptions", [])
+        if unhandled:
+            exc_values = [exc_info[1] for exc_info in unhandled]
+            raise RuntimeError(
+                f"Unhandled exception(s) in parallel subsuite worker: {exc_values}"
+            )
+
     return subsuite_index, result.events
 
 

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -51,6 +51,7 @@ from django.test.signals import template_rendered
 from django.test.utils import (
     CaptureQueriesContext,
     ContextList,
+    _TestState,
     compare_xml,
     modify_settings,
     override_settings,
@@ -375,6 +376,17 @@ class SimpleTestCase(unittest.TestCase):
                     raise
                 result.addError(self, sys.exc_info())
                 return
+
+        if hasattr(_TestState, "saved_data"):
+            unhandled = getattr(
+                _TestState.saved_data, "unhandled_thread_exceptions", []
+            )
+
+            for exc_info in unhandled:
+                if debug:
+                    raise exc_info[1]
+                result.addError(self, exc_info)
+            unhandled.clear()
 
     @classmethod
     def _pre_setup(cls):

--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -4,6 +4,7 @@ import logging
 import os
 import re
 import sys
+import threading
 import time
 import warnings
 from contextlib import contextmanager
@@ -163,6 +164,19 @@ def setup_test_environment(debug=None):
 
     deactivate()
 
+    saved_data.unhandled_thread_exceptions = []
+
+    saved_data.original_threading_excepthook = threading.excepthook
+
+    def threading_excepthook(args):
+        saved_data.unhandled_thread_exceptions.append(
+            (args.exc_type, args.exc_value, args.exc_traceback)
+        )
+        if saved_data.original_threading_excepthook:
+            saved_data.original_threading_excepthook(args)
+
+    threading.excepthook = threading_excepthook
+
 
 def teardown_test_environment():
     """
@@ -182,8 +196,17 @@ def teardown_test_environment():
     Template._render = saved_data.template_render
     PartialTemplate._render = saved_data.partial_template_render
 
+    threading.excepthook = saved_data.original_threading_excepthook
+    unhandled_thread_exceptions = saved_data.unhandled_thread_exceptions
+
     del _TestState.saved_data
     del mail.outbox
+
+    exceptions = [exc_value for _, exc_value, _ in unhandled_thread_exceptions]
+    if exceptions:
+        raise RuntimeError(
+            f"Unhandled exception(s) occurred outside of a test case: {exceptions}"
+        )
 
 
 def setup_databases(

--- a/tests/test_runner/test_discover_runner.py
+++ b/tests/test_runner/test_discover_runner.py
@@ -1,6 +1,7 @@
 import logging
 import multiprocessing
 import os
+import threading
 import unittest.loader
 from argparse import ArgumentParser
 from contextlib import contextmanager
@@ -856,3 +857,23 @@ class DiscoverRunnerGetDatabasesTests(SimpleTestCase):
             ["test_runner_apps.databases.tests.DefaultDatabaseSerializedTests"]
         )
         self.assertEqual(databases, {"default": True})
+
+
+class UnhandledExceptionsTests(SimpleTestCase):
+    def test_unhandled_thread_exception_fails_test(self):
+        class DummyThreadExceptionTest(SimpleTestCase):
+            def test_thread_exception(self):
+                def crash():
+                    raise ValueError("Intentional thread crash")
+
+                with captured_stderr():
+                    t = threading.Thread(target=crash)
+                    t.start()
+                    t.join()
+
+        result = unittest.TestResult()
+        test = DummyThreadExceptionTest("test_thread_exception")
+        test(result)
+
+        self.assertEqual(len(result.errors), 1)
+        self.assertIn("Intentional thread crash", str(result.errors[0][1]))


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-32558

#### Branch description
This PR fixes [#32558](https://code.djangoproject.com/ticket/32558) by ensuring unhandled thread exceptions fail the active test. It overrides `threading.excepthook` during test setup and routes captured exceptions directly to the specific `SimpleTestCase` via `result.addError()`. 

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [X] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
Used gemini to generate the boilerplate and verify that all the edge cases have been covered.

#### Checklist
- [X] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [X] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [X] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
