### PR TITLE
Fixed #27095 -- Allowed expressions in nested ArrayField lookup arrays.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -76,6 +76,7 @@ answer newbie questions, and generally made Django that much better:
     Amit Chakradeo <https://amit.chakradeo.net/>
     Amit Ramon <amit.ramon@gmail.com>
     Amit Upadhyay <http://www.amitu.com/blog/>
+    Ammar Abdur Raheman <https://github.com/AmmarAR97>
     A. Murat Eren <meren@pardus.org.tr>
     Ana Belen Sarabia <belensarabia@gmail.com>
     Ana Krivokapic <https://github.com/infraredgirl>

--- a/django/contrib/postgres/fields/array.py
+++ b/django/contrib/postgres/fields/array.py
@@ -10,6 +10,7 @@ from django.contrib.postgres.validators import ArrayMaxLengthValidator
 from django.core import checks, exceptions
 from django.db.models import Field, Func, IntegerField, Transform, Value
 from django.db.models.fields.mixins import CheckFieldDefaultMixin
+from django.db.models.functions import Cast
 from django.db.models.lookups import Exact, In
 from django.utils.translation import gettext_lazy as _
 
@@ -251,22 +252,32 @@ class ArrayField(CheckPostgresInstalledMixin, CheckFieldDefaultMixin, Field):
         return SliceTransform(start, end, expression)
 
 
+def _array_expression(values, base_field):
+    """
+    Build an ARRAY[...] expression, so that elements which are expressions are
+    rendered as SQL instead of being passed as query parameters.
+    """
+    expressions = [
+        (
+            value
+            if hasattr(value, "resolve_expression")
+            else Value(base_field.get_prep_value(value))
+        )
+        for value in values
+    ]
+    return Func(
+        *expressions,
+        function="ARRAY",
+        template="%(function)s[%(expressions)s]",
+    )
+
+
 class ArrayRHSMixin:
     def __init__(self, lhs, rhs):
         # Don't wrap arrays that contains only None values, psycopg doesn't
         # allow this.
         if isinstance(rhs, (tuple, list)) and any(self._rhs_not_none_values(rhs)):
-            expressions = []
-            for value in rhs:
-                if not hasattr(value, "resolve_expression"):
-                    field = lhs.output_field
-                    value = Value(field.base_field.get_prep_value(value))
-                expressions.append(value)
-            rhs = Func(
-                *expressions,
-                function="ARRAY",
-                template="%(function)s[%(expressions)s]",
-            )
+            rhs = _array_expression(rhs, lhs.output_field.base_field)
         super().__init__(lhs, rhs)
 
     def process_rhs(self, compiler, connection):
@@ -328,6 +339,14 @@ class ArrayInLookup(In):
         for value in values:
             if hasattr(value, "resolve_expression"):
                 prepared_values.append(value)
+            elif any(hasattr(item, "resolve_expression") for item in value):
+                output_field = self.lhs.output_field
+                prepared_values.append(
+                    Cast(
+                        _array_expression(value, output_field.base_field),
+                        output_field,
+                    )
+                )
             else:
                 prepared_values.append(tuple(value))
         return prepared_values

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -80,7 +80,8 @@ Minor features
 :mod:`django.contrib.postgres`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* ...
+* Lookups for :class:`~django.contrib.postgres.fields.ArrayField` now allow
+  nested arrays containing expressions as right-hand sides.
 
 :mod:`django.contrib.redirects`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -326,14 +326,25 @@ class TestQuerying(PostgreSQLTestCase):
             self.objs[2:3],
         )
 
-    @unittest.expectedFailure
     def test_in_including_F_object(self):
-        # This test asserts that Array objects passed to filters can be
-        # constructed to contain F objects. This currently doesn't work as the
-        # psycopg mogrify method that generates the ARRAY() syntax is
-        # expecting literals, not column references (#27095).
         self.assertSequenceEqual(
             NullableIntegerArrayModel.objects.filter(field__in=[[models.F("id")]]),
+            self.objs[:2],
+        )
+
+    def test_in_including_F_object_and_literal(self):
+        self.assertSequenceEqual(
+            NullableIntegerArrayModel.objects.filter(
+                field__in=[[2, models.F("order")]]
+            ),
+            self.objs[2:3],
+        )
+
+    def test_in_including_literal_and_F_object_arrays(self):
+        self.assertCountEqual(
+            NullableIntegerArrayModel.objects.filter(
+                field__in=[[1], [models.F("order")]]
+            ),
             self.objs[:2],
         )
 


### PR DESCRIPTION
#### Trac ticket number

ticket-27095

#### Branch description

Lookups on `ArrayField` accept expressions as top-level elements of the
right-hand side, but not inside a nested array. `filter(field__in=[[F("id")]])`
raised `TypeError: Field 'field' expected a number but got Col(...)`, because a
nested list is not itself an expression and so was prepared as a query
parameter.

Commit 33403bf8 fixed the non-nested half of this ticket by building an
`ARRAY[...]` expression. Mariusz Felisiak then reopened the ticket, noting that
nested arrays still don't work with expressions. `tests/postgres_tests/test_array.py`
has carried `test_in_including_F_object` as an `@unittest.expectedFailure` for
this since then; this PR unmarks it.

`ArrayInLookup` now builds the same `ARRAY[...]` expression for nested arrays
that contain expressions, reusing the builder extracted from `ArrayRHSMixin`.
The expression is cast to the left-hand side type, which keeps an `IN` list
containing both literal and expression arrays resolvable to a single type;
without the cast, `field__in=[[1], [F("order")]]` fails with
`operator does not exist: bigint[] = integer[]`.

Tested against PostgreSQL 17 and SQLite. Full suite passes on SQLite (19822
tests); `postgres_tests`, `queries`, `expressions`, `lookup`, `annotations`,
`aggregation`, `model_fields` and `custom_lookups` pass against PostgreSQL.

#### AI Assistance Disclosure (REQUIRED)

- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude Code (Claude Opus 5) was used to investigate the ticket, draft the
change, write the tests, and draft this description. All output was reviewed
and verified by me: the failure was reproduced against a local PostgreSQL 17
instance before any fix, each candidate approach was tested rather than
assumed, and the full test suite was run.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
