### PR TITLE
docs: fix 'allows to' grammar in sync_and_async_middleware docs

### DIFF
--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -214,7 +214,7 @@ The functions defined in this module share the following properties:
 .. function:: sync_and_async_middleware(middleware)
 
     Marks a middleware as :ref:`sync and async compatible <async-middleware>`,
-    this allows to avoid converting requests. You must implement detection of
+    this allows avoiding converting requests. You must implement detection of
     the current request type to use this decorator. See :ref:`asynchronous
     middleware documentation <async-middleware>` for details.
 


### PR DESCRIPTION
Tiny docs fix: change `allows to avoid` to `allows avoiding` in the sync_and_async_middleware documentation.