### PR TITLE
Fail fast on __Host- / __Secure- cookie prefixes that browsers would silently drop

### DIFF
--- a/django/http/response.py
+++ b/django/http/response.py
@@ -245,6 +245,23 @@ class HttpResponseBase:
         - int/float specifying seconds,
         - ``datetime.timedelta`` object.
         """
+        if key.startswith("__Secure-") and not secure:
+            raise ValueError(
+                'Cookies with names starting with "__Secure-" must set secure=True.'
+            )
+        if key.startswith("__Host-"):
+            if not secure:
+                raise ValueError(
+                    'Cookies with names starting with "__Host-" must set secure=True.'
+                )
+            if path != "/":
+                raise ValueError(
+                    'Cookies with names starting with "__Host-" must set path="/".'
+                )
+            if domain is not None:
+                raise ValueError(
+                    'Cookies with names starting with "__Host-" must not set domain.'
+                )
         self.cookies[key] = value
         if expires is not None:
             if isinstance(expires, datetime.datetime):

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -1052,6 +1052,13 @@ Methods
       Use ``samesite='None'`` (string) to explicitly state that this cookie is
       sent with all same-site and cross-site requests.
 
+    * Cookies with names starting with ``__Secure-`` must set ``secure=True``.
+      Cookies with names starting with ``__Host-`` must set ``secure=True``,
+      ``path="/"``, and must not set ``domain``. Browsers silently reject
+      cookies with these prefixes that don't meet these requirements, so a
+      ``ValueError`` is raised instead of emitting a cookie that would never
+      be stored.
+
     .. _HttpOnly: https://owasp.org/www-community/HttpOnly
     .. _SameSite: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value
 

--- a/tests/responses/test_cookie.py
+++ b/tests/responses/test_cookie.py
@@ -118,6 +118,39 @@ class SetCookieTests(SimpleTestCase):
         with self.assertRaisesMessage(ValueError, msg):
             HttpResponse().set_cookie("example", samesite="invalid")
 
+    def test_secure_prefix_requires_secure(self):
+        """
+        set_cookie() refuses to emit __Secure-/__Host- cookies without
+        Secure, which browsers would silently drop.
+        """
+        for prefix in ("Secure", "Host"):
+            with self.subTest(prefix=prefix):
+                msg = (
+                    'Cookies with names starting with "__%s-" must set '
+                    "secure=True." % prefix
+                )
+                with self.assertRaisesMessage(ValueError, msg):
+                    HttpResponse().set_cookie("__%s-c" % prefix, "value")
+
+    def test_secure_prefix_with_secure(self):
+        response = HttpResponse()
+        for prefix in ("Secure", "Host"):
+            with self.subTest(prefix=prefix):
+                response.set_cookie("__%s-c" % prefix, "value", secure=True)
+                self.assertIs(response.cookies["__%s-c" % prefix]["secure"], True)
+
+    def test_host_prefix_requires_path_root(self):
+        msg = 'Cookies with names starting with "__Host-" must set path="/".'
+        with self.assertRaisesMessage(ValueError, msg):
+            HttpResponse().set_cookie("__Host-c", "value", secure=True, path="/sub/")
+
+    def test_host_prefix_forbids_domain(self):
+        msg = 'Cookies with names starting with "__Host-" must not set domain.'
+        with self.assertRaisesMessage(ValueError, msg):
+            HttpResponse().set_cookie(
+                "__Host-c", "value", secure=True, domain="example.com"
+            )
+
 
 class DeleteCookieTests(SimpleTestCase):
     def test_default(self):


### PR DESCRIPTION
Supersedes #21955, which the bot auto-closed with a no-ticket label before Trac ticket #37342 existed. Same tree as #21955 head; commit message now references the ticket.

#### Trac ticket number

Ticket #37342 (https://code.djangoproject.com/ticket/37342; filed by the reporter; no existing ticket covered this — Trac search for "__Host- cookie prefix set_cookie" returned no matches)

#### Branch description

`HttpResponse.set_cookie()` silently emits cookies whose names use the `__Secure-` or `__Host-` prefixes without the attributes browsers require for those prefixes: `__Secure-*` without `Secure` is rejected by browsers, and `__Host-*` without `Secure`, with `Domain` set, or with `Path` other than `/` is rejected by browsers. The failure is silent — no exception, passing tests, broken sessions/auth in production over HTTPS only. This patch turns that silent misconfiguration into an immediate, descriptive `ValueError`, consistent with the existing `ValueError` for an invalid `samesite` argument and the existing prefix handling in `delete_cookie()` (which already auto-sets `Secure` for these prefixes). This is a pure hardening (defense-in-depth), not an exploitable vulnerability in Django, so no private security disclosure applies. `set_signed_cookie()` delegates to `set_cookie()`, so it is covered too. Prefix matching is case-sensitive, matching `delete_cookie()`.

Changes: `django/http/response.py` (validation before mutating the cookie jar), `docs/ref/request-response.txt` (documents the new `ValueError` conditions), `tests/responses/test_cookie.py` (4 new tests in `SetCookieTests`).

Test evidence (local): `tests/runtests.py responses.test_cookie` → 20 tests OK; `responses sessions_tests csrf_tests signed_cookies_tests` → 847 tests OK (skipped=4, expected failures=1, both pre-existing). New tests fail on unpatched code with `AssertionError: ValueError not raised`.

#### AI Assistance Disclosure (REQUIRED)
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
AI tools used: OpenCode with Muse Spark (model `muse-spark-1.3-contributor-free`) drafted the implementation and tests under human-operator direction; the operator reviewed the final diff, ran the full relevant test suites locally (evidence above), and verified every claim in this description.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have not requested, and will not request, an automated AI review for this PR.
- [ ] I have checked the "Has patch" ticket flag in the Trac system. (ticket exists; flag to be set)
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes. (N/A — no UI changes)
