### PR TITLE
Fixed #11580 -- Fixed TextField contains, exact, and regex lookups Oracle.

### DIFF
--- a/django/db/backends/oracle/operations.py
+++ b/django/db/backends/oracle/operations.py
@@ -357,10 +357,13 @@ END;
     def lookup_cast(self, lookup_type, internal_type=None):
         if lookup_type in ("iexact", "icontains", "istartswith", "iendswith"):
             return "UPPER(%s)"
-        if lookup_type != "isnull" and internal_type in (
-            "BinaryField",
-            "TextField",
-        ):
+        if lookup_type not in (
+            "isnull",
+            "contains",
+            "exact",
+            "regex",
+            "iregex",
+        ) and internal_type in ("BinaryField", "TextField"):
             return "DBMS_LOB.SUBSTR(%s)"
         return "%s"
 

--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -409,6 +409,16 @@ class Exact(FieldGetDbPrepValueMixin, BuiltinLookup):
             return template % lhs_sql, params
         return super().as_sql(compiler, connection)
 
+    def as_oracle(self, compiler, connection):
+        if (
+            hasattr(self.lhs, "output_field")
+            and self.lhs.output_field.get_internal_type() == "TextField"
+        ):
+            lhs, lhs_params = self.process_lhs(compiler, connection)
+            rhs, rhs_params = self.process_rhs(compiler, connection)
+            return f"DBMS_LOB.COMPARE({lhs}, {rhs}) = 0", (*lhs_params, *rhs_params)
+        return super().as_oracle(compiler, connection)
+
 
 @Field.register_lookup
 class IExact(BuiltinLookup):

--- a/tests/backends/oracle/test_operations.py
+++ b/tests/backends/oracle/test_operations.py
@@ -127,3 +127,9 @@ class OperationsTests(TransactionTestCase):
         self.assertIn("BACKENDS_PERSON_SQ", statements[5])
         self.assertIn("BACKENDS_VERYLONGMODELN7BE2_SQ", statements[6])
         self.assertIn("BACKENDS_TAG_SQ", statements[7])
+
+    def test_lookup_cast(self):
+        self.assertEqual(connection.ops.lookup_cast("contains", "TextField"), "%s")
+        self.assertEqual(connection.ops.lookup_cast("exact", "TextField"), "%s")
+        self.assertEqual(connection.ops.lookup_cast("regex", "TextField"), "%s")
+        self.assertEqual(connection.ops.lookup_cast("iregex", "TextField"), "%s")

--- a/tests/backends/oracle/tests.py
+++ b/tests/backends/oracle/tests.py
@@ -138,6 +138,17 @@ class Tests(TestCase):
         with self.assertRaisesMessage(ImproperlyConfigured, msg):
             new_connection.pool
 
+    def test_large_textfield_lookups(self):
+        from ..models import Post
+
+        large_text = "A" * 2500 + "HELLO_TARGET" + "B" * 2500
+        self.assertGreater(len(large_text), 4000)
+        Post.objects.create(name="large_post", text=large_text)
+
+        self.assertEqual(Post.objects.filter(text__contains="HELLO_TARGET").count(), 1)
+        self.assertEqual(Post.objects.filter(text=large_text).count(), 1)
+        self.assertEqual(Post.objects.filter(text__regex=r"HELLO_TARGET").count(), 1)
+
 
 @unittest.skipUnless(connection.vendor == "oracle", "Oracle tests")
 class TransactionalTests(TransactionTestCase):


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-11580

#### Branch description
<!-- Provide a concise overview of the issue or rationale behind the proposed changes. Minimum five words. -->
This PR fixes three errors on oracle text lookup on very lengthy text values because of Oracle's standard SQL VARCHAR2 ceiling limit is 4,000 bytes:
- contains lookup (error ORA-06502)
- exact lookup on LOB (error ORA-22848)
- regex lookup on LOB (error ORA-06502)

Also, I believe it will be faster for `contain` now since it does not need to do the `DBMS_LOB.SUBSTR()` for each row.

Reproduced and Tested after fixing on oracle `Oracle 23 Free`. Since django 6, requires minimum oracle 19, so this will work for all.

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
<!-- If AI tools were used, provide which tools were used here. -->
Used Gemini 3.8 Flash to discuss about oracle query and clob behaviour and better replacement. All responsed were verified manullay. 

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
