### PR TITLE
Fixed #33945 -- Added instance hints to ordered neighbor queries.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1386,12 +1386,15 @@ class Model(AltersData, metaclass=ModelBase):
             order = "_order" if is_next else "-_order"
             order_field = self._meta.order_with_respect_to
             filter_args = order_field.get_filter_kwargs_for_object(self)
+            manager = self.__class__._default_manager.db_manager(
+                hints={"instance": self}
+            )
             obj = (
-                self.__class__._default_manager.filter(**filter_args)
+                manager.filter(**filter_args)
                 .filter(
                     **{
                         "_order__%s"
-                        % op: self.__class__._default_manager.values("_order").filter(
+                        % op: manager.values("_order").filter(
                             **{self._meta.pk.name: self.pk}
                         )
                     }

--- a/tests/order_with_respect_to/tests.py
+++ b/tests/order_with_respect_to/tests.py
@@ -1,4 +1,5 @@
 from operator import attrgetter
+from unittest.mock import Mock
 
 from django.db import models
 from django.test import SimpleTestCase, TestCase
@@ -12,6 +13,62 @@ class OrderWithRespectToBaseTests(BaseOrderWithRespectToTests, TestCase):
     Answer = Answer
     Post = Post
     Question = Question
+
+
+class OrderWithRespectToDatabaseTests(TestCase):
+    databases = {"default", "other"}
+
+    @classmethod
+    def setUpTestData(cls):
+        for database, order in (("default", [1, 2, 3]), ("other", [2, 3, 1])):
+            question = Question.objects.using(database).create(pk=1, text=database)
+            for pk in order:
+                Answer.objects.using(database).create(
+                    pk=pk, text=f"{database}-{pk}", question=question
+                )
+
+    def test_previous_and_next_database(self):
+        for database, pk, previous, next_ in (
+            ("default", 2, 1, 3),
+            ("other", 3, 2, 1),
+        ):
+            answer = Answer.objects.using(database).get(pk=pk)
+            for method, expected_pk in (
+                ("get_previous_in_order", previous),
+                ("get_next_in_order", next_),
+            ):
+                with self.subTest(database=database, method=method):
+                    unused_database = "other" if database == "default" else "default"
+                    with (
+                        self.assertNumQueries(1, using=database),
+                        self.assertNumQueries(0, using=unused_database),
+                    ):
+                        neighbor = getattr(answer, method)()
+                    self.assertEqual(neighbor.text, f"{database}-{expected_pk}")
+                    self.assertEqual(neighbor._state.db, database)
+
+    def test_previous_and_next_router_hints(self):
+        for source_database, routed_database in (("other", None), ("default", "other")):
+            answer = Answer.objects.using(source_database).get(pk=3)
+            for method, expected_pk in (
+                ("get_previous_in_order", 2),
+                ("get_next_in_order", 1),
+            ):
+                with self.subTest(source_database=source_database, method=method):
+                    router = Mock()
+                    router.db_for_read.return_value = routed_database
+                    with (
+                        self.settings(DATABASE_ROUTERS=[router]),
+                        self.assertNumQueries(1, using="other"),
+                        self.assertNumQueries(0, using="default"),
+                    ):
+                        neighbor = getattr(answer, method)()
+                    self.assertEqual(neighbor.text, f"other-{expected_pk}")
+                    self.assertEqual(neighbor._state.db, "other")
+                    router.db_for_read.assert_called_once_with(Answer, instance=answer)
+                    self.assertIs(
+                        router.db_for_read.call_args.kwargs["instance"], answer
+                    )
 
 
 class OrderWithRespectToTests(SimpleTestCase):


### PR DESCRIPTION
#### Trac ticket number

[ticket-33945](https://code.djangoproject.com/ticket/33945)

#### Branch description

`get_next_in_order()` and `get_previous_in_order()` can read the wrong database for an instance loaded from a non-default database. Pass instance hints to the manager so routers choose the connection before the normal instance-database fallback. Add regression coverage for both directions and router overrides.

159 related tests passed on SQLite; Black, isort, and flake8 passed.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

OpenAI Codex (GPT-6-based) assisted with ticket analysis, the patch, tests, validation, and this description.

#### Checklist

- [ ] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.