### PR TITLE
Fixed #37333 -- Added de_CH to LANG_INFO

### DIFF
--- a/django/conf/locale/__init__.py
+++ b/django/conf/locale/__init__.py
@@ -339,6 +339,14 @@ LANG_INFO = {
         "name": "Khmer",
         "name_local": "Khmer",
     },
+
+    'de_CH': {
+    'bidi': False,
+    'code': 'de_CH',
+    'name': 'Swiss German',
+    'name_local': 'Schwiizerdütsch',
+    'script': 'Latn',
+     },
     "kn": {
         "bidi": False,
         "code": "kn",


### PR DESCRIPTION
Fixed #37333 -- Added de_CH to LANG_INFO

This adds Swiss German (de_CH) to the LANG_INFO dictionary
in django/conf/locale/__init__.py.

- Allows Django to detect de_CH language
- Enables translated language names for de_CH
- Follows the pattern of other regional variants

The change was tested manually:
```python
from django.utils.translation import get_language_info
info = get_language_info('de_CH')
print(info['name'])  # 'Swiss German'

Ticket: https://code.djangoproject.com/ticket/37333

<img width="1902" height="1032" alt="git contributions" src="https://github.com/user-attachments/assets/f56b4974-fe99-4828-8c13-d130761d2f71" />
