### PR TITLE
Fix flake8-bugbear B017: replace assertRaises(Exception) with specific types

### DIFF
--- a/tests/backends/base/test_base.py
+++ b/tests/backends/base/test_base.py
@@ -125,7 +125,7 @@ class DatabaseWrapperLoggingTests(TransactionTestCase):
         conn = connections[DEFAULT_DB_ALIAS]
         with CaptureQueriesContext(conn):
             with self.assertLogs("django.db.backends", "DEBUG") as cm:
-                with self.assertRaises(Exception), transaction.atomic():
+                with self.assertRaises(Exception), transaction.atomic():  # noqa: B017 - intentionally catching forced Exception
                     Person.objects.create(first_name="first", last_name="last")
                     raise Exception("Force rollback")
 
@@ -140,7 +140,7 @@ class DatabaseWrapperLoggingTests(TransactionTestCase):
         if isinstance(self._outcome.result, DebugSQLTextTestResult):
             self.skipTest("--debug-sql interferes with this test")
         with self.assertNoLogs("django.db.backends", "DEBUG"):
-            with self.assertRaises(Exception), transaction.atomic():
+            with self.assertRaises(Exception), transaction.atomic():  # noqa: B017 - intentionally catching forced Exception
                 Person.objects.create(first_name="first", last_name="last")
                 raise Exception("Force rollback")
 

--- a/tests/backends/tests.py
+++ b/tests/backends/tests.py
@@ -11,6 +11,7 @@ from django.db import (
     DEFAULT_DB_ALIAS,
     DatabaseError,
     IntegrityError,
+    ProgrammingError,
     connection,
     connections,
     reset_queries,
@@ -180,9 +181,9 @@ class ParameterHandlingTest(TestCase):
                 connection.ops.quote_name("root"),
                 connection.ops.quote_name("square"),
             )
-            with self.assertRaises(Exception):
+            with self.assertRaises(ProgrammingError):
                 cursor.executemany(query, [(1, 2, 3)])
-            with self.assertRaises(Exception):
+            with self.assertRaises(ProgrammingError):
                 cursor.executemany(query, [(1,)])
 
 

--- a/tests/httpwrappers/tests.py
+++ b/tests/httpwrappers/tests.py
@@ -797,11 +797,11 @@ class StreamingHttpResponseTests(SimpleTestCase):
 
         # additional content cannot be written to the response.
         r = StreamingHttpResponse(iter(["hello", "world"]))
-        with self.assertRaises(Exception):
+        with self.assertRaises(OSError):
             r.write("!")
 
         # and we can't tell the current position.
-        with self.assertRaises(Exception):
+        with self.assertRaises(OSError):
             r.tell()
 
         r = StreamingHttpResponse(iter(["hello", "world"]))

--- a/tests/utils_tests/test_autoreload.py
+++ b/tests/utils_tests/test_autoreload.py
@@ -110,7 +110,7 @@ class TestIterModulesAndFiles(SimpleTestCase):
         filename.write_text("raise Exception")
         with extend_sys_path(str(filename.parent)):
             try:
-                with self.assertRaises(Exception):
+                with self.assertRaises(Exception):  # noqa: B017 - intentionally catching arbitrary import exceptions
                     autoreload.check_errors(import_module)("test_exception")
             finally:
                 autoreload._exception = None


### PR DESCRIPTION
﻿## Ticket
N/A - typo fix

## Description
This PR fixes 7 flake8-bugbear B017 violations across 4 test files.

**What problem does this solve?**
flake8-bugbear B017 warns when ssertRaises(Exception) is used, as it catches too broadly (including KeyboardInterrupt, SystemExit, etc.).

**Why is this change necessary?**
To enable B017 in the lint configuration and improve test precision by specifying exact exception types.

**What approach was taken?**
- Replaced ssertRaises(Exception) with specific exception types where the type is deterministic
- Added # noqa: B017 with explanatory comments where the exception type genuinely varies by code path

## Changes
- tests/backends/base/test_base.py: 2 sites → # noqa: B017 (forced Exception rollback)
- tests/backends/tests.py: 2 sites → ProgrammingError (cursor.executemany parameter mismatch)
- tests/httpwrappers/tests.py: 2 sites → OSError (StreamingHttpResponse write/tell)
- tests/utils_tests/test_autoreload.py: 1 site → # noqa: B017 (arbitrary import exceptions)

## AI Assistance Disclosure
- [ ] No AI tools were used in preparing this PR.
- [x] If AI tools were used, I have disclosed which ones, and fully reviewed and verified their output.
  - Tool: opencode/Claude
  - All changes reviewed and verified by human author.

## Checklist
- [x] The commit messages follow our guidelines
- [x] Tests have been added/updated where applicable
- [x] Documentation has been added/updated where applicable
- [x] The PR description is complete
