### PR TITLE
Refs #23582 -- Clarified data migration dependencies and post_migrate timing.

### DIFF
--- a/docs/topics/migrations.txt
+++ b/docs/topics/migrations.txt
@@ -723,6 +723,22 @@ added a dependency that specifies the last migration of ``app2``::
             migrations.RunPython(move_m1),
         ]
 
+When a data migration requires data created by another migration, add a
+dependency on the migration that creates that data. This ensures that the
+required data migration runs first.
+
+.. note::
+
+    Migration dependencies do not ensure that data created by
+    :data:`~django.db.models.signals.post_migrate` handlers is available.
+    This signal is sent after the :djadmin:`migrate` command finishes
+    running migrations, rather than after each individual migration.
+
+    For example, :mod:`django.contrib.auth` creates model permissions in a
+    ``post_migrate`` handler. A data migration cannot assume that these
+    permissions already exist, particularly when migrating a new database,
+    even if it depends on the migrations of the ``auth`` app.
+
 More advanced migrations
 ------------------------
 


### PR DESCRIPTION
#### Trac ticket number

ticket-23582

#### Branch description

I added a note explaining that migration dependencies do not guarantee that data created by `post_migrate` handlers is available during a data migration. The note uses model permissions on a fresh database as an example.

I also clarified that a data migration should depend on the migration that creates the data it needs.

Validation:

- `git diff --check` passed.
- The documentation build passed with `python -m sphinx -b html -n -W --keep-going docs docs/_build/html`.
- I checked the generated page in my browser.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

I used ChatGPT (Codex) to help understand the ticket, inspect relevant Django source, draft the documentation change, and write the commit message and PR description. I applied the change locally, built the docs, and checked the rendered page.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability.
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.

<!-- Leave the following items unchecked if not applicable. -->

- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.