### PR TITLE
Fixed #37317 -- Deprecated passing table names to createcachetable.

### DIFF
--- a/django/core/management/commands/createcachetable.py
+++ b/django/core/management/commands/createcachetable.py
@@ -1,3 +1,4 @@
+import warnings
 from django.conf import settings
 from django.core.cache import caches
 from django.core.cache.backends.db import BaseDatabaseCache
@@ -10,7 +11,8 @@ from django.db import (
     router,
     transaction,
 )
-
+from django.utils.deprecation import RemovedInDjango2029Warning
+from django.utils.warnings import django_file_prefixes
 
 class Command(BaseCommand):
     help = "Creates the tables needed to use the SQL cache backend."
@@ -46,6 +48,12 @@ class Command(BaseCommand):
         dry_run = options["dry_run"]
         if tablenames:
             # Legacy behavior, tablename specified as argument
+            warnings.warn(
+                "Passing table names to createcachetable is deprecated. "
+                "The command will use cache table names from settings.CACHES.",
+                RemovedInDjango2029Warning,
+                skip_file_prefixes=django_file_prefixes(),
+            )
             for tablename in tablenames:
                 self.create_table(db, tablename, dry_run)
         else:

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -28,6 +28,9 @@ details on these changes.
   the current timezone in migrations when the ``tzinfo`` argument is omitted
   and :setting:`USE_TZ` is ``True``.
 
+* Passing positional table names to :djadmin:`createcachetable` will no longer
+  be supported.
+
 .. _deprecation-removed-in-2028:
 
 2028

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -385,3 +385,6 @@ Miscellaneous
   :setting:`TIME_ZONE` changes. Pass the ``tzinfo`` argument explicitly to
   suppress this warning. In Django 2029, the current timezone will be captured
   automatically when ``tzinfo`` is omitted.
+
+* Passing positional table names to :djadmin:`createcachetable` is deprecated.
+  The command will use cache table names from the :setting:`CACHES` setting.

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -13,7 +13,7 @@ import unittest
 from functools import wraps
 from pathlib import Path
 from unittest import mock, skipIf
-
+from django.utils.deprecation import RemovedInDjango2029Warning
 import django
 from django.conf import settings
 from django.core import management, signals
@@ -1433,12 +1433,17 @@ class DBCacheTests(BaseCacheTests, TransactionTestCase):
         """
         self.drop_table()
         out = io.StringIO()
-        management.call_command(
-            "createcachetable",
-            "test cache table",
-            verbosity=2,
-            stdout=out,
+        msg = (
+            "Passing table names to createcachetable is deprecated. "
+            "The command will use cache table names from settings.CACHES."
         )
+        with self.assertWarnsMessage(RemovedInDjango2029Warning, msg):
+            management.call_command(
+                "createcachetable",
+                "test cache table",
+                verbosity=2,
+                stdout=out,
+            )
         self.assertEqual(out.getvalue(), "Cache table 'test cache table' created.\n")
 
     def test_has_key_query_columns_quoted(self):


### PR DESCRIPTION
#### Trac ticket number

ticket-37317

#### Branch description

The `createcachetable` command still accepts undocumented positional table names, leftover from before the command started using `CACHES` (#15888). This deprecates that legacy path with `RemovedInDjango2029Warning`. Without arguments, the command continues to create cache tables from `settings.CACHES` as documented.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Cursor was used to rebase onto `main` and to draft this PR description. The patch itself was reviewed and verified.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.