### PR TITLE
Fixed #37332 -- Display generated boolean fields with icons

### DIFF
--- a/django/contrib/admin/utils.py
+++ b/django/contrib/admin/utils.py
@@ -447,7 +447,10 @@ def display_for_field(value, field, empty_value_display, avoid_link=False):
 
     # BooleanField needs special-case null-handling, so it comes before the
     # general null test.
-    elif isinstance(field, models.BooleanField):
+    elif isinstance(field, models.BooleanField) or (
+        isinstance(field, models.GeneratedField)
+        and isinstance(field.output_field, models.BooleanField)
+    ):
         if isinstance(value, DatabaseDefault):
             return _boolean_icon(None)
         return _boolean_icon(value)

--- a/tests/admin_changelist/models.py
+++ b/tests/admin_changelist/models.py
@@ -20,6 +20,15 @@ class Child(models.Model):
     is_active = models.BooleanField(default=True)
 
 
+class GeneratedBoolean(models.Model):
+    value = models.BooleanField(default=False)
+    is_done = models.GeneratedField(
+        expression=models.F("value"),
+        output_field=models.BooleanField(),
+        db_persist=True,
+    )
+
+
 class GrandChild(models.Model):
     parent = models.ForeignKey(Child, models.SET_NULL, editable=False, null=True)
     name = models.CharField(max_length=30, blank=True)

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -62,6 +62,7 @@ from .models import (
     Concert,
     CustomIdUser,
     Event,
+    GeneratedBoolean,
     Genre,
     GrandChild,
     Group,
@@ -1979,6 +1980,26 @@ class ChangeListTests(TestCase):
         self.assertContains(response, 'alt="True"')
         self.assertContains(response, 'alt="False"')
         # Ensure "True" and "False" text are NOT in the response.
+        self.assertNotContains(response, ">True<")
+        self.assertNotContains(response, ">False<")
+
+    @skipUnlessDBFeature("supports_stored_generated_columns")
+    def test_list_display_generated_boolean_display(self):
+        """Generated BooleanField values display boolean icons (#37332)."""
+        GeneratedBoolean.objects.create(value=True)
+        GeneratedBoolean.objects.create(value=False)
+
+        class GeneratedBooleanAdmin(admin.ModelAdmin):
+            list_display = ["is_done"]
+
+        m = GeneratedBooleanAdmin(GeneratedBoolean, custom_site)
+        request = self._mocked_authenticated_request(
+            "/generatedboolean/", self.superuser
+        )
+        response = m.changelist_view(request)
+
+        self.assertContains(response, 'alt="True"')
+        self.assertContains(response, 'alt="False"')
         self.assertNotContains(response, ">True<")
         self.assertNotContains(response, ">False<")
 


### PR DESCRIPTION
#### Trac ticket number

 ticket-37332

#### Branch description

A `GeneratedField` with `output_field=models.BooleanField()` is rendered as the strings `True` and `False` in the admin changelist instead of Django’s boolean icons. This change makes generated boolean fields use the existing boolean icon rendering, with a regression test covering both values.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

AI tool used: OpenAI Codex. The final patch and tests were manually reviewed.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.

- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.