### PR TITLE
Fixed #37329 -- Allowed customizing ValidationError code in UniqueConstraint.

### DIFF
--- a/django/db/models/constraints.py
+++ b/django/db/models/constraints.py
@@ -674,8 +674,9 @@ class UniqueConstraint(BaseConstraint):
                         model, self.fields
                     )
                     raise ValidationError(
-                        validation_error_message,
-                        code=validation_error_message.code,
+                        validation_error_message.message,
+                        code=self.violation_error_code or validation_error_message.code,
+                        params=validation_error_message.params,
                     )
                 raise ValidationError(
                     self.get_violation_error_message(),

--- a/tests/constraints/tests.py
+++ b/tests/constraints/tests.py
@@ -977,6 +977,38 @@ class UniqueConstraintTests(TestCase):
             )
         self.assertEqual(cm.exception.code, code)
 
+    def test_validate_unique_custom_code(self):
+        product = UniqueConstraintProduct.objects.create(
+            name="test", color="red", age=42
+        )
+        code = "custom_code"
+        multiple_fields_constraint = models.UniqueConstraint(
+            fields=["color", "age"],
+            name="color_age_uniq",
+            violation_error_code=code,
+        )
+        single_field_constraint = models.UniqueConstraint(
+            fields=["color"],
+            name="color_uniq",
+            violation_error_code=code,
+        )
+
+        with self.assertRaises(ValidationError) as cm:
+            multiple_fields_constraint.validate(
+                UniqueConstraintProduct,
+                UniqueConstraintProduct(
+                    name="new-test", color=product.color, age=product.age
+                ),
+            )
+        self.assertEqual(cm.exception.code, code)
+
+        with self.assertRaises(ValidationError) as cm:
+            single_field_constraint.validate(
+                UniqueConstraintProduct,
+                UniqueConstraintProduct(name="new-test", color=product.color),
+            )
+        self.assertEqual(cm.exception.code, code)
+
     @skipUnlessDBFeature("supports_table_check_constraints")
     def test_validate_fields_unattached(self):
         Product.objects.create(price=42)


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-37329

#### Branch description
<!-- Provide a concise overview of the issue or rationale behind the proposed changes. Minimum five words. -->
Ensured `UniqueConstraint.validate()` respects `violation_error_code` when `fields` is set and `violation_error_message` is default. Previously, passing `unique_error_message()` directly to `ValidationError()` caused the custom error code to be overwritten with `"unique"` or `"unique_together"`.

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
<!-- If AI tools were used, provide which tools were used here. -->

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
