### PR TITLE
Fixed #37333 -- Added de_CH to LANG_INFO

### DIFF
--- a/django/conf/locale/__init__.py
+++ b/django/conf/locale/__init__.py
@@ -339,6 +339,14 @@ LANG_INFO = {
         "name": "Khmer",
         "name_local": "Khmer",
     },
+
+    'de_CH': {
+    'bidi': False,
+    'code': 'de_CH',
+    'name': 'Swiss German',
+    'name_local': 'Schwiizerdütsch',
+    'script': 'Latn',
+     },
     "kn": {
         "bidi": False,
         "code": "kn",


### PR DESCRIPTION
Fixed #37333 -- Added de_CH to LANG_INFO

This PR adds Swiss German (de_CH) to the LANG_INFO dictionary in 
django/conf/locale/__init__.py. Currently, de_CH translations exist 
in the locale directory but the language metadata is missing, which 
prevents automatic language detection and proper display of translated 
language names.

Ticket: ticket-37333

Checklist:
- [x] This PR follows the contribution guidelines.
- [x] This PR does not disclose a security vulnerability.
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have not requested, and will not request, an automated AI review.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes (N/A - no UI changes).

AI Disclosure:
- [ ] No AI tools were used in preparing this PR.
- [x] If AI tools were used, I have disclosed which ones, and fully reviewed and verified their output.

AI Assistance: Used ChatGPT to help understand the Django contribution 
workflow and pull request requirements. I manually reviewed and verified 
the code change and PR content.