### PR TITLE
Fixed #37089 -- Made ignore_warnings() match substrings by default.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -440,6 +440,7 @@ answer newbie questions, and generally made Django that much better:
     Hasan Ramezani <hasan.r67@gmail.com>
     Hawkeye
     Helen Sherwood-Taylor <helen@rrdlabs.co.uk>
+    HelmiDev03 <helmipaty@gmail.com>
     Henrique Romano <onaiort@gmail.com>
     Henry Dang <henrydangprg@gmail.com>
     Hidde Bultsma

--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -758,18 +758,54 @@ class CaptureQueriesContext:
 
 
 class ignore_warnings(TestContextDecorator):
-    def __init__(self, **kwargs):
-        self.ignore_kwargs = kwargs
-        if "message" in self.ignore_kwargs or "module" in self.ignore_kwargs:
-            self.filter_func = warnings.filterwarnings
-        else:
-            self.filter_func = warnings.simplefilter
+    """
+    Ignore warnings matching the given criteria.
+
+    ``message`` is matched as a literal, case-sensitive substring of the
+    warning's message, for consistency with
+    SimpleTestCase.assertWarnsMessage(). Pass ``message_re`` to match it
+    against a regular expression instead.
+
+    ``category``, ``module`` and ``lineno`` are passed through to
+    warnings.filterwarnings(), so ``module`` is a regular expression matched
+    against the start of the name of the module raising the warning.
+    """
+
+    def __init__(
+        self,
+        category=None,
+        message=None,
+        *,
+        module=None,
+        lineno=None,
+        message_re=None,
+    ):
+        self.ignore_kwargs = {}
+        if category is not None:
+            self.ignore_kwargs["category"] = category
+
+        if message is not None:
+            if message_re is not None:
+                raise TypeError("Cannot specify both message and message_re.")
+            # Ignore warnings containing message as a substring: "(?s:.*)"
+            # allows any prefix, including newlines, and "(?-i:...)" undoes
+            # the re.IGNORECASE that filterwarnings() compiles with.
+            self.ignore_kwargs["message"] = rf"(?s:.*)(?-i:{re.escape(message)})"
+        elif message_re is not None:
+            self.ignore_kwargs["message"] = message_re
+
+        if module is not None:
+            self.ignore_kwargs["module"] = module
+
+        if lineno is not None:
+            self.ignore_kwargs["lineno"] = lineno
+
         super().__init__()
 
     def enable(self):
         self.catch_warnings = warnings.catch_warnings()
         self.catch_warnings.__enter__()
-        self.filter_func("ignore", **self.ignore_kwargs)
+        warnings.filterwarnings("ignore", **self.ignore_kwargs)
 
     def disable(self):
         self.catch_warnings.__exit__(*sys.exc_info())

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -338,6 +338,14 @@ Miscellaneous
   database connections used during error handling are managed by
   ``close_old_connections()``.
 
+* The undocumented ``django.test.ignore_warnings()`` helper now accepts
+  explicit arguments instead of passing ``**kwargs`` through to
+  ``warnings.filterwarnings()``, and matches its ``message`` argument as a
+  literal, case-sensitive substring of the warning's message, rather than as a
+  case-insensitive regular expression anchored at the start, for consistency
+  with ``SimpleTestCase.assertWarnsMessage()``. Use the new ``message_re``
+  argument to match against a regular expression instead.
+
 .. _deprecated-features-6.2:
 
 Features deprecated in 6.2

--- a/tests/aggregation_regress/tests.py
+++ b/tests/aggregation_regress/tests.py
@@ -888,7 +888,7 @@ class AggregationTests(TestCase):
         # queryset and assertion can be removed.
         with ignore_warnings(
             category=RemovedInDjango2028Warning,
-            message=r"Calling select_related\(\) with no arguments is deprecated\.",
+            message="Calling select_related() with no arguments is deprecated.",
         ):
             qs = (
                 Book.objects.filter(rating__lt=4.5)

--- a/tests/defer/tests.py
+++ b/tests/defer/tests.py
@@ -154,7 +154,7 @@ class DeferTests(AssertionMixin, TestCase):
         with self.assertNumQueries(1):
             with ignore_warnings(
                 category=RemovedInDjango2028Warning,
-                message=r"Calling select_related\(\) with no arguments is deprecated\.",
+                message="Calling select_related() with no arguments is deprecated.",
             ):
                 obj = Primary.objects.defer("related").select_related()[0]
             self.assert_delayed(obj, 1)
@@ -338,7 +338,7 @@ class TestDefer2(AssertionMixin, TestCase):
         ChildProxy.objects.create(name="p1", value="xx", related=related)
         with ignore_warnings(
             category=RemovedInDjango2028Warning,
-            message=r"Calling select_related\(\) with no arguments is deprecated\.",
+            message="Calling select_related() with no arguments is deprecated.",
         ):
             children = ChildProxy.objects.select_related().only("id", "name")
         self.assertEqual(len(children), 1)

--- a/tests/gis_tests/relatedapp/tests.py
+++ b/tests/gis_tests/relatedapp/tests.py
@@ -21,7 +21,7 @@ class RelatedGeoModelTest(TestCase):
         # queryset can be removed.
         with ignore_warnings(
             category=RemovedInDjango2028Warning,
-            message=r"Calling select_related\(\) with no arguments is deprecated\.",
+            message="Calling select_related() with no arguments is deprecated.",
         ):
             qs2 = City.objects.order_by("id").select_related()
         qs3 = City.objects.order_by("id").select_related("location")

--- a/tests/mail/__init__.py
+++ b/tests/mail/__init__.py
@@ -32,7 +32,7 @@ class override_deprecated_email_settings(override_settings):
                 re.escape("{name}"), rf"(?:{deprecated_names_re})"
             )
             self.ignore_warnings = ignore_warnings(
-                category=RemovedInDjango2028Warning, message=message_re
+                category=RemovedInDjango2028Warning, message_re=message_re
             )
         else:
             self.ignore_warnings = nullcontext()
@@ -50,5 +50,5 @@ class override_deprecated_email_settings(override_settings):
 def ignore_no_default_mailer_warning():
     return ignore_warnings(
         category=RemovedInDjango2028Warning,
-        message=re.escape(NO_DEFAULT_MAILER_WARNING),
+        message=NO_DEFAULT_MAILER_WARNING,
     )

--- a/tests/mail/test_backends.py
+++ b/tests/mail/test_backends.py
@@ -1,5 +1,4 @@
 import os
-import re
 import shutil
 import socket
 import ssl
@@ -236,9 +235,7 @@ class SharedEmailBackendTests(MailTestsMixin):
             self.assertWarnsMessage(RemovedInDjango2028Warning, msg),
             ignore_warnings(
                 category=RemovedInDjango2028Warning,
-                message=re.escape(
-                    "Directly creating EmailBackend instances is deprecated."
-                ),
+                message="Directly creating EmailBackend instances is deprecated.",
             ),
         ):
             # alias=None tells create_backend() to _omit_ the `alias` arg.
@@ -320,7 +317,7 @@ class LocmemBackendTests(SharedEmailBackendTests, SimpleTestCase):
 
 @ignore_warnings(
     category=RemovedInDjango2028Warning,
-    message=r"The EMAIL_FILE_PATH setting is deprecated\.",
+    message="The EMAIL_FILE_PATH setting is deprecated.",
 )
 class FileBackendTests(SharedEmailBackendTests, SimpleTestCase):
     backend_class = filebased.EmailBackend
@@ -600,7 +597,7 @@ class SMTPHandler:
 @skipUnless(HAS_AIOSMTPD, "No aiosmtpd library detected.")
 @ignore_warnings(
     category=RemovedInDjango2028Warning,
-    message=r"The EMAIL_\w+ setting is deprecated\.",
+    message_re=r"The EMAIL_\w+ setting is deprecated\.",
 )
 class SMTPBackendTestsBase(SimpleTestCase):
     @classmethod
@@ -627,7 +624,7 @@ class SMTPBackendTestsBase(SimpleTestCase):
 @skipUnless(HAS_AIOSMTPD, "No aiosmtpd library detected.")
 @ignore_warnings(
     category=RemovedInDjango2028Warning,
-    message=re.escape("Directly creating EmailBackend instances is deprecated."),
+    message="Directly creating EmailBackend instances is deprecated.",
 )
 class SMTPBackendTests(SharedEmailBackendTests, SMTPBackendTestsBase):
     backend_class = smtp.EmailBackend

--- a/tests/mail/test_deprecated.py
+++ b/tests/mail/test_deprecated.py
@@ -288,7 +288,7 @@ class DeprecatedEmailSettingsTests(SimpleTestCase):
             self.assertWarnsMessage(RemovedInDjango2028Warning, msg),
             ignore_warnings(
                 category=RemovedInDjango2028Warning,
-                message=re.escape("get_connection() is deprecated."),
+                message="get_connection() is deprecated.",
             ),
         ):
             get_connection()

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -2948,7 +2948,9 @@ class MailDeprecatedPositionalArgsTests(SimpleTestCase):
             ignore_no_default_mailer_warning(),
             ignore_warnings(
                 category=RemovedInDjango2028Warning,
-                message=re.escape("get_connection() is deprecated."),
+                # Matches only this deprecation, and not the warnings about
+                # positional arguments to get_connection().
+                message="get_connection() is deprecated. See 'Migrating email",
             ),
         ):
             return mail.get_connection(*args, **kwargs)

--- a/tests/model_fields/test_booleanfield.py
+++ b/tests/model_fields/test_booleanfield.py
@@ -97,7 +97,7 @@ class BooleanFieldTests(TestCase):
         # part of the test.
         with ignore_warnings(
             category=RemovedInDjango2028Warning,
-            message=r"Calling select_related\(\) with no arguments is deprecated\.",
+            message="Calling select_related() with no arguments is deprecated.",
         ):
             mb = FksToBooleans.objects.select_related().get(pk=m1.id)
             mc = FksToBooleans.objects.select_related().get(pk=m2.id)

--- a/tests/model_inheritance_regress/tests.py
+++ b/tests/model_inheritance_regress/tests.py
@@ -258,7 +258,7 @@ class ModelInheritanceTest(TestCase):
         # be removed.
         with ignore_warnings(
             category=RemovedInDjango2028Warning,
-            message=r"Calling select_related\(\) with no arguments is deprecated\.",
+            message="Calling select_related() with no arguments is deprecated.",
         ):
             wholesalers = list(Wholesaler.objects.select_related())
         self.assertEqual(wholesalers, [])

--- a/tests/modeladmin/tests.py
+++ b/tests/modeladmin/tests.py
@@ -1046,7 +1046,7 @@ class ModelAdminTests(TestCase):
     def test_list_select_related_true_deprecated_subclass(self):
         with ignore_warnings(
             category=RemovedInDjango2028Warning,
-            message=r"Setting ModelAdmin.list_select_related to True is deprecated\.",
+            message="Setting ModelAdmin.list_select_related to True is deprecated.",
         ):
 
             class BaseTestModelAdmin(ModelAdmin):

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -2018,7 +2018,7 @@ class SelectRelatedTests(TestCase):
         # test case.
         with ignore_warnings(
             category=RemovedInDjango2028Warning,
-            message=r"Calling select_related\(\) with no arguments is deprecated\.",
+            message="Calling select_related() with no arguments is deprecated.",
         ):
             self.assertSequenceEqual(X.objects.select_related(), [])
 

--- a/tests/select_related/tests.py
+++ b/tests/select_related/tests.py
@@ -117,7 +117,7 @@ class SelectRelatedTests(TestCase):
         with self.assertNumQueries(1):
             with ignore_warnings(
                 category=RemovedInDjango2028Warning,
-                message=r"Calling select_related\(\) with no arguments is deprecated\.",
+                message="Calling select_related() with no arguments is deprecated.",
             ):
                 world = Species.objects.select_related()
             families = [o.genus.family.name for o in world]

--- a/tests/select_related_onetoone/tests.py
+++ b/tests/select_related_onetoone/tests.py
@@ -94,7 +94,7 @@ class ReverseSelectRelatedTestCase(TestCase):
             self.assertNumQueries(2),
             ignore_warnings(
                 category=RemovedInDjango2028Warning,
-                message=r"Calling select_related\(\) with no arguments is deprecated\.",
+                message="Calling select_related() with no arguments is deprecated.",
             ),
         ):
             u = User.objects.select_related().get(username="test")

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -1356,6 +1356,148 @@ class AssertWarnsMessageTests(SimpleTestCase):
             func1()
 
 
+class IgnoreWarningsTests(SimpleTestCase):
+    @contextmanager
+    def captured_warnings(self):
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always")
+            yield captured
+
+    def test_message_matched_anywhere(self):
+        with self.captured_warnings() as captured:
+            with ignore_warnings(message="is deprecated"):
+                warnings.warn("get_connection() is deprecated.", UserWarning)
+        self.assertEqual(captured, [])
+
+    def test_message_special_re_chars(self):
+        with self.captured_warnings() as captured:
+            with ignore_warnings(message="[.*x+]y?"):
+                warnings.warn("A message with [.*x+]y? in it.", UserWarning)
+        self.assertEqual(captured, [])
+
+    def test_message_case_sensitive(self):
+        with self.captured_warnings() as captured:
+            with ignore_warnings(message="IS DEPRECATED"):
+                warnings.warn("get_connection() is deprecated.", UserWarning)
+        self.assertEqual(len(captured), 1)
+
+    def test_message_matched_across_newlines(self):
+        with self.captured_warnings() as captured:
+            with ignore_warnings(message="second line"):
+                warnings.warn("first line\nsecond line", UserWarning)
+        self.assertEqual(captured, [])
+
+    def test_message_not_matched(self):
+        with self.captured_warnings() as captured:
+            with ignore_warnings(message="is deprecated"):
+                warnings.warn("Expected message", UserWarning)
+        self.assertEqual(len(captured), 1)
+
+    def test_message_re(self):
+        with self.captured_warnings() as captured:
+            with ignore_warnings(message_re=r"get_\w+\(\) is deprecated\."):
+                warnings.warn("get_connection() is deprecated.", UserWarning)
+        self.assertEqual(captured, [])
+
+    def test_message_re_not_matched(self):
+        with self.captured_warnings() as captured:
+            with ignore_warnings(message_re=r"get_\w+\(\) is deprecated\."):
+                warnings.warn("Expected message", UserWarning)
+        self.assertEqual(len(captured), 1)
+
+    def test_module_matched_by_prefix(self):
+        # test_module_* assume this name for the current module.
+        self.assertEqual(__name__, "test_utils.tests")
+        with self.captured_warnings() as captured:
+            with ignore_warnings(module="test_utils"):
+                warnings.warn("Expected message", UserWarning)
+        self.assertEqual(captured, [])
+
+    def test_module_not_matched_in_the_middle(self):
+        with self.captured_warnings() as captured:
+            with ignore_warnings(module="utils.tests"):
+                warnings.warn("Expected message", UserWarning)
+        self.assertEqual(len(captured), 1)
+
+    def test_module_not_matched(self):
+        with self.captured_warnings() as captured:
+            with ignore_warnings(module="nonexistent.module"):
+                warnings.warn("Expected message", UserWarning)
+        self.assertEqual(len(captured), 1)
+
+    def test_module_regex(self):
+        with self.captured_warnings() as captured:
+            with ignore_warnings(module=r"test_utils\.\w+"):
+                warnings.warn("Expected message", UserWarning)
+        self.assertEqual(captured, [])
+
+    def test_message_and_message_re(self):
+        msg = "Cannot specify both message and message_re."
+        with self.assertRaisesMessage(TypeError, msg):
+            ignore_warnings(message="Expected message", message_re="Expected")
+        with self.assertRaisesMessage(TypeError, msg):
+            ignore_warnings(message="Expected message", message_re="")
+
+    def test_category(self):
+        with self.captured_warnings() as captured:
+            with ignore_warnings(category=UserWarning):
+                warnings.warn("Expected message", UserWarning)
+                warnings.warn("Another message", UserWarning)
+                warnings.warn("Expected message", DeprecationWarning)
+        self.assertEqual(len(captured), 1)
+        self.assertIs(captured[0].category, DeprecationWarning)
+
+    def test_module_and_message(self):
+        with self.captured_warnings() as captured:
+            with ignore_warnings(module="test_utils", message="is deprecated"):
+                warnings.warn("get_connection() is deprecated.", UserWarning)
+                warnings.warn("Expected message", UserWarning)
+                warnings.warn_explicit(
+                    "other_function() is deprecated.",
+                    UserWarning,
+                    "other.py",
+                    1,
+                    module="other.module",
+                )
+        self.assertEqual(
+            [str(warning.message) for warning in captured],
+            ["Expected message", "other_function() is deprecated."],
+        )
+
+    def test_category_and_message_positional(self):
+        with self.captured_warnings() as captured:
+            with ignore_warnings(UserWarning, "is deprecated"):
+                warnings.warn("get_connection() is deprecated.", UserWarning)
+                warnings.warn("get_connection() is deprecated.", DeprecationWarning)
+        self.assertEqual(len(captured), 1)
+        self.assertIs(captured[0].category, DeprecationWarning)
+
+    def test_lineno(self):
+        def func1():
+            warnings.warn("Expected message", UserWarning)
+
+        lineno = func1.__code__.co_firstlineno + 1
+        with self.captured_warnings() as captured:
+            with ignore_warnings(lineno=lineno):
+                func1()
+        self.assertEqual(captured, [])
+
+    def test_lineno_not_matched(self):
+        def func1():
+            warnings.warn("Expected message", UserWarning)
+
+        lineno = func1.__code__.co_firstlineno + 1
+        with self.captured_warnings() as captured:
+            with ignore_warnings(lineno=lineno + 1):
+                func1()
+        self.assertEqual(len(captured), 1)
+
+    def test_unsupported_argument(self):
+        msg = "unexpected keyword argument 'append'"
+        with self.assertRaisesMessage(TypeError, msg):
+            ignore_warnings(append=True)
+
+
 class AssertFieldOutputTests(SimpleTestCase):
     def test_assert_field_output(self):
         error_invalid = ["Enter a valid email address."]


### PR DESCRIPTION
Supersedes #21767, which was closed by mistake — its fork had been deleted, so
GitHub would not reopen it — and #21927, which the quality bot closed because I
filled in this description incorrectly (malformed ticket reference and a missing
checklist); GitHub would not reopen that one either. Opening a fresh PR as
suggested by @jonbiemond. Apologies for the noise.

#### Trac ticket number

ticket-37089

#### Branch description

`ignore_warnings()` passes its `message` argument straight to
`warnings.filterwarnings()`, which compiles it as a regular expression and
matches it with `re.match()`. That is inconsistent with the other test
helpers: `assertWarnsMessage()` does a substring check and `assertWarnsRegex()`
uses `re.search()`.

Two consequences bite callers:

* Regex metacharacters in a message are not matched literally, so
  `ignore_warnings(message="get_connection() is deprecated.")` silently fails
  to ignore the warning it names — `()` is parsed as an empty group.
* The pattern is anchored at the start, so a fragment such as
  `message="is deprecated"` never matches.

The workaround is to write `r".*" + re.escape(...)` by hand, and Django's own
test suite already carried a number of those, e.g.:

```python
ignore_warnings(
    category=RemovedInDjango2028Warning,
    message=re.escape("Directly creating EmailBackend instances is deprecated."),
)
```

This PR matches `message` as a literal substring of the warning's message, for
consistency with `assertWarnsMessage()`, and adds `message_re` for the cases
that genuinely want a regular expression. Passing both raises `TypeError`.

Following review, the arguments are now explicit rather than `**kwargs`
forwarded to `filterwarnings()`: `category` and `message` are
positional-or-keyword, `module`, `lineno` and `message_re` are keyword-only,
and `append` is no longer accepted. `category`, `module` and `lineno` are
passed straight through, so `module` keeps the regular-expression behavior it
has today.

The substring match is built as `rf"(?s:.*)(?-i:{re.escape(message)})"`, where
`(?s:.*)` allows any prefix including newlines and `(?-i:...)` undoes the
`re.IGNORECASE` that `filterwarnings()` compiles with, so matching is
case-sensitive like `assertWarnsMessage()`.

Callers in the test suite that pre-escaped their patterns were updated to pass
the literal message. One call site keeps regex matching via the new argument:
`tests/mail/test_backends.py`, which matches an alternation over setting names.

`ignore_warnings()` is undocumented, but it is importable from `django.test`,
so a release note is included. As discussed on the ticket, no deprecation path
is proposed since this is internal API.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude Code (Claude Opus 5) was used to investigate the ticket, write the patch
and the tests, run the test suite, and rebase the branch. The output has been
reviewed and verified.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.

- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.

