### PR TITLE
Fix flake8-bugbear B017: replace assertRaises(Exception) with specific types

### DIFF
--- a/tests/backends/base/test_base.py
+++ b/tests/backends/base/test_base.py
@@ -125,7 +125,7 @@ class DatabaseWrapperLoggingTests(TransactionTestCase):
         conn = connections[DEFAULT_DB_ALIAS]
         with CaptureQueriesContext(conn):
             with self.assertLogs("django.db.backends", "DEBUG") as cm:
-                with self.assertRaises(Exception), transaction.atomic():
+                with self.assertRaises(Exception), transaction.atomic():  # noqa: B017 - intentionally catching forced Exception
                     Person.objects.create(first_name="first", last_name="last")
                     raise Exception("Force rollback")
 
@@ -140,7 +140,7 @@ class DatabaseWrapperLoggingTests(TransactionTestCase):
         if isinstance(self._outcome.result, DebugSQLTextTestResult):
             self.skipTest("--debug-sql interferes with this test")
         with self.assertNoLogs("django.db.backends", "DEBUG"):
-            with self.assertRaises(Exception), transaction.atomic():
+            with self.assertRaises(Exception), transaction.atomic():  # noqa: B017 - intentionally catching forced Exception
                 Person.objects.create(first_name="first", last_name="last")
                 raise Exception("Force rollback")
 

--- a/tests/backends/tests.py
+++ b/tests/backends/tests.py
@@ -11,6 +11,7 @@ from django.db import (
     DEFAULT_DB_ALIAS,
     DatabaseError,
     IntegrityError,
+    ProgrammingError,
     connection,
     connections,
     reset_queries,
@@ -180,9 +181,9 @@ class ParameterHandlingTest(TestCase):
                 connection.ops.quote_name("root"),
                 connection.ops.quote_name("square"),
             )
-            with self.assertRaises(Exception):
+            with self.assertRaises(ProgrammingError):
                 cursor.executemany(query, [(1, 2, 3)])
-            with self.assertRaises(Exception):
+            with self.assertRaises(ProgrammingError):
                 cursor.executemany(query, [(1,)])
 
 

--- a/tests/httpwrappers/tests.py
+++ b/tests/httpwrappers/tests.py
@@ -797,11 +797,11 @@ class StreamingHttpResponseTests(SimpleTestCase):
 
         # additional content cannot be written to the response.
         r = StreamingHttpResponse(iter(["hello", "world"]))
-        with self.assertRaises(Exception):
+        with self.assertRaises(OSError):
             r.write("!")
 
         # and we can't tell the current position.
-        with self.assertRaises(Exception):
+        with self.assertRaises(OSError):
             r.tell()
 
         r = StreamingHttpResponse(iter(["hello", "world"]))

--- a/tests/utils_tests/test_autoreload.py
+++ b/tests/utils_tests/test_autoreload.py
@@ -110,7 +110,7 @@ class TestIterModulesAndFiles(SimpleTestCase):
         filename.write_text("raise Exception")
         with extend_sys_path(str(filename.parent)):
             try:
-                with self.assertRaises(Exception):
+                with self.assertRaises(Exception):  # noqa: B017 - intentionally catching arbitrary import exceptions
                     autoreload.check_errors(import_module)("test_exception")
             finally:
                 autoreload._exception = None


### PR DESCRIPTION
﻿This PR fixes 7 B017 violations across 4 test files.

## Changes

### tests/backends/base/test_base.py
- Added # noqa: B017 to two sites where ssertRaises(Exception) intentionally catches a forced Exception("Force rollback") in transaction rollback tests.

### tests/backends/tests.py
- Changed ssertRaises(Exception) to ssertRaises(ProgrammingError) for cursor.executemany parameter mismatch tests (2 sites).
- Added ProgrammingError to imports.

### tests/httpwrappers/tests.py
- Changed ssertRaises(Exception) to ssertRaises(OSError) for StreamingHttpResponse.write() and StreamingHttpResponse.tell() tests (2 sites). These methods raise OSError when called on a streaming response.

### tests/utils_tests/test_autoreload.py
- Added # noqa: B017 for ssertRaises(Exception) that intentionally catches arbitrary import exceptions in check_errors().

## Verification
- uff check --select B017 - PASS (0 violations)
