### PR TITLE
Refs #34597 -- Avoided outer joins for reverse relation absence.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -132,6 +132,7 @@ answer newbie questions, and generally made Django that much better:
     Arthur Rio <arthur.rio44@gmail.com>
     Arvis Bickovskis <viestards.lists@gmail.com>
     Arya Khaligh <bartararya@gmail.com>
+    Aryan Hamedani <https://github.com/AryanHamedani>
     Aryeh Leib Taurog <http://www.aryehleib.com/>
     A S Alam <aalam@users.sf.net>
     Asif Saif Uddin <auvipy@gmail.com>

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -34,7 +34,7 @@ from django.db.models.expressions import (
     Value,
 )
 from django.db.models.fields import Field
-from django.db.models.lookups import Lookup
+from django.db.models.lookups import IsNull, Lookup
 from django.db.models.query_utils import (
     Q,
     check_rel_lookup_compatibility,
@@ -2146,6 +2146,12 @@ class Query(BaseExpression):
             filter_rhs = OuterRef(filter_rhs.name)
         query.add_filter(filter_lhs, filter_rhs)
         query.clear_ordering(force=True)
+        negate_exists = query._can_invert_reverse_relation_absence()
+        if negate_exists:
+            # Removing the absence check allows the parent join to be trimmed.
+            related_alias = query.where.children[0].lhs.alias
+            query.clear_where()
+            query.demote_joins([related_alias])
         # Try to have as simple as possible subquery -> trim leading joins from
         # the subquery.
         trimmed_prefix, contains_louter = query.trim_start(names_with_path)
@@ -2153,7 +2159,9 @@ class Query(BaseExpression):
         col = query.select[0]
         select_field = col.target
         alias = col.alias
-        if alias in can_reuse:
+        # An inverted absence lookup must correlate to the parent, regardless
+        # of any outer joins which happen to reuse the inner table's alias.
+        if alias in can_reuse and not negate_exists:
             pk = select_field.model._meta.pk
             # Need to add a restriction so that outer query's filters are in
             # effect for the subquery, too.
@@ -2169,7 +2177,10 @@ class Query(BaseExpression):
             lookup = lookup_class(col, ResolvedOuterRef(trimmed_prefix))
             query.where.add(lookup, AND)
 
-        condition, needed_inner = self.build_filter(Exists(query))
+        exists = Exists(query)
+        condition, needed_inner = self.build_filter(
+            ~exists if negate_exists else exists
+        )
 
         if contains_louter:
             or_null_condition, _ = self.build_filter(
@@ -2185,6 +2196,53 @@ class Query(BaseExpression):
             # correct. If the IS NULL check is removed, then if outercol
             # IS NULL we will not match the row.
         return condition, needed_inner
+
+    def _can_invert_reverse_relation_absence(self):
+        """Check if reverse relation absence can use a negated EXISTS."""
+        from django.db.models.fields.related_lookups import RelatedIsNull
+
+        if len(self.where.children) != 1:
+            return False
+
+        lookup = self.where.children[0]
+        if (
+            type(lookup) not in (IsNull, RelatedIsNull)
+            or lookup.rhs is not True
+            or not isinstance(lookup.lhs, Col)
+        ):
+            return False
+
+        # A direct reverse relation's nonnullable primary key is NULL only
+        # when no related row exists. Nullable fields and longer paths can
+        # contain both NULL and non-NULL values among related rows.
+        related_field = lookup.lhs.target
+        if (
+            not related_field.primary_key
+            or self.is_nullable(related_field)
+            or len(self._lookup_joins) != 2
+        ):
+            return False
+
+        join = self.alias_map[lookup.lhs.alias]
+        if (
+            not join.join_field.one_to_many
+            or join.filtered_relation
+            or len(join.join_fields) != 1
+        ):
+            return False
+
+        parent_field, _ = join.join_fields[0]
+        if self.is_nullable(parent_field):
+            return False
+        # Non-PK text keys can be NULL on Oracle, even with null=False.
+        # Don't rely on the default connection's nullability rules.
+        if not parent_field.primary_key and parent_field.empty_strings_allowed:
+            return False
+
+        return (
+            join.join_field.get_extra_restriction(join.table_alias, join.parent_alias)
+            is None
+        )
 
     def set_empty(self):
         self.where.add(NothingNode(), AND)

--- a/tests/foreign_object/tests.py
+++ b/tests/foreign_object/tests.py
@@ -61,6 +61,19 @@ class MultiColumnFKTests(TestCase):
         person = membership.person
         self.assertEqual((person.id, person.name), (self.bob.id, "Bob"))
 
+    def test_exclude_missing_reverse_relation(self):
+        Membership.objects.create(
+            membership_country=self.usa,
+            person_id=self.bob.pk,
+            group_id=self.cia.pk,
+        )
+        Membership.objects.create(
+            membership_country=self.soviet_union,
+            person_id=self.jim.pk,
+            group_id=self.kgb.pk,
+        )
+        self.assertSequenceEqual(Person.objects.exclude(membership=None), [self.bob])
+
     def test_get_fails_on_multicolumn_mismatch(self):
         # Membership objects returns DoesNotExist error when there is no
         # Person with the same id and country_id

--- a/tests/many_to_one_null/tests.py
+++ b/tests/many_to_one_null/tests.py
@@ -4,6 +4,15 @@ from .models import Article, Car, Driver, Reporter
 
 
 class ManyToOneNullTests(TestCase):
+    def test_exclude_reverse_relation_with_nullable_target(self):
+        null_make = Car.objects.create(make=None)
+        driven = Car.objects.create(make="driven")
+        Car.objects.create(make="undriven")
+        Driver.objects.create(car=driven)
+        Driver.objects.create(car=None)
+        # Preserve the existing correlation semantics for NULL target keys.
+        self.assertCountEqual(Car.objects.exclude(drivers=None), [null_make, driven])
+
     @classmethod
     def setUpTestData(cls):
         # Create a Reporter.

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -4,12 +4,24 @@ import sys
 import unittest
 from itertools import chain
 from operator import attrgetter
+from unittest import mock
 
 from django.core.exceptions import EmptyResultSet, FieldError, FullResultSet
 from django.db import DEFAULT_DB_ALIAS, connection
-from django.db.models import CharField, Count, Exists, F, Max, OuterRef, Q
+from django.db.models import (
+    CharField,
+    Count,
+    Exists,
+    F,
+    FilteredRelation,
+    Max,
+    OuterRef,
+    Q,
+)
 from django.db.models.expressions import RawSQL
+from django.db.models.fields.related_lookups import RelatedIsNull
 from django.db.models.functions import ExtractYear, Length, LTrim
+from django.db.models.lookups import Exact
 from django.db.models.sql.constants import LOUTER
 from django.db.models.sql.where import AND, OR, NothingNode, WhereNode
 from django.test import SimpleTestCase, TestCase, skipUnlessDBFeature
@@ -4540,6 +4552,177 @@ class TestInvalidFilterArguments(TestCase):
         msg = "The following kwargs are invalid: '_connector', '_negated'"
         with self.assertRaisesMessage(TypeError, msg):
             School.objects.filter(pk=school.pk, _negated=True, _connector="evil")
+
+
+class ReverseRelationExcludeTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.alive_related = Individual.objects.create(alive=True)
+        cls.dead_related = Individual.objects.create(alive=False)
+        cls.alive_unrelated = Individual.objects.create(alive=True)
+        cls.dead_unrelated = Individual.objects.create(alive=False)
+        RelatedIndividual.objects.bulk_create(
+            [
+                RelatedIndividual(related=cls.alive_related),
+                RelatedIndividual(related=cls.alive_related),
+                RelatedIndividual(related=cls.dead_related),
+            ]
+        )
+
+    def test_exclude_missing_related_rows(self):
+        for lookup, value in (
+            ("related_individual", None),
+            ("related_individual__exact", None),
+            ("related_individual__isnull", True),
+            ("related_individual__pk", None),
+            ("related_individual__pk__isnull", True),
+        ):
+            with self.subTest(lookup=lookup):
+                query = Individual.objects.exclude(**{lookup: value})
+                self.assertCountEqual(query, [self.alive_related, self.dead_related])
+                self.assertNotIn("LEFT OUTER JOIN", str(query.query))
+
+    def test_negated_absence_with_other_conditions(self):
+        missing = Q(related_individual=None)
+        for condition, expected in (
+            (Q(alive=True) & ~missing, [self.alive_related]),
+            (
+                Q(alive=True) | ~missing,
+                [
+                    self.alive_related,
+                    self.dead_related,
+                    self.alive_unrelated,
+                ],
+            ),
+            (
+                ~(Q(alive=True) & missing),
+                [
+                    self.alive_related,
+                    self.dead_related,
+                    self.dead_unrelated,
+                ],
+            ),
+            (~~missing, [self.alive_unrelated, self.dead_unrelated]),
+        ):
+            with self.subTest(condition=condition):
+                self.assertCountEqual(Individual.objects.filter(condition), expected)
+
+    def test_nullable_related_field(self):
+        category = NamedCategory.objects.create(name="category")
+        mixed = Tag.objects.create(name="mixed")
+        populated = Tag.objects.create(name="populated")
+        Tag.objects.create(name="empty")
+        Tag.objects.create(name="null", parent=mixed)
+        Tag.objects.create(name="set", parent=mixed, category=category)
+        Tag.objects.create(name="set2", parent=populated, category=category)
+        self.assertSequenceEqual(
+            Tag.objects.exclude(children__category__isnull=True), [populated]
+        )
+
+    def test_nullable_prefix(self):
+        parent = Tag.objects.create(name="parent")
+        child = Tag.objects.create(name="child", parent=parent)
+        Tag.objects.create(name="unrelated")
+        self.assertSequenceEqual(Tag.objects.exclude(parent__children=None), [child])
+
+    def test_reused_join(self):
+        related = self.alive_related.related_individual.first()
+        for condition, expected in (
+            (
+                Q(related_individual=related) & ~Q(related_individual=None),
+                [self.alive_related],
+            ),
+            (
+                Q(related_individual=related) | ~Q(related_individual=None),
+                [self.alive_related, self.alive_related, self.dead_related],
+            ),
+        ):
+            with self.subTest(condition=condition):
+                self.assertCountEqual(Individual.objects.filter(condition), expected)
+
+    def test_to_field(self):
+        parent = Node.objects.create(num=17)
+        Node.objects.create(num=42, parent=parent)
+        Node.objects.create(num=31)
+        query = Node.objects.exclude(node=None)
+        self.assertSequenceEqual(query, [parent])
+        self.assertNotIn("LEFT OUTER JOIN", str(query.query))
+
+    def test_to_field_with_empty_strings(self):
+        eaten = Food.objects.create(name="eaten")
+        Food.objects.create(name="uneaten")
+        Eaten.objects.create(food=eaten, meal="dinner")
+        Eaten.objects.create(food=None, meal="lunch")
+        query = Food.objects.exclude(eaten=None)
+        self.assertSequenceEqual(query, [eaten])
+        # Oracle allows NULL in this non-PK CharField, even with null=False.
+        # The query may use Oracle while the default connection does not.
+        with mock.patch.object(
+            connection.features, "interprets_empty_strings_as_nulls", False
+        ):
+            query = Food.objects.exclude(eaten=None)
+            self.assertIn("LEFT OUTER JOIN", str(query.query))
+
+    def test_self_referential_relation_with_forward_join(self):
+        root = Tag.objects.create(name="root")
+        branch = Tag.objects.create(name="branch", parent=root)
+        leaf = Tag.objects.create(name="leaf", parent=root)
+        Tag.objects.create(name="grand", parent=branch)
+        for condition, expected in (
+            (Q(parent__name="root") & ~Q(children=None), [branch]),
+            (Q(parent__name="root") | ~Q(children=None), [root, branch, leaf]),
+        ):
+            with self.subTest(condition=condition):
+                self.assertCountEqual(Tag.objects.filter(condition), expected)
+
+    def test_longer_reverse_path(self):
+        mixed = Tag.objects.create(name="mixed")
+        populated = Tag.objects.create(name="populated")
+        Tag.objects.create(name="empty", parent=mixed)
+        child = Tag.objects.create(name="child", parent=mixed)
+        Tag.objects.create(name="grand1", parent=child)
+        child = Tag.objects.create(name="child2", parent=populated)
+        Tag.objects.create(name="grand2", parent=child)
+        self.assertSequenceEqual(
+            Tag.objects.exclude(children__children=None), [populated]
+        )
+
+    def test_filtered_relation(self):
+        related = self.alive_related.related_individual.first()
+        query = Individual.objects.alias(
+            matching=FilteredRelation(
+                "related_individual", condition=Q(related_individual__pk=related.pk)
+            )
+        ).exclude(matching=None)
+        self.assertSequenceEqual(query, [self.alive_related])
+
+    def test_extra_join_restriction(self):
+        root = Tag.objects.create(name="root")
+        branch = Tag.objects.create(name="branch", parent=root)
+        Tag.objects.create(name="leaf", parent=branch)
+        name = Tag._meta.get_field("name")
+
+        def restriction(alias, related_alias):
+            return Exact(name.get_col(alias), "root")
+
+        with mock.patch.object(
+            Tag._meta.get_field("parent"), "get_extra_restriction", restriction
+        ):
+            self.assertSequenceEqual(Tag.objects.exclude(children=None), [root])
+
+    def test_custom_isnull_lookup(self):
+        class NotIsNull(RelatedIsNull):
+            def as_sql(self, compiler, connection):
+                return RelatedIsNull(self.lhs, not self.rhs).as_sql(
+                    compiler, connection
+                )
+
+        field = RelatedIndividual._meta.get_field("related")
+        with register_lookup(field, NotIsNull):
+            self.assertCountEqual(
+                Individual.objects.exclude(related_individual=None),
+                [self.alive_unrelated, self.dead_unrelated],
+            )
 
 
 class TestTicket24605(TestCase):


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number. -->
<!-- Or delete the line and write "N/A - typo" for typo fixes. -->

ticket-34597

#### Branch description
<!-- Provide a concise overview of the issue or rationale behind the proposed changes. Minimum five words. -->

`Blog.objects.filter(Q(is_published=True) & ~Q(translation=None))` retains a
parent LEFT OUTER JOIN inside the exclusion subquery, even after #16906.
For a built-in absence lookup on a direct reverse relation, replace that
missing-row check with negated existence so `trim_start()` can remove the
parent join. Keep existing behavior for nullable keys and longer, composite,
filtered or custom conditions, and preserve correlation when aliases are reused.
Keep eligibility checks in a private predicate, with query mutations and
correlation visible in `split_exclude()`.

The optimization is deliberately limited to the demonstrated case in #34597.
It retains Django's surrounding negation and does not change public APIs.

[Reproduction script, complete execution plans and validation results](https://gist.github.com/AryanHamedani/0b748b5f9968f98b9937bc2f6bc56674).
On PostgreSQL 18.6, the sparse 20,000-blog case changed from 3287.759 ms to
3.097 ms (median of five warmed EXPLAIN ANALYZE runs). At 200,000 blogs, the
baseline hit the 30-second timeout; the patch measured 43.105 ms. All four
20,000-row distributions and the explicit Exists control are included.
These synthetic results do not imply a universal speedup.

Validation: 14 new regression tests; SQLite suite (19,834 tests across the full
invocation and supplemental cache run, 1,523 skips, 4 expected failures);
affected PostgreSQL ORM suites (1,029 tests, 9 skips, 1 expected failure); Black, isort and flake8. Deterministic
comparisons against the baseline found no result or multiplicity differences.
The readability refactor also preserves SQL and parameters across 800
deterministic comparisons and the recorded benchmark query shapes.
Actual MySQL and Oracle were not run. The Oracle text-key edge case was
reproduced separately using Django's nullability schema rule on isolated
SQLite; the guard does not rely on the default database backend.


#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
<!-- If AI tools were used, provide which tools were used here. -->

OpenAI Codex (GPT-6) assisted with contribution-policy and history research,
reproduction, implementation, regression tests, local independent reviews,
benchmark/test execution, commit-message drafting and this PR description.


#### Checklist
- [x] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [x] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [x] I have checked the "Has patch" ticket flag in the Trac system ([ticket update](https://code.djangoproject.com/ticket/34597#comment:16)).
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
